### PR TITLE
Fix member separation and trailing whitespace in the generated file

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
@@ -134,6 +134,7 @@ internal static class EmbeddedConstantsGeneratorTask
                 sb.Append("    ").Append(options.MemberVisibility).Append(" const string ").Append(entry.BaseName).Append("Text = ");
                 AppendStringLiteral(sb, entry.File.Text!);
                 sb.AppendLine(";");
+                first = false;
             }
 
             if (entry.File.Kind.HasFlag(EmbeddedConstantKind.Binary))
@@ -146,9 +147,8 @@ internal static class EmbeddedConstantsGeneratorTask
                 sb.Append("    ").Append(options.MemberVisibility).Append(" static global::System.ReadOnlySpan<byte> ").Append(entry.BaseName).Append("Bytes => ");
                 AppendByteArray(sb, entry.File.Bytes);
                 sb.AppendLine(";");
+                first = false;
             }
-
-            first = false;
         }
 
         sb.AppendLine("}");
@@ -433,12 +433,17 @@ internal static class EmbeddedConstantsGeneratorTask
             sb.Append(bytes[i].ToString("X2", CultureInfo.InvariantCulture));
             if (i != bytes.Length - 1)
             {
-                sb.Append(", ");
+                sb.Append(',');
             }
 
+            // The separating space goes before the next byte so the line does not end with trailing whitespace
             if (i % 16 == 15 || i == bytes.Length - 1)
             {
                 sb.AppendLine();
+            }
+            else
+            {
+                sb.Append(' ');
             }
         }
 

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -226,7 +226,7 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
     private static void AssertNoTrailingWhitespace(string generatedSource)
     {
         var lines = generatedSource.ReplaceLineEndings("\n").Split('\n');
-        Assert.Empty(lines.Where(line => line != line.TrimEnd()));
+        Assert.DoesNotContain(lines, line => line != line.TrimEnd());
     }
 
     private static FullPath GetGeneratedFilePath(FullPath projectDirectory)

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -88,7 +88,8 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
                 public static int Length => Generated.EmbeddedConstants.LogoBytes.Length;
             }
             """);
-        CreateBinaryFile(projectDirectory / "Assets" / "logo.bin", [0x89, 0x50, 0x4E, 0x47]);
+        // More than 16 bytes so the byte array spans several lines
+        CreateBinaryFile(projectDirectory / "Assets" / "logo.bin", [0x89, 0x50, 0x4E, 0x47, .. Enumerable.Range(0, 16).Select(i => (byte)i)]);
 
         await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
         await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
@@ -97,6 +98,7 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         Assert.DoesNotContain("LogoText", generatedSource);
         Assert.Contains("public static global::System.ReadOnlySpan<byte> LogoBytes => new byte[]", generatedSource);
         Assert.Contains("0x89, 0x50, 0x4E, 0x47", generatedSource);
+        AssertNoTrailingWhitespace(generatedSource);
     }
 
     [Fact]
@@ -138,6 +140,12 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         var generatedSource = await File.ReadAllTextAsync(GetGeneratedFilePath(projectDirectory), XunitCancellationToken);
         Assert.Contains("public const string ConfigJsonText = \"{}\";", generatedSource);
         Assert.Contains("public static global::System.ReadOnlySpan<byte> ConfigJsonBytes => new byte[]", generatedSource);
+
+        // The two members of the first entry are separated like every other pair of members
+        Assert.Contains(
+            "public const string ConfigJsonText = \"{}\";\n\n    public static global::System.ReadOnlySpan<byte> ConfigJsonBytes",
+            generatedSource.ReplaceLineEndings("\n"));
+        AssertNoTrailingWhitespace(generatedSource);
     }
 
     [Fact]
@@ -213,6 +221,12 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
               </ItemGroup>
             </Project>
             """;
+    }
+
+    private static void AssertNoTrailingWhitespace(string generatedSource)
+    {
+        var lines = generatedSource.ReplaceLineEndings("\n").Split('\n');
+        Assert.Empty(lines.Where(line => line != line.TrimEnd()));
     }
 
     private static FullPath GetGeneratedFilePath(FullPath projectDirectory)


### PR DESCRIPTION
Two whitespace defects in the emitted C#.

## Finding 1 — the first entry's members are not separated

`EmbeddedConstantsGeneratorTask.cs:124-151`. `first` is only set to `false` at the end of the loop body, so the `Binary` block still sees `first == true` while emitting the *first* entry. For an entry with `Kind="Both"`, its `Text` and `Bytes` members come out adjacent, while every later entry gets a blank line:

```csharp
    public const string ConfigJsonText = "{}";
    public static global::System.ReadOnlySpan<byte> ConfigJsonBytes => new byte[]
```

Fixed by setting `first = false` as each member is emitted rather than once per entry.

## Finding 2 — every full row of a byte array ends with trailing whitespace

`EmbeddedConstantsGeneratorTask.cs:434-442`. `", "` is appended before the end-of-line check, so each complete 16-byte row ends with `0x0F, ` followed by the newline:

```
        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, ⏎
```

`AGENTS.md` states the repo's rule that there should be no trailing whitespace in any lines, and it makes the generated file noisy in diffs and in editors that highlight it. Fixed by emitting the comma with the byte and the separating space only when another byte follows on the same line.

Neither affects compilation — this is the shape of the emitted file only.

## Verification

- `GenerateOnBuild_BinaryKind_GeneratesBytesOnly` now embeds 20 bytes instead of 4, so the array spans more than one row, and asserts no line has trailing whitespace.
- `GenerateOnBuild_BothKind_GeneratesStringAndBytes` asserts the blank line between the first entry's two members, and also asserts no trailing whitespace.

Checked both assertions are not vacuous: with `EmbeddedConstantsGeneratorTask.cs` reverted, both tests fail. Full suite: 6/6 pass.
