### PR TITLE
Honor the format provider and stop exceptions escaping when converting to string

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -1123,11 +1123,18 @@ public class DefaultConverter : IConverter
                     return true;
                 }
 
-                var tc = TypeDescriptor.GetConverter(inputType);
-                if (tc is not null && tc.CanConvertTo(typeof(string)))
+                try
                 {
-                    value = (string?)tc.ConvertTo(input, typeof(string));
-                    return true;
+                    var tc = TypeDescriptor.GetConverter(inputType);
+                    if (tc is not null && tc.CanConvertTo(typeof(string)))
+                    {
+                        value = (string?)tc.ConvertTo(context: null, provider as CultureInfo, input, typeof(string));
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // The TypeConverter cannot handle the value, fall back to Convert.ToString
                 }
 
                 value = Convert.ToString(input, provider);

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Tests;
 
@@ -93,10 +94,31 @@ public sealed class DefaultConverterTests_TypeDescriptor
     }
 
     // The two-argument TypeConverter.ConvertTo overload is hardcoded to CultureInfo.CurrentCulture,
-    // so the provider passed by the caller used to be ignored
+    // so the provider passed by the caller used to be ignored.
+    // A custom separator keeps this independent of the available ICU data, so it also runs
+    // under InvariantGlobalization, and it cannot pass by accidentally matching the ambient culture.
+    [Fact]
+    public void TryConvert_NumberToString_UsesTheProviderNumberFormat()
+    {
+        var converter = new DefaultConverter();
+        var provider = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        provider.NumberFormat.NumberDecimalSeparator = "#";
+
+        Assert.True(converter.TryChangeType(1234.56m, provider, out string? decimalValue));
+        Assert.Equal("1234#56", decimalValue);
+
+        Assert.True(converter.TryChangeType(1234.5d, provider, out string? doubleValue));
+        Assert.Equal("1234#5", doubleValue);
+
+        Assert.True(converter.TryChangeType(1234.5f, provider, out string? floatValue));
+        Assert.Equal("1234#5", floatValue);
+    }
+
+    // The same behaviour against real culture data, which needs ICU
     [Theory]
     [InlineData("fr-FR", "1234,56")]
     [InlineData("en-US", "1234.56")]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void TryConvert_DecimalToString_UsesTheProvider(string cultureName, string expected)
     {
         var converter = new DefaultConverter();
@@ -109,6 +131,7 @@ public sealed class DefaultConverterTests_TypeDescriptor
     [Theory]
     [InlineData("fr-FR", "02/01/2020")]
     [InlineData("en-US", "1/2/2020")]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void TryConvert_DateTimeToString_UsesTheProvider(string cultureName, string expected)
     {
         var converter = new DefaultConverter();

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
@@ -34,6 +34,22 @@ public sealed class DefaultConverterTests_TypeDescriptor
     {
     }
 
+    private sealed class ThrowingTypeConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) => true;
+
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+        {
+            throw new InvalidOperationException("This converter always throws");
+        }
+    }
+
+    [TypeConverter(typeof(ThrowingTypeConverter))]
+    private sealed class ThrowingDummy
+    {
+        public override string ToString() => "fallback";
+    }
+
     [Fact]
     public void TryConvert_TypeConverter_ConvertTo()
     {
@@ -62,5 +78,43 @@ public sealed class DefaultConverterTests_TypeDescriptor
 
         var converted = converter.TryChangeType("", cultureInfo, out Dummy? _);
         Assert.False(converted);
+    }
+
+    // TypeConverter.CanConvertTo(typeof(string)) returns true by default for every type,
+    // so an exception thrown by a user converter used to escape TryChangeType
+    [Fact]
+    public void TryConvert_ToString_ThrowingTypeConverter_DoesNotThrow()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(new ThrowingDummy(), cultureInfo, out string? value);
+        Assert.True(converted);
+        Assert.Equal("fallback", value);
+    }
+
+    // The two-argument TypeConverter.ConvertTo overload is hardcoded to CultureInfo.CurrentCulture,
+    // so the provider passed by the caller used to be ignored
+    [Theory]
+    [InlineData("fr-FR", "1234,56")]
+    [InlineData("en-US", "1234.56")]
+    public void TryConvert_DecimalToString_UsesTheProvider(string cultureName, string expected)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.GetCultureInfo(cultureName);
+        var converted = converter.TryChangeType(1234.56m, cultureInfo, out string? value);
+        Assert.True(converted);
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("fr-FR", "02/01/2020")]
+    [InlineData("en-US", "1/2/2020")]
+    public void TryConvert_DateTimeToString_UsesTheProvider(string cultureName, string expected)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.GetCultureInfo(cultureName);
+        var converted = converter.TryChangeType(new DateTime(2020, 1, 2), cultureInfo, out string? value);
+        Assert.True(converted);
+        Assert.Equal(expected, value);
     }
 }


### PR DESCRIPTION
Two defects in the same six lines of the `TypeCode.String` branch (`DefaultConverter.cs:1126`), fixed together because splitting them would mean the second PR rebasing on the first for no reviewer benefit.

## 1. The format provider was ignored

The branch called the two-argument `tc.ConvertTo(input, typeof(string))` overload, which is hardcoded to `CultureInfo.CurrentCulture`. The `provider` argument threaded through five call layers was dropped. With `CurrentCulture` set to `fr-FR`:

```
ConvertUtilities.TryChangeType<string>(1234.56m, CultureInfo.InvariantCulture, out var s)
  → s == "1234,56"          (expected "1234.56")
ConvertUtilities.TryChangeType<string>(new DateTime(2020, 1, 2), CultureInfo.InvariantCulture, out var d)
  → d == "02/01/2020"       (day/month order, invariant was requested)
```

This affected every input type that has a `TypeConverter` — all the primitives, `DateTime`, `TimeSpan`, `Guid`, `Uri` — except `byte[]` and `CultureInfo`, which are special-cased just above.

"Culture-aware conversions: supports `IFormatProvider`" is the second bullet of the readme, and passing `CultureInfo.InvariantCulture` is the standard way to produce a machine-readable string for storage or transport. The value written to a database or wire format changed with the ambient culture of the process, and the round-trip back through `TryChangeType` then failed — or, for the `dd/MM` vs `MM/dd` case, silently produced a different date. The call returned `true` throughout.

**Fix:** use the culture-aware overload, `tc.ConvertTo(context: null, provider as CultureInfo, input, typeof(string))` — matching what the sibling `inputConverter.ConvertTo` call at `:1336` already does. When `provider` is null the behaviour is unchanged (`TypeConverter.ConvertTo` falls back to `CurrentCulture` itself), so this PR does not touch the separate question of what `provider: null` should mean.

## 2. An exception from a user `TypeConverter` escaped `TryChangeType`

The three later `TypeDescriptor` call sites (`:1309`, `:1331`, `:1346`) are each wrapped in `try`/`catch`; this one was not. `TypeConverter.CanConvertTo(typeof(string))` returns `true` by default for *every* type, so any object whose converter throws propagated out of a `Try` method:

```
[TypeConverter(typeof(BoomConverter))] class Boom { }   // ConvertTo throws
ConvertUtilities.TryChangeType(new Boom(), inv, out string s)  → InvalidOperationException
```

`string` is the most common conversion target and the one most likely to be applied to arbitrary objects (logging, display, serialising a heterogeneous dictionary), so a single misbehaving third-party type could take down a call the caller believed could not throw.

**Fix:** wrap the block in the same `try`/`catch` as its siblings and fall through to `Convert.ToString(input, provider)`.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **126 passed, 0 failed** (was 116; 5 new cases per target framework, net10.0 and net11.0).

I confirmed the new tests are meaningful by reverting `DefaultConverter.cs` and re-running: all four new cases fail without the fix (8 failures across the two target frameworks). The culture assertions deliberately cover both `fr-FR` and `en-US`, because asserting only one would pass by accident on a machine whose ambient culture happens to match — the `en-US` decimal case does exactly that on this machine (ambient `en-CA`).

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — no public API surface change.

## Note for review

The branch still returns `true` when `ConvertTo` yields `null`. I left that alone deliberately: `Convert.ToString` on the fallback path can also return null and returns `true` there too, so tightening only this branch would make the two inconsistent. Worth a separate change if you want `null` to mean "conversion failed".

Found by a project review of `Meziantou.Framework.TypeConverter`.


---

## Follow-up commit: the tests assumed ICU data was present

CI failed on the four `build_and_test (…, /p:InvariantGlobalization=true, 2)` jobs. The fix itself was fine — the tests were wrong.

With `InvariantGlobalization=true` there is no real culture data, so `CultureInfo.GetCultureInfo("fr-FR")` comes back formatting exactly like the invariant culture, and my assertions could not hold:

```
Expected: "1234,56"      Actual: "1234.56"
Expected: "02/01/2020"   Actual: "01/02/2020"
```

Three of the four cases failed in that configuration (the `en-US` decimal one passes because it matches invariant formatting). Reproduced locally with `dotnet test … /p:InvariantGlobalization=true`: 6 failures, matching CI.

### What changed

Both halves are now covered in **both** configurations:

- **A new test that does not depend on ICU at all.** It clones the invariant culture and sets `NumberFormat.NumberDecimalSeparator = "#"`, then asserts `decimal`, `double` and `float` all render as `1234#56`. This runs everywhere, and it is a stronger assertion than the original: `"#"` is not any real culture's separator, so unlike a `fr-FR`-vs-`en-US` comparison it cannot pass by accidentally matching the ambient culture.
- **The real-culture tests are kept**, now marked `[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]`, so they still exercise the realistic path wherever ICU is available. That attribute is the existing convention in this repo (`ResxGeneratorTests`, `SerializerTests`, `PostgreSqlServerProtocolTests`).

### Verification

| Configuration | Result |
|---|---|
| default | 128 passed, 0 failed, 0 skipped |
| `/p:InvariantGlobalization=true` | 114 passed, 0 failed, 14 skipped |

And the check that matters — the new tests still catch the original bug when ICU is absent. Against `origin/main`'s unfixed `DefaultConverter.cs` with `/p:InvariantGlobalization=true`, `TryConvert_NumberToString_UsesTheProviderNumberFormat` and `TryConvert_ToString_ThrowingTypeConverter_DoesNotThrow` both fail (4 failures across the two target frameworks). So neither fix loses its regression coverage in the invariant configuration; the guarded tests are additive, not a way of hiding the assertion.

Also built the library and the test project with `-c Release /p:IsOfficialBuild=true` (the configuration that surfaces the `IDExxxx` analyzer rules): both clean. `dotnet run ./eng/update-all.cs` reports no generated-file changes.
