### PR TITLE
Cache AnsiStyle.None instead of allocating on every access

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -100,7 +100,7 @@ public static class AnsiTextProcessor
     {
         char[]? rented = null;
         var buffer = value.Length <= StackAllocThreshold
-            ? stackalloc char[StackAllocThreshold]
+            ? stackalloc char[value.Length]
             : (rented = ArrayPool<char>.Shared.Rent(value.Length));
 
         try
@@ -372,7 +372,7 @@ public static class AnsiTextProcessor
 
     public sealed record AnsiStyle(AnsiColor? Foreground, AnsiColor? Background, bool Bold, bool Italic, bool Underline, bool Inverse)
     {
-        public static AnsiStyle None => new(Foreground: null, Background: null, Bold: false, Italic: false, Underline: false, Inverse: false);
+        public static AnsiStyle None { get; } = new(Foreground: null, Background: null, Bold: false, Italic: false, Underline: false, Inverse: false);
     }
 
     public sealed record AnsiColor(AnsiColorKind Kind, byte Red, byte Green, byte Blue, byte IndexedValue)

--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -100,7 +100,7 @@ public static class AnsiTextProcessor
     {
         char[]? rented = null;
         var buffer = value.Length <= StackAllocThreshold
-            ? stackalloc char[value.Length]
+            ? stackalloc char[StackAllocThreshold]
             : (rented = ArrayPool<char>.Shared.Rent(value.Length));
 
         try

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -39,6 +39,35 @@ public class AnsiTextProcessorTests
     }
 
     [Theory]
+    [InlineData(8)]
+    [InlineData(100)]
+    [InlineData(511)]
+    [InlineData(512)]
+    [InlineData(513)]
+    [InlineData(5000)]
+    public void RemoveAnsiSequences_LengthsAroundStackAllocThreshold(int inputLength)
+    {
+        var expected = new string('a', inputLength - 8);
+        var input = "\u001b[31m" + expected + "\u001b[0m";
+        Assert.Equal(expected, AnsiTextProcessor.RemoveAnsiSequences(input));
+        Assert.Equal(expected, AnsiTextProcessor.RemoveAnsiSequences(input.AsSpan()));
+    }
+
+    [Fact]
+    public void AnsiStyle_None_IsCached()
+    {
+        Assert.Same(AnsiTextProcessor.AnsiStyle.None, AnsiTextProcessor.AnsiStyle.None);
+    }
+
+    [Fact]
+    public void AnsiStyle_None_EqualsAnEquivalentInstance()
+    {
+        var constructed = new AnsiTextProcessor.AnsiStyle(Foreground: null, Background: null, Bold: false, Italic: false, Underline: false, Inverse: false);
+        Assert.Equal(AnsiTextProcessor.AnsiStyle.None, constructed);
+        Assert.NotSame(AnsiTextProcessor.AnsiStyle.None, constructed);
+    }
+
+    [Theory]
     [InlineData("\x1b[31mRed Text\x1b[0m")]
     [InlineData("\x1b[1;31mBold Red Text\x1b[0m")]
     [InlineData("Normal \x1b[4mUnderlined\x1b[0m Text")]


### PR DESCRIPTION
## Problem

`AnsiStyle.None` allocates on every access (`src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs:375`):

```csharp
public static AnsiStyle None => new(Foreground: null, Background: null, Bold: false, Italic: false, Underline: false, Inverse: false);
```

It is an expression-bodied property, so each read constructs a fresh `AnsiStyle`. Verified against the built library: `ReferenceEquals(AnsiStyle.None, AnsiStyle.None)` was `false`.

It is read in the `ApplySgr` switch on every reset, and once per rendered segment in `LogHighlighter.AppendStyledSegment` (`src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/LogHighlighter.cs:137`), which runs per log line on every render pass.

This is inconsistent with the rest of the file — `RemoveAnsiSequencesCore` goes to real trouble to avoid allocating, with a stackalloc/`ArrayPool` split.

## Change

`None` becomes a get-only auto-property (`{ get; } = new(...)`), so the instance is created once.

The public API shape is unchanged: `ref/Meziantou.Framework.AnsiFormatting.cs` still reads `public static AnsiStyle None { get => throw null; }`. Because `AnsiStyle` is a record, every existing `==`/`Equals` comparison keeps working on value equality. No behaviour change.

## Verification

- New test asserting `None` is now reference-cached.
- New test asserting an independently constructed equivalent `AnsiStyle` is still `Equal` to `None` but not `Same` — so the caching cannot quietly be mistaken for reference-equality semantics.
- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 64 passed, 0 failed (32 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` → 24 passed, 0 failed.
- `ref/` unchanged, confirmed with a `-c Release /p:IsOfficialBuild=true` build.

## Review feedback

The original PR also sized the stackalloc to `value.Length` instead of the fixed `StackAllocThreshold`. **That change has been reverted** per review — `RemoveAnsiSequencesCore` is untouched again.

The `RemoveAnsiSequences_LengthsAroundStackAllocThreshold` theory added alongside it has been kept: it exercises input lengths `8, 100, 511, 512, 513, 5000` across both the stackalloc and `ArrayPool` strategies, through both the `string` and `ReadOnlySpan<char>` overloads, and that path had no boundary coverage before. Say the word if you would rather this PR carried nothing but the `AnsiStyle.None` change and I will drop it.

This is a hygiene change, not a measured optimisation — no profiling was done. The separate `List<int>`-per-SGR-sequence allocation from the same audit was deliberately left alone; it needs a profile first and would collide with #2751.

## Context

One of 8 PRs from an audit of `Meziantou.Framework.AnsiFormatting`. Independent — mergeable in any order.
