### PR TITLE
Cover the negative MaximumLength contract and multi-character Replace truncation

### DIFF
--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -80,10 +80,13 @@ public class SlugTests
         Assert.Equal("hello", slug);
     }
 
-    [Fact]
-    public void Slug_MaximumLength_ZeroMeansUnlimited()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Slug_MaximumLength_ZeroOrNegativeMeansUnlimited(int maximumLength)
     {
-        var options = new SlugOptions { MaximumLength = 0 };
+        var options = new SlugOptions { MaximumLength = maximumLength };
         var slug = Slug.Create("hello world this is long", options);
         Assert.Equal("hello-world-this-is-long", slug);
     }
@@ -148,6 +151,22 @@ public class SlugTests
         var options = new ExpandingSlugOptions();
         var slug = Slug.Create("ab c", options);
         Assert.Equal("aabb-cc", slug);
+    }
+
+    [Theory]
+    [InlineData(1, "")]
+    [InlineData(2, "aa")]
+    [InlineData(3, "aa")]
+    [InlineData(4, "aabb")]
+    [InlineData(5, "aabb")]
+    [InlineData(6, "aabb")]
+    [InlineData(7, "aabb-cc")]
+    [InlineData(8, "aabb-cc")]
+    public void Slug_OverriddenReplace_IsNeverSplitByMaximumLength(int maximumLength, string expected)
+    {
+        var options = new ExpandingSlugOptions { MaximumLength = maximumLength };
+        var slug = Slug.Create("ab c", options);
+        Assert.Equal(expected, slug);
     }
 
     [Fact]
@@ -220,6 +239,7 @@ public class SlugTests
     }
 
     [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Slug_MaximumLength_FillsTheLimitWhenComposingFreesRoom()
     {
         var options = new SlugOptions { MaximumLength = 17 };


### PR DESCRIPTION
Tests only — no source change. Three gaps found by instrumenting which branches the existing suite actually reaches.

## 1. A test that passed for the wrong reason under `InvariantGlobalization`

`Slug_MaximumLength_FillsTheLimitWhenComposingFreesRoom` is the sole assertion that `MaximumLength` is actually *filled* rather than merely not exceeded, and it is the only unmarked test that drives the budget/recovery loop. It was not marked `[RunIf(NotInvariant)]` and did pass in invariant mode — but only because `Normalize` is a no-op there:

```
"café crème brûlée".Normalize(FormD).Length  ==  21   (ICU)
                                             ==  17   (DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1)
```

With no decomposition the whole string fits on the first pass, the loop never runs a second iteration, and the test degenerates into "a 17-char string under a 17-char limit is unchanged".

Feeding it pre-decomposed input would not help — `Normalize(FormC)` is equally a no-op there, so the composed expectation cannot hold. So it is now marked `[RunIf(NotInvariant)]` like its three siblings, which makes the inertness explicit instead of accidental. Skipped count in invariant mode goes from 7 to 8 per target framework.

## 2. No regression test for "a multi-character `Replace` is never split by `MaximumLength`"

`Slug.cs:91-92` and the `MaximumLength` remarks both promise replacements are appended atomically so the limit cannot split one. `#1907` added regression tests for the other two things it fixed — a split surrogate pair and a split multi-character `Separator` — but the multi-character *`Replace`* case only had `Slug_OverriddenReplace_IsUsedWhenItReturnsMultipleCharacters`, which runs at the default 80-char limit on a 4-char input, so `sb.Length + replacement.Length > budget` is never true on that path.

New theory drives `ExpandingSlugOptions` (whose `Replace` returns 2 chars per rune) through `MaximumLength` 1–8. The behavior is correct today and this pins it — note the limit lands *between* replacements, never inside one:

| limit | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|---|---|---|
| slug | `""` | `aa` | `aa` | `aabb` | `aabb` | `aabb` | `aabb-cc` | `aabb-cc` |

`Replace` is the main public extension point for transliteration, where multi-character output is the normal case.

## 3. Only `MaximumLength = 0` was tested for the "≤ 0 means no truncation" contract

`SlugOptions.cs:32` documents the contract for *any* value ≤ 0; `Slug.cs:40` implements it as `options.MaximumLength > 0 ? … : int.MaxValue`. Only `0` was covered, so refactoring that ternary to `>= 0` or `!= 0` would turn a negative limit into an empty slug with nothing failing. `Slug_MaximumLength_ZeroMeansUnlimited` is now a theory over `0`, `-1` and `int.MinValue` (renamed to `Slug_MaximumLength_ZeroOrNegativeMeansUnlimited`).

## Verification

- ICU: 126/126 pass across net10.0 and net11.0 (63 per TFM, was 53).
- `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`: 110 pass, 16 skipped, 0 fail.
- Expected values for the new rows were derived by running the real implementation, not assumed.

Found by a project review of `Meziantou.Framework.Slug` (findings M9 items 1–2, and L5). M9's third item — equivalence between the fast and slow `Replace` paths — ships with #2741 instead, where it is the regression test for that change.
