### PR TITLE
Unit test the embedded constants generator core

### DIFF
--- a/slnx/Meziantou.Framework.EmbeddedConstantsGenerator.slnx
+++ b/slnx/Meziantou.Framework.EmbeddedConstantsGenerator.slnx
@@ -1,5 +1,15 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests.csproj" />
   </Folder>
 </Solution>

--- a/slnx/Meziantou.Framework.ProcessWrapper.slnx
+++ b/slnx/Meziantou.Framework.ProcessWrapper.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
     <Project Path="../src/Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj" />
+    <Project Path="../src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -10,6 +10,7 @@
     <Project Path="../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
     <Project Path="../src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
     <Project Path="../src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
+    <Project Path="../src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.EmbeddedConstantsGenerator.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.14.28" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" ExcludeAssets="runtime" />
   </ItemGroup>

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
@@ -1,0 +1,162 @@
+using System.Text;
+using Options = Meziantou.Framework.EmbeddedConstantsGenerator.EmbeddedConstantsGeneratorTask.GeneratorOptions;
+using Generator = Meziantou.Framework.EmbeddedConstantsGenerator.EmbeddedConstantsGeneratorTask;
+using InputFile = Meziantou.Framework.EmbeddedConstantsGenerator.EmbeddedConstantsGeneratorTask.InputFile;
+
+namespace Meziantou.Framework.EmbeddedConstantsGenerator.Tests;
+
+/// <summary>
+/// Covers the generator core directly. The end-to-end tests in <see cref="EmbeddedConstantsGeneratorTests"/>
+/// pack the NuGet package and run a real build, which is too expensive for edge cases.
+/// </summary>
+public sealed class EmbeddedConstantsGeneratorUnitTests
+{
+    [Fact]
+    public void Create_InvalidNamespace_ReportsError()
+    {
+        var result = Generator.Create(CreateOptions("temp", ns: "My.class.Ns"), []);
+
+        Assert.Equal(["MFECG0001"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public void Create_InvalidClassName_ReportsError()
+    {
+        var result = Generator.Create(CreateOptions("temp", className: "9Bad"), []);
+
+        Assert.Equal(["MFECG0002"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public void Create_InvalidVisibility_ReportsError()
+    {
+        var result = Generator.Create(CreateOptions("temp", classVisibility: "private"), []);
+
+        Assert.Equal(["MFECG0009"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public async Task Create_FileDoesNotExist_ReportsError()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "missing.txt")]);
+
+        Assert.Equal(["MFECG0006"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public async Task Create_TextFileIsNotValidUtf8_ReportsError()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        File.WriteAllBytes(temporaryDirectory.FullPath / "invalid.txt", [0xFF, 0xFE, 0x41]);
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "invalid.txt")]);
+
+        Assert.Equal(["MFECG0007"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public async Task Create_TextFileExceedsMaximumSize_ReportsError()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        temporaryDirectory.CreateTextFile("big.txt", new string('a', Generator.MaxTextFileBytes + 1));
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "big.txt")]);
+
+        Assert.Equal(["MFECG0008"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public async Task GenerateSource_TextWithCharactersThatNeedEscaping_ProducesAValidLiteral()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var content = "q:\" bs:\\ nl:\n crlf:\r\n tab:\t nul:\0 u2028:\u2028 u2029:\u2029 nel:\u0085 emoji:\U0001F600 zwj:\u200D";
+        File.WriteAllText(temporaryDirectory.FullPath / "nasty.txt", content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "nasty.txt")]);
+        Assert.Empty(result.Errors);
+
+        var source = Generator.GenerateSource(result.Options, result.Entries);
+
+        // Nothing may terminate the literal or the line it is on
+        Assert.Contains(@"\"" bs:\\ nl:\n crlf:\r\n tab:\t nul:\0 u2028:\u2028 u2029:\u2029 nel:\u0085", source);
+        Assert.Contains("emoji:\U0001F600 zwj:\u200D\";", source);
+        Assert.Equal(1, source.Split('\n').Count(line => line.Contains("NastyText", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task Create_TextFileStartsWithByteOrderMark_RemovesIt()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        File.WriteAllBytes(temporaryDirectory.FullPath / "bom.txt", [0xEF, 0xBB, 0xBF, (byte)'{', (byte)'}']);
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "bom.txt")]);
+        var source = Generator.GenerateSource(result.Options, result.Entries);
+
+        Assert.Contains("""public const string BomText = "{}";""", source);
+    }
+
+    [Fact]
+    public async Task Create_ImplicitNamesCollide_UsesPathBasedNames()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        temporaryDirectory.CreateTextFile("a/settings.txt", "A");
+        temporaryDirectory.CreateTextFile("b/settings.txt", "B");
+
+        var result = Generator.Create(
+            CreateOptions(temporaryDirectory.FullPath),
+            [TextFile(temporaryDirectory, "a/settings.txt"), TextFile(temporaryDirectory, "b/settings.txt")]);
+        Assert.Empty(result.Errors);
+
+        var source = Generator.GenerateSource(result.Options, result.Entries);
+
+        Assert.Contains("""public const string ASettingsText = "A";""", source);
+        Assert.Contains("""public const string BSettingsText = "B";""", source);
+    }
+
+    [Fact]
+    public async Task Create_ExplicitNamesNormaliseToTheSameIdentifier_ReportsError()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        temporaryDirectory.CreateTextFile("p.txt", "p");
+        temporaryDirectory.CreateTextFile("q.txt", "q");
+
+        var result = Generator.Create(
+            CreateOptions(temporaryDirectory.FullPath),
+            [TextFile(temporaryDirectory, "p.txt", name: "my-name"), TextFile(temporaryDirectory, "q.txt", name: "My Name")]);
+
+        Assert.Equal(["MFECG0005"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public async Task GenerateSource_OrdersMembersByName()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        temporaryDirectory.CreateTextFile("zebra.txt", "z");
+        temporaryDirectory.CreateTextFile("apple.txt", "a");
+
+        var result = Generator.Create(
+            CreateOptions(temporaryDirectory.FullPath),
+            [TextFile(temporaryDirectory, "zebra.txt"), TextFile(temporaryDirectory, "apple.txt")]);
+
+        var source = Generator.GenerateSource(result.Options, result.Entries);
+
+        Assert.True(source.IndexOf("AppleText", StringComparison.Ordinal) < source.IndexOf("ZebraText", StringComparison.Ordinal));
+    }
+
+    private static Options CreateOptions(string projectDirectory, string ns = "Demo", string className = "EmbeddedFiles", string classVisibility = "internal", string memberVisibility = "public")
+    {
+        return new Options(ns, className, classVisibility, memberVisibility, projectDirectory);
+    }
+
+    private static InputFile TextFile(TemporaryDirectory temporaryDirectory, string relativePath, string kind = "Text", string? name = null)
+    {
+        return new InputFile(relativePath, kind, name, temporaryDirectory.FullPath);
+    }
+
+    private static string[] ErrorCodes(Generator.Result result)
+    {
+        return [.. result.Errors.Select(error => error.Code)];
+    }
+}

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>


### PR DESCRIPTION
**Stack 1 of 4** · merges into `main` · must merge before #2777, #2778, #2779

Adds unit coverage for the generator core, so the fixes stacked above this can be tested cheaply.

## The finding

The suite is 6 tests, all of them full `dotnet restore` + `dotnet build` round-trips against the packed `.nupkg`.

Covered today: `MFECG0003`, `MFECG0004`, `MFECG0005`, and three happy paths. **Not covered at all:** `MFECG0001` (invalid namespace), `MFECG0002` (invalid class name), `MFECG0006` (unreadable file), `MFECG0007` (invalid UTF-8), `MFECG0008` (oversized text), `MFECG0009` (invalid visibility) — six of the nine documented diagnostics. Also uncovered: string escaping (the highest-risk function in the file), BOM handling, and the implicit-duplicate path-based rename documented at `readme.md:77`.

The structural cause is that `EmbeddedConstantsGeneratorTask` is `internal` and the test project has no reference to it, so the only way to test anything is to pack a package and spawn two `dotnet` processes. That makes each case expensive enough that nobody adds edge cases.

This matters because the generator's output is compiled into other people's assemblies. An escaping regression would not be caught by anything here; it would ship, and it would break every consumer with a quote or a newline in a text asset.

## The change

- `InternalsVisibleTo` on the generator project and a `ProjectReference` from the test project — matching the convention already used by `Meziantou.Framework.SnapshotTesting`, `Meziantou.Framework.DiffEngine` and others.
- `EmbeddedConstantsGeneratorUnitTests` with 11 tests over `Create` / `GenerateSource`: all six uncovered diagnostics, the escaping round trip, BOM removal, the path-based rename, explicit names that normalise to the same identifier, and deterministic member ordering.

The escaping test pushes a quote, a backslash, LF, CRLF, tab, NUL, U+2028, U+2029, U+0085 NEL, an astral emoji and a ZWJ through in one string and asserts none of them terminate the literal or the line.

No production code changes. The existing end-to-end tests are untouched — they cover the MSBuild wiring, which unit tests cannot, and that is the right split.

`slnx/` files are the regenerated output of `dotnet run ./eng/update-all.cs`, which picks up the new project reference.

## Verification

17/17 pass (11 new unit tests + the 6 existing end-to-end tests) on `net10.0` and `net11.0`.
