### PR TITLE
Return the default value when a converter fails with a mismatched value

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/ConvertUtilities.cs
+++ b/src/Meziantou.Framework.TypeConverter/ConvertUtilities.cs
@@ -51,20 +51,18 @@ public static class ConvertUtilities
         var b = converter.TryChangeType(input, typeof(T), provider, out var v);
         if (!b)
         {
-            if (v is null)
+            // A custom IConverter may report a failure with a value that is not assignable to T
+            if (v is T failureValue)
             {
-                if (typeof(T).IsValueType)
-                {
-                    value = Activator.CreateInstance<T>()!;
-                }
-                else
-                {
-                    value = default!;
-                }
+                value = failureValue;
+            }
+            else if (typeof(T).IsValueType)
+            {
+                value = Activator.CreateInstance<T>()!;
             }
             else
             {
-                value = (T)v;
+                value = default!;
             }
 
             return false;

--- a/tests/Meziantou.Framework.TypeConverter.Tests/ConvertUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/ConvertUtilitiesTests.cs
@@ -1,0 +1,65 @@
+namespace Meziantou.Framework.Tests;
+
+public sealed class ConvertUtilitiesTests
+{
+    // IConverter is public, so a third party can report a failure with a value of any type
+    private sealed class MismatchedFailureConverter : IConverter
+    {
+        public bool TryChangeType(object? input, Type conversionType, IFormatProvider? provider, out object? value)
+        {
+            value = "not an int";
+            return false;
+        }
+    }
+
+    private sealed class NullFailureConverter : IConverter
+    {
+        public bool TryChangeType(object? input, Type conversionType, IFormatProvider? provider, out object? value)
+        {
+            value = null;
+            return false;
+        }
+    }
+
+    [Fact]
+    public void TryChangeType_ConverterFailsWithMismatchedValue_ReturnsDefault()
+    {
+        var converter = new MismatchedFailureConverter();
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out int intValue));
+        Assert.Equal(0, intValue);
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out Guid guidValue));
+        Assert.Equal(Guid.Empty, guidValue);
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out int? nullableValue));
+        Assert.Null(nullableValue);
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out Uri? referenceValue));
+        Assert.Null(referenceValue);
+    }
+
+    [Fact]
+    public void TryChangeType_ConverterFailsWithMatchingValue_KeepsTheValue()
+    {
+        var converter = new MismatchedFailureConverter();
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out string? value));
+        Assert.Equal("not an int", value);
+    }
+
+    [Fact]
+    public void TryChangeType_ConverterFailsWithNull_ReturnsDefault()
+    {
+        var converter = new NullFailureConverter();
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out int intValue));
+        Assert.Equal(0, intValue);
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out int? nullableValue));
+        Assert.Null(nullableValue);
+
+        Assert.False(converter.TryChangeType("x", CultureInfo.InvariantCulture, out string? referenceValue));
+        Assert.Null(referenceValue);
+    }
+}


### PR DESCRIPTION
A custom `IConverter` that reports failure with a value that is not assignable to `T` caused an `InvalidCastException` from inside a `Try` method.

## The bug

On the failure branch, `ConvertUtilities.TryChangeType<T>` cast the converter's out-value with an unchecked `(T)v` (`ConvertUtilities.cs:65`):

```csharp
if (v is null) { /* default */ }
else { value = (T)v; }   // <-- throws if the converter returned something else
return false;
```

`DefaultConverter` always sets a value of the right type there, so the built-in path was safe. But `IConverter` is public and the readme advertises extensibility, and a third-party implementation has no way to know the rule:

```csharp
sealed class MyConverter : IConverter
{
    public bool TryChangeType(object? input, Type conversionType, IFormatProvider? provider, out object? value)
    {
        value = "not an int";
        return false;
    }
}

new MyConverter().TryChangeType<int>("x", CultureInfo.InvariantCulture, out var v);
  → InvalidCastException
```

The constraint was undocumented and unenforced, and the consequence was an exception from the exact API shape that exists to avoid one.

## What changed

The failure branch now type-tests instead of casting:

```csharp
// A custom IConverter may report a failure with a value that is not assignable to T
if (v is T failureValue)          { value = failureValue; }
else if (typeof(T).IsValueType)   { value = Activator.CreateInstance<T>()!; }
else                              { value = default!; }
```

All three pre-existing behaviours are preserved exactly:

- `v` is null and `T` is a value type → `Activator.CreateInstance<T>()` as before (kept rather than `default(T)`, because a struct with a user-defined parameterless constructor makes those two differ)
- `v` is null and `T` is a reference type → `default`
- `v` is non-null and assignable to `T` → passed through unchanged

Only the fourth case — non-null and *not* assignable — changes, from throwing to yielding the default.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **122 passed, 0 failed** (was 116; 3 new cases per target framework, net10.0 and net11.0).

Reverting `ConvertUtilities.cs` and re-running reproduces the original defect: 2 failures with `System.InvalidCastException : Unable to cast object of type 'System.String' to type 'System.Int32'`.

New tests cover a converter that fails with a mismatched value against a value type, a `Guid`, a nullable value type and a reference type; that a failure value which *is* assignable to `T` is still passed through; and that a converter failing with `null` still yields the default for all three shapes.

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — no public API surface change.

## Notes for review

**New test file.** `AGENTS.md` asks to prefer existing test files, but none of the current ones is about `ConvertUtilities` with a custom `IConverter` — they all exercise `DefaultConverter` or the dictionary extensions. `ConvertUtilitiesTests.cs` seemed like the right home rather than a poor fit in an existing file; happy to fold it elsewhere if you disagree.

**The success path is deliberately unchanged.** `value = (T)v!` still throws if a converter returns `true` with a mismatched value. That asymmetry is intentional: a converter reporting *success* is claiming it produced the requested type, so a contract violation there is a real bug worth surfacing loudly, whereas the failure value is incidental and callers do not read it. Say the word if you would rather both paths be lenient.

Found by a project review of `Meziantou.Framework.TypeConverter`.
