### PR TITLE
Remove the unreachable UriFormatException handlers and document the match timeout

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -297,6 +297,7 @@ public sealed class UrlPattern
     /// <see href="https://urlpattern.spec.whatwg.org/#dom-urlpattern-test">WHATWG URL Pattern Spec - test method</see>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/test">MDN - URLPattern.test()</see>
     /// </remarks>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public bool IsMatch(string url)
     {
@@ -307,28 +308,23 @@ public sealed class UrlPattern
     /// <param name="url">The URL string to test.</param>
     /// <param name="baseUrl">The base URL to use for resolving relative URLs.</param>
     /// <returns><see langword="true"/> if the pattern matches the URL; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public bool IsMatch(string url, string? baseUrl)
     {
         ArgumentNullException.ThrowIfNull(url);
 
-        try
-        {
-            var uri = ParseUrl(url, baseUrl);
-            if (uri is null)
-                return false;
-
-            return IsMatchUrl(uri);
-        }
-        catch (UriFormatException)
-        {
+        var uri = ParseUrl(url, baseUrl);
+        if (uri is null)
             return false;
-        }
+
+        return IsMatchUrl(uri);
     }
 
     /// <summary>Indicates whether the pattern finds a match in the specified URL.</summary>
     /// <param name="url">The URL to test.</param>
     /// <returns><see langword="true"/> if the pattern matches the URL; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public bool IsMatch(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -338,6 +334,7 @@ public sealed class UrlPattern
     /// <summary>Indicates whether the pattern finds a match in the specified URL input.</summary>
     /// <param name="input">The URL input dictionary to test.</param>
     /// <returns><see langword="true"/> if the pattern matches the input; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public bool IsMatch(UrlPatternInit input)
     {
         ArgumentNullException.ThrowIfNull(input);
@@ -352,6 +349,7 @@ public sealed class UrlPattern
     /// <see href="https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec">WHATWG URL Pattern Spec - exec method</see>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/exec">MDN - URLPattern.exec()</see>
     /// </remarks>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public UrlPatternResult? Match(string url)
     {
@@ -362,28 +360,23 @@ public sealed class UrlPattern
     /// <param name="url">The URL string to match.</param>
     /// <param name="baseUrl">The base URL to use for resolving relative URLs.</param>
     /// <returns>A <see cref="UrlPatternResult"/> containing the match result, or <see langword="null"/> if no match.</returns>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public UrlPatternResult? Match(string url, string? baseUrl)
     {
         ArgumentNullException.ThrowIfNull(url);
 
-        try
-        {
-            var uri = ParseUrl(url, baseUrl);
-            if (uri is null)
-                return null;
-
-            return MatchUrl(uri, url);
-        }
-        catch (UriFormatException)
-        {
+        var uri = ParseUrl(url, baseUrl);
+        if (uri is null)
             return null;
-        }
+
+        return MatchUrl(uri, url);
     }
 
     /// <summary>Searches the specified URL for the first occurrence of the pattern and returns the match result with captured groups.</summary>
     /// <param name="url">The URL to match.</param>
     /// <returns>A <see cref="UrlPatternResult"/> containing the match result, or <see langword="null"/> if no match.</returns>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public UrlPatternResult? Match(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -393,6 +386,7 @@ public sealed class UrlPattern
     /// <summary>Searches the specified URL input for the first occurrence of the pattern and returns the match result with captured groups.</summary>
     /// <param name="input">The URL input dictionary to match.</param>
     /// <returns>A <see cref="UrlPatternResult"/> containing the match result, or <see langword="null"/> if no match.</returns>
+    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public UrlPatternResult? Match(UrlPatternInit input)
     {
         ArgumentNullException.ThrowIfNull(input);

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -810,6 +810,28 @@ public sealed class UrlPatternTests
         Assert.False(pattern.IsMatch("not-a-valid-url"));
     }
 
+    [Theory]
+    [InlineData("not-a-valid-url")]
+    [InlineData("::::")]
+    [InlineData("http://[/")]
+    [InlineData("")]
+    public void MatchAndIsMatch_WithUnparsableUrl_ReportNoMatch(string url)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/path" });
+
+        Assert.False(pattern.IsMatch(url));
+        Assert.Null(pattern.Match(url));
+    }
+
+    [Fact]
+    public void MatchAndIsMatch_WithUnparsableBaseUrl_ReportNoMatch()
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/path" });
+
+        Assert.False(pattern.IsMatch("/path", "not-a-valid-base"));
+        Assert.Null(pattern.Match("/path", "not-a-valid-base"));
+    }
+
     // File URLs
     [Fact]
     public void IsMatch_FileProtocol()


### PR DESCRIPTION
`IsMatch(string, string?)` and `Match(string, string?)` each wrapped their body in `try { … } catch (UriFormatException) { return false/null; }`. Nothing inside can throw it: the only parsing is `ParseUrl`, which uses `Uri.TryCreate` and returns `null` on failure rather than throwing. Both catches were unreachable.

Meanwhile the exception these methods *can* throw was undocumented. Components are compiled with a one-second match timeout (`UrlPatternComponent.cs:56`), so `RegexMatchTimeoutException` propagates out of every matching method — and a `UrlPatternCollection` over *n* patterns can spend up to `n × 8` seconds of matching before one surfaces.

## What changed

- Both dead `try`/`catch` blocks are gone. Unparsable input still reports no match, because `ParseUrl` already returns `null` for it — that path is unchanged.
- Every public `IsMatch`/`Match` overload gains an `<exception cref="RegexMatchTimeoutException">` tag.

On the timeout itself this keeps the current behaviour — it propagates — rather than swallowing it as `false` or rewrapping it as `UrlPatternException`. Turning a timeout into `false` would silently report "no match" for a pattern that was merely slow, and rewrapping it would be a breaking change for anyone already catching it. Documenting it is the smallest honest option; say the word if you would rather it be caught.

## Verification

Six new cases in `UrlPatternTests`:

- `MatchAndIsMatch_WithUnparsableUrl_ReportNoMatch` — four theory cases (`not-a-valid-url`, `::::`, `http://[/`, empty) through both `IsMatch` and `Match`, confirming the removed catch was not load-bearing.
- `MatchAndIsMatch_WithUnparsableBaseUrl_ReportNoMatch` — same for an unparsable base URL.

The existing `IsMatch_WithInvalidUrl_ShouldReturnFalse` is kept as-is.

Full suite: 538 passed, 0 failed, both target frameworks, no warnings. `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `src/Meziantou.Framework.Uri`.
