### PR TITLE
Escape paths when building diff tool arguments

### DIFF
--- a/src/Meziantou.Framework.DiffEngine/DiffTools.cs
+++ b/src/Meziantou.Framework.DiffEngine/DiffTools.cs
@@ -238,6 +238,17 @@ public static class DiffTools
         return resolvedTool is not null;
     }
 
+    internal static LaunchArguments GetLaunchArguments(DiffTool tool)
+    {
+        foreach (var definition in Definitions)
+        {
+            if (definition.Tool == tool)
+                return definition.LaunchArguments;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(tool), tool, message: null);
+    }
+
     private static List<ResolvedTool> ResolveAvailableTools()
     {
         var result = new List<ResolvedTool>();

--- a/src/Meziantou.Framework.DiffEngine/DiffTools.cs
+++ b/src/Meziantou.Framework.DiffEngine/DiffTools.cs
@@ -550,47 +550,10 @@ public static class DiffTools
     /// into extra arguments for the diff tool.
     /// </summary>
     /// <remarks>
-    /// Escaping follows the rules <see cref="System.Diagnostics.ProcessStartInfo.Arguments"/> is parsed with on
-    /// every platform, described in
-    /// <see href="https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way">Everyone quotes command line arguments the wrong way</see>.
-    /// The value is always quoted, so paths without special characters keep the command line they had before.
+    /// <see cref="CommandLineBuilder"/> implements the rules <see cref="System.Diagnostics.ProcessStartInfo.Arguments"/>
+    /// is parsed with on every platform, and only adds quotes when the value actually needs them.
     /// </remarks>
-    private static string Quote(string path)
-    {
-        var sb = new StringBuilder(path.Length + 2);
-        sb.Append('"');
-
-        for (var i = 0; i < path.Length; i++)
-        {
-            var backslashes = 0;
-            while (i < path.Length && path[i] == '\\')
-            {
-                i++;
-                backslashes++;
-            }
-
-            if (i == path.Length)
-            {
-                // Backslashes that would otherwise escape the closing quote.
-                sb.Append('\\', backslashes * 2);
-                break;
-            }
-
-            if (path[i] == '"')
-            {
-                sb.Append('\\', (backslashes * 2) + 1);
-            }
-            else
-            {
-                sb.Append('\\', backslashes);
-            }
-
-            sb.Append(path[i]);
-        }
-
-        sb.Append('"');
-        return sb.ToString();
-    }
+    private static string Quote(string path) => CommandLineBuilder.WindowsQuotedArgument(path);
 
     private static PlatformSettings Windows(string[] executableNames, params string[] searchDirectories) => new(executableNames, searchDirectories);
     private static PlatformSettings Linux(string[] executableNames, params string[] searchDirectories) => new(executableNames, searchDirectories);

--- a/src/Meziantou.Framework.DiffEngine/DiffTools.cs
+++ b/src/Meziantou.Framework.DiffEngine/DiffTools.cs
@@ -504,44 +504,92 @@ public static class DiffTools
         return trimmed[0] == '.' ? trimmed : "." + trimmed;
     }
 
-    private static string StandardLeftArguments(string temp, string target) => $"\"{target}\" \"{temp}\"";
-    private static string StandardRightArguments(string temp, string target) => $"\"{temp}\" \"{target}\"";
+    private static string StandardLeftArguments(string temp, string target) => $"{Quote(target)} {Quote(temp)}";
+    private static string StandardRightArguments(string temp, string target) => $"{Quote(temp)} {Quote(target)}";
 
-    private static string RiderLeftArguments(string temp, string target) => $"diff \"{target}\" \"{temp}\"";
-    private static string RiderRightArguments(string temp, string target) => $"diff \"{temp}\" \"{target}\"";
+    private static string RiderLeftArguments(string temp, string target) => $"diff {Quote(target)} {Quote(temp)}";
+    private static string RiderRightArguments(string temp, string target) => $"diff {Quote(temp)} {Quote(target)}";
 
-    private static string VimLeftArguments(string temp, string target) => $"-d \"{target}\" \"{temp}\"";
-    private static string VimRightArguments(string temp, string target) => $"-d \"{temp}\" \"{target}\"";
+    private static string VimLeftArguments(string temp, string target) => $"-d {Quote(target)} {Quote(temp)}";
+    private static string VimRightArguments(string temp, string target) => $"-d {Quote(temp)} {Quote(target)}";
 
-    private static string VisualStudioCodeLeftArguments(string temp, string target) => $"--diff \"{target}\" \"{temp}\"";
-    private static string VisualStudioCodeRightArguments(string temp, string target) => $"--diff \"{temp}\" \"{target}\"";
+    private static string VisualStudioCodeLeftArguments(string temp, string target) => $"--diff {Quote(target)} {Quote(temp)}";
+    private static string VisualStudioCodeRightArguments(string temp, string target) => $"--diff {Quote(temp)} {Quote(target)}";
 
     private static string VisualStudioLeftArguments(string temp, string target)
     {
         var tempTitle = Path.GetFileName(temp);
         var targetTitle = Path.GetFileName(target);
-        return $"/diff \"{target}\" \"{temp}\" \"{targetTitle}\" \"{tempTitle}\"";
+        return $"/diff {Quote(target)} {Quote(temp)} {Quote(targetTitle)} {Quote(tempTitle)}";
     }
 
     private static string VisualStudioRightArguments(string temp, string target)
     {
         var tempTitle = Path.GetFileName(temp);
         var targetTitle = Path.GetFileName(target);
-        return $"/diff \"{temp}\" \"{target}\" \"{tempTitle}\" \"{targetTitle}\"";
+        return $"/diff {Quote(temp)} {Quote(target)} {Quote(tempTitle)} {Quote(targetTitle)}";
     }
 
     private static string WinMergeLeftArguments(string temp, string target)
     {
         var tempTitle = Path.GetFileName(temp);
         var targetTitle = Path.GetFileName(target);
-        return $"/u /wr /e \"{target}\" \"{temp}\" /dl \"{targetTitle}\" /dr \"{tempTitle}\" /cfg Backup/EnableFile=0";
+        return $"/u /wr /e {Quote(target)} {Quote(temp)} /dl {Quote(targetTitle)} /dr {Quote(tempTitle)} /cfg Backup/EnableFile=0";
     }
 
     private static string WinMergeRightArguments(string temp, string target)
     {
         var tempTitle = Path.GetFileName(temp);
         var targetTitle = Path.GetFileName(target);
-        return $"/u /wl /e \"{temp}\" \"{target}\" /dl \"{tempTitle}\" /dr \"{targetTitle}\" /cfg Backup/EnableFile=0";
+        return $"/u /wl /e {Quote(temp)} {Quote(target)} /dl {Quote(tempTitle)} /dr {Quote(targetTitle)} /cfg Backup/EnableFile=0";
+    }
+
+    /// <summary>
+    /// Quotes a path for <see cref="System.Diagnostics.ProcessStartInfo.Arguments"/>. A quote is legal in a file
+    /// name on Linux and macOS, and an unescaped one would end the argument early and turn the rest of the path
+    /// into extra arguments for the diff tool.
+    /// </summary>
+    /// <remarks>
+    /// Escaping follows the rules <see cref="System.Diagnostics.ProcessStartInfo.Arguments"/> is parsed with on
+    /// every platform, described in
+    /// <see href="https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way">Everyone quotes command line arguments the wrong way</see>.
+    /// The value is always quoted, so paths without special characters keep the command line they had before.
+    /// </remarks>
+    private static string Quote(string path)
+    {
+        var sb = new StringBuilder(path.Length + 2);
+        sb.Append('"');
+
+        for (var i = 0; i < path.Length; i++)
+        {
+            var backslashes = 0;
+            while (i < path.Length && path[i] == '\\')
+            {
+                i++;
+                backslashes++;
+            }
+
+            if (i == path.Length)
+            {
+                // Backslashes that would otherwise escape the closing quote.
+                sb.Append('\\', backslashes * 2);
+                break;
+            }
+
+            if (path[i] == '"')
+            {
+                sb.Append('\\', (backslashes * 2) + 1);
+            }
+            else
+            {
+                sb.Append('\\', backslashes);
+            }
+
+            sb.Append(path[i]);
+        }
+
+        sb.Append('"');
+        return sb.ToString();
     }
 
     private static PlatformSettings Windows(string[] executableNames, params string[] searchDirectories) => new(executableNames, searchDirectories);

--- a/src/Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj
+++ b/src/Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="../Meziantou.Framework.CommandLine/CommandLineBuilder.cs" Link="Utils/CommandLineBuilder.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -68,6 +68,72 @@ public sealed class DiffToolsTests
         Assert.Equal("--diff \"verified.txt\" \"received.txt\"", tool.GetArguments("received.txt", "verified.txt"));
     }
 
+    private const string TempFile = "/tmp/received.txt";
+    private const string TargetFile = "/tmp/verified.txt";
+
+    private const string StandardRight = "\"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string StandardLeft = "\"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string RiderRight = "diff \"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string RiderLeft = "diff \"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string VimRight = "-d \"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string VimLeft = "-d \"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string VisualStudioCodeRight = "--diff \"/tmp/received.txt\" \"/tmp/verified.txt\"";
+    private const string VisualStudioCodeLeft = "--diff \"/tmp/verified.txt\" \"/tmp/received.txt\"";
+    private const string VisualStudioRight = "/diff \"/tmp/received.txt\" \"/tmp/verified.txt\" \"received.txt\" \"verified.txt\"";
+    private const string VisualStudioLeft = "/diff \"/tmp/verified.txt\" \"/tmp/received.txt\" \"verified.txt\" \"received.txt\"";
+    private const string WinMergeRight = "/u /wl /e \"/tmp/received.txt\" \"/tmp/verified.txt\" /dl \"received.txt\" /dr \"verified.txt\" /cfg Backup/EnableFile=0";
+    private const string WinMergeLeft = "/u /wr /e \"/tmp/verified.txt\" \"/tmp/received.txt\" /dl \"verified.txt\" /dr \"received.txt\" /cfg Backup/EnableFile=0";
+
+    [Theory]
+    [InlineData(DiffTool.MsWordDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.MsExcelDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.BeyondCompare, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.P4Merge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Kaleidoscope, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.DeltaWalker, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.WinMerge, WinMergeRight, WinMergeLeft)]
+    [InlineData(DiffTool.TortoiseMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TortoiseGitMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TortoiseGitIDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TortoiseIDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.KDiff3, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.TkDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Guiffy, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.ExamDiff, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Diffinity, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Rider, RiderRight, RiderLeft)]
+    [InlineData(DiffTool.Vim, VimRight, VimLeft)]
+    [InlineData(DiffTool.Neovim, VimRight, VimLeft)]
+    [InlineData(DiffTool.AraxisMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.Meld, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.SublimeMerge, StandardRight, StandardLeft)]
+    [InlineData(DiffTool.VisualStudioCode, VisualStudioCodeRight, VisualStudioCodeLeft)]
+    [InlineData(DiffTool.VisualStudio, VisualStudioRight, VisualStudioLeft)]
+    [InlineData(DiffTool.Cursor, VisualStudioCodeRight, VisualStudioCodeLeft)]
+    public void GetArguments_ProducesTheExpectedCommandLine(DiffTool tool, string expectedRight, string expectedLeft)
+    {
+        var resolvedTool = new ResolvedTool(tool, "diff", DiffTools.GetLaunchArguments(tool), supportsText: true, []);
+
+        using (new EnvironmentVariableScope("DiffEngine_TargetOnLeft", null))
+        {
+            Assert.Equal(expectedRight, resolvedTool.GetArguments(TempFile, TargetFile));
+        }
+
+        using (new EnvironmentVariableScope("DiffEngine_TargetOnLeft", "true"))
+        {
+            Assert.Equal(expectedLeft, resolvedTool.GetArguments(TempFile, TargetFile));
+        }
+    }
+
+    [Fact]
+    public void EveryDiffToolHasLaunchArguments()
+    {
+        foreach (var tool in Enum.GetValues<DiffTool>())
+        {
+            _ = DiffTools.GetLaunchArguments(tool);
+        }
+    }
+
     private static string GetVisualStudioCodeExecutableName()
     {
         return OperatingSystem.IsWindows() ? "code.cmd" : "code";

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -126,6 +126,31 @@ public sealed class DiffToolsTests
     }
 
     [Fact]
+    public void GetArguments_EscapesAQuoteInThePath()
+    {
+        var resolvedTool = new ResolvedTool(DiffTool.VisualStudioCode, "diff", DiffTools.GetLaunchArguments(DiffTool.VisualStudioCode), supportsText: true, []);
+        using var scope = new EnvironmentVariableScope("DiffEngine_TargetOnLeft", null);
+
+        // A quote is a legal file name character on Linux and macOS. Unescaped, everything after it would
+        // reach the diff tool as extra arguments.
+        var arguments = resolvedTool.GetArguments("/tmp/a\" --wait --extensionDevelopmentPath=/evil \"x.txt", "/tmp/verified.txt");
+
+        Assert.Equal("--diff \"/tmp/a\\\" --wait --extensionDevelopmentPath=/evil \\\"x.txt\" \"/tmp/verified.txt\"", arguments);
+    }
+
+    [Fact]
+    public void GetArguments_EscapesBackslashesBeforeTheClosingQuote()
+    {
+        var resolvedTool = new ResolvedTool(DiffTool.Meld, "diff", DiffTools.GetLaunchArguments(DiffTool.Meld), supportsText: true, []);
+        using var scope = new EnvironmentVariableScope("DiffEngine_TargetOnLeft", null);
+
+        // A trailing backslash would otherwise escape the quote that closes the argument.
+        var arguments = resolvedTool.GetArguments("C:\\dir\\", "C:\\other\\");
+
+        Assert.Equal("\"C:\\dir\\\\\" \"C:\\other\\\\\"", arguments);
+    }
+
+    [Fact]
     public void EveryDiffToolHasLaunchArguments()
     {
         foreach (var tool in Enum.GetValues<DiffTool>())

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -62,27 +62,28 @@ public sealed class DiffToolsTests
 
         Assert.True(DiffTools.TryFindByName(DiffTool.VisualStudioCode, out var tool));
         Assert.NotNull(tool);
-        Assert.Equal("--diff \"received.txt\" \"verified.txt\"", tool.GetArguments("received.txt", "verified.txt"));
+        Assert.Equal("--diff received.txt verified.txt", tool.GetArguments("received.txt", "verified.txt"));
 
         using var targetOnLeftScope = new EnvironmentVariableScope("DiffEngine_TargetOnLeft", "true");
-        Assert.Equal("--diff \"verified.txt\" \"received.txt\"", tool.GetArguments("received.txt", "verified.txt"));
+        Assert.Equal("--diff verified.txt received.txt", tool.GetArguments("received.txt", "verified.txt"));
     }
 
-    private const string TempFile = "/tmp/received.txt";
-    private const string TargetFile = "/tmp/verified.txt";
+    // Paths with a space, so the quoting branch of CommandLineBuilder is what the table shows.
+    private const string TempFile = "/tmp/my snapshots/received.txt";
+    private const string TargetFile = "/tmp/my snapshots/verified.txt";
 
-    private const string StandardRight = "\"/tmp/received.txt\" \"/tmp/verified.txt\"";
-    private const string StandardLeft = "\"/tmp/verified.txt\" \"/tmp/received.txt\"";
-    private const string RiderRight = "diff \"/tmp/received.txt\" \"/tmp/verified.txt\"";
-    private const string RiderLeft = "diff \"/tmp/verified.txt\" \"/tmp/received.txt\"";
-    private const string VimRight = "-d \"/tmp/received.txt\" \"/tmp/verified.txt\"";
-    private const string VimLeft = "-d \"/tmp/verified.txt\" \"/tmp/received.txt\"";
-    private const string VisualStudioCodeRight = "--diff \"/tmp/received.txt\" \"/tmp/verified.txt\"";
-    private const string VisualStudioCodeLeft = "--diff \"/tmp/verified.txt\" \"/tmp/received.txt\"";
-    private const string VisualStudioRight = "/diff \"/tmp/received.txt\" \"/tmp/verified.txt\" \"received.txt\" \"verified.txt\"";
-    private const string VisualStudioLeft = "/diff \"/tmp/verified.txt\" \"/tmp/received.txt\" \"verified.txt\" \"received.txt\"";
-    private const string WinMergeRight = "/u /wl /e \"/tmp/received.txt\" \"/tmp/verified.txt\" /dl \"received.txt\" /dr \"verified.txt\" /cfg Backup/EnableFile=0";
-    private const string WinMergeLeft = "/u /wr /e \"/tmp/verified.txt\" \"/tmp/received.txt\" /dl \"verified.txt\" /dr \"received.txt\" /cfg Backup/EnableFile=0";
+    private const string StandardRight = "\"/tmp/my snapshots/received.txt\" \"/tmp/my snapshots/verified.txt\"";
+    private const string StandardLeft = "\"/tmp/my snapshots/verified.txt\" \"/tmp/my snapshots/received.txt\"";
+    private const string RiderRight = "diff \"/tmp/my snapshots/received.txt\" \"/tmp/my snapshots/verified.txt\"";
+    private const string RiderLeft = "diff \"/tmp/my snapshots/verified.txt\" \"/tmp/my snapshots/received.txt\"";
+    private const string VimRight = "-d \"/tmp/my snapshots/received.txt\" \"/tmp/my snapshots/verified.txt\"";
+    private const string VimLeft = "-d \"/tmp/my snapshots/verified.txt\" \"/tmp/my snapshots/received.txt\"";
+    private const string VisualStudioCodeRight = "--diff \"/tmp/my snapshots/received.txt\" \"/tmp/my snapshots/verified.txt\"";
+    private const string VisualStudioCodeLeft = "--diff \"/tmp/my snapshots/verified.txt\" \"/tmp/my snapshots/received.txt\"";
+    private const string VisualStudioRight = "/diff \"/tmp/my snapshots/received.txt\" \"/tmp/my snapshots/verified.txt\" received.txt verified.txt";
+    private const string VisualStudioLeft = "/diff \"/tmp/my snapshots/verified.txt\" \"/tmp/my snapshots/received.txt\" verified.txt received.txt";
+    private const string WinMergeRight = "/u /wl /e \"/tmp/my snapshots/received.txt\" \"/tmp/my snapshots/verified.txt\" /dl received.txt /dr verified.txt /cfg Backup/EnableFile=0";
+    private const string WinMergeLeft = "/u /wr /e \"/tmp/my snapshots/verified.txt\" \"/tmp/my snapshots/received.txt\" /dl verified.txt /dr received.txt /cfg Backup/EnableFile=0";
 
     [Theory]
     [InlineData(DiffTool.MsWordDiff, StandardRight, StandardLeft)]
@@ -135,7 +136,7 @@ public sealed class DiffToolsTests
         // reach the diff tool as extra arguments.
         var arguments = resolvedTool.GetArguments("/tmp/a\" --wait --extensionDevelopmentPath=/evil \"x.txt", "/tmp/verified.txt");
 
-        Assert.Equal("--diff \"/tmp/a\\\" --wait --extensionDevelopmentPath=/evil \\\"x.txt\" \"/tmp/verified.txt\"", arguments);
+        Assert.Equal("--diff \"/tmp/a\\\" --wait --extensionDevelopmentPath=/evil \\\"x.txt\" /tmp/verified.txt", arguments);
     }
 
     [Fact]
@@ -145,9 +146,9 @@ public sealed class DiffToolsTests
         using var scope = new EnvironmentVariableScope("DiffEngine_TargetOnLeft", null);
 
         // A trailing backslash would otherwise escape the quote that closes the argument.
-        var arguments = resolvedTool.GetArguments("C:\\dir\\", "C:\\other\\");
+        var arguments = resolvedTool.GetArguments("C:\\my dir\\", "C:\\other dir\\");
 
-        Assert.Equal("\"C:\\dir\\\\\" \"C:\\other\\\\\"", arguments);
+        Assert.Equal("\"C:\\my dir\\\\\" \"C:\\other dir\\\\\"", arguments);
     }
 
     [Fact]


### PR DESCRIPTION
Every argument builder was `$"\"{temp}\" \"{target}\""`-shaped, wrapping paths in quotes
with no escaping. A quote is a legal file name character on Linux and macOS, so a path
containing one ends the argument early and the rest becomes extra arguments to the diff
tool:

```c#
tool.GetArguments("/tmp/a\" --wait --extensionDevelopmentPath=/evil \"x.txt", "/tmp/verified.txt")
// --diff "/tmp/a" --wait --extensionDevelopmentPath=/evil "x.txt" "/tmp/verified.txt"
```

`--wait` and `--extensionDevelopmentPath=/evil` are now real arguments to VS Code. Both
snapshot-testing packages pass this string straight to
`new ProcessStartInfo(resolvedTool.ExePath, arguments)`.

The realistic failure is corruption rather than attack — a snapshot file whose name came
from a parameterised test case containing a quote produces a garbled command line, a diff
of the wrong files, or an opaque launch failure. But the flags reachable this way
(`--extensionDevelopmentPath`, `--install-extension`) are ones you would rather not have
reachable at all.

A trailing backslash has the same problem from the other end: `"C:\dir\"` escapes its own
closing quote.

## What changed

Escaping is delegated to the repo's existing `CommandLineBuilder`, imported with
`<Compile Include>` the same way `ProcessWrapper` and `TemporaryContainers` do — no project
reference:

```xml
<Compile Include="../Meziantou.Framework.CommandLine/CommandLineBuilder.cs" Link="Utils/CommandLineBuilder.cs" />
```

Each path now goes through `CommandLineBuilder.WindowsQuotedArgument`, which implements the
rules `ProcessStartInfo.Arguments` is parsed with on every platform, not just Windows.

**This changes the generated command line for ordinary paths.** `WindowsQuotedArgument`
only quotes when the value contains one of `' '`, `\t`, `\n`, `\v`, `"`:

```
before:  --diff "/tmp/received.txt" "/tmp/verified.txt"
after:   --diff /tmp/received.txt /tmp/verified.txt
```

Both parse to the same `argv`. `GetArguments_HonorsTargetPosition`, which predates this PR,
is updated accordingly, and the argument-builder theory now uses paths containing a space so
it still exercises and displays the quoting branch — the WinMerge and Visual Studio rows show
both at once, with quoted paths and unquoted `/dl` / `/dr` titles.

### Includes the argument-builder coverage from the closed #2768

This PR previously sat on top of #2768 in a stack. Since that PR is now closed and its
work was never merged, its commit is carried here — the escaping tests depend on the
`internal static DiffTools.GetLaunchArguments(DiffTool)` hook it introduced, without which
`WinMerge` and `VisualStudio` cannot be reached from a test at all (they have no `Osx` or
`Linux` platform settings, so they never resolve on a non-Windows machine).

That commit adds a table-driven theory over all 25 tools × both `DiffEngine_TargetOnLeft`
values. Before it, only VS Code had any coverage — 10 of the 11 argument builders were
untested, including the two that compute display titles via `Path.GetFileName`. The theory
rows also pin the tool → builder mapping, which was previously only visible by reading the
200-line `Definitions` table: `Cursor` shares `VisualStudioCode`'s builder and `Neovim`
shares `Vim`'s, and nothing would have caught one being pointed at the wrong one.

**If you closed #2768 because you did not want that table**, say so and I will strip it
back to just the `GetLaunchArguments` hook plus the two escaping tests. I kept it on the
assumption that closing the lower PR was about collapsing the stack rather than rejecting
the tests.

## Verification

Beyond the unit tests, I round-tripped the output through .NET's real argument parser —
feeding the escaped string to `ProcessStartInfo.Arguments` on a process that prints its
`argv`, and checking the two original paths come back intact:

```
PASS  /tmp/received.txt /tmp/verified.txt
PASS  "/tmp/my snapshots/received.txt" "/tmp/my snapshots/verified.txt"
PASS  "/tmp/a\" --wait --extensionDevelopmentPath=/evil \"x.txt" /tmp/verified.txt
PASS  "C:\my dir\\" "C:\other dir\\"
PASS  C:\dir\ C:\other\
PASS  "/tmp/quote\".txt" /tmp/back\slash.txt
PASS  "/tmp/tab\there.txt" /tmp/b.txt
```

Note the two trailing-backslash cases: quoted, the backslash is doubled; unquoted, it is left
alone — both correct.

`dotnet test /p:TreatsWarningsAsErrors=true` — 64 of 66 pass on net10.0 and net11.0,
rebased onto current `main`. The two failures are the pre-existing, unrelated
`TryFindByExtension_ReturnsTextTool`, fixed by #2736.

## Not in this PR

Adding a `GetArgumentList` returning `IReadOnlyList<string>` so consumers could use
`ProcessStartInfo.ArgumentList` and skip string quoting entirely. That is the more robust
design, but it is a public API addition, and `ArgumentList` is mutually exclusive with the
`UseShellExecute = true` both `DiffEngineTool` implementations set — so it needs a decision
about shell-execute semantics rather than a mechanical change. Escaping correctly fixes the
defect on its own.

---

**Merge note:** this PR and #2745 touch adjacent lines of `DiffTools.cs` — #2745 deletes
`NormalizeExtension`, which sits directly above the argument builders rewritten here. They
are logically independent and can merge in either order, but git reports an adjacent-hunk
conflict on whichever goes second (re-verified after this rebase). Resolution is to keep
both sides.

