### PR TITLE
Keep the allocation-free path for subclasses that do not override Replace

### DIFF
--- a/src/Meziantou.Framework.Slug/SlugOptions.cs
+++ b/src/Meziantou.Framework.Slug/SlugOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Unicode;
 
 namespace Meziantou.Framework;
@@ -18,6 +19,9 @@ namespace Meziantou.Framework;
 public class SlugOptions
 {
     internal static SlugOptions Default { get; } = new SlugOptions();
+
+    /// <summary>Caches, per derived type, whether <see cref="Replace(Rune)"/> is still the one declared here.</summary>
+    private static readonly ConcurrentDictionary<Type, bool> UsesDefaultReplaceByType = new();
 
     /// <summary>The default maximum length for generated slugs (80 characters).</summary>
     public const int DefaultMaximumLength = 80;
@@ -122,5 +126,22 @@ public class SlugOptions
     /// Gets a value indicating whether <see cref="Replace(Rune)"/> still has its default implementation, in which case
     /// <see cref="Transform(Rune)"/> produces the same result without allocating a string for every rune.
     /// </summary>
-    internal bool UsesDefaultReplace => GetType() == typeof(SlugOptions);
+    internal bool UsesDefaultReplace
+    {
+        get
+        {
+            var type = GetType();
+            if (type == typeof(SlugOptions))
+                return true;
+
+            return UsesDefaultReplaceByType.GetOrAdd(type, _ =>
+            {
+                // Binding the delegate resolves the virtual call, so its target is the override that would run.
+                // Reading the method off a delegate keeps this trimmer-friendly, unlike looking the override up
+                // by name on a type that is only known at run time.
+                Func<Rune, string> replace = Replace;
+                return replace.Method.DeclaringType == typeof(SlugOptions);
+            });
+        }
+    }
 }

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -194,6 +194,32 @@ public class SlugTests
         }
     }
 
+    [Theory]
+    [InlineData(CasingTransformation.PreserveCase)]
+    [InlineData(CasingTransformation.ToLowerCase)]
+    [InlineData(CasingTransformation.ToUpperCase)]
+    public void Slug_SubclassNotOverridingReplace_MatchesTheBaseClass(CasingTransformation casingTransformation)
+    {
+        string[] texts = ["Hello World", "Caf\u00E9 cr\u00E8me br\u00FBl\u00E9e", "a\U0001F600b", "TeSt:test ", "!!!"];
+        foreach (var text in texts)
+        {
+            foreach (var maximumLength in new[] { 0, 1, 3, 8, 80 })
+            {
+                var expected = Slug.Create(text, new SlugOptions { CasingTransformation = casingTransformation, MaximumLength = maximumLength });
+                var actual = Slug.Create(text, new PassThroughSlugOptions { CasingTransformation = casingTransformation, MaximumLength = maximumLength });
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+
+    private sealed class PassThroughSlugOptions : SlugOptions
+    {
+        public override bool IsAllowed(Rune character)
+        {
+            return base.IsAllowed(character);
+        }
+    }
+
     private sealed class NoVowelSlugOptions : SlugOptions
     {
         public override bool IsAllowed(Rune character)


### PR DESCRIPTION
`SlugOptions.UsesDefaultReplace` decides whether `Slug.Create` can use the rune-based path that avoids allocating a string per rune. It tested exact type identity:

```csharp
internal bool UsesDefaultReplace => GetType() == typeof(SlugOptions);
```

That is false for *any* derived type — including one that overrides only `IsAllowed`, or that merely adds a property. Since restricting which characters are allowed is the most obvious reason to subclass `SlugOptions`, the optimization switched itself off for the users most likely to be slugifying a lot of text. The library's own `NoVowelSlugOptions` test double is in that bucket.

The check was conservative in the safe direction, so this was never a correctness bug — only a silent performance cliff.

## What changed

`UsesDefaultReplace` now asks whether `Replace` itself is overridden, rather than whether the object is exactly a `SlugOptions`. Binding a delegate to the virtual method resolves it to the override that would actually run, so its `DeclaringType` answers the question:

```csharp
Func<Rune, string> replace = Replace;
return replace.Method.DeclaringType == typeof(SlugOptions);
```

Reading the method off a delegate rather than looking it up by name on a run-time type keeps this trimmer-friendly, which matters because the package sets `IsTrimmable`. The build is clean with `/p:TreatsWarningsAsErrors=true` and produces no `IL2xxx` warnings.

The result is cached in a `static ConcurrentDictionary<Type, bool>`, so the delegate is allocated once per subclass rather than once per `Create` call. The exact-type check stays as a fast path so the common non-subclassed case never touches the dictionary.

## Measured

200-char title, 200,000 calls, `MaximumLength = 0`, Release, net10.0, 20k-iteration warmup:

| options | bytes/call | |
|---|---|---|
| `SlugOptions` (base) | 912 | fast path, unchanged |
| subclass overriding only `IsAllowed` | 976 | **was 5,008** — now takes the fast path |
| subclass overriding `Replace` | 5,008 | slow path, correctly still used |

Allocations for the middle case drop 5.1×. Wall-clock on this machine was between 1.5 and 3.0 µs/call for every row across repeated rounds with no stable ordering, so I am not claiming a throughput win — the allocation reduction is the real effect.

## Verification

- New `Slug_SubclassNotOverridingReplace_MatchesTheBaseClass` theory: a subclass overriding only `IsAllowed` produces output identical to the base class across 5 texts × 3 casing transformations × 5 `MaximumLength` values, so the newly-taken fast path is proven equivalent to the slow path it replaces.
- `dotnet test -c Release /p:TreatsWarningsAsErrors=true` — 112/112 across net10.0 and net11.0.
- No public API change; `ref/Meziantou.Framework.Slug.cs` is untouched.

Found by a project review of `Meziantou.Framework.Slug` (finding L1). The equivalence test also closes the third item of finding M9.
