### PR TITLE
Report undecodable RPC parameters instead of reporting success

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
@@ -9,6 +9,16 @@ internal static class TdsQueryRequestParser
 {
     private static readonly DateTime SqlEpoch = new(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
 
+    /// <summary>The largest day count that <see cref="DateTime"/> and <see cref="DateOnly"/> can represent.</summary>
+    /// <remarks>
+    /// Temporal values carry a 24-bit day count, which reaches far beyond year 9999. A value out of range has to
+    /// take the same path as any other value the server cannot decode, rather than throwing out of the parser.
+    /// </remarks>
+    private const int MaxDayCount = 3652058;
+
+    /// <summary>The largest UTC offset, in minutes, that <see cref="DateTimeOffset"/> accepts.</summary>
+    private const int MaxOffsetMinutes = 14 * 60;
+
     public static TdsQueryContext Parse(TdsPacket packet, EndPoint remoteEndPoint, ClaimsPrincipal? userContext)
     {
         ArgumentNullException.ThrowIfNull(packet);
@@ -33,6 +43,7 @@ internal static class TdsQueryRequestParser
         var request = TryParseRpc(payload) ?? new TdsRpcRequest
         {
             Parameters = [],
+            HasCompleteParameters = false,
         };
 
         return new TdsQueryContext
@@ -552,7 +563,7 @@ internal static class TdsQueryRequestParser
         var value = valueLength switch
         {
             4 => SqlEpoch.AddDays(BinaryPrimitives.ReadUInt16LittleEndian(encoded[..2])).AddMinutes(BinaryPrimitives.ReadUInt16LittleEndian(encoded[2..4])),
-            8 => SqlEpoch.AddDays(BinaryPrimitives.ReadInt32LittleEndian(encoded[..4])).AddTicks(BinaryPrimitives.ReadUInt32LittleEndian(encoded[4..8]) * TimeSpan.TicksPerSecond / 300),
+            8 => TryReadSqlDateTime(encoded),
             _ => (DateTime?)null,
         };
 
@@ -580,7 +591,13 @@ internal static class TdsQueryRequestParser
             return null;
         }
 
-        var value = DateOnly.MinValue.AddDays(ReadUInt24LittleEndian(payload.Slice(position, 3)));
+        var days = ReadUInt24LittleEndian(payload.Slice(position, 3));
+        if (days > MaxDayCount)
+        {
+            return null;
+        }
+
+        var value = DateOnly.MinValue.AddDays(days);
         position += valueLength;
         return CreateParameter(name, value, TdsColumnType.Date);
     }
@@ -668,7 +685,19 @@ internal static class TdsQueryRequestParser
             return null;
         }
 
-        var offset = TimeSpan.FromMinutes(BinaryPrimitives.ReadInt16LittleEndian(encoded[^2..]));
+        var offsetMinutes = BinaryPrimitives.ReadInt16LittleEndian(encoded[^2..]);
+        if (offsetMinutes is < -MaxOffsetMinutes or > MaxOffsetMinutes)
+        {
+            return null;
+        }
+
+        var offset = TimeSpan.FromMinutes(offsetMinutes);
+        var localTicks = utcValue.Ticks + offset.Ticks;
+        if (localTicks < DateTime.MinValue.Ticks || localTicks > DateTime.MaxValue.Ticks)
+        {
+            return null;
+        }
+
         position += valueLength;
         return CreateParameter(name, new DateTimeOffset(utcValue, TimeSpan.Zero).ToOffset(offset), TdsColumnType.DateTimeOffset);
     }
@@ -686,7 +715,13 @@ internal static class TdsQueryRequestParser
             return false;
         }
 
-        value = DateTime.MinValue.AddDays(ReadUInt24LittleEndian(encoded[^3..])).Add(timeOfDay);
+        var days = ReadUInt24LittleEndian(encoded[^3..]);
+        if (days > MaxDayCount)
+        {
+            return false;
+        }
+
+        value = DateTime.MinValue.AddDays(days).Add(timeOfDay);
         return true;
     }
 
@@ -719,6 +754,24 @@ internal static class TdsQueryRequestParser
 
         value = TimeSpan.FromTicks(ticks);
         return true;
+    }
+
+    private static DateTime? TryReadSqlDateTime(ReadOnlySpan<byte> encoded)
+    {
+        var days = BinaryPrimitives.ReadInt32LittleEndian(encoded[..4]);
+        var timeOfDayTicks = BinaryPrimitives.ReadUInt32LittleEndian(encoded[4..8]) * TimeSpan.TicksPerSecond / 300;
+        if (timeOfDayTicks >= TimeSpan.TicksPerDay)
+        {
+            return null;
+        }
+
+        var daysFromMinValue = (SqlEpoch - DateTime.MinValue).Days + (long)days;
+        if (daysFromMinValue is < 0 or > MaxDayCount)
+        {
+            return null;
+        }
+
+        return SqlEpoch.AddDays(days).AddTicks(timeOfDayTicks);
     }
 
     private static int ReadUInt24LittleEndian(ReadOnlySpan<byte> value)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Data;
 using System.Net;
@@ -666,6 +667,95 @@ public sealed class TdsServerProtocolTests
 
         Assert.False(capturedContext.HasCompleteParameters);
         Assert.DoesNotContain(capturedContext.Parameters, parameter => parameter.Name == "@int");
+    }
+
+    [Fact]
+    public async Task RawClient_RpcRequest_ThatCannotBeParsed_ReportsIncompleteParameters()
+    {
+        // The whole RPC payload is undecodable, so there is no parameter list at all. Reporting it as complete
+        // would tell a handler the client sent no parameters, which is exactly the case the flag exists to warn
+        // about.
+        var context = await SendRawRpcRequestAsync([0xAA, 0xBB, 0xCC, 0xDD]);
+
+        Assert.False(context.HasCompleteParameters);
+        Assert.Empty(context.Parameters);
+    }
+
+    [Fact]
+    public async Task RawClient_RpcRequest_WithAnOutOfRangeDate_ReportsIncompleteParameters()
+    {
+        // A DATE value carries a 24-bit day count, which reaches far past year 9999. Out-of-range values have to
+        // take the same "cannot decode" path as any other bad parameter instead of throwing out of the parser.
+        var payload = new List<byte> { 0x01, 0x00 };
+        payload.AddRange(Encoding.Unicode.GetBytes("p"));
+        payload.AddRange([0x00, 0x00]); // option flags
+        payload.Add(0x02); // parameter name length, in characters
+        payload.AddRange(Encoding.Unicode.GetBytes("@d"));
+        payload.Add(0x00); // status
+        payload.Add(0x28); // DATEN
+        payload.Add(0x03); // value length
+        payload.AddRange([0xFF, 0xFF, 0xFF]); // day count far beyond DateOnly.MaxValue
+
+        var context = await SendRawRpcRequestAsync([.. payload]);
+
+        Assert.False(context.HasCompleteParameters);
+        Assert.Empty(context.Parameters);
+    }
+
+    private static async Task<TdsQueryContext> SendRawRpcRequestAsync(byte[] rpcPayload)
+    {
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                queryContextTask.TrySetResult(context);
+                return ValueTask.FromResult(new TdsQueryResult());
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port, cancellationTokenSource.Token);
+        using var stream = client.GetStream();
+
+        // PRELOGIN advertising NOT_SUPPORTED so the session stays in clear text.
+        await stream.WriteAsync(CreateTdsMessage(0x12, [0x01, 0x00, 0x06, 0x00, 0x01, 0xFF, 0x02]), cancellationTokenSource.Token);
+        await ReadTdsMessageAsync(stream, cancellationTokenSource.Token);
+
+        // LOGIN7 with every variable-length field empty: the authentication callback above accepts anything.
+        await stream.WriteAsync(CreateTdsMessage(0x10, new byte[94]), cancellationTokenSource.Token);
+        await ReadTdsMessageAsync(stream, cancellationTokenSource.Token);
+
+        await stream.WriteAsync(CreateTdsMessage(0x03, rpcPayload), cancellationTokenSource.Token);
+
+        return await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationTokenSource.Token);
+    }
+
+    private static byte[] CreateTdsMessage(byte packetType, ReadOnlySpan<byte> payload)
+    {
+        var message = new byte[8 + payload.Length];
+        message[0] = packetType;
+        message[1] = 0x01; // end of message
+        BinaryPrimitives.WriteUInt16BigEndian(message.AsSpan(2, 2), (ushort)message.Length);
+        message[6] = 1; // packet id
+        payload.CopyTo(message.AsSpan(8));
+        return message;
+    }
+
+    private static async Task ReadTdsMessageAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var header = new byte[8];
+        await stream.ReadExactlyAsync(header, cancellationToken);
+        var length = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
+        await stream.ReadExactlyAsync(new byte[length - 8], cancellationToken);
     }
 
     private static object? GetParameterValue(TdsQueryContext context, string name, TdsColumnType expectedType)


### PR DESCRIPTION
Two ways the RPC parameter parser reported success on input it had not actually decoded. `TdsQueryContext.HasCompleteParameters` is the one signal the API gives a handler for "do not trust this parameter list", and its own doc comment says requests with incomplete parameters should be rejected rather than acted on — so it has to be right in exactly these cases.

### 1. A fully unparseable RPC payload claimed a complete parameter list

`TdsQueryRequestParser.cs:33-36` — when `TryParseRpc` returns `null` (malformed header, truncated procedure name, bad ALL_HEADERS), `CreateRpcContext` substituted `new TdsRpcRequest { Parameters = [] }`. `HasCompleteParameters` was not set in that initializer, so it took the property's `= true` default (`TdsRpcRequest.cs:11`). The handler received a context claiming a complete, empty parameter list.

The built-in query engine happened to be safe — `ProcedureName` is also `null`, so it fails with "The RPC request does not specify a stored procedure name." A hand-written handler that follows the readme and checks `HasCompleteParameters` was not: it would take its parameterless branch.

### 2. Out-of-range temporal values threw instead of taking the undecodable path

`DATE`, `DATETIME2` and `DATETIMEOFFSET` carry a 24-bit day count that reaches 16 777 215 — far past `DateOnly.MaxValue` / `DateTime.MaxValue` — so `AddDays` threw `ArgumentOutOfRangeException`. `DATETIMEOFFSET` also read a signed-minute offset up to ±32 767 while `DateTimeOffset` rejects anything beyond ±14 hours, and `DATETIME`'s 1/300-second counter is a `uint` that can exceed a day.

These were contained — `TdsConnectionProcessor.cs:188-202` turns them into error `50005` — but they bypassed the deliberate "return `null` → `HasCompleteParameters = false`" design the rest of the parser follows carefully. The client got "Failed to build the query response" instead of the accurate "a parameter could not be decoded", and every occurrence logged at **Error** with a stack trace, so any client could flood the operator's logs at will.

### What changed

- `CreateRpcContext`'s fallback sets `HasCompleteParameters = false`.
- Day counts are range-checked against `MaxDayCount` in `ParseDateParameter` and `TryReadDateTime2`.
- `DATETIMEOFFSET` rejects offsets outside ±14 hours, and checks that applying the offset stays inside `DateTime`'s range (a UTC value near `DateTime.MinValue` with a negative offset would otherwise underflow).
- `DATETIME`'s 8-byte form moved into `TryReadSqlDateTime`, which rejects a time-of-day counter of a day or more and a day count that lands outside `DateTime`'s range.

All of these now `return null`, which is what the surrounding parser already treats as "cannot decode this parameter".

### Verification

Two new raw-socket tests drive the real handshake (PRELOGIN → LOGIN7 → RPC) and hand-craft the RPC payload, since the wire shapes involved cannot be produced by `SqlClient`:

- `RawClient_RpcRequest_ThatCannotBeParsed_ReportsIncompleteParameters`
- `RawClient_RpcRequest_WithAnOutOfRangeDate_ReportsIncompleteParameters`

Confirmed **both fail** with the fixes reverted (the first sees `HasCompleteParameters == true`; the second never reaches the query handler at all, because the parser throws first) and pass now.

Full suite: 396 passed / 0 failed (198 × net10.0, 198 × net11.0). No public API change, so `ref/` is unchanged.

Found during a review of `src/Meziantou.Framework.TdsServer`.
