### PR TITLE
Trim whitespace around the Link header target URI

### DIFF
--- a/src/Meziantou.Framework.Http/LinkHeaderValue.cs
+++ b/src/Meziantou.Framework.Http/LinkHeaderValue.cs
@@ -100,7 +100,7 @@ public sealed class LinkHeaderValue
                 continue;
             }
 
-            var targetLink = value[..index].ToString();
+            var targetLink = value[..index].Trim().ToString();
             value = value[(index + 1)..];
 
             // Parse parameters

--- a/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
+++ b/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
@@ -107,6 +107,16 @@ public sealed class LinkHeaderValueTests
         Assert.Equal(expectedUrl, LinkHeaderValue.Parse(header).GetLinkUrl("next"));
     }
 
+    [Theory]
+    [InlineData("<  https://example.com/a  >; rel=next")]
+    [InlineData("<\thttps://example.com/a\t>; rel=next")]
+    [InlineData("<https://example.com/a>; rel=next")]
+    public void Parse_TrimsWhitespaceAroundTheTargetUri(string header)
+    {
+        var link = Assert.Single(LinkHeaderValue.Parse(header));
+        Assert.Equal("https://example.com/a", link.Url);
+    }
+
     private sealed class CustomHttpHeaders : HttpHeaders
     {
     }


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/link-element-recovery` (#2744) · merge #2744 first**

## The problem

Whatever sat between `<` and `>` became `Url` verbatim, including surrounding whitespace. `src/Meziantou.Framework.Http/LinkHeaderValue.cs:91`

```
Input:  <  https://example.com/a  >; rel=next
Before: Url == "  https://example.com/a  "
After:  Url == "https://example.com/a"
```

Minor on its own, but every consumer then had to redo the same trim before it could build a `Uri`.

## The change

Trim the target span before allocating the string — the same treatment #2732 gave parameter values.

## Why this is stacked

It edits the line immediately inside the block #2744 rewrites, so the two cannot go out as independent PRs without conflicting. Reviewing this on its own diff is the point of the stack: it is a one-character change once #2744 is in.

`Url` stays a `string` (the `CA1056` suppression at line 14 documents that as a deliberate breaking-change avoidance). Exposing a `Uri?` companion property would be a reasonable follow-up, but that is public API and would need a `ref/` regeneration, so it is out of scope.

## Verification

`dotnet test tests/Meziantou.Framework.Http.Tests /p:TreatsWarningsAsErrors=true` — 30 passed, 0 failed, with #2744 applied beneath it. `dotnet run ./eng/update-all.cs` produces no changes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
