### PR TITLE
Walk ancestors iteratively when resolving namespaces

### DIFF
--- a/ref/Meziantou.Framework.Html.cs
+++ b/ref/Meziantou.Framework.Html.cs
@@ -129,7 +129,6 @@ namespace Meziantou.Framework.Html
         public void AddNamespace(string? prefix, string? uri) { }
         public override string GetNamespaceOfPrefix(string prefix) => throw null;
         public override string GetPrefixOfNamespace(string namespaceURI) => throw null;
-        protected override void GetNamespaceAttributes(System.Collections.Generic.IDictionary<string, string> namespaces) { }
         public Meziantou.Framework.Html.HtmlAttribute CreateAttribute(string prefix, string localName, string? namespaceURI) => throw null;
         public Meziantou.Framework.Html.HtmlText CreateText() => throw null;
         public Meziantou.Framework.Html.HtmlText CreateText(string value) => throw null;

--- a/src/Meziantou.Framework.Html/HtmlDocument.cs
+++ b/src/Meziantou.Framework.Html/HtmlDocument.cs
@@ -469,9 +469,28 @@ sealed class HtmlDocument : HtmlNode
         return "";
     }
 
-    protected override void GetNamespaceAttributes(IDictionary<string, string> namespaces)
+    // A document resolves prefixes from its own declarations only, so the ancestor walk of a descendant node
+    // must reach these and not the attribute-based lookup of the base node.
+
+    private protected override string? GetDeclaredNamespaceOfPrefix(string prefix)
     {
-        base.GetNamespaceAttributes(namespaces);
+        if (_declaredPrefixes is not null && _declaredPrefixes.TryGetValue(prefix, out var namespaceURI))
+            return namespaceURI;
+
+        return null;
+    }
+
+    private protected override string? GetDeclaredPrefixOfNamespace(string namespaceURI)
+    {
+        if (_declaredNamespaces is not null && _declaredNamespaces.TryGetValue(namespaceURI, out var prefix))
+            return prefix;
+
+        return null;
+    }
+
+    private protected override void GetDeclaredNamespaceAttributes(IDictionary<string, string> namespaces)
+    {
+        base.GetDeclaredNamespaceAttributes(namespaces);
         if (_declaredPrefixes is not null)
         {
             foreach (var kv in _declaredPrefixes)

--- a/src/Meziantou.Framework.Html/HtmlNode.cs
+++ b/src/Meziantou.Framework.Html/HtmlNode.cs
@@ -1009,6 +1009,25 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
     {
         ArgumentNullException.ThrowIfNull(prefix);
 
+        // The ancestors are walked iteratively: a document can be nested thousands of levels deep and a
+        // recursive walk would overflow the stack, which cannot be caught and takes the whole process down.
+        for (var node = this; node is not null; node = node.ParentNode)
+        {
+            var namespaceURI = node.GetDeclaredNamespaceOfPrefix(prefix);
+            if (namespaceURI is not null)
+                return namespaceURI;
+        }
+
+        if (OwnerDocument is not null && OwnerDocument != this)
+            return OwnerDocument.GetNamespaceOfPrefix(prefix);
+
+        return "";
+    }
+
+    /// <summary>Resolves <paramref name="prefix"/> against the declarations carried by this node alone, without looking at its ancestors.</summary>
+    /// <returns>The namespace URI, or <see langword="null"/> when this node declares nothing for <paramref name="prefix"/>.</returns>
+    private protected virtual string? GetDeclaredNamespaceOfPrefix(string prefix)
+    {
         if (prefix.EqualsIgnoreCase(Prefix) && DeclaredNamespaceURI is not null)
             return DeclaredNamespaceURI;
 
@@ -1018,13 +1037,7 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
                 return att.Value ?? "";
         }
 
-        if (ParentNode is not null && ParentNode != this)
-            return ParentNode.GetNamespaceOfPrefix(prefix);
-
-        if (OwnerDocument is not null && OwnerDocument != this)
-            return OwnerDocument.GetNamespaceOfPrefix(prefix);
-
-        return "";
+        return null;
     }
 
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "Breaking change")]
@@ -1032,6 +1045,25 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
     {
         ArgumentNullException.ThrowIfNull(namespaceURI);
 
+        // The ancestors are walked iteratively: a document can be nested thousands of levels deep and a
+        // recursive walk would overflow the stack, which cannot be caught and takes the whole process down.
+        for (var node = this; node is not null; node = node.ParentNode)
+        {
+            var prefix = node.GetDeclaredPrefixOfNamespace(namespaceURI);
+            if (prefix is not null)
+                return prefix;
+        }
+
+        if (OwnerDocument is not null && OwnerDocument != this)
+            return OwnerDocument.GetPrefixOfNamespace(namespaceURI);
+
+        return "";
+    }
+
+    /// <summary>Resolves <paramref name="namespaceURI"/> against the declarations carried by this node alone, without looking at its ancestors.</summary>
+    /// <returns>The prefix, or <see langword="null"/> when this node declares nothing for <paramref name="namespaceURI"/>.</returns>
+    private protected virtual string? GetDeclaredPrefixOfNamespace(string namespaceURI)
+    {
         if (namespaceURI.EqualsIgnoreCase(NamespaceURI))
             return Prefix;
 
@@ -1041,13 +1073,7 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
                 return att.LocalName;
         }
 
-        if (ParentNode is not null && ParentNode != this)
-            return ParentNode.GetPrefixOfNamespace(namespaceURI);
-
-        if (OwnerDocument is not null && OwnerDocument != this)
-            return OwnerDocument.GetPrefixOfNamespace(namespaceURI);
-
-        return "";
+        return null;
     }
 
     public virtual HtmlNode? GetParent(Func<HtmlNode, bool> func)
@@ -1074,6 +1100,17 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
     {
         ArgumentNullException.ThrowIfNull(namespaces);
 
+        // The ancestors are walked iteratively: a document can be nested thousands of levels deep and a
+        // recursive walk would overflow the stack, which cannot be caught and takes the whole process down.
+        for (var node = this; node is not null; node = node.ParentNode)
+        {
+            node.GetDeclaredNamespaceAttributes(namespaces);
+        }
+    }
+
+    /// <summary>Adds the namespaces declared by this node alone to <paramref name="namespaces"/>, without looking at its ancestors.</summary>
+    private protected virtual void GetDeclaredNamespaceAttributes(IDictionary<string, string> namespaces)
+    {
         foreach (var att in Attributes)
         {
             if (att.Prefix.EqualsIgnoreCase(XmlnsPrefix))
@@ -1084,8 +1121,6 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
                 }
             }
         }
-
-        ParentNode?.GetNamespaceAttributes(namespaces);
     }
 
     [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]

--- a/tests/Meziantou.Framework.Html.Tests/HtmlNodeTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlNodeTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.ExceptionServices;
+
 namespace Meziantou.Framework.Html.Tests;
 
 public class HtmlNodeTests
@@ -36,5 +38,95 @@ public class HtmlNodeTests
         var node = doc.SelectSingleNode("/p/node()");
         Assert.NotNull(node);
         Assert.Equal("p", node!.ParentElement!.Name);
+    }
+
+    // Detaching a node collects the namespaces declared by its ancestors. That walk used to recurse once per
+    // ancestor, so removing a node from a deeply nested document overflowed the stack, which cannot be caught
+    // and takes the whole process down. The tests below run on a thread with the stack size a server gives a
+    // request, not the much larger stack of the test runner's main thread.
+
+    [Fact]
+    public void HtmlNode_Remove_DeeplyNestedDocument()
+    {
+        RunWithBoundedStack(() =>
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(Nest("<div>", "<span>x</span>", "</div>", DeepNestingLevels));
+
+            var node = doc.SelectSingleNode("//span");
+            Assert.NotNull(node);
+            Assert.True(node!.Remove());
+        });
+    }
+
+    [Fact]
+    public void HtmlNode_RemoveAttribute_DeeplyNestedDocument()
+    {
+        RunWithBoundedStack(() =>
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(Nest("<div>", "<span class='x'>y</span>", "</div>", DeepNestingLevels));
+
+            var node = doc.SelectSingleNode("//span");
+            Assert.NotNull(node);
+            node!.Attributes.RemoveAt(0);
+            Assert.Empty(node.Attributes);
+        });
+    }
+
+    [Fact]
+    public void HtmlNode_GetAllNamespaces_DeeplyNestedDocument()
+    {
+        RunWithBoundedStack(() =>
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(Nest("<div>", "<span xmlns:x='urn:sample'>y</span>", "</div>", DeepNestingLevels));
+
+            var node = doc.SelectSingleNode("//span");
+            Assert.NotNull(node);
+            Assert.Equal("urn:sample", Assert.Contains("x", node!.GetAllNamespaces()));
+        });
+    }
+
+    [Fact]
+    public void HtmlNode_GetNamespaceOfPrefix_DeeplyNestedDocument()
+    {
+        RunWithBoundedStack(() =>
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(Nest("<div xmlns:x='urn:sample'>", "<span>y</span>", "</div>", DeepNestingLevels));
+
+            var node = doc.SelectSingleNode("//span");
+            Assert.NotNull(node);
+            Assert.Equal("urn:sample", node!.GetNamespaceOfPrefix("x"));
+            Assert.Equal("x", node.GetPrefixOfNamespace("urn:sample"));
+        });
+    }
+
+    private const int DeepNestingLevels = 8_000;
+
+    private static string Nest(string open, string content, string close, int levels)
+        => string.Concat(Enumerable.Repeat(open, levels)) + content + string.Concat(Enumerable.Repeat(close, levels));
+
+    // 1 MB is the stack an ASP.NET Core request runs on; the test runner's main thread has several times more,
+    // which is enough to hide a per-ancestor recursion at these depths.
+    private static void RunWithBoundedStack(Action action)
+    {
+        ExceptionDispatchInfo? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                failure = ExceptionDispatchInfo.Capture(ex);
+            }
+        }, maxStackSize: 1024 * 1024);
+
+        thread.Start();
+        thread.Join();
+        failure?.Throw();
     }
 }


### PR DESCRIPTION
Removing a node from a deeply nested document aborts the process with an uncatchable `StackOverflowException`.

### The failure

`HtmlNode.ParentNode`'s setter collects the namespaces declared by the ancestors whenever a node is detached, and `GetNamespaceAttributes` recursed once per ancestor to do it. `GetNamespaceOfPrefix` and `GetPrefixOfNamespace` have the same shape.

So any removal from a deep tree — `Remove()`, `Remove(keepChildren: true)`, `Attributes.RemoveAt(...)` — recurses as deep as the document is nested. On a 1 MB stack, which is what an ASP.NET Core request thread gets, that overflows at a nesting depth of roughly 5 500:

```
Stack overflow.
Repeated 5092 times:
   at Meziantou.Framework.Html.HtmlNode.GetNamespaceAttributes(...)
   at Meziantou.Framework.Html.HtmlNode.GetAllNamespaces()
   at Meziantou.Framework.Html.HtmlNode.set_ParentNode(...)
   at Meziantou.Framework.Html.HtmlNodeList.Remove(...)
   at Meziantou.Framework.Html.HtmlNode.RemoveChild(HtmlNode, Boolean)
```

This is reachable from `Meziantou.Framework.HtmlSanitizer`, which exists to process untrusted HTML. An **88 KB** fragment — 8 000 nested `<div>`s around a single HTML comment — kills the process, and a `StackOverflowException` cannot be caught, so it drops every in-flight request rather than just the offending one. Every kind of removal the sanitizer performs triggers it: a comment, a disallowed attribute, an unwrapped element, a blocked element.

`HtmlSanitizer.Sanitize` already walks the tree iteratively for exactly this reason — the removal path underneath it was still recursive.

### The change

The three ancestor walks in `HtmlNode` become loops. Each keeps its public signature and its contract ("collect from this node and its ancestors"); the per-node half moves to a new `private protected virtual` hook that does not recurse:

- `GetNamespaceOfPrefix` → `GetDeclaredNamespaceOfPrefix`
- `GetPrefixOfNamespace` → `GetDeclaredPrefixOfNamespace`
- `GetNamespaceAttributes` → `GetDeclaredNamespaceAttributes`

`HtmlDocument` resolves prefixes from its own declaration dictionaries rather than from attributes, so it overrides the new hooks — otherwise an ancestor walk that reaches the document would miss them. Its `GetNamespaceAttributes` override is no longer needed and is dropped from `ref/`; the inherited base does the same work through the hook, so nothing a caller can invoke has been removed.

This matches the treatment already applied to `WriteChildNodesTo` and `ClearCaches`.

### Verification

Four regression tests in `HtmlNodeTests`, all running on a thread with a 1 MB stack at 8 000 levels of nesting, covering node removal, attribute removal, `GetAllNamespaces` and prefix/namespace resolution. On `main` they do not fail — they take the test host down with `Stack overflow.` and exit code 134.

Green after the change:

| project | tests |
|---|---|
| `Meziantou.Framework.Html.Tests` | 278 |
| `Meziantou.Framework.HtmlSanitizer.Tests` | 336 |
| `Meziantou.Framework.HtmlToMarkdown.Tests` | 1698 |
| `Meziantou.Framework.Html.Tool.Tests` | 12 |
| `Meziantou.Framework.Templating.Html.Tests` | 18 |

`dotnet run ./eng/update-all.cs` reports no further changes.

Found during a review of `Meziantou.Framework.HtmlSanitizer`.
