### PR TITLE
Recognize OSC escape sequences

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -5,6 +5,7 @@ namespace Meziantou.Framework;
 public static class AnsiTextProcessor
 {
     private const char EscapeCharacter = '\u001b';
+    private const char BellCharacter = '\u0007';
     // Sequences shorter than this are processed using a stack-allocated buffer to avoid renting an array.
     private const int StackAllocThreshold = 512;
     // The longest SGR parameter is 38:2:<color-space>:r:g:b
@@ -49,7 +50,7 @@ public static class AnsiTextProcessor
             escapeIndex += i;
 
             // Only a sequence that reaches its terminator is one RemoveAnsiSequences would strip.
-            if (escapeIndex + 1 < value.Length && value[escapeIndex + 1] == '[' && FindCsiTerminator(value, escapeIndex + 2) >= 0)
+            if (FindSequenceEnd(value, escapeIndex) >= 0)
                 return true;
 
             i = escapeIndex + 1;
@@ -117,10 +118,11 @@ public static class AnsiTextProcessor
 
                 var escapeIndex = searchFrom + relativeIndex;
 
-                // A removable sequence is a CSI: ESC '[' ... <terminator in 0x40-0x7E>
-                if (escapeIndex + 1 < value.Length && value[escapeIndex + 1] == '[')
+                // Removable sequences are CSI (ESC '[' ... <terminator in 0x40-0x7E>)
+                // and OSC (ESC ']' ... BEL or ST).
+                if (escapeIndex + 1 < value.Length && value[escapeIndex + 1] is '[' or ']')
                 {
-                    var terminator = FindCsiTerminator(value, escapeIndex + 2);
+                    var terminator = FindSequenceEnd(value, escapeIndex);
                     if (terminator >= 0)
                     {
                         var segment = value[copiedFrom..escapeIndex];
@@ -137,7 +139,7 @@ public static class AnsiTextProcessor
                     break;
                 }
 
-                // Lone ESC (not part of a CSI sequence): kept as-is.
+                // Lone ESC (not the start of a CSI or OSC sequence): kept as-is.
                 searchFrom = escapeIndex + 1;
             }
 
@@ -164,8 +166,21 @@ public static class AnsiTextProcessor
         if (index >= text.Length || text[index] != EscapeCharacter)
             return false;
 
-        if (index + 1 >= text.Length || text[index + 1] != '[')
+        if (index + 1 >= text.Length)
             return false;
+
+        if (text[index + 1] is '[')
+            return TryConsumeCsiSequence(text, ref index, out sgrParameters);
+
+        if (text[index + 1] is ']')
+            return TryConsumeOscSequence(text, ref index);
+
+        return false;
+    }
+
+    private static bool TryConsumeCsiSequence(string text, ref int index, out List<int>? sgrParameters)
+    {
+        sgrParameters = null;
 
         var sequenceStart = index;
         index += 2;
@@ -190,6 +205,17 @@ public static class AnsiTextProcessor
 
         index = sequenceStart;
         return false;
+    }
+
+    // OSC sequences carry no styling, so they are consumed and dropped from the text.
+    private static bool TryConsumeOscSequence(string text, ref int index)
+    {
+        var terminator = FindOscTerminator(text, index + 2);
+        if (terminator < 0)
+            return false;
+
+        index = terminator + 1;
+        return true;
     }
 
     private static List<int> ParseSgrParameters(ReadOnlySpan<char> sequenceContent)
@@ -399,6 +425,38 @@ public static class AnsiTextProcessor
         }
 
         return style;
+    }
+
+    /// <summary>
+    /// Returns the index of the last character of the sequence introduced at <paramref name="escapeIndex"/>,
+    /// or -1 when the introducer is unknown or the sequence is cut off before its terminator.
+    /// </summary>
+    private static int FindSequenceEnd(ReadOnlySpan<char> value, int escapeIndex)
+    {
+        if (escapeIndex + 1 >= value.Length)
+            return -1;
+
+        return value[escapeIndex + 1] switch
+        {
+            '[' => FindCsiTerminator(value, escapeIndex + 2),
+            ']' => FindOscTerminator(value, escapeIndex + 2),
+            _ => -1,
+        };
+    }
+
+    // OSC sequences are terminated by BEL, or by ST which is written as ESC '\'.
+    private static int FindOscTerminator(ReadOnlySpan<char> value, int start)
+    {
+        for (var i = start; i < value.Length; i++)
+        {
+            if (value[i] is BellCharacter)
+                return i;
+
+            if (value[i] is EscapeCharacter && i + 1 < value.Length && value[i + 1] is '\\')
+                return i + 1;
+        }
+
+        return -1;
     }
 
     private static int FindCsiTerminator(ReadOnlySpan<char> value, int start)

--- a/src/Meziantou.Framework.AnsiFormatting/readme.md
+++ b/src/Meziantou.Framework.AnsiFormatting/readme.md
@@ -27,3 +27,14 @@ foreach (var run in parsed.Runs)
     Console.WriteLine($"{run.Start}-{run.End}: Bold={run.Style.Bold}, Underline={run.Style.Underline}");
 }
 ```
+
+## Supported sequences
+
+`AnsiTextProcessor` recognizes two families of escape sequences:
+
+- **CSI** (`ESC [` ... terminated by a byte in `0x40`-`0x7E`) covers SGR styling such as `ESC[1;31m`, as well as cursor movement and erase sequences.
+- **OSC** (`ESC ]` ... terminated by `BEL` or by `ST`, written `ESC \`) covers hyperlinks (`OSC 8`) and window titles (`OSC 0` and `OSC 2`).
+
+Only SGR sequences (those ending with `m`) produce styles. Every other recognized sequence is removed from the text without contributing any styling.
+
+A sequence that never reaches its terminator is left in the text unchanged, so a value that was cut off mid-sequence is not silently truncated. `ContainsAnsiSequences` reports `true` for exactly the inputs that `RemoveAnsiSequences` would change.

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -137,10 +137,66 @@ public class AnsiTextProcessorTests
     [InlineData("\u001b[?25lHidden cursor\u001b[?25h")]
     [InlineData("Text with\u001b[A cursor up")]
     [InlineData("\u001b[1m\u001b[31m\u001b[4mBold\u001b[0m")]
+    [InlineData("\u001b]0;window title\u0007hello")]
+    [InlineData("\u001b]8;;https://example.com\u001b\\click me\u001b]8;;\u001b\\")]
+    [InlineData("\u001b]8;;https://example.com")]
+    [InlineData("\u001b]")]
+    [InlineData("\u001b]0;no terminator here")]
     public void ContainsAnsiSequences_AgreesWithRemoveAnsiSequences(string input)
     {
         var removeChangedTheText = !string.Equals(AnsiTextProcessor.RemoveAnsiSequences(input), input, StringComparison.Ordinal);
         Assert.Equal(removeChangedTheText, AnsiTextProcessor.ContainsAnsiSequences(input));
+    }
+
+    [Theory]
+    [InlineData("\u001b]0;window title\u0007hello", "hello")]
+    [InlineData("\u001b]8;;https://example.com\u001b\\click me\u001b]8;;\u001b\\", "click me")]
+    [InlineData("a\u001b]52;c;Zm9v\u0007b", "ab")]
+    [InlineData("\u001b[31m\u001b]0;t\u0007red\u001b[0m", "red")]
+    [InlineData("\u001b]0;a\u0007\u001b]0;b\u0007x", "x")]
+    public void RemoveAnsiSequences_OscSequences(string input, string expected)
+    {
+        Assert.Equal(expected, AnsiTextProcessor.RemoveAnsiSequences(input));
+        Assert.Equal(expected, AnsiTextProcessor.RemoveAnsiSequences(input.AsSpan()));
+        Assert.True(AnsiTextProcessor.ContainsAnsiSequences(input));
+    }
+
+    [Theory]
+    [InlineData("\u001b]")]
+    [InlineData("\u001b]8;;https://example.com")]
+    [InlineData("\u001b]0;window title")]
+    [InlineData("text\u001b]0;cut off")]
+    public void RemoveAnsiSequences_IncompleteOscSequenceIsKept(string input)
+    {
+        Assert.Equal(input, AnsiTextProcessor.RemoveAnsiSequences(input));
+        Assert.False(AnsiTextProcessor.ContainsAnsiSequences(input));
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_OscSequenceIsRemovedAndCarriesNoStyle()
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("\u001b[1m\u001b]8;;https://example.com\u001b\\link\u001b]8;;\u001b\\");
+
+        Assert.Equal("link", parsed.Text);
+        var run = Assert.Single(parsed.Runs);
+        Assert.True(run.Style.Bold);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_OscSequenceWithBellTerminator()
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("a\u001b]0;title\u0007b");
+
+        Assert.Equal("ab", parsed.Text);
+        Assert.Equal(AnsiTextProcessor.AnsiStyle.None, Assert.Single(parsed.Runs).Style);
+    }
+
+    [Fact]
+    public void ParseTextWithAnsiStyles_IncompleteOscSequenceIsKept()
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles("a\u001b]0;cut off");
+
+        Assert.Equal("a\u001b]0;cut off", parsed.Text);
     }
 
     [Theory]


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/ansi-contains-terminator` (#2771) · merge #2771 first**

## Problem

The library only ever recognised CSI (`ESC [`). OSC sequences (`ESC ]` … terminated by `BEL` or `ST`) were invisible to all three entry points. Verified against the built library, for the OSC 8 hyperlink `ESC]8;;https://example.com ESC\ click me ESC]8;; ESC\`:

- `RemoveAnsiSequences` returned the input **completely unchanged** — escape bytes and URL included
- `ContainsAnsiSequences` returned **`false`**
- `ParseTextWithAnsiStyles` put the whole thing, raw `ESC` characters and all, into `AnsiText.Text`

Same for the BEL-terminated form: `ESC]0;window title BEL hello` came back with the title sequence intact.

Two impacts. Functionally, "remove ANSI sequences" produced output containing a URL and control bytes that were never meant to be visible — OSC 8 hyperlinks are routine in `gh`, `cargo`, `npm`, `docker` and `ls` output, so this is ordinary input. Second, the plausible use of this API is sanitising untrusted text before writing it to a terminal, and OSC passed straight through — including `OSC 0`/`OSC 2` (set window title) and `OSC 52` (write the user's clipboard) on terminals that permit them.

This was never exploitable through the in-repo LogViewer, which HTML-encodes everything before emitting `MarkupString`, so the escapes render inert there. The exposure is in the library's public contract, not in the current consumer.

## Change

Recognise OSC in all three paths, with the same rules CSI already follows:

- `FindOscTerminator` scans for `BEL`, or for `ST` written as `ESC \`.
- `FindSequenceEnd` dispatches on the introducer (`[` → CSI, `]` → OSC), and is now shared by `ContainsAnsiSequences` and `RemoveAnsiSequencesCore` so the two cannot drift apart again.
- `TryConsumeControlSequence` splits into `TryConsumeCsiSequence` (the previous body, unchanged) and `TryConsumeOscSequence`. OSC carries no styling, so it is consumed and dropped.
- An unterminated OSC is kept as-is, matching the existing rule for unterminated CSI. That consistency is deliberate: the two paths should stay explainable together, and it keeps chunked input from being silently truncated.

The package readme gains a "Supported sequences" section stating which families are recognised, that only SGR produces styles, and that `ContainsAnsiSequences` is true for exactly the inputs `RemoveAnsiSequences` would change.

## Verification

- `RemoveAnsiSequences` over OSC 0 (BEL-terminated), OSC 8 (ST-terminated hyperlink, both halves), OSC 52, back-to-back OSC sequences, and OSC mixed with CSI — through both the `string` and `ReadOnlySpan<char>` overloads.
- Unterminated OSC (`ESC]`, `ESC]8;;https://example.com`, `ESC]0;window title`, and one with leading text) is kept unchanged and reported as containing no sequence.
- `ParseTextWithAnsiStyles` drops OSC while preserving the surrounding style, handles the BEL form, and keeps an unterminated OSC in `Text`.
- The `ContainsAnsiSequences_AgreesWithRemoveAnsiSequences` corpus from #2771 is extended with 5 OSC cases, so the detector/remover contract is re-proved for the new family rather than assumed.
- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 114 passed, 0 failed (57 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` → 24 passed, 0 failed.
- `dotnet run ./eng/update-all.cs` reports no generated-file changes; `ref/` unchanged (all new members are private).

## Not addressed

Two-character escapes (`ESC ( B`, `ESC =`) and the C1 introducers, including C1 CSI `U+009B`, are still not recognised. They were in the same audit; C1 is genuinely rare in .NET UTF-16 strings, since text decoded from a UTF-8 terminal stream carries the two-byte `ESC [` form. Happy to add either on request — the `FindSequenceEnd` switch is now the single place it would go.

## Context

From an audit of `Meziantou.Framework.AnsiFormatting` (8 PRs total). Top of a 2-PR stack.
