### PR TITLE
Parse enums with the non-generic Enum.TryParse instead of reflection

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -27,18 +27,8 @@ namespace Meziantou.Framework;
 /// </summary>
 public class DefaultConverter : IConverter
 {
-    private static readonly MethodInfo EnumTryParseMethodInfo = GetEnumTryParseMethodInfo();
-
     /// <summary>Gets or sets the format to use when converting byte arrays to strings.</summary>
     public ByteArrayToStringFormat ByteArrayToStringFormat { get; set; } = ByteArrayToStringFormat.Base64;
-
-    private static MethodInfo GetEnumTryParseMethodInfo()
-    {
-        // Enum.TryParse<T>(string value, bool ignoreCase, out T value)
-        return typeof(Enum)
-            .GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .First(m => string.Equals(m.Name, nameof(Enum.TryParse), StringComparison.Ordinal) && m.IsGenericMethod && m.GetParameters().Length == 3);
-    }
 
     /// <summary>Attempts to convert an input value to the specified type.</summary>
     /// <param name="input">The value to convert.</param>
@@ -125,15 +115,6 @@ public class DefaultConverter : IConverter
             return string.IsNullOrWhiteSpace(s);
 
         return false;
-    }
-
-    private static bool EnumTryParse(Type type, string? input, out object? value)
-    {
-        var mi = EnumTryParseMethodInfo.MakeGenericMethod(type);
-        object?[] args = [input, true, Enum.ToObject(type, 0)];
-        var b = (bool)mi.Invoke(null, args)!;
-        value = args[2];
-        return b;
     }
 
     private static string ToHexa(byte[]? bytes)
@@ -294,7 +275,7 @@ public class DefaultConverter : IConverter
     /// <returns><see langword="true"/> if the conversion succeeded; otherwise, <see langword="false"/>.</returns>
     protected virtual bool TryConvertEnum(object? input, Type conversionType, IFormatProvider? provider, out object? value)
     {
-        return EnumTryParse(conversionType, Convert.ToString(input, provider), out value);
+        return Enum.TryParse(conversionType, Convert.ToString(input, provider), ignoreCase: true, out value);
     }
 
     /// <summary>Converts a string to a byte array, supporting Base64 and hexadecimal formats.</summary>

--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -41,20 +41,6 @@ public class DefaultConverter : IConverter
         return TryConvert(input, conversionType, provider, out value);
     }
 
-    private static byte GetHexaByte(char c)
-    {
-        if (c is >= '0' and <= '9')
-            return (byte)(c - '0');
-
-        if (c is >= 'A' and <= 'F')
-            return (byte)(c - 'A' + 10);
-
-        if (c is >= 'a' and <= 'f')
-            return (byte)(c - 'a' + 10);
-
-        return 0xFF;
-    }
-
     private static bool NormalizeHexString(ref string? s)
     {
         if (s is null)

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
@@ -82,6 +82,78 @@ public class DefaultConverterTests_StringTo
         Assert.Equal(SampleEnum.Option1 | SampleEnum.Option2, value);
     }
 
+    private enum ByteEnum : byte
+    {
+        None = 0,
+        First = 1,
+        Max = 255,
+    }
+
+    private enum LongEnum : long
+    {
+        None = 0,
+        Big = 4294967296L,
+    }
+
+    [Theory]
+    [InlineData("Option1")]
+    [InlineData("option1")]
+    [InlineData("OPTION1")]
+    public void TryConvert_StringToEnum_IsCaseInsensitive(string text)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out SampleEnum value);
+        Assert.True(converted);
+        Assert.Equal(SampleEnum.Option1, value);
+    }
+
+    // Enums whose underlying type is not Int32 must round-trip through the same path
+    [Fact]
+    public void TryConvert_StringToEnum_NonInt32UnderlyingType()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        Assert.True(converter.TryChangeType("Max", cultureInfo, out ByteEnum byteValue));
+        Assert.Equal(ByteEnum.Max, byteValue);
+
+        Assert.True(converter.TryChangeType("255", cultureInfo, out ByteEnum byteFromNumber));
+        Assert.Equal(ByteEnum.Max, byteFromNumber);
+
+        Assert.True(converter.TryChangeType("Big", cultureInfo, out LongEnum longValue));
+        Assert.Equal(LongEnum.Big, longValue);
+
+        Assert.True(converter.TryChangeType("4294967296", cultureInfo, out LongEnum longFromNumber));
+        Assert.Equal(LongEnum.Big, longFromNumber);
+    }
+
+    [Theory]
+    [InlineData("NotAnOption")]
+    [InlineData("")]
+    [InlineData("Option1, NotAnOption")]
+    public void TryConvert_StringToEnum_InvalidValue(string text)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out SampleEnum value);
+        Assert.False(converted);
+        Assert.Equal(default, value);
+    }
+
+    [Fact]
+    public void TryConvert_StringToNullableEnum()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        Assert.True(converter.TryChangeType("Option2", cultureInfo, out SampleEnum? value));
+        Assert.Equal(SampleEnum.Option2, value);
+
+        Assert.True(converter.TryChangeType("", cultureInfo, out SampleEnum? empty));
+        Assert.Null(empty);
+    }
+
     [Fact]
     public void TryConvert_StringToNullableLong()
     {


### PR DESCRIPTION
Every enum conversion built a generic method with reflection and invoked it.

## What it was doing

`EnumTryParse` called `MakeGenericMethod(type)` and `MethodInfo.Invoke` on **every** conversion, with no cache, plus an `Enum.ToObject` boxing allocation and an `object?[]` for the arguments — all to emulate `Enum.TryParse<T>(string, bool, out T)`, which had a non-generic sibling this could have called directly since .NET Core 2.0:

```csharp
private static readonly MethodInfo EnumTryParseMethodInfo = GetEnumTryParseMethodInfo();

private static MethodInfo GetEnumTryParseMethodInfo()
    => typeof(Enum).GetMethods(BindingFlags.Public | BindingFlags.Static)
        .First(m => string.Equals(m.Name, nameof(Enum.TryParse), StringComparison.Ordinal) && m.IsGenericMethod && m.GetParameters().Length == 3);

private static bool EnumTryParse(Type type, string? input, out object? value)
{
    var mi = EnumTryParseMethodInfo.MakeGenericMethod(type);
    object?[] args = [input, true, Enum.ToObject(type, 0)];
    var b = (bool)mi.Invoke(null, args)!;
    value = args[2];
    return b;
}
```

## What changed

The whole apparatus — the cached `MethodInfo`, its factory, and the helper — is replaced by one call:

```csharp
return Enum.TryParse(conversionType, Convert.ToString(input, provider), ignoreCase: true, out value);
```

Net effect: 21 lines removed, 1 added.

Beyond the allocations, this drops a `MakeGenericMethod` call. That API is annotated `RequiresDynamicCode`, so removing it is a small step toward the package being AOT-friendly should you ever want to flip `IsTrimmable`.

## On the performance claim

The review that found this quoted "~500× slower", measured as 1096 ms vs 2 ms for 200k conversions. **That figure was inflated** — it came from a loop with no warm-up, so it charged JIT and first-call reflection setup to the reflection implementation. With a 10,000-iteration warm-up and the same harness on the same machine:

```
OLD (reflection):     206 ms / 412 ms / 137 ms   for 200k conversions
NEW (Enum.TryParse):   70 ms /  25 ms /  32 ms
```

So roughly **4–5× faster**, not 500×. The variance is high because this machine was running several other builds; these are Debug-mode microbenchmark numbers, not a rigorous benchmark, and the honest summary is "meaningfully faster and allocates less" rather than a specific multiple. The structural argument — two fewer allocations per call and no dynamic code generation — does not depend on the timing at all.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **132 passed, 0 failed** (was 116; 8 new cases per target framework, net10.0 and net11.0).

This is a pure refactor, so the meaningful check is not that the new tests pass — it is that they pass **against both implementations**. I ran the new test file against the old reflection-based `DefaultConverter.cs` as well: 132 passed, 0 failed there too. That pins the equivalence rather than just the new behaviour.

The new tests cover the parts where the two implementations could plausibly diverge: case-insensitive matching, enums whose underlying type is not `Int32` (`byte` and `long` backed, by name and by number), invalid values including an empty string and a partially-valid flags list, and nullable enums. One behavioural detail worth naming: on failure the old helper left the zero-valued enum in `value` while `Enum.TryParse` leaves `null`. That is unobservable — the caller overwrites `value` on every path after `TryConvertEnum` returns `false` — and the invalid-value tests assert the caller-visible result is still `default`.

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — everything removed was private.

Found by a project review of `Meziantou.Framework.TypeConverter`.


---

## Follow-up commit: removing `GetHexaByte`

CI failed on the first push with `error IDE0051: Private member 'DefaultConverter.GetHexaByte' is unused`, and the cause is worth explaining because it looks unrelated to this PR.

`GetHexaByte` is **pre-existing dead code** — `git grep` finds only its declaration, on `main` as well as here. It was not flagged before because Roslyn's unused-member analyzer conservatively disables itself for a type when it sees the type reflecting over members, and `GetEnumTryParseMethodInfo`'s `typeof(Enum).GetMethods(...)` was doing exactly that. Removing the reflection removed the suppression, and the analyzer immediately reported a method that had been dead all along.

Verified locally with the configuration CI uses, which is the only one that surfaces `IDExxxx` rules:

```
git switch origin/main && dotnet build …/Meziantou.Framework.TypeConverter.csproj -c Release /p:IsOfficialBuild=true   → Build succeeded
git switch this-branch  && dotnet build …/Meziantou.Framework.TypeConverter.csproj -c Release /p:IsOfficialBuild=true   → IDE0051
```

That is also why my local verification missed it: the `dotnet test` runs in the original description are Debug builds, where these rules do not run.

The second commit deletes the 11-line method. Suppressing the rule instead would have meant keeping dead code to preserve an accidental suppression. Re-verified in the CI configuration: `Build succeeded` for both the library and the test project, `ref/` unchanged, `dotnet run ./eng/update-all.cs` clean, and 132 tests still passing.
