### PR TITLE
Drop the unused test helper and redundant nullable directives

### DIFF
--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -225,11 +225,6 @@ public sealed class HttpBasicAuthenticationTests
             return new TestApplication(app, client);
         }
 
-        public Task SendAndAssert(string url, Func<HttpResponseMessage, Task> assert)
-        {
-            return SendAndAssert(url, null, null, assert);
-        }
-
         public async Task SendAndAssert(string url, string? username, string? password, Func<HttpResponseMessage, Task> assert)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -267,7 +262,6 @@ public sealed class HttpBasicAuthenticationTests
         }
     }
 
-#nullable enable
     private sealed class InMemoryIdentityUserStore : IUserPasswordStore<IdentityUser>
     {
         private readonly List<IdentityUser> _users;
@@ -366,5 +360,4 @@ public sealed class HttpBasicAuthenticationTests
             return Task.FromResult(IdentityResult.Success);
         }
     }
-    #nullable restore
 }


### PR DESCRIPTION
## Finding

Two pieces of dead weight in `HttpBasicAuthenticationTests.cs`:

1. **`SendAndAssert(string url, Func<HttpResponseMessage, Task> assert)`** (`:228-231`) — the two-parameter overload has no callers. Every one of the eight call sites uses the four-parameter form.

2. **`#nullable enable` (`:270`) / `#nullable restore` (`:369`)** around `InMemoryIdentityUserStore` — redundant. The repo enabled nullable for the AspNetCore test projects in 6d7eab3d3 ("Enable nullable in AspNetCore tests"), and the surrounding file already relies on it. The `#nullable restore` was also indented inconsistently with its matching `#nullable enable`.

Small maintainability drag. The directives in particular suggest a constraint that no longer exists, and would make the next person hesitate before touching them.

## Verification

Confirmed the directives are genuinely no-ops rather than load-bearing before removing them — the effective MSBuild property resolves to `enable` for this project:

```
$ dotnet msbuild ...Tests.csproj -getProperty:Nullable -p:TargetFramework=net10.0
enable
```

So `#nullable enable` matched the project default and `#nullable restore` restored it to the same value.

Build and suite green on both target frameworks with `/p:TreatsWarningsAsErrors=true`: **16 passed**, no new warnings. `dotnet run ./eng/update-all.cs` reports no changes.

Note: this touches the same file as #2753, so whichever merges second needs a trivial rebase — the two edit different regions.
