### PR TITLE
Trim only separators the slug generation emitted, not matching input characters

### DIFF
--- a/src/Meziantou.Framework.Slug/Slug.cs
+++ b/src/Meziantou.Framework.Slug/Slug.cs
@@ -41,10 +41,11 @@ public static class Slug
 
         var sb = new StringBuilder(Math.Min(text.Length, maximumLength));
         var budget = maximumLength;
+        int trailingSeparatorStart;
         string slug;
         while (true)
         {
-            var completed = AppendSlug(sb, text, options, separator, budget);
+            var completed = AppendSlug(sb, text, options, separator, budget, out trailingSeparatorStart);
             slug = sb.ToString().Normalize(NormalizationForm.FormC);
             if (completed)
                 break;
@@ -64,10 +65,11 @@ public static class Slug
             budget = extendedBudget;
         }
 
-        // Trimmed on the decomposed buffer, so a separator that is itself decomposed is still recognized.
-        if (!options.CanEndWithSeparator && separator.Length > 0 && EndsWith(sb, separator))
+        // Only a separator AppendSlug emitted is trimmed. A character that came from the input is content, even
+        // when it matches the separator, so CanEndWithSeparator never deletes something the caller typed.
+        if (!options.CanEndWithSeparator && separator.Length > 0 && trailingSeparatorStart >= 0)
         {
-            sb.Length -= separator.Length;
+            sb.Length = trailingSeparatorStart;
             slug = sb.ToString().Normalize(NormalizationForm.FormC);
         }
 
@@ -75,10 +77,18 @@ public static class Slug
     }
 
     /// <summary>Rebuilds the slug into <paramref name="sb"/>, using at most <paramref name="budget"/> characters.</summary>
+    /// <param name="trailingSeparatorStart">
+    /// The offset of the separator this method emitted at the end of <paramref name="sb"/>, or -1 when the buffer does
+    /// not end with one. A separator character that came from the input is content and never reported here.
+    /// </param>
     /// <returns><see langword="true"/> if the whole text was consumed; otherwise, <see langword="false"/>.</returns>
-    private static bool AppendSlug(StringBuilder sb, string text, SlugOptions options, string separator, int budget)
+    private static bool AppendSlug(StringBuilder sb, string text, SlugOptions options, string separator, int budget, out int trailingSeparatorStart)
     {
         sb.Clear();
+
+        // Offset of the most recent separator this method emitted. It is not cleared when more characters are
+        // appended, so that dropping a character below still leaves it describing the buffer correctly.
+        var lastSeparatorStart = -1;
         var usesDefaultReplace = options.UsesDefaultReplace;
         Span<char> transformed = stackalloc char[MaxUtf16CharsPerRune];
         var characterStart = 0;
@@ -114,6 +124,7 @@ public static class Slug
                     if (isCombiningMark)
                         sb.Length = characterStart;
 
+                    trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
                     return false;
                 }
 
@@ -123,31 +134,35 @@ public static class Slug
             {
                 // Combining marks attached to a disallowed character are dropped silently instead of
                 // producing a separator. A slug never starts with a separator, and separators are never repeated.
-                if (sb.Length == 0 || EndsWith(sb, separator))
+                if (sb.Length == 0 || EndsWithEmittedSeparator(sb, lastSeparatorStart, separator))
                     continue;
 
                 if (sb.Length + separator.Length > budget)
+                {
+                    trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
                     return false;
+                }
 
+                lastSeparatorStart = sb.Length;
                 sb.Append(separator);
                 characterStart = sb.Length;
             }
         }
 
+        trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
         return true;
     }
 
-    private static bool EndsWith(StringBuilder stringBuilder, string suffix)
+    /// <summary>Determines whether <paramref name="sb"/> ends with the separator emitted at <paramref name="lastSeparatorStart"/>.</summary>
+    private static bool EndsWithEmittedSeparator(StringBuilder sb, int lastSeparatorStart, string separator)
     {
-        if (stringBuilder.Length < suffix.Length)
-            return false;
-
-        for (var index = 0; index < suffix.Length; index++)
-        {
-            if (stringBuilder[stringBuilder.Length - 1 - index] != suffix[suffix.Length - 1 - index])
-                return false;
-        }
-
-        return true;
+        return lastSeparatorStart >= 0 && lastSeparatorStart + separator.Length == sb.Length;
     }
+
+    /// <summary>Returns the offset of the emitted separator at the end of <paramref name="sb"/>, or -1 when there is none.</summary>
+    private static int TrailingSeparatorStart(StringBuilder sb, int lastSeparatorStart, string separator)
+    {
+        return EndsWithEmittedSeparator(sb, lastSeparatorStart, separator) ? lastSeparatorStart : -1;
+    }
+
 }

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Unicode;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Tests;
@@ -101,6 +102,48 @@ public class SlugTests
         var options = new SlugOptions { Separator = "" };
         var slug = Slug.Create("a b", options);
         Assert.Equal("ab", slug);
+    }
+
+    [Theory]
+    [InlineData("Ajax", "x", "Ajax")]
+    [InlineData("version 10", "0", "version010")]
+    [InlineData("ax b", "x", "axxb")]
+    public void Slug_SeparatorCharacterFromTheInput_IsContentAndIsNotTrimmed(string text, string separator, string expected)
+    {
+        var options = new SlugOptions { Separator = separator };
+        var slug = Slug.Create(text, options);
+        Assert.Equal(expected, slug);
+    }
+
+    [Theory]
+    [InlineData("hello-world-", "hello-world-")]
+    [InlineData("end-", "end-")]
+    [InlineData("a-", "a-")]
+    [InlineData("wrap-up -", "wrap-up--")]
+    public void Slug_AllowedSeparatorCharacter_IsKeptEvenWhenItEndsTheSlug(string text, string expected)
+    {
+        var options = new SlugOptions();
+        options.AllowedRanges.Add(UnicodeRange.Create('-', '-'));
+        var slug = Slug.Create(text, options);
+        Assert.Equal(expected, slug);
+    }
+
+    [Theory]
+    [InlineData("\u1100__")]
+    [InlineData("_b\u00C1\u11A8--__a!")]
+    public void Slug_MaximumLength_RaisingTheLimitNeverShortensTheSlug_WhenTheInputContainsTheSeparator(string text)
+    {
+        var previousLength = 0;
+        for (var maximumLength = 1; maximumLength <= 16; maximumLength++)
+        {
+            var options = new SlugOptions { Separator = "__", MaximumLength = maximumLength };
+            options.AllowedRanges.Clear();
+
+            var slug = Slug.Create(text, options);
+
+            Assert.HasCountGreaterThanOrEqual(previousLength, slug, $"limit {maximumLength} produced fewer characters than limit {maximumLength - 1}");
+            previousLength = slug.Length;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
> **Stack 1 of 4 · base `main` · merge before the three PRs above it.**
> The four layers rewrite overlapping parts of `AppendSlug`, so they are stacked rather than independent.

`Slug` decided "does the buffer end with a separator?" by comparing the buffer's last characters against the separator string, in two places. That cannot tell a separator the algorithm *emitted* from input content that merely matches it.

## What went wrong

**The trailing trim deleted real input** (`Slug.cs:68-72`). `sb.Length -= separator.Length` fired on any matching suffix:

```csharp
Slug.Create("Ajax", new SlugOptions { Separator = "x" });   // "Aja"  - the letter x is gone
Slug.Create("version 10", new SlugOptions { Separator = "0" }); // "version01"
```

With the natural "keep the hyphens the user typed" configuration — `AllowedRanges.Add(UnicodeRange.Create('-','-'))` — it ate the user's own trailing hyphen, and *still* left a separator at the end in other cases:

```csharp
Slug.Create("hello-world-", options);  // "hello-world"   - content deleted
Slug.Create("wrap-up -", options);     // "wrap-up-"      - ends with a separator despite CanEndWithSeparator = false
```

**Word boundaries were swallowed** (`Slug.cs:126`). The same comparison suppressed a genuine separator when the buffer happened to end with matching content.

**Raising `MaximumLength` could shorten the slug.** Because the trim depends on where the limit happened to cut, a higher limit could expose a matching suffix the lower limit did not reach. A 30k-case fuzz found counterexamples in seconds — with `Separator = "__"` and cleared ranges, `"ᄀ__"` gave 2 characters at limit 2 but 1 character at limit 3. `Slug_MaximumLength_RaisingTheLimitNeverShortensTheSlug` asserts this invariant; it simply had no input that contained the separator.

## What changed

`AppendSlug` now records the offset of the separator it emitted and reports it through a new `out int trailingSeparatorStart`. Both decisions use that offset instead of a suffix comparison:

- the "never repeat a separator" check asks whether the buffer ends with an *emitted* separator;
- the trim in `Create` truncates to that offset, and does nothing when the trailing characters came from the input.

The offset is kept rather than cleared as characters are appended, and the "does the buffer end with it" test is derived (`lastSeparatorStart + separator.Length == sb.Length`). That matters because the combining-mark rollback (`sb.Length = characterStart`) can re-expose a separator that was no longer at the end, and a derived predicate stays correct across it.

`EndsWith` is now unused and removed.

## Behavior

**Default options are bit-identical.** The default separator `-` is outside the default ranges, so the buffer can only end with the separator if the algorithm put it there — the old and new predicates agree exactly. All 106 pre-existing tests pass unchanged.

Behavior changes only where a separator character can also come from the input, which is the broken configuration:

| input | separator | before | after |
|---|---|---|---|
| `"Ajax"` | `x` | `"Aja"` | `"Ajax"` |
| `"hello-world-"` | `-` (allowed) | `"hello-world"` | `"hello-world-"` |
| `"ax b"` | `x` | `"axb"` | `"axxb"` |

The third row is the deliberate consequence: a real word boundary now emits a separator instead of being swallowed. `CanEndWithSeparator = false` now means "the slug does not end with a separator *this class emitted*" — a trailing hyphen the caller typed is content and is preserved.

## Verification

- 9 new tests: content preservation, the allowed-separator-character configuration, and monotonicity over the two fuzzed counterexamples.
- Monotonicity fuzz re-run: **0 violations in 30,000 cases** (previously several within seconds).
- `dotnet test -c Release /p:TreatsWarningsAsErrors=true` — 124/124 across net10.0 and net11.0.

Found by a project review of `Meziantou.Framework.Slug` (finding M3, and the root cause of the monotonicity half of H2).
