### PR TITLE
Verify a dummy password hash when the Identity user does not exist

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationIdentityExtensions.cs
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationIdentityExtensions.cs
@@ -9,6 +9,13 @@ namespace Meziantou.AspNetCore.Authentication.HttpBasic;
 /// <summary>Extension methods to register HTTP Basic authentication with ASP.NET Core Identity.</summary>
 public static class HttpBasicAuthenticationIdentityExtensions
 {
+    // Verifying this hash when the user does not exist keeps the presence of an account from being
+    // observable through response time. It is produced once, with Identity's default options; if the
+    // application customises PasswordHasherOptions the two paths cost approximately, not exactly, the same.
+    private static readonly PasswordHasher<object> DummyPasswordHasher = new();
+    private static readonly object DummyPasswordHasherUser = new();
+    private static readonly string DummyPasswordHash = DummyPasswordHasher.HashPassword(DummyPasswordHasherUser, "8OqA2Zs4kkGm1sJv");
+
     /// <summary>Adds HTTP Basic authentication using ASP.NET Core Identity to validate credentials and build user principals.</summary>
     public static AuthenticationBuilder AddHttpBasicIdentity<TUser>(this AuthenticationBuilder builder)
         where TUser : class
@@ -76,7 +83,10 @@ public static class HttpBasicAuthenticationIdentityExtensions
         var signInManager = context.RequestServices.GetRequiredService<SignInManager<TUser>>();
         var user = await signInManager.UserManager.FindByNameAsync(username).ConfigureAwait(false);
         if (user is null)
+        {
+            DummyPasswordHasher.VerifyHashedPassword(DummyPasswordHasherUser, DummyPasswordHash, password);
             return null;
+        }
 
         var result = await signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure).ConfigureAwait(false);
         if (!result.Succeeded)

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -125,6 +126,52 @@ public sealed class HttpBasicAuthenticationTests
         {
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         });
+    }
+
+    [Fact]
+    public async Task AspNetCoreIdentity_UnknownUser_IsRejected()
+    {
+        var user = CreateIdentityUser(id: "user-id", username: "myName", password: "myPassword");
+        await using var application = await TestApplication.CreateWithIdentityAsync([user], _ => { });
+
+        await application.SendAndAssert("/", "unknownUser", "myPassword", response =>
+        {
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        });
+    }
+
+    [Fact]
+    public async Task AspNetCoreIdentity_UnknownUser_DoesNotShortCircuitPasswordVerification()
+    {
+        var user = CreateIdentityUser(id: "user-id", username: "myName", password: "myPassword");
+        await using var application = await TestApplication.CreateWithIdentityAsync([user], _ => { });
+
+        for (var i = 0; i < 3; i++)
+        {
+            await application.SendAndAssert("/", "myName", "wrong", _ => { });
+            await application.SendAndAssert("/", "unknownUser", "wrong", _ => { });
+        }
+
+        var knownUser = await MeasureAsync(application, "myName", "wrong");
+        var unknownUser = await MeasureAsync(application, "unknownUser", "wrong");
+
+        // Before the fix an unknown user skipped password verification entirely and was ~300x faster,
+        // which made valid usernames trivially enumerable. The bound is deliberately loose: this is a
+        // ratio between two paths doing the same work, so it is insensitive to how loaded the machine is.
+        Assert.InRange(knownUser.TotalMilliseconds / unknownUser.TotalMilliseconds, 0, 10);
+    }
+
+    private static async Task<TimeSpan> MeasureAsync(TestApplication application, string username, string password)
+    {
+        const int Iterations = 10;
+
+        var stopwatch = Stopwatch.StartNew();
+        for (var i = 0; i < Iterations; i++)
+        {
+            await application.SendAndAssert("/", username, password, _ => { });
+        }
+
+        return stopwatch.Elapsed;
     }
 
     private static IdentityUser CreateIdentityUser(string id, string username, string password)


### PR DESCRIPTION
## Finding

`HttpBasicAuthenticationIdentityExtensions.cs:77-79` returned immediately when `FindByNameAsync` yielded `null`, skipping password verification entirely. A valid username with a wrong password ran the full PBKDF2 verification; an unknown username did not.

Measured over 30 requests each, same host, after warmup:

```
known user   + wrong password : 41.843 ms/req
unknown user + wrong password :  0.139 ms/req
ratio                         : 302.0x
```

A 302x gap is not a subtle side channel — it is trivially measurable across the internet through normal jitter, and it lets an attacker enumerate valid accounts before spending any effort on passwords.

In fairness this mirrors ASP.NET Core Identity's own `SignInManager.PasswordSignInAsync`, so it is an inherited pattern rather than a novel mistake — but a Basic-auth front door is a much more exposed place to inherit it, and the fix is local to this file.

## What changed

When the user lookup misses, the handler now verifies the supplied password against a cached dummy hash before returning `null`, so both paths do comparable work.

The dummy hash is produced once by a standalone `PasswordHasher<object>`. That deliberately avoids `IPasswordHasher<TUser>`: `VerifyHashedPassword` requires a `TUser` instance, and `TUser` is constrained only to `class` — there is no `new()` constraint to construct one, and `Activator.CreateInstance<TUser>()` would be both failure-prone and hostile to this package's `IsTrimmable` setting. Using a separate hasher keeps `TUser` out of it entirely and cannot break a custom `IPasswordHasher<TUser>` implementation.

The tradeoff, noted in a comment: the dummy hash uses Identity's **default** `PasswordHasherOptions`. An application that customises the iteration count will see the two paths cost approximately, not exactly, the same. That removes the dominant signal (300x) and leaves noise.

No public API change, so `ref/` is untouched.

## Verification

`AspNetCoreIdentity_UnknownUser_DoesNotShortCircuitPasswordVerification` measures both paths and asserts the ratio. Confirmed it **fails against the unfixed code**, reproducing the finding almost exactly:

```
failed  AspNetCoreIdentity_UnknownUser_DoesNotShortCircuitPasswordVerification
  Actual:   335.2928837311145
  total: 10  failed: 1  succeeded: 9
```

**On the timing assertion:** it compares two paths that, after the fix, do the same work, so the ratio is insensitive to how loaded the machine is — a slow runner slows both sides equally. The bound is 10x against a pre-fix value of 335x, so the margin is large. If you would still rather not carry a timing-sensitive test in CI, drop that test and keep `AspNetCoreIdentity_UnknownUser_IsRejected`, which is a plain functional check.

Full suite green on both target frameworks with `/p:TreatsWarningsAsErrors=true`: **20 passed** (10 x net10.0/net11.0). `dotnet run ./eng/update-all.cs` reports no changes.
