### PR TITLE
Return a query engine error for a duplicate CTE name

### DIFF
--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -277,7 +277,13 @@ internal sealed class TdsQueryEngineExecutor
                 query = ApplyColumnList(query, cte.ColumnList, scopeName: "CTE");
             }
 
-            result.Add(cteName, new TdsQueryRoot(cteName, query));
+            // The SQL parser only reports syntax errors, and a repeated CTE name is a semantic one, so the
+            // statement parses and lands here. Dictionary.Add would throw ArgumentException straight out of the
+            // engine, past the catch in ExecuteAsync.
+            if (!result.TryAdd(cteName, new TdsQueryRoot(cteName, query)))
+            {
+                throw new TdsQueryEngineException($"Duplicate common table expression name '{cteName}'.");
+            }
         }
 
         return result;

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -3312,6 +3312,24 @@ public sealed class TdsQueryEngineTests
     }
 
     [Fact]
+    public async Task SqlClient_QueryEngine_DuplicateCteName_ReturnsAQueryEngineError()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQueryExpectingServerError(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    WITH c AS (SELECT Id FROM customers), c AS (SELECT Id FROM customers)
+                    SELECT Id FROM c
+                    """;
+            },
+            expectedErrorNumber: 50004,
+            expectedMessageContains: "Duplicate common table expression name 'c'");
+    }
+
+    [Fact]
     public async Task SqlClient_QueryEngine_InvalidQuery_ReturnsServerError()
     {
         var invalidQueryTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
`BuildCteRoots` accumulated common table expressions with `result.Add(cteName, …)`. `SqlParser.Parse` only reports *syntax* errors, and a repeated CTE name is a semantic one, so the statement parses cleanly and `Dictionary.Add` throws `ArgumentException`.

`ExecuteAsync` catches only `TdsQueryAuthorizationException` and `TdsQueryEngineException` (`TdsQueryEngineExecutor.cs:88-104`), so that exception escaped the engine entirely.

### Failure scenario

```sql
WITH c AS (SELECT Id FROM customers), c AS (SELECT Id FROM customers)
SELECT Id FROM c
```

produces `System.ArgumentException: An item with the same key has already been added. Key: c`, which `TdsConnectionProcessor` logs at **Error** with a full stack trace (`TdsConnectionProcessor.cs:176`) before returning the opaque `50002: Unhandled query handler exception`.

Two consequences: the client gets a useless error for a diagnosable mistake, and any client can flood the operator's logs with Error-level stack traces at will, by sending a query that is four characters longer than a valid one.

For comparison, SQL Server answers this with `Msg 8156: The column 'Id' was specified multiple times`-style diagnostics — a real error naming the real problem.

### What changed

`TryAdd` plus a `TdsQueryEngineException` naming the duplicate, so it takes the same path as every other query-translation error and comes back as `50004` with a message the client can act on. No log noise.

### Verification

`SqlClient_QueryEngine_DuplicateCteName_ReturnsAQueryEngineError` asserts error `50004` and the message. Full suite: 394 passed / 0 failed (197 × net10.0, 197 × net11.0). No public API change, so `ref/` is unchanged.

Found during a review of `src/Meziantou.Framework.TdsServer`. A sibling PR covers the same failure mode for `IIF` containing a subquery; the two are independent.
