### PR TITLE
Fix the Slug readme customization example, which never compiled

### DIFF
--- a/src/Meziantou.Framework.Slug/readme.md
+++ b/src/Meziantou.Framework.Slug/readme.md
@@ -9,18 +9,28 @@ var result = Slug.Create("This is a text");
 You can customize the slug generation:
 
 ````c#
-var options = new SlugOptions()
+using System.Text.Unicode;
+
+var options = new SlugOptions
 {
     MaximumLength = 20,
     Separator = "-",
     CanEndWithSeparator = false,
     CasingTransformation = CasingTransformation.ToLowerCase,
-    AllowedRanges = new List<UnicodeRange>
-    {
-        UnicodeRange.Create('a', 'z'),
-        UnicodeRange.Create('A', 'Z'),
-        UnicodeRange.Create('0', '9'),
-    },
 };
+
+// AllowedRanges is read-only, so change the list in place instead of assigning a new one.
+// It already contains a-z, A-Z and 0-9, so clear it first to replace that set.
+options.AllowedRanges.Clear();
+options.AllowedRanges.Add(UnicodeRange.Create('a', 'z'));
+options.AllowedRanges.Add(UnicodeRange.Create('A', 'Z'));
+options.AllowedRanges.Add(UnicodeRange.Create('0', '9'));
+
 Slug.Create("This is a text", options); // this-is-a-text
 ````
+
+Note that an **empty** `AllowedRanges` allows every character instead of none, so clearing the list without
+adding a range returns the text unfiltered.
+
+`Slug.Create` returns `null` for `null`, and an empty string when no character of the input is allowed - which
+is the case for any text written outside the default ranges, such as a Cyrillic or CJK title.


### PR DESCRIPTION
Documentation only. The package readme's only customization example does not compile, and has not since it was written.

## The problem

`readme.md:11-26` assigns to `AllowedRanges` in an object initializer:

```csharp
var options = new SlugOptions()
{
    ...
    AllowedRanges = new List<UnicodeRange> { ... },
};
```

but `SlugOptions.cs:29` declares `public IList<UnicodeRange> AllowedRanges { get; }` — no setter. Compiled verbatim:

```
error CS0200: Property or indexer 'SlugOptions.AllowedRanges' cannot be assigned to -- it is read only
```

The snippet also omits `using System.Text.Unicode;`, which `UnicodeRange` needs.

`AllowedRanges` has been get-only since 2020 (`04b2aa11c`) and the readme was written in 2021 (`29f82dd61`) and never touched since — so this snippet has never compiled in the package's published history. It is the nuget.org landing page and the one example showing how to restrict the character set, which is the most likely reason to customize. The working idiom appeared nowhere in the docs, only in tests.

## What changed

The snippet now mutates the list in place, has the missing `using`, and says why:

```csharp
options.AllowedRanges.Clear();
options.AllowedRanges.Add(UnicodeRange.Create('a', 'z'));
...
```

I kept the readme-only fix rather than adding a setter to `AllowedRanges`: a setter would make the published snippet correct as written, but it widens the public API surface and regenerates `ref/Meziantou.Framework.Slug.cs` for a documentation bug. Happy to switch if you'd rather have the setter.

Two short notes were added below it, both behaviors that were previously undocumented and are easy to trip over right after reading this example:

- an **empty** `AllowedRanges` allows every character rather than none, so clearing without adding returns the text unfiltered;
- `Create` returns `null` for `null` and an empty string when no character is allowed — the case for any title outside the default ranges.

## Verification

Both code blocks were extracted from the rendered readme and compiled verbatim against the real project, then run:

| block | compiles | output | documented |
|---|---|---|---|
| 1 | yes | `This-is-a-text` | — |
| 2 | yes | `this-is-a-text` | `// this-is-a-text` ✓ |

`dotnet run ./eng/update-all.cs` — no generated files changed.

Found by a project review of `Meziantou.Framework.Slug` (finding M5).
