### PR TITLE
Do not reset the style when SGR parameters cannot be parsed

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -224,8 +224,12 @@ public static class AnsiTextProcessor
 
     private static AnsiStyle ApplySgr(AnsiStyle style, List<int> parameters)
     {
+        // An empty list means the sequence carried parameters but none of them could be parsed.
+        // Such a sequence is ignored: a reset would drop styling the caller never asked to clear.
+        // ESC[m, which carries no parameter at all, is reported as [0] by ParseSgrParameters and
+        // still resets the style through the switch below.
         if (parameters.Count is 0)
-            return AnsiStyle.None;
+            return style;
 
         var result = style;
 

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -59,6 +59,45 @@ public class AnsiTextProcessorTests
         Assert.Equal(expected, actual);
     }
 
+    [Theory]
+    [InlineData("\u001b[38:5:208m")]
+    [InlineData("\u001b[38:2:10:20:30m")]
+    [InlineData("\u001b[4:3m")]
+    [InlineData("\u001b[99999999999m")]
+    [InlineData("\u001b[<m")]
+    [InlineData("\u001b[?m")]
+    public void ParseTextWithAnsiStyles_UnparsableSgrParametersDoNotResetStyle(string sequence)
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("\u001b[1;4m" + sequence + "A");
+
+        Assert.Equal("A", parsed.Text);
+        var run = Assert.Single(parsed.Runs);
+        Assert.True(run.Style.Bold);
+        Assert.True(run.Style.Underline);
+    }
+
+    [Theory]
+    [InlineData("\u001b[0m")]
+    [InlineData("\u001b[m")]
+    public void ParseTextWithAnsiStyles_ResetStillClearsStyle(string sequence)
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("\u001b[1;4m" + sequence + "A");
+
+        var run = Assert.Single(parsed.Runs);
+        Assert.False(run.Style.Bold);
+        Assert.False(run.Style.Underline);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_PartlyParsableSgrParametersApplyTheKnownOnes()
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("\u001b[1;?;4mA");
+
+        var run = Assert.Single(parsed.Runs);
+        Assert.True(run.Style.Bold);
+        Assert.True(run.Style.Underline);
+    }
+
     [Fact]
     public void RemoveAnsiSequences_MultipleSequencesInRow()
     {


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2751**

## Problem

When an SGR sequence carries parameters that cannot be parsed, `ParseTextWithAnsiStyles` does not ignore it — it **wipes every style currently in effect**.

`ParseSgrParameters` drops any segment that fails `int.TryParse`. If every segment fails it returns an empty list, and `ApplySgr` maps `parameters.Count is 0` to `AnsiStyle.None`, a full reset (`src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs:227-228`).

Reproduced against the built library:

| Input | Expected | Before this PR |
|---|---|---|
| `ESC[1mbold ESC[38:5:208mORANGE` | bold kept | bold **lost** |
| `ESC[1mBOLD ESC[4:3mtext` | bold kept | bold **lost** |
| `ESC[1mBOLD ESC[99999999999mtext` | bold kept | bold **lost** |

The trigger is not exotic. `38:5:n` / `38:2:r:g:b` is the ITU T.416 colon sub-parameter syntax, and `4:3` (curly underline) is emitted by GCC, Clang and Rust diagnostics; an `int` overflow or a private parameter byte such as `ESC[<m` hits the same path.

The failure is silent, and it is *worse than doing nothing*: because the reset sticks until the next recognised SGR, one unrecognised sequence flattens the rest of the line. In the LogViewer this shows up as formatting dropping out mid-line for no visible reason.

## Change

One line in `ApplySgr`: an empty parameter list now leaves the style untouched instead of resetting it.

The distinction that makes this safe is that the two cases are already separable:

- `ESC[m` — no parameters at all — is turned into `[0]` by the `IsEmpty` branch of `ParseSgrParameters`, so it still resets through the normal `case 0:` path.
- An empty list can *only* arise from "parameters were present, none were understood", which is precisely the case that should be ignored.

This PR deliberately does **not** teach the parser to understand colon sub-parameters — that is #2751, stacked on top. On its own this PR converts a corruption bug into benign "the colour is not applied", which is the more important half and is worth merging even if the follow-up stalls.

## Verification

- New theory covering `38:5:208`, `38:2:10:20:30`, `4:3`, an `int`-overflowing parameter, and the private parameter bytes `<` and `?`: the previously applied bold and underline must survive.
- New theory pinning that both reset spellings, `ESC[0m` and the parameterless `ESC[m`, still clear the style — the over-correction this change could have caused.
- New test that a partly-parsable list (`ESC[1;?;4m`) still applies the parameters it did understand.
- Confirmed these tests **fail** against the old behaviour and pass with the fix.
- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 66 passed, 0 failed (33 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` → 24 passed, 0 failed.
- `ref/` unchanged.

## Context

From an audit of `Meziantou.Framework.AnsiFormatting` (8 PRs total). This is the bottom of a 2-PR stack; #2751 sits on top and adds actual colon sub-parameter support.
