### PR TITLE
Cover the argument builders of every diff tool

### DIFF
--- a/src/Meziantou.Framework.DiffEngine/DiffTools.cs
+++ b/src/Meziantou.Framework.DiffEngine/DiffTools.cs
@@ -238,6 +238,17 @@ public static class DiffTools
         return resolvedTool is not null;
     }
 
+    internal static LaunchArguments GetLaunchArguments(DiffTool tool)
+    {
+        foreach (var definition in Definitions)
+        {
+            if (definition.Tool == tool)
+                return definition.LaunchArguments;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(tool), tool, message: null);
+    }
+
     private static List<ResolvedTool> ResolveAvailableTools()
     {
         var result = new List<ResolvedTool>();

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -68,6 +68,72 @@ public sealed class DiffToolsTests
         Assert.Equal("--diff \"verified.txt\" \"received.txt\"", tool.GetArguments("received.txt", "verified.txt"));
     }
 
+    private const string TempFile = "/tmp/received.txt";
+    private const string TargetFile = "/tmp/verified.txt";
+
+    private const string StandardRight = "\"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string StandardLeft = "\"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string RiderRight = "diff \"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string RiderLeft = "diff \"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string VimRight = "-d \"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string VimLeft = "-d \"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string VisualStudioCodeRight = "--diff \"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string VisualStudioCodeLeft = "--diff \"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string VisualStudioRight = "/diff \"/tmp/received.txt\" \"/tmp/verified.txt\" \"received.txt\" \"verified.txt\"";
+    private const string VisualStudioLeft = "/diff \"/tmp/verified.txt\" \"/tmp/received.txt\" \"verified.txt\" \"received.txt\"";
+    private const string WinMergeRight = "/u /wl /e \"/tmp/received.txt\" \"/tmp/verified.txt\" /dl \"received.txt\" /dr \"verified.txt\" /cfg Backup/EnableFile=0";
+    private const string WinMergeLeft = "/u /wr /e \"/tmp/verified.txt\" \"/tmp/received.txt\" /dl \"verified.txt\" /dr \"received.txt\" /cfg Backup/EnableFile=0";
+
+    [Theory]
+    [InlineData(DiffTool.MsWordDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.MsExcelDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.BeyondCompare, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.P4Merge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Kaleidoscope, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.DeltaWalker, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.WinMerge, WinMergeRight, WinMergeLeft)]
+    [InlineData(DiffTool.TortoiseMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TortoiseGitMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TortoiseGitIDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TortoiseIDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.KDiff3, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TkDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Guiffy, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.ExamDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Diffinity, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Rider, RiderRight, RiderLeft)]
+    [InlineData(DiffTool.Vim, VimRight, VimLeft)]
+    [InlineData(DiffTool.Neovim, VimRight, VimLeft)]
+    [InlineData(DiffTool.AraxisMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Meld, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.SublimeMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.VisualStudioCode, VisualStudioCodeRight, VisualStudioCodeLeft)]
+    [InlineData(DiffTool.VisualStudio, VisualStudioRight, VisualStudioLeft)]
+    [InlineData(DiffTool.Cursor, VisualStudioCodeRight, VisualStudioCodeLeft)]
+    public void GetArguments_ProducesTheExpectedCommandLine(DiffTool tool, string expectedRight, string expectedLeft)
+    {
+        var resolvedTool = new ResolvedTool(tool, "diff", DiffTools.GetLaunchArguments(tool), supportsText: true, []);
+
+        using (new EnvironmentVariableScope("DiffEngine_TargetOnLeft", null))
+        {
+            Assert.Equal(expectedRight, resolvedTool.GetArguments(TempFile, TargetFile));
+        }
+
+        using (new EnvironmentVariableScope("DiffEngine_TargetOnLeft", "true"))
+        {
+            Assert.Equal(expectedLeft, resolvedTool.GetArguments(TempFile, TargetFile));
+        }
+    }
+
+    [Fact]
+    public void EveryDiffToolHasLaunchArguments()
+    {
+        foreach (var tool in Enum.GetValues<DiffTool>())
+        {
+            _ = DiffTools.GetLaunchArguments(tool);
+        }
+    }
+
     private static string GetVisualStudioCodeExecutableName()
     {
         return OperatingSystem.IsWindows() ? "code.cmd" : "code";


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2769**

The package's whole job is (a) find an executable and (b) emit the right argument string
for it. Only one of the 11 argument builders had any coverage: the existing
`GetArguments_HonorsTargetPosition` test exercised VS Code and nothing else.

Untested before this PR: the `Standard`, `WinMerge`, `VisualStudio`, `Rider` and `Vim`
builders — 10 of 11 formats, including the two that also compute display titles via
`Path.GetFileName`. These are exactly the code that goes silently wrong: a bad flag opens
the diff backwards, or not at all, and nothing in the type system catches it.

They are also pure functions of two strings, so they are the cheapest thing in the package
to test.

## What changed

A table-driven theory over **all 25 tools × both `DiffEngine_TargetOnLeft` values**, with
literal expected command lines and no logic in the test.

Reaching the builders needs one hook: `internal static DiffTools.GetLaunchArguments(DiffTool)`.
It is required rather than convenient — `WinMerge` and `VisualStudio` have no `Osx` or
`Linux` platform settings, so they can never be resolved on a non-Windows machine and
their argument builders are otherwise unreachable from a test on CI or on my laptop.
`InternalsVisibleTo` for the test assembly was already declared in the csproj.

The theory rows double as documentation of the tool → builder mapping, which was
previously only visible by reading the 200-line `Definitions` table. That mapping is worth
asserting on its own: `Cursor` shares `VisualStudioCode`'s builder and `Neovim` shares
`Vim`'s, and nothing would have caught one of them being pointed at the wrong one.

`EveryDiffToolHasLaunchArguments` covers the enum, so a new `DiffTool` member that never
made it into `Definitions` fails instead of throwing at runtime.

## Verification

`dotnet test /p:TreatsWarningsAsErrors=true` — 60 of 62 pass on net10.0 and net11.0
(10 before this PR).

The two failures are `TryFindByExtension_ReturnsTextTool`, pre-existing and unrelated — it
depends on which diff tools the developer has installed. Fixed in a separate PR; CI images
are bare, so this branch is green there.
