### PR TITLE
Report task failures as MFECG0011 instead of an unhandled exception

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/GenerateEmbeddedConstantsTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/GenerateEmbeddedConstantsTask.cs
@@ -5,6 +5,8 @@ namespace Meziantou.Framework.EmbeddedConstantsGenerator;
 
 public sealed class GenerateEmbeddedConstantsTask : Microsoft.Build.Utilities.Task
 {
+    private const string UnexpectedFailureCode = "MFECG0011";
+
     [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "MSBuild task item parameters are represented as arrays.")]
     [Required]
     public ITaskItem[] EmbeddedConstants { get; set; } = [];
@@ -24,16 +26,27 @@ public sealed class GenerateEmbeddedConstantsTask : Microsoft.Build.Utilities.Ta
 
     public override bool Execute()
     {
-        var options = new EmbeddedConstantsGeneratorTask.GeneratorOptions(Namespace, ClassName, ClassVisibility, MemberVisibility, ProjectDirectory);
-        var files = EmbeddedConstants
-            .Select(item => new EmbeddedConstantsGeneratorTask.InputFile(
-                item.ItemSpec,
-                GetMetadata(item, "Meziantou_EmbeddedConstantKind", "EmbeddedConstantKind", "Kind"),
-                GetMetadata(item, "Meziantou_EmbeddedConstantName", "EmbeddedConstantName", "Name"),
-                ProjectDirectory))
-            .ToArray();
+        EmbeddedConstantsGeneratorTask.Result result;
+        try
+        {
+            var options = new EmbeddedConstantsGeneratorTask.GeneratorOptions(Namespace, ClassName, ClassVisibility, MemberVisibility, ProjectDirectory);
+            var files = EmbeddedConstants
+                .Select(item => new EmbeddedConstantsGeneratorTask.InputFile(
+                    item.ItemSpec,
+                    GetMetadata(item, "Meziantou_EmbeddedConstantKind", "EmbeddedConstantKind", "Kind"),
+                    GetMetadata(item, "Meziantou_EmbeddedConstantName", "EmbeddedConstantName", "Name"),
+                    ProjectDirectory))
+                .ToArray();
 
-        var result = EmbeddedConstantsGeneratorTask.Create(options, files);
+            result = EmbeddedConstantsGeneratorTask.Create(options, files);
+        }
+        catch (Exception ex)
+        {
+            // Without this the failure surfaces as MSB4018 with a stack trace instead of a documented diagnostic
+            LogError(UnexpectedFailureCode, filePath: null, string.Create(CultureInfo.InvariantCulture, $"The embedded constants could not be computed: {ex.Message}"));
+            return false;
+        }
+
         foreach (var error in result.Errors)
         {
             LogValidationError(error);
@@ -43,22 +56,36 @@ public sealed class GenerateEmbeddedConstantsTask : Microsoft.Build.Utilities.Ta
             return false;
 
         var source = EmbeddedConstantsGeneratorTask.GenerateSource(result.Options, result.Entries);
-        WriteFileIfChanged(OutputPath, source);
+        try
+        {
+            WriteFileIfChanged(OutputPath, source);
+        }
+        catch (Exception ex)
+        {
+            LogError(UnexpectedFailureCode, OutputPath, string.Create(CultureInfo.InvariantCulture, $"The generated file could not be written: {ex.Message}"));
+            return false;
+        }
+
         return !Log.HasLoggedErrors;
     }
 
     private void LogValidationError(EmbeddedConstantsGeneratorTask.ValidationError error)
     {
+        LogError(error.Code, error.FilePath, error.Message);
+    }
+
+    private void LogError(string code, string? filePath, string message)
+    {
         Log.LogError(
             subcategory: string.Empty,
-            errorCode: error.Code,
+            errorCode: code,
             helpKeyword: string.Empty,
-            file: error.FilePath ?? string.Empty,
+            file: filePath ?? string.Empty,
             lineNumber: 0,
             columnNumber: 0,
             endLineNumber: 0,
             endColumnNumber: 0,
-            message: error.Message);
+            message: message);
     }
 
     private static string? GetMetadata(ITaskItem item, params string[] names)

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
@@ -95,3 +95,4 @@ Text files larger than 1 MiB are rejected to avoid producing impractically large
 | `MFECG0007` | Embedded constant text file is not valid UTF-8 |
 | `MFECG0008` | Embedded constant text file is too large |
 | `MFECG0009` | Embedded constants visibility is invalid |
+| `MFECG0011` | The embedded constants could not be computed or written |

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -199,6 +199,41 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         Assert.Contains("MFECG0005", string.Join('\n', result.Output));
     }
 
+    [Fact]
+    public async Task GenerateOnBuild_OutputPathCannotBeWritten_ReportsDiagnosticInsteadOfUnhandledException()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("unwritable-output-path");
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile("unwritable-output-path/Sample.csproj", $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <EmbeddedConstantsNamespace>Generated</EmbeddedConstantsNamespace>
+                <EmbeddedConstantsOutputPath>Generated/EmbeddedConstants.g.cs</EmbeddedConstantsOutputPath>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{{EmbeddedConstantsGeneratorPackageFixture.PackageName}}" Version="{{fixture.PackageVersion}}" PrivateAssets="all" />
+                <EmbeddedConstant Include="Assets/sample.txt" Kind="Text" />
+              </ItemGroup>
+            </Project>
+            """);
+        temporaryDirectory.CreateTextFile("unwritable-output-path/Assets/sample.txt", "Hello");
+
+        // The generated file path is an existing directory, so writing it throws inside the task
+        Directory.CreateDirectory(projectDirectory / "Generated" / "EmbeddedConstants.g.cs");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        var output = string.Join('\n', result.Output);
+        Assert.Contains("MFECG0011", output);
+        Assert.DoesNotContain("MSB4018", output);
+    }
+
     private static string CreateProjectFile(EmbeddedConstantsGeneratorPackageFixture fixture, string embeddedConstants)
     {
         return $$"""


### PR DESCRIPTION
An I/O or path failure inside the task surfaces as `MSB4018` with a .NET stack trace instead of a documented `MFECG` diagnostic.

## The finding

`Execute` has no exception handling (`GenerateEmbeddedConstantsTask.cs:25-48`). Two reachable throw sites:

- `InputFile`'s constructor calls `Path.GetFullPath`, which throws on invalid path characters or an over-long path (`GenerateEmbeddedConstantsTask.cs:28-34`).
- `WriteFileIfChanged` does `Directory.CreateDirectory` / `File.WriteAllText` with no handling, so a read-only, missing, or occupied output path throws (`GenerateEmbeddedConstantsTask.cs:76-88`).

Both escape as unhandled task exceptions, and MSBuild reports `MSB4018: The "GenerateEmbeddedConstantsTask" task failed unexpectedly` followed by a stack trace. Every other failure in this task is a clean, documented diagnostic — this is the difference between "I misconfigured a path" and "this package is broken".

## The change

Wrap the two phases and report `MFECG0011` with the underlying exception message, attributing the write failure to the output path. Also extracts the shared `LogError(code, filePath, message)` helper that `LogValidationError` now delegates to.

The catch is deliberately broad. That is the standard contract for an MSBuild task: anything that escapes becomes `MSB4018`, so there is no benefit in letting a subset through.

This is reported from the task rather than added to the generator's `ValidationError` type, because it describes an MSBuild-level I/O failure rather than a problem with the embedded constants themselves.

## Verification

New test `GenerateOnBuild_OutputPathCannotBeWritten_ReportsDiagnosticInsteadOfUnhandledException` points `EmbeddedConstantsOutputPath` at a path that is an existing directory, so `MakeDir` succeeds and the write throws inside the task. It asserts `MFECG0011` is reported and `MSB4018` is not.

Checked the assertion is not vacuous: with `GenerateEmbeddedConstantsTask.cs` reverted the test fails and `MSB4018` appears in the build output. Full suite: 7/7 pass.

## Note for reviewers

Diagnostic IDs are coordinated across the batch of PRs opened from this review: this one takes `MFECG0011`.
