### PR TITLE
Make ContainsAnsiSequences require a sequence terminator

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -45,7 +45,9 @@ public static class AnsiTextProcessor
                 return false;
 
             escapeIndex += i;
-            if (escapeIndex + 1 < value.Length && value[escapeIndex + 1] == '[')
+
+            // Only a sequence that reaches its terminator is one RemoveAnsiSequences would strip.
+            if (escapeIndex + 1 < value.Length && value[escapeIndex + 1] == '[' && FindCsiTerminator(value, escapeIndex + 2) >= 0)
                 return true;
 
             i = escapeIndex + 1;

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -50,6 +50,36 @@ public class AnsiTextProcessorTests
     }
 
     [Theory]
+    [InlineData("\u001b")]
+    [InlineData("\u001b[")]
+    [InlineData("Text\u001b")]
+    [InlineData("abc\u001b[31")]
+    [InlineData("\u001b[38;5")]
+    public void ContainsAnsiSequences_IncompleteSequences(string input)
+    {
+        Assert.False(AnsiTextProcessor.ContainsAnsiSequences(input));
+        Assert.False(AnsiTextProcessor.ContainsAnsiSequences(input.AsSpan()));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Hello World")]
+    [InlineData("\u001b")]
+    [InlineData("\u001b[")]
+    [InlineData("Text\u001b")]
+    [InlineData("abc\u001b[31")]
+    [InlineData("\u001b[31mRed\u001b[0m")]
+    [InlineData("Start\u001b[2KMiddle\u001b[0mEnd")]
+    [InlineData("\u001b[?25lHidden cursor\u001b[?25h")]
+    [InlineData("Text with\u001b[A cursor up")]
+    [InlineData("\u001b[1m\u001b[31m\u001b[4mBold\u001b[0m")]
+    public void ContainsAnsiSequences_AgreesWithRemoveAnsiSequences(string input)
+    {
+        var removeChangedTheText = !string.Equals(AnsiTextProcessor.RemoveAnsiSequences(input), input, StringComparison.Ordinal);
+        Assert.Equal(removeChangedTheText, AnsiTextProcessor.ContainsAnsiSequences(input));
+    }
+
+    [Theory]
     [InlineData("\x1b", "\x1b")]
     [InlineData("\x1b[", "\x1b[")]
     [InlineData("Text\x1b", "Text\x1b")]


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2772**

## Problem

`ContainsAnsiSequences` and `RemoveAnsiSequences` disagree about the same input.

`ContainsAnsiSequences` returns `true` as soon as it sees `ESC [`, without requiring a final byte (`src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs:48`). `RemoveAnsiSequences` requires a terminator and deliberately keeps an unterminated sequence, as the comment at `:137` says. Verified against the built library:

| Input | `ContainsAnsiSequences` | `RemoveAnsiSequences` |
|---|---|---|
| `ESC[` | `true` | unchanged |
| `abc ESC[31` | `true` | unchanged |

So the obvious calling pattern

```csharp
if (AnsiTextProcessor.ContainsAnsiSequences(s))
    s = AnsiTextProcessor.RemoveAnsiSequences(s);
```

is a no-op for these inputs, and anyone using the detector as a "does this need cleaning?" gate gets an answer the cleaner will not honour. It matters most for streamed or chunked terminal output, where a chunk legitimately ends mid-sequence.

The existing tests encoded both halves of the contradiction — `AnsiTextProcessorTests.cs:54` asserts `ESC[` survives removal, and the `ContainsAnsiSequences_HasSequences` theory asserts the detector is positive on CSI — but nothing put the two side by side.

## Change

`ContainsAnsiSequences` now also requires the CSI terminator, reusing the existing `FindCsiTerminator`. That makes `true` mean exactly "`RemoveAnsiSequences` would change this value", which is the contract callers assume.

This is a behaviour change to a public method: `ContainsAnsiSequences` now returns `false` for an input whose only escape sequence is unterminated. No existing test asserted the old behaviour, and the alternative — making `RemoveAnsiSequences` strip unterminated sequences instead — would truncate data on chunked input, which the current code goes out of its way to avoid.

## Verification

- New theory asserting `ESC`, `ESC[`, `Text ESC`, `abc ESC[31`, `ESC[38;5` are all reported as containing no sequence, through both the `string` and `ReadOnlySpan<char>` overloads.
- New theory pinning the actual contract across an 11-input corpus: `ContainsAnsiSequences(x)` must equal `RemoveAnsiSequences(x) != x`. This is the test that would have caught the original defect, and it is the one to extend when a new sequence family is added — which is exactly what #2772 does on top of this.
- Confirmed 5 of the new cases **fail** against the old behaviour.
- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 80 passed, 0 failed (40 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` → 24 passed, 0 failed.
- `ref/` unchanged.

## Context

From an audit of `Meziantou.Framework.AnsiFormatting` (8 PRs total). Bottom of a 2-PR stack; #2772 adds OSC support on top and has to extend this method again, which is why the two are stacked rather than independent.
