### PR TITLE
Keep Hangul syllables and dangling combining marks whole when truncating

### DIFF
--- a/src/Meziantou.Framework.Slug/Slug.cs
+++ b/src/Meziantou.Framework.Slug/Slug.cs
@@ -14,6 +14,15 @@ public static class Slug
     /// <summary>The number of UTF-16 characters needed to encode any single rune.</summary>
     private const int MaxUtf16CharsPerRune = 2;
 
+    // A Hangul syllable decomposes into a leading jamo, a vowel jamo and an optional trailing jamo. Those are
+    // letters rather than marks, so the mark test alone does not recognize them as part of the same character.
+    private const int HangulLeadingJamoFirst = 0x1100;
+    private const int HangulLeadingJamoLast = 0x1112;
+    private const int HangulVowelJamoFirst = 0x1161;
+    private const int HangulVowelJamoLast = 0x1175;
+    private const int HangulTrailingJamoFirst = 0x11A8;
+    private const int HangulTrailingJamoLast = 0x11C2;
+
     /// <summary>Creates a slug from the specified text using default options.</summary>
     /// <param name="text">The text to convert to a slug.</param>
     /// <returns>A slug generated from the input text, or <see langword="null"/> if <paramref name="text"/> is <see langword="null"/>.</returns>
@@ -92,10 +101,17 @@ public static class Slug
         var usesDefaultReplace = options.UsesDefaultReplace;
         Span<char> transformed = stackalloc char[MaxUtf16CharsPerRune];
         var characterStart = 0;
+        var previousRuneWasHangulJamo = false;
 
         foreach (var rune in text.EnumerateRunes())
         {
             var isCombiningMark = Rune.GetUnicodeCategory(rune) is UnicodeCategory.NonSpacingMark or UnicodeCategory.SpacingCombiningMark or UnicodeCategory.EnclosingMark;
+
+            // Everything that composes back into the character before it has to travel with it, so that the
+            // maximum length only ever cuts between characters.
+            var continuesCharacter = isCombiningMark || (previousRuneWasHangulJamo && IsHangulSyllableContinuation(rune));
+            var appended = false;
+
             if (options.IsAllowed(rune))
             {
                 // Append the replacement atomically, so the maximum length can never split a
@@ -112,16 +128,25 @@ public static class Slug
                     replacement = options.Replace(rune);
                 }
 
-                // A combining mark belongs to the character before it, so only a rune that is not one
-                // starts a new character.
-                if (!isCombiningMark)
+                // A continuation belongs to the character before it, so only a rune that is not one starts
+                // a new character.
+                if (!continuesCharacter)
+                {
                     characterStart = sb.Length;
+                }
+                else if (characterStart == sb.Length)
+                {
+                    // Nothing was written for the current character, so this continuation has no base to attach
+                    // to and would leave a floating accent or a bare jamo at the start of the slug or right
+                    // after a separator. Drop it, the way a disallowed character's marks are dropped below.
+                    continue;
+                }
 
                 if (sb.Length + replacement.Length > budget)
                 {
-                    // Keeping a base character while dropping the mark that follows it would silently
-                    // strip the accent off the last character of the slug. Drop the character instead.
-                    if (isCombiningMark)
+                    // Keeping a base character while dropping what follows it would silently strip the accent
+                    // off the last character of the slug, or cut a syllable in half. Drop the character instead.
+                    if (continuesCharacter)
                         sb.Length = characterStart;
 
                     trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
@@ -129,11 +154,13 @@ public static class Slug
                 }
 
                 sb.Append(replacement);
+                appended = true;
             }
             else if (!isCombiningMark)
             {
-                // Combining marks attached to a disallowed character are dropped silently instead of
-                // producing a separator. A slug never starts with a separator, and separators are never repeated.
+                // A disallowed combining mark is dropped rather than emitting a separator, because it is part of
+                // the character before it and not a word boundary.
+                // A slug never starts with a separator, and separators are never repeated.
                 if (sb.Length == 0 || EndsWithEmittedSeparator(sb, lastSeparatorStart, separator))
                     continue;
 
@@ -147,10 +174,27 @@ public static class Slug
                 sb.Append(separator);
                 characterStart = sb.Length;
             }
+
+            previousRuneWasHangulJamo = appended && IsHangulJamo(rune);
         }
 
         trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
         return true;
+    }
+
+    /// <summary>Determines whether the rune is one of the Hangul jamo a syllable decomposes into.</summary>
+    private static bool IsHangulJamo(Rune rune)
+    {
+        return rune.Value is (>= HangulLeadingJamoFirst and <= HangulLeadingJamoLast)
+            or (>= HangulVowelJamoFirst and <= HangulVowelJamoLast)
+            or (>= HangulTrailingJamoFirst and <= HangulTrailingJamoLast);
+    }
+
+    /// <summary>Determines whether the rune continues the Hangul syllable started by the jamo before it.</summary>
+    private static bool IsHangulSyllableContinuation(Rune rune)
+    {
+        return rune.Value is (>= HangulVowelJamoFirst and <= HangulVowelJamoLast)
+            or (>= HangulTrailingJamoFirst and <= HangulTrailingJamoLast);
     }
 
     /// <summary>Determines whether <paramref name="sb"/> ends with the separator emitted at <paramref name="lastSeparatorStart"/>.</summary>

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -92,6 +92,62 @@ public class SlugTests
         Assert.Equal("hello-world-this-is-long", slug);
     }
 
+    [Theory]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    [InlineData(1, "")]
+    [InlineData(2, "\uAC00")]
+    [InlineData(3, "\uAC00")]
+    [InlineData(4, "\uAC00\uAC01")]
+    [InlineData(5, "\uAC00\uAC01\uAC02")]
+    public void Slug_MaximumLength_DoesNotSplitHangulSyllables(int maximumLength, string expected)
+    {
+        var options = new SlugOptions { MaximumLength = maximumLength };
+        options.AllowedRanges.Clear();
+
+        var slug = Slug.Create("\uAC00\uAC01\uAC02", options);
+
+        Assert.Equal(expected, slug);
+    }
+
+    [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void Slug_MaximumLength_NeverLeavesALoneHangulJamo()
+    {
+        string[] texts = ["\uD55C\uAD6D\uC5B4 \uC81C\uBAA9", "\uAC00\uAC01\uAC02", "a\uAC00b\uAC01", "\uD55C a \uAD6D"];
+        foreach (var text in texts)
+        {
+            foreach (var separator in new[] { "-", "__", "" })
+            {
+                for (var maximumLength = 1; maximumLength <= 20; maximumLength++)
+                {
+                    var options = new SlugOptions { MaximumLength = maximumLength, Separator = separator };
+                    options.AllowedRanges.Clear();
+
+                    var slug = Slug.Create(text, options);
+
+                    Assert.DoesNotContain(slug, c => c is >= '\u1100' and <= '\u11FF');
+                }
+            }
+        }
+    }
+
+    [Theory]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    [InlineData("!\u0301b", "b")]
+    [InlineData("\u0301abc", "abc")]
+    [InlineData("!\u0301", "")]
+    [InlineData("\u20AC\u0301x", "x")]
+    [InlineData("a\u0301b", "\u00E1b")]
+    public void Slug_AllowedCombiningMark_WithNoBaseCharacter_IsDropped(string text, string expected)
+    {
+        var options = new SlugOptions();
+        options.AllowedRanges.Add(UnicodeRange.Create('\u0300', '\u036F'));
+
+        var slug = Slug.Create(text, options);
+
+        Assert.Equal(expected, slug);
+    }
+
     [Fact]
     public void Slug_Separator_CannotBeSetToNull()
     {


### PR DESCRIPTION
> **Stack 2 of 4 · base `fix/slug-separator-tracking` (#2757) · merge after #2757.**

`MaximumLength` promises a slug "is only cut between characters". The guard that enforces that was written in terms of Unicode Mark categories, which does not cover everything that composes back into the character before it.

## 1. Hangul syllables were split, leaving a bare jamo

NFD decomposes a Hangul syllable into a leading jamo, a vowel jamo and an optional trailing jamo. Those are `UnicodeCategory.OtherLetter`, not marks — verified for U+1100, U+1161 and U+11A8 — so `isCombiningMark` was false, `characterStart` never grouped the syllable, and the limit cut it in half:

```csharp
Slug.Create("한국어 제목", new SlugOptions { MaximumLength = 5 });  // "한국어 ᄌ"  - a bare initial consonant
Slug.Create("가각갂", new SlugOptions { MaximumLength = 3 });        // "가각ᄀ"
```

(with `AllowedRanges` cleared or widened to cover Hangul). The recovery loop could not rescue it either: composing a lone `ᄀ` reclaims nothing, so `recovered == 0` and the loop broke immediately. Unlike the merely-short results elsewhere, this ends the slug in a character the user never typed.

The existing suite does exercise `"가각갂"`, but only asserts length and NFC-ness, so it passed.

## 2. A slug could begin with a floating accent

With combining marks allowed but the base character before them not, the mark was appended with nothing to attach to, and `Normalize(FormC)` had no starter to compose it into:

```csharp
options.AllowedRanges.Add(UnicodeRange.Create('̀', 'ͯ'));
Slug.Create("!́b", options);   // "́b" - starts with a floating COMBINING ACUTE ACCENT
Slug.Create("€́x", options); // "́x"
```

The code already guarantees the analogous case for separators ("a slug never starts with a separator") but said nothing about marks. A leading combining mark renders as a floating accent and is a known homograph vector in URLs.

## What changed

`isCombiningMark` is replaced, for the purposes of character grouping, by `continuesCharacter`:

```csharp
var continuesCharacter = isCombiningMark || (previousRuneWasHangulJamo && IsHangulSyllableContinuation(rune));
```

A vowel or trailing jamo only ever follows another jamo, so "the previous rune was a jamo" is enough to recognize a mid-syllable position without tracking which part of the syllable is expected next. The existing `sb.Length = characterStart` rollback is reused unchanged, so a syllable that does not fit is dropped whole rather than truncated.

The dangling-continuation case falls out of the same bookkeeping: when `characterStart == sb.Length`, nothing has been written for the current character, so a continuation has no base — at the start of the buffer or straight after a separator — and is dropped, exactly as a disallowed character's marks already were.

The disallowed branch still keys on `isCombiningMark`, so a disallowed jamo emits a separator as before; only the allowed path changed.

Also fixes the comment at `Slug.cs:122-125` (finding L6), which claimed marks are dropped only when "attached to a disallowed character". The guard is `else if (!isCombiningMark)`, so it drops *every* disallowed mark — including one following an allowed base, which is how `Slug.Create("testé")` produces `"teste"`.

## Verification

| input | limit | before | after |
|---|---|---|---|
| `"한국어 제목"` | 5 | `"한국어 ᄌ"` | `"한국어 "` |
| `"가각갂"` | 3 | `"가각ᄀ"` | `"가각"`* |
| `"!́b"` | — | `"́b"` | `"b"` |

\* shown at limit 4; limit 3 now yields `"가"` — see the sweep below.

- **Lone-jamo sweep: 0 results.** 4 Korean inputs × 3 separators × limits 1–20, asserting no `U+1100..U+11FF` survives. Added as a test.
- Combining-mark behavior is unchanged: `"éééé"` still yields 0/1/2/3/4 characters at limits 1–5, identical to before.
- Monotonicity fuzz: still 0 violations in 30,000 cases.
- `dotnet test -c Release /p:TreatsWarningsAsErrors=true` — 146/146 across net10.0 and net11.0.

Found by a project review of `Meziantou.Framework.Slug` (findings M1, L2, L6).
