### PR TITLE
Convert byte arrays back to DateTime, TimeSpan and decimal

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.ComponentModel;
 using System.Reflection;
 
@@ -415,6 +416,18 @@ public class DefaultConverter : IConverter
 
     protected virtual bool TryConvert(object? input, IFormatProvider? provider, out TimeSpan value)
     {
+        if (input is byte[] inputBytes)
+        {
+            if (inputBytes.Length == 8)
+            {
+                value = new TimeSpan(BitConverter.ToInt64(inputBytes, 0));
+                return true;
+            }
+
+            value = TimeSpan.Zero;
+            return false;
+        }
+
         if (TimeSpan.TryParse(Convert.ToString(input, provider), provider, out value))
             return true;
 
@@ -517,6 +530,30 @@ public class DefaultConverter : IConverter
         {
             value = 0;
             return false;
+        }
+
+        if (input is byte[] inputBytes)
+        {
+            value = 0;
+            if (inputBytes.Length != 16)
+                return false;
+
+            var bits = new int[4];
+            for (var i = 0; i < bits.Length; i++)
+            {
+                bits[i] = BinaryPrimitives.ReadInt32LittleEndian(inputBytes.AsSpan(i * 4));
+            }
+
+            try
+            {
+                value = new decimal(bits);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                // The scale or the reserved bits are invalid
+                return false;
+            }
         }
 
         if (input is not string)
@@ -643,6 +680,24 @@ public class DefaultConverter : IConverter
         {
             value = DateTime.MinValue;
             return false;
+        }
+
+        if (input is byte[] inputBytes)
+        {
+            value = DateTime.MinValue;
+            if (inputBytes.Length != 8)
+                return false;
+
+            try
+            {
+                value = DateTime.FromBinary(BitConverter.ToInt64(inputBytes, 0));
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                // The ticks are out of the range supported by DateTime
+                return false;
+            }
         }
 
         if (input is not string)

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ByteArrayTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ByteArrayTo.cs
@@ -37,4 +37,93 @@ public class DefaultConverterTests_ByteArrayTo
         Assert.True(converted);
         Assert.Equal("01020304", value);
     }
+
+    // These types have a byte[] encoder but had no decoder, so the round-trip silently failed
+    [Fact]
+    public void TryConvert_DateTimeToByteArrayAndBack()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var expected = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+        Assert.True(converter.TryChangeType(expected, cultureInfo, out byte[]? bytes));
+        Assert.NotNull(bytes);
+        Assert.True(converter.TryChangeType(bytes, cultureInfo, out DateTime value));
+        Assert.Equal(expected, value);
+        Assert.Equal(expected.Kind, value.Kind);
+    }
+
+    [Fact]
+    public void TryConvert_TimeSpanToByteArrayAndBack()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var expected = new TimeSpan(1, 2, 3, 4, 5);
+
+        Assert.True(converter.TryChangeType(expected, cultureInfo, out byte[]? bytes));
+        Assert.NotNull(bytes);
+        Assert.True(converter.TryChangeType(bytes, cultureInfo, out TimeSpan value));
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("1.5")]
+    [InlineData("-42.24")]
+    [InlineData("0")]
+    [InlineData("79228162514264337593543950335")]
+    public void TryConvert_DecimalToByteArrayAndBack(string text)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var expected = decimal.Parse(text, NumberStyles.Float, cultureInfo);
+
+        Assert.True(converter.TryChangeType(expected, cultureInfo, out byte[]? bytes));
+        Assert.NotNull(bytes);
+        Assert.True(converter.TryChangeType(bytes, cultureInfo, out decimal value));
+        Assert.Equal(expected, value);
+    }
+
+    [Fact]
+    public void TryConvert_GuidToByteArrayAndBack()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var expected = new Guid("2d8a54aa-569b-404f-933b-693918885dba");
+
+        Assert.True(converter.TryChangeType(expected, cultureInfo, out byte[]? bytes));
+        Assert.NotNull(bytes);
+        Assert.True(converter.TryChangeType(bytes, cultureInfo, out Guid value));
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    [InlineData(7)]
+    [InlineData(9)]
+    public void TryConvert_ByteArrayOfWrongLength_ReturnsFalse(int length)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var bytes = new byte[length];
+
+        Assert.False(converter.TryChangeType(bytes, cultureInfo, out DateTime _));
+        Assert.False(converter.TryChangeType(bytes, cultureInfo, out TimeSpan _));
+        Assert.False(converter.TryChangeType(bytes, cultureInfo, out decimal _));
+    }
+
+    // DateTime.FromBinary rejects these, and new decimal(int[]) rejects an invalid scale
+    [Fact]
+    public void TryConvert_ByteArrayWithInvalidPayload_ReturnsFalse()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        var invalidDateTime = BitConverter.GetBytes(long.MaxValue);
+        Assert.False(converter.TryChangeType(invalidDateTime, cultureInfo, out DateTime _));
+
+        var invalidDecimal = new byte[16];
+        invalidDecimal[14] = 0xFF; // scale byte, valid range is 0-28
+        Assert.False(converter.TryChangeType(invalidDecimal, cultureInfo, out decimal _));
+    }
 }


### PR DESCRIPTION
`DateTime`, `TimeSpan` and `decimal` could be converted **to** `byte[]` but not back.

## The bug

The `byte[]` target has a full binary encoding path — `DateTime.ToBinary()`, `TimeSpan.Ticks`, `decimal.GetBits` — but the return trip only had `byte[]` special cases for `bool`, `short`, `int`, `long` and `Guid`. Everything else fell through to `Convert.ToString(byte[])`, which yields the literal `"System.Byte[]"`, and the parse then failed:

```
DateTime → byte[] → DateTime   → false, DateTime.MinValue
TimeSpan → byte[] → TimeSpan   → false, TimeSpan.Zero
decimal  → byte[] → decimal    → false, 0
Guid     → byte[] → Guid       → true  (the only one that worked)
```

Binary encoding of a value is almost always done in order to decode it later, and the asymmetry was silent: the write succeeded, the read returned `false`. A caller discovered it only at read time, potentially after the data was already persisted.

## What changed

Three decoders added, alongside the existing `Guid` handling and following the same shape as the `short`/`int`/`long` cases already in the file (check `byte[]`, check length, convert, return `false` on a length mismatch):

| Target | Length | Decoder |
|---|---|---|
| `DateTime` | 8 | `DateTime.FromBinary(BitConverter.ToInt64(…))` |
| `TimeSpan` | 8 | `new TimeSpan(BitConverter.ToInt64(…))` |
| `decimal` | 16 | `new decimal(int[4])` |

The 8-vs-8 ambiguity (`long`, `DateTime` and `TimeSpan` all encode to 8 bytes) resolves cleanly because the target type is known — the dispatcher selects the overload by `conversionType`, exactly as the existing `Guid` case does.

Two details worth a look:

- **Endianness is symmetric with each encoder.** `DateTime` and `TimeSpan` are written with `BitConverter.GetBytes` (host endianness), so they are read with `BitConverter.ToInt64` — matching both their encoder and the neighbouring `int`/`long`/`short` decoders. `decimal` is different: its `GetBytes` helper is written out byte by byte in explicit little-endian order, so it is read back with `BinaryPrimitives.ReadInt32LittleEndian`. Using host-endian reads for the decimal would have broken the round-trip on a big-endian host.
- **Both fallible decoders are guarded.** `DateTime.FromBinary` throws `ArgumentException` for out-of-range ticks and `new decimal(int[])` throws for an invalid scale or reserved bits; both return `false` instead of letting the exception escape a `Try` method.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **140 passed, 0 failed** (was 116; 12 new cases per target framework, net10.0 and net11.0).

Reverting `DefaultConverter.cs` and re-running gives 12 failures — the 6 new `DateTime`/`TimeSpan`/`decimal` round-trip cases per target framework. The other 6 (the `Guid` round-trip, the four wrong-length cases and the invalid-payload case) pass either way, which is the point: they pin down behaviour this PR must *not* change.

New tests cover the three round-trips including `decimal.MaxValue` and a negative value, that `DateTime.Kind` survives, that wrong-length arrays (0, 4, 7, 9 bytes) return `false`, and that an out-of-range `DateTime` payload and an invalid `decimal` scale byte return `false` rather than throwing.

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — the decoders live inside the existing `protected virtual` overloads, so there is no public API surface change.

## Note for review

A knock-on effect worth being aware of: `byte[]` → `DateTimeOffset` now also succeeds, because that overload falls back to the `DateTime` one. The offset is not preserved (the encoder writes `dateTimeOffset.DateTime` and discards it), so the round-trip yields a `DateTimeOffset` with the local offset rather than the original. That is strictly better than the previous `false`, but if you would rather `DateTimeOffset` round-trip exactly, that needs an encoder change and belongs in its own PR.

Found by a project review of `Meziantou.Framework.TypeConverter`.
