### PR TITLE
Stop the TryFindByExtension tests depending on the developer's installed tools

### DIFF
--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -26,6 +26,10 @@ public sealed class DiffToolsTests
         AssertPathEqual(Path.GetFullPath(executable), tool.ExePath);
     }
 
+    // These two tests can override PATH and DiffEngine_VisualStudioCode, but not the hard-coded search
+    // directories of the tools that precede VisualStudioCode in DiffTools.Definitions. So they assert the
+    // property the API actually promises for the extension, not one specific tool: any real installation on
+    // the developer's machine is a legitimate answer.
     [Fact]
     public void TryFindByExtension_ReturnsBinaryTool()
     {
@@ -36,7 +40,7 @@ public sealed class DiffToolsTests
 
         Assert.True(DiffTools.TryFindByExtension(".bin", out var tool));
         Assert.NotNull(tool);
-        Assert.Equal(DiffTool.VisualStudioCode, tool.Tool);
+        Assert.Contains(".bin", tool.BinaryExtensions, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -49,7 +53,7 @@ public sealed class DiffToolsTests
 
         Assert.True(DiffTools.TryFindByExtension(".txt", out var tool));
         Assert.NotNull(tool);
-        Assert.Equal(DiffTool.VisualStudioCode, tool.Tool);
+        Assert.True(tool.SupportsText);
     }
 
     [Fact]


### PR DESCRIPTION
`TryFindByExtension_ReturnsTextTool` fails on any machine that has a text diff tool
installed in a standard location. It fails on mine:

```
Expected: VisualStudioCode
Actual:   Rider
```

The test overrides `PATH` and `DiffEngine_VisualStudioCode` to a temp directory, then
asserts that `.txt` resolves to `VisualStudioCode`. But `.txt` matches no
`BinaryExtensions`, so resolution falls through to
`tools.FirstOrDefault(t => t.SupportsText)` — the first text-capable tool in
`Definitions` order. Overriding `PATH` does nothing for the ~12 text tools that come
before `VisualStudioCode` and have **hard-coded** search directories:
`/Applications/Rider.app/…`, `%ProgramFiles%\WinMerge\`, `%ProgramFiles%\TortoiseGit\bin\`
and so on. `/Applications/Rider.app` exists here, so Rider resolves and wins on ordering.

`TryFindByExtension_ReturnsBinaryTool` has the same defect, which I found while fixing
the first one: `WinMerge` also declares `.bin` (DiffTools.cs:56-60) and precedes
`VisualStudioCode` (DiffTools.cs:179). It passes on macOS and Linux only because WinMerge
is Windows-only — on Windows with WinMerge installed it returns WinMerge and fails.

CI passes today only because CI images are bare. Any contributor with Rider, WinMerge,
TortoiseGit, Beyond Compare or Sublime Merge hits it, and a test that is red for reasons
unrelated to the code under test is one people learn to ignore.

## What changed

Both tests now assert the property the API actually promises for the extension, rather
than one specific tool:

- `.bin` → the returned tool declares `.bin` in `BinaryExtensions`
- `.txt` → the returned tool has `SupportsText`

Any real installation on the developer's machine is a legitimate answer to
`TryFindByExtension`, so pinning the result to `VisualStudioCode` was asserting something
the method never guaranteed. These assertions still catch the regressions that matter:
returning nothing, or returning a tool that cannot handle the extension.

The stronger alternative is to make the hard-coded search directories injectable so tests
can exclude the ambient machine entirely. That is a design change to production code, so
I have left it out of this PR — happy to do it separately if you want resolution itself
covered.

## Verification

`dotnet test /p:TreatsWarningsAsErrors=true` — 10 of 10 pass on net10.0 and net11.0. This
is the first time the suite is fully green on a machine with Rider installed.
