### PR TITLE
Remove the unreachable run fallback in ParseTextWithAnsiStyles

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -88,11 +88,6 @@ public static class AnsiTextProcessor
 
         AddRun(runs, currentStyle, currentRunStart, builder.Length);
 
-        if (runs.Count is 0 && builder.Length > 0)
-        {
-            runs.Add(new AnsiTextRun(0, builder.Length, AnsiStyle.None));
-        }
-
         return new AnsiText(builder.ToString(), runs);
     }
 

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -68,6 +68,33 @@ public class AnsiTextProcessorTests
         Assert.Equal(expected, actual);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("\u001b[1m")]
+    [InlineData("\u001b[1m\u001b[0m")]
+    [InlineData("\u001b[1ma")]
+    [InlineData("a\u001b[1m")]
+    [InlineData("\u001b[0ma")]
+    [InlineData("\u001b[1m\u001b[22ma")]
+    [InlineData("a\u001b[1mb\u001b[0mc")]
+    [InlineData("a\u001b[2Kb")]
+    [InlineData("\u001b[31m日本語\u001b[0m テキスト")]
+    public void ParseTextWithAnsiStyles_RunsCoverAllTextWithoutGaps(string input)
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles(input);
+
+        var position = 0;
+        foreach (var run in parsed.Runs)
+        {
+            Assert.Equal(position, run.Start);
+            Assert.True(run.End > run.Start, "Runs must not be empty");
+            position = run.End;
+        }
+
+        Assert.Equal(parsed.Text.Length, position);
+    }
+
     [Fact]
     public void RemoveAnsiSequences_PreservesUnicode()
     {


### PR DESCRIPTION
## Problem

`ParseTextWithAnsiStyles` ends with a fallback that can never run (`src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs:91-94`):

```csharp
AddRun(runs, currentStyle, currentRunStart, builder.Length);

if (runs.Count is 0 && builder.Length > 0)
{
    runs.Add(new AnsiTextRun(0, builder.Length, AnsiStyle.None));
}
```

`currentRunStart` is only ever advanced to `builder.Length` immediately after an `AddRun` call, and `builder` only grows, so `currentRunStart <= builder.Length` always holds at the final `AddRun` — which therefore adds a run whenever any text was produced. `runs.Count is 0 && builder.Length > 0` is unsatisfiable.

The cost is not the four lines, it is what they imply: that `Runs` may fail to cover `Text`. `LogHighlighter.AppendStyledText` already half-defends against that (`src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/LogHighlighter.cs:110`), and if the runs really could be sparse it would silently drop characters, since it renders text only by iterating runs.

## Change

Delete the unreachable branch, and replace it with a test that states the invariant it was pretending to uphold — that the runs tile `[0, Text.Length)` exactly, with no gaps and no empty runs. That is the property consumers actually depend on, and unlike the dead branch it will fail if a future change breaks it.

The test covers 11 shapes: empty input, plain text, sequence-only input, sequences before/after text, a redundant style change, a non-SGR sequence, and multi-run text with Unicode.

## Verification

- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 70 passed, 0 failed (35 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` → 24 passed, 0 failed.
- `ref/` unchanged; `dotnet run ./eng/update-all.cs` reports no generated-file changes.

To be explicit about what the new test does and does not prove: it passes both with and without the deleted branch, because the branch was unreachable. It is there to pin the invariant going forward, not to demonstrate a behaviour change. There is no behaviour change in this PR.

## Context

One of 8 PRs from an audit of `Meziantou.Framework.AnsiFormatting`. Independent — mergeable in any order.
