### PR TITLE
Cover query root authorization through joins, CTEs and subqueries

### DIFF
--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -3293,6 +3293,61 @@ public sealed class TdsQueryEngineTests
             expectedMessageContains: "SELECT permission was denied");
     }
 
+    [Theory]
+    // A denied query root has to stay denied however the SQL reaches it, not just as the top-level FROM. Every
+    // one of these funnels through BuildTableSource -> ResolveConfiguredQueryRoot today; these cases pin that
+    // down so a future translation feature cannot resolve a root some other way and skip the check.
+    [InlineData("SELECT Id FROM orders")]
+    [InlineData("SELECT Id FROM dbo.orders")]
+    [InlineData("SELECT o.Id FROM customers c INNER JOIN orders o ON c.Id = o.Id")]
+    [InlineData("SELECT o.Id FROM customers c LEFT JOIN orders o ON c.Id = o.Id")]
+    [InlineData("WITH o AS (SELECT Id FROM orders) SELECT Id FROM o")]
+    [InlineData("SELECT d.Id FROM (SELECT Id FROM orders) d")]
+    [InlineData("SELECT Id FROM customers WHERE Id IN (SELECT Id FROM orders)")]
+    [InlineData("SELECT Id FROM customers WHERE EXISTS (SELECT 1 FROM orders)")]
+    [InlineData("SELECT Id FROM customers UNION ALL SELECT Id FROM orders")]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The query text comes from the test's own inline data.")]
+    public async Task SqlClient_QueryEngine_QueryRoot_Unauthorized_IsDeniedThroughEveryReference(string commandText)
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+        queryEngineOptions.IsAuthorized = (context, resourceKind, resourceName) =>
+            resourceKind != TdsQueryEngineResourceKind.QueryRoot ||
+            !string.Equals(resourceName, "orders", StringComparison.OrdinalIgnoreCase);
+
+        await ExecuteQueryExpectingServerError(
+            queryEngineOptions,
+            command => command.CommandText = commandText,
+            expectedErrorNumber: 229,
+            expectedMessageContains: "SELECT permission was denied on the object 'orders'");
+    }
+
+    [Theory]
+    // The mirror of the theory above: with the same handler, a root that is allowed still resolves through each
+    // of those shapes, so the check is not simply denying everything.
+    [InlineData("SELECT Id FROM customers")]
+    [InlineData("SELECT c2.Id FROM customers c1 INNER JOIN customers c2 ON c1.Id = c2.Id")]
+    [InlineData("WITH c AS (SELECT Id FROM customers) SELECT Id FROM c")]
+    [InlineData("SELECT Id FROM customers WHERE EXISTS (SELECT 1 FROM customers)")]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The query text comes from the test's own inline data.")]
+    public async Task SqlClient_QueryEngine_QueryRoot_Authorized_StillResolvesThroughEveryReference(string commandText)
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+        queryEngineOptions.IsAuthorized = (context, resourceKind, resourceName) =>
+            resourceKind != TdsQueryEngineResourceKind.QueryRoot ||
+            !string.Equals(resourceName, "orders", StringComparison.OrdinalIgnoreCase);
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command => command.CommandText = commandText,
+            """
+            Id
+            1
+            2
+            4
+            """,
+            expectedMaterializedQueries: null);
+    }
+
     [Fact]
     [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The stored procedure name is generated within the test and not user-controlled.")]
     public async Task SqlClient_QueryEngine_UnknownStoredProcedure_RemainsNotFoundError()


### PR DESCRIPTION
`IsAuthorized` is the library's only security control, and it had three tests: a stored procedure, a top-level `FROM`, and unknown-name precedence. Nothing covered a denied query root reached *indirectly*.

The behaviour is correct today — I checked each shape against a live engine before writing this, and `JOIN`, `LEFT JOIN`, `WITH`-CTE, derived table, `IN (SELECT …)`, `EXISTS (SELECT …)`, `UNION ALL` and schema-qualified names all return error 229 and leak nothing. So **this PR changes no product code**; it pins down an invariant that was untested.

### Why it is worth pinning

Every one of those paths funnels through `BuildTableSource` → `ResolveConfiguredQueryRoot`, which is the single place `EnsureAuthorized` is called for a query root. That is a good design, and it is entirely load-bearing: a future translation feature that resolves a root by any other route would silently bypass authorization, and the existing suite would stay green.

`TdsQueryEngineExecutor.cs` is the most-churned file in the project — 10 commits in the last six months — so that is not a hypothetical.

### What changed

Two theories in `TdsQueryEngineTests`:

- `SqlClient_QueryEngine_QueryRoot_Unauthorized_IsDeniedThroughEveryReference` — nine SQL shapes referencing a denied root, each asserting error `229` **and** the message naming `orders`, so a case cannot pass by failing for an unrelated reason (a parse error, say).
- `SqlClient_QueryEngine_QueryRoot_Authorized_StillResolvesThroughEveryReference` — the control. Four of the same shapes against an *allowed* root, asserting the rows still come back, so the first theory cannot be satisfied by a handler that denies everything.

### Verification

Full suite: 418 passed / 0 failed (209 × net10.0, 209 × net11.0) — 392 before, plus the 26 new theory cases across both target frameworks. No product code touched, so `ref/` is unchanged.

Found during a review of `src/Meziantou.Framework.TdsServer`.
