### PR TITLE
Trim whitespace around unquoted Link header parameter values

### DIFF
--- a/src/Meziantou.Framework.Http/LinkHeaderValue.cs
+++ b/src/Meziantou.Framework.Http/LinkHeaderValue.cs
@@ -192,12 +192,14 @@ public sealed class LinkHeaderValue
                         index = value.IndexOfAny(';', ',');
                         if (index == -1)
                         {
-                            parameterValue = value.ToString();
+                            // Trim the trailing whitespace: an unquoted value is terminated by the next
+                            // ';' or ',', and RFC 7230 allows optional whitespace before that separator.
+                            parameterValue = value.Trim().ToString();
                             value = [];
                         }
                         else
                         {
-                            parameterValue = value[0..index].ToString();
+                            parameterValue = value[0..index].Trim().ToString();
                             value = value[index..];
                         }
                     }

--- a/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
+++ b/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
@@ -45,6 +45,25 @@ public sealed class LinkHeaderValueTests
         Assert.Equal("b", LinkHeaderValue.Parse("<a>; rel=prev, <b>;rel=next").GetLinkUrl("Next"));
     }
 
+    [Theory]
+    [InlineData("<https://example.com/2>; rel=next ; title=Page2")]
+    [InlineData("<https://example.com/2>; rel=next , <https://example.com/1>; rel=prev")]
+    [InlineData("<https://example.com/2>; rel=next\t")]
+    [InlineData("<https://example.com/2>; rel=next ")]
+    public void UnquotedParameterValue_TrailingWhitespaceIsTrimmed(string header)
+    {
+        var link = Assert.Single(LinkHeaderValue.Parse(header), l => l.Url is "https://example.com/2");
+        Assert.Equal("next", link.Rel);
+        Assert.Equal("https://example.com/2", LinkHeaderValue.Parse(header).GetLinkUrl("next"));
+    }
+
+    [Fact]
+    public void UnquotedParameterValue_InnerWhitespaceIsPreserved()
+    {
+        var link = Assert.Single(LinkHeaderValue.Parse("<a>; title = test title ; rel=next"));
+        Assert.Equal("test title", link.GetParameterValue("title"));
+    }
+
     private sealed class CustomHttpHeaders : HttpHeaders
     {
     }


### PR DESCRIPTION
## The problem

When a `Link` header parameter value is not quoted, the parser takes everything up to the next `;` or `,` verbatim, without trimming. `src/Meziantou.Framework.Http/LinkHeaderValue.cs:192-202`

```
Input:  <https://ex.com/2>; rel=next ; title=Page2
Before: Rel == "next "      <- trailing space
After:  Rel == "next"
```

Because `GetLink`/`GetLinkUrl` compare with `OrdinalIgnoreCase` but do not trim, this made the library's primary use case fail silently on valid input:

```c#
LinkHeaderValue.Parse("<https://ex.com/2>; rel=next ; title=x").GetLinkUrl("next")  // => null
```

This is not malformed input: RFC 8288 defines a parameter value as `token / quoted-string`, and RFC 7230 permits optional whitespace before the `;` separator. Servers that quote their `rel` (GitHub's pagination, for example) were unaffected, which is why it went unnoticed.

## The change

Trim the value span before allocating the string.

Deliberately **not** done: terminating the value at the first whitespace, which is the more RFC-faithful reading of `token`. That would break the existing assertion at `LinkHeaderValueTests.cs:22`, where the unquoted `title = test title` is expected to yield `"test title"`. Supporting internal spaces in unquoted values is existing behaviour, so trimming is the fix that preserves it.

## Verification

`dotnet test tests/Meziantou.Framework.Http.Tests /p:TreatsWarningsAsErrors=true` — 16 passed (8 per TFM, up from 3), 0 failed. The new tests were confirmed to fail against `main` before the fix was applied. `dotnet run ./eng/update-all.cs` produces no changes.

## Compatibility

Behaviour change on a published package: values that previously round-tripped surrounding whitespace now come back trimmed. No public API change, so `ref/` is unaffected.
