### PR TITLE
Reject a null extension and share one extension normalizer

### DIFF
--- a/src/Meziantou.Framework.DiffEngine/DiffTools.cs
+++ b/src/Meziantou.Framework.DiffEngine/DiffTools.cs
@@ -220,10 +220,15 @@ public static class DiffTools
 
     public static bool TryFindByExtension(string extension, [NotNullWhen(true)] out ResolvedTool? resolvedTool)
     {
+        ArgumentNullException.ThrowIfNull(extension);
+
         var tools = ResolveAvailableTools();
-        var normalizedExtension = NormalizeExtension(extension);
-        if (normalizedExtension.Length > 0)
+
+        // An empty extension is a legitimate input: Path.GetExtension returns it for a file that has none.
+        // There is nothing to match against BinaryExtensions, so go straight to the text tool.
+        if (!string.IsNullOrWhiteSpace(extension))
         {
+            var normalizedExtension = FileExtension.Normalize(extension);
             foreach (var tool in tools)
             {
                 if (tool.BinaryExtensions.Contains(normalizedExtension, StringComparer.OrdinalIgnoreCase))
@@ -482,15 +487,6 @@ public static class DiffTools
         }
 
         return pathExtensions.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-    }
-
-    private static string NormalizeExtension(string extension)
-    {
-        if (string.IsNullOrWhiteSpace(extension))
-            return "";
-
-        var trimmed = extension.Trim();
-        return trimmed[0] == '.' ? trimmed : "." + trimmed;
     }
 
     private static string StandardLeftArguments(string temp, string target) => $"\"{target}\" \"{temp}\"";

--- a/src/Meziantou.Framework.DiffEngine/FileExtension.cs
+++ b/src/Meziantou.Framework.DiffEngine/FileExtension.cs
@@ -1,0 +1,12 @@
+namespace Meziantou.Framework.DiffEngine;
+
+internal static class FileExtension
+{
+    public static string Normalize(string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+
+        var trimmed = extension.Trim();
+        return trimmed[0] == '.' ? trimmed : "." + trimmed;
+    }
+}

--- a/src/Meziantou.Framework.DiffEngine/ResolvedTool.cs
+++ b/src/Meziantou.Framework.DiffEngine/ResolvedTool.cs
@@ -16,7 +16,7 @@ public sealed class ResolvedTool
         ExePath = exePath;
         _launchArguments = launchArguments;
         SupportsText = supportsText;
-        BinaryExtensions = new ReadOnlyCollection<string>(binaryExtensions.Select(static extension => NormalizeExtension(extension)).Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
+        BinaryExtensions = new ReadOnlyCollection<string>(binaryExtensions.Select(static extension => FileExtension.Normalize(extension)).Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
     }
 
     public string Name { get; }
@@ -33,11 +33,5 @@ public sealed class ResolvedTool
         return TargetPosition.TargetOnLeft
             ? _launchArguments.Left(tempFile, targetFile)
             : _launchArguments.Right(tempFile, targetFile);
-    }
-
-    private static string NormalizeExtension(string extension)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(extension);
-        return extension[0] == '.' ? extension : "." + extension;
     }
 }

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -53,6 +53,38 @@ public sealed class DiffToolsTests
     }
 
     [Fact]
+    public void TryFindByExtension_ThrowsWhenExtensionIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => DiffTools.TryFindByExtension(null!, out _));
+    }
+
+    [Fact]
+    public void TryFindByExtension_AcceptsAnExtensionWithoutALeadingDot()
+    {
+        using var temp = TemporaryDirectory.Create();
+        _ = temp.CreateTextFile(GetVisualStudioCodeExecutableName(), "");
+        using var scope = new EnvironmentVariableScope("DiffEngine_VisualStudioCode", temp.FullPath);
+        using var pathScope = new EnvironmentVariableScope("PATH", temp.FullPath);
+
+        Assert.True(DiffTools.TryFindByExtension("bin", out var tool));
+        Assert.NotNull(tool);
+        Assert.Contains(".bin", tool.BinaryExtensions, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryFindByExtension_AcceptsAnEmptyExtension()
+    {
+        using var temp = TemporaryDirectory.Create();
+        _ = temp.CreateTextFile(GetVisualStudioCodeExecutableName(), "");
+        using var scope = new EnvironmentVariableScope("DiffEngine_VisualStudioCode", temp.FullPath);
+        using var pathScope = new EnvironmentVariableScope("PATH", temp.FullPath);
+
+        Assert.True(DiffTools.TryFindByExtension(Path.GetExtension("Makefile"), out var tool));
+        Assert.NotNull(tool);
+        Assert.True(tool.SupportsText);
+    }
+
+    [Fact]
     public void GetArguments_HonorsTargetPosition()
     {
         using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
`DiffTools` and `ResolvedTool` each had their own `NormalizeExtension` with **different
contracts**: `DiffTools`' returned `""` for null or whitespace, `ResolvedTool`'s threw via
`ArgumentException.ThrowIfNullOrEmpty`.

The consequence was that a public API silently accepted null:

```c#
DiffTools.TryFindByExtension(null!, out var tool);
// returned true, with an arbitrary text tool (Rider on my machine)
```

Every other public entry point in the package guards its arguments —
`ResolvedTool.GetArguments` and the `ResolvedTool` constructor both use
`ArgumentException.ThrowIfNullOrEmpty`. For a package whose contract is "give me the right
tool", silently returning an arbitrary one is worse than throwing.

## What changed

- `TryFindByExtension` starts with `ArgumentNullException.ThrowIfNull(extension)`.
- The two normalizers collapse into one `FileExtension.Normalize`, in its own file
  alongside the other small internal helpers (`TargetPosition`, `BuildArguments`,
  `LaunchArguments`).

**An empty extension stays valid**, which is the part worth reviewing. `Path.GetExtension`
returns `""` for a file with no extension, and both `AutoDiffEngineTool` implementations
feed it straight in — so `""` is a normal input meaning "nothing to match against
`BinaryExtensions`, go to the text tool", not a caller error. Only null is rejected. The
emptiness check moved out of the normalizer and into `TryFindByExtension`, where that
decision belongs.

No public signature changed, so `ref/Meziantou.Framework.DiffEngine.cs` is untouched;
`FileExtension` is internal.

## Not in this PR

The review that produced this also noted that `TryFindByExtension(".docx")` on a machine
without `MsWordDiff` falls back to a text tool and hands a Word document to VS Code — the
`SupportsText: false` metadata is only ever used to *include* a tool, never to reject a
text one for a known-binary extension. That is a behavior decision rather than a fix
(should it return `false` instead?), so it is left alone here.

## Verification

`dotnet test /p:TreatsWarningsAsErrors=true` — 14 of 16 pass on net10.0 and net11.0. Three
new tests cover null, an extension without a leading dot, and the empty extension.

The two failures are `TryFindByExtension_ReturnsTextTool`, pre-existing and unrelated —
it depends on which diff tools the developer has installed. Fixed in a sibling PR; CI
images are bare, so this branch is green there.



---

**Merge note:** this PR and #2769 touch adjacent lines of `DiffTools.cs` — this one deletes `NormalizeExtension`, which sits directly above the argument builders that #2769 rewrites. They are logically independent and can merge in either order, but git reports an adjacent-hunk conflict on whichever goes second. Resolution is to keep both sides (the deletion and the rewritten builders). I test-merged every other pair in this batch and they are all clean.