### PR TITLE
Support colon-separated SGR sub-parameters

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -7,6 +7,8 @@ public static class AnsiTextProcessor
     private const char EscapeCharacter = '\u001b';
     // Sequences shorter than this are processed using a stack-allocated buffer to avoid renting an array.
     private const int StackAllocThreshold = 512;
+    // The longest SGR parameter is 38:2:<color-space>:r:g:b
+    private const int MaxSgrSubParameters = 6;
 
     public static string RemoveAnsiSequences(string value)
     {
@@ -194,27 +196,78 @@ public static class AnsiTextProcessor
             return [0];
 
         var values = new List<int>();
-        var segmentStart = 0;
-
-        for (var i = 0; i <= sequenceContent.Length; i++)
+        foreach (var parameterRange in sequenceContent.Split(';'))
         {
-            if (i < sequenceContent.Length && sequenceContent[i] != ';')
-                continue;
-
-            var segment = sequenceContent[segmentStart..i];
-            if (segment.IsEmpty)
-            {
-                values.Add(0);
-            }
-            else if (int.TryParse(segment, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
-            {
-                values.Add(value);
-            }
-
-            segmentStart = i + 1;
+            AddSgrParameter(values, sequenceContent[parameterRange]);
         }
 
         return values;
+    }
+
+    /// <summary>
+    /// Normalizes a single ';'-delimited SGR parameter, which may carry ':'-delimited sub-parameters
+    /// (ITU T.416), into the flat form the rest of the parser consumes.
+    /// </summary>
+    private static void AddSgrParameter(List<int> values, ReadOnlySpan<char> parameter)
+    {
+        Span<int> parts = stackalloc int[MaxSgrSubParameters];
+        var count = 0;
+
+        foreach (var partRange in parameter.Split(':'))
+        {
+            if (count >= parts.Length)
+                return; // More sub-parameters than any SGR parameter uses: ignore the whole parameter
+
+            var part = parameter[partRange];
+            if (part.IsEmpty)
+            {
+                parts[count++] = 0;
+            }
+            else if (int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out var value))
+            {
+                parts[count++] = value;
+            }
+            else
+            {
+                return; // Not a value this parser understands: ignore it rather than reset the style
+            }
+        }
+
+        // No sub-parameters: the classic ';'-only form, which the rest of the parser reads directly.
+        if (count is 1)
+        {
+            values.Add(parts[0]);
+            return;
+        }
+
+        // Sub-parameters belong to the parameter that introduces them. Only the extended-color
+        // parameters consume them; for anything else (for example 4:3, curly underline) the base
+        // parameter is applied and the sub-parameters are ignored.
+        if (parts[0] is not (38 or 48))
+        {
+            values.Add(parts[0]);
+            return;
+        }
+
+        // 38:5:n and 48:5:n
+        if (count is 3 && parts[1] is 5)
+        {
+            values.Add(parts[0]);
+            values.Add(parts[1]);
+            values.Add(parts[2]);
+            return;
+        }
+
+        // 38:2:r:g:b, and 38:2:<color-space>:r:g:b which carries an extra leading id to skip
+        if (parts[1] is 2 && count is 5 or 6)
+        {
+            var red = count is 6 ? 3 : 2;
+            values.Add(parts[0]);
+            values.Add(parts[1]);
+            values.Add(parts[red]);
+            values.Add(parts[red + 1]);
+            values.Add(parts[red + 2]);
+        }
     }
 
     private static AnsiStyle ApplySgr(AnsiStyle style, List<int> parameters)

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -162,6 +162,104 @@ public class AnsiTextProcessorTests
         Assert.True(run.Style.Underline);
     }
 
+    [Theory]
+    [InlineData("\u001b[38:5:208mA", 208)]
+    [InlineData("\u001b[38:5:0mA", 0)]
+    [InlineData("\u001b[38:5:255mA", 255)]
+    public void ParseTextWithAnsiStyles_ColonIndexedForeground(string input, int expectedIndex)
+    {
+        var style = SingleColonRunStyle(input);
+        Assert.NotNull(style.Foreground);
+        Assert.Equal(AnsiTextProcessor.AnsiColorKind.Indexed, style.Foreground.Kind);
+        Assert.Equal(expectedIndex, style.Foreground.IndexedValue);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_ColonIndexedBackground()
+    {
+        var style = SingleColonRunStyle("\u001b[48:5:208mA");
+        Assert.NotNull(style.Background);
+        Assert.Equal(208, style.Background.IndexedValue);
+    }
+
+    [Theory]
+    [InlineData("\u001b[38:2:10:20:30mA")]
+    [InlineData("\u001b[38:2::10:20:30mA")]
+    [InlineData("\u001b[38:2:1:10:20:30mA")]
+    public void ParseTextWithAnsiStyles_ColonRgbForeground(string input)
+    {
+        var style = SingleColonRunStyle(input);
+        Assert.NotNull(style.Foreground);
+        Assert.Equal(AnsiTextProcessor.AnsiColorKind.Rgb, style.Foreground.Kind);
+        Assert.Equal(10, style.Foreground.Red);
+        Assert.Equal(20, style.Foreground.Green);
+        Assert.Equal(30, style.Foreground.Blue);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_ColonRgbBackground()
+    {
+        var style = SingleColonRunStyle("\u001b[48:2:10:20:30mA");
+        Assert.NotNull(style.Background);
+        Assert.Equal(AnsiTextProcessor.AnsiColorKind.Rgb, style.Background.Kind);
+        Assert.Equal(10, style.Background.Red);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_ColonSubParametersOfOtherParametersAreIgnored()
+    {
+        // 4:3 is a curly underline: the underline applies, the style variant is not modelled
+        var style = SingleColonRunStyle("\u001b[4:3mA");
+        Assert.True(style.Underline);
+        Assert.False(style.Italic);
+        Assert.False(style.Bold);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_ColonParameterMixedWithClassicParameters()
+    {
+        var style = SingleColonRunStyle("\u001b[1;38:5:208;4mA");
+        Assert.True(style.Bold);
+        Assert.True(style.Underline);
+        Assert.NotNull(style.Foreground);
+        Assert.Equal(208, style.Foreground.IndexedValue);
+    }
+
+    [Theory]
+    [InlineData("\u001b[38:5:300mA")]
+    [InlineData("\u001b[38:2:300:1:1mA")]
+    [InlineData("\u001b[38:9:1mA")]
+    [InlineData("\u001b[38:5mA")]
+    [InlineData("\u001b[38:2:1:2mA")]
+    [InlineData("\u001b[38:2:1:2:3:4:5mA")]
+    public void ParseTextWithAnsiStyles_InvalidColonExtendedColorIsIgnored(string input)
+    {
+        var style = SingleColonRunStyle(input);
+        Assert.Null(style.Foreground);
+        Assert.Null(style.Background);
+    }
+
+    [Theory]
+    [InlineData("\u001b[ 4m")]
+    [InlineData("\u001b[+4m")]
+    [InlineData("\u001b[-4m")]
+    public void ParseTextWithAnsiStyles_NonDigitSgrParametersAreIgnored(string sequence)
+    {
+        // ECMA-48 parameter bytes are digits, ';' and ':' only
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("\u001b[1m" + sequence + "A");
+
+        var run = Assert.Single(parsed.Runs);
+        Assert.True(run.Style.Bold);
+        Assert.False(run.Style.Underline);
+    }
+
+    private static AnsiTextProcessor.AnsiStyle SingleColonRunStyle(string input)
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles(input);
+        Assert.Equal("A", parsed.Text);
+        return Assert.Single(parsed.Runs).Style;
+    }
+
     [Fact]
     public void RemoveAnsiSequences_MultipleSequencesInRow()
     {


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/ansi-sgr-no-reset` (#2750) · merge #2750 first**

## Problem

`ParseSgrParameters` splits only on `;`, so the colon sub-parameter form defined by ITU T.416 is not understood at all. #2750 stops that from destroying the surrounding style, but the colour still never gets applied:

- `ESC[38:5:208m` — 256-colour foreground, no colour applied
- `ESC[38:2:10:20:30m` — 24-bit foreground, no colour applied
- `ESC[4:3m` — curly underline, no underline applied

This form is emitted by GCC, Clang and Rust diagnostics and is understood by most modern terminals, so it turns up in ordinary build-log input.

## Change

`ParseSgrParameters` now splits each `;`-delimited parameter into its `:`-delimited sub-parameters and normalises the result into the flat shape the rest of the parser already consumes, so `ApplySgr` and `ApplyExtendedColor` are untouched.

The normalisation rules, in `AddSgrParameter`:

| Form | Result |
|---|---|
| `38:5:n`, `48:5:n` | flattened to `38, 5, n` |
| `38:2:r:g:b` | flattened to `38, 2, r, g, b` |
| `38:2:<color-space>:r:g:b` | leading colour-space id dropped, then as above |
| any other parameter with sub-parameters (`4:3`) | base parameter applied, sub-parameters ignored |
| a malformed extended-colour group (`38:9:1`, `38:5`) | ignored entirely |
| no sub-parameters | unchanged — the classic `;` form is untouched |

**The sub-parameter scoping is the part worth reviewing.** Naively splitting on `:` as if it were `;` would turn `ESC[4:3m` into parameters `4` and `3`, i.e. underline *plus italic* — a new bug. Sub-parameters belong to the parameter that introduces them, so only `38`/`48` consume theirs and everything else ignores them. That is why `4:3` correctly yields underline and nothing else; the curly-underline *variant* is simply not modelled by `AnsiStyle`.

The `38:2` arity ambiguity called out in the audit is resolved by length: 5 parts means `r:g:b`, 6 means a colour-space id precedes them. The empty-id spelling `38:2::r:g:b` lands in the 6-part case, since an empty sub-parameter already parses as `0`.

Also folded in, because it is the same three lines: `int.TryParse` moves from `NumberStyles.Integer` to `NumberStyles.None`. ECMA-48 parameter bytes are digits, `;` and `:` only, but `NumberStyles.Integer` accepts leading whitespace and a sign, so `ESC[ 1m` used to apply bold. It is now ignored (and, thanks to #2750, ignored without resetting anything).

## Verification

- Colon 256-colour foreground (`0`, `208`, `255`) and background.
- Colon 24-bit foreground in all three spellings (`38:2:r:g:b`, `38:2::r:g:b`, `38:2:1:r:g:b`) and background.
- `4:3` yields underline only — explicitly asserting italic is **not** set, which is the regression a naive split would introduce.
- Colon and classic parameters mixed in one sequence (`ESC[1;38:5:208;4m`).
- Invalid colon groups ignored: out-of-range values, unknown mode (`38:9:1`), truncated (`38:5`, `38:2:1:2`), and over-long (`38:2:1:2:3:4:5`).
- `ESC[ 4m`, `ESC[+4m`, `ESC[-4m` ignored while leaving the existing bold intact.
- All 24 pre-existing tests plus #2750's still pass, so the classic `;` form is unaffected.
- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 104 passed, 0 failed (52 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` → 24 passed, 0 failed.
- `ref/` unchanged.

## Not addressed

`AnsiStyle` has no way to express the underline *variant* from `4:3`, nor faint/strikethrough. Adding fields to it is a breaking change today because it is a positional record — a separate finding from the same audit, left for you to decide on.

## Context

From an audit of `Meziantou.Framework.AnsiFormatting` (8 PRs total). Top of a 2-PR stack.
