### PR TITLE
Reject binary files that are too large to embed as a byte array

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
@@ -4,6 +4,7 @@ namespace Meziantou.Framework.EmbeddedConstantsGenerator;
 internal static class EmbeddedConstantsGeneratorTask
 {
     internal const int MaxTextFileBytes = 1024 * 1024;
+    internal const int DefaultMaxBinaryFileBytes = 1024 * 1024;
 
     private static readonly UTF8Encoding Utf8NoBomThrowOnInvalidBytes = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
@@ -97,7 +98,7 @@ internal static class EmbeddedConstantsGeneratorTask
         var validFiles = new List<EmbeddedFile>(files.Count);
         foreach (var file in files)
         {
-            var embeddedFile = EmbeddedFile.Create(file);
+            var embeddedFile = EmbeddedFile.Create(file, options.MaxBinaryFileBytes);
             errors.AddRange(embeddedFile.Errors);
             if (embeddedFile.Errors.Count == 0)
             {
@@ -462,13 +463,14 @@ internal static class EmbeddedConstantsGeneratorTask
 
     internal sealed class GeneratorOptions
     {
-        public GeneratorOptions(string ns, string className, string classVisibility, string memberVisibility, string? projectDirectory)
+        public GeneratorOptions(string ns, string className, string classVisibility, string memberVisibility, string? projectDirectory, int maxBinaryFileBytes = DefaultMaxBinaryFileBytes)
         {
             Namespace = ns;
             ClassName = className;
             ClassVisibility = classVisibility.ToLowerInvariant();
             MemberVisibility = memberVisibility.ToLowerInvariant();
             ProjectDirectory = projectDirectory;
+            MaxBinaryFileBytes = maxBinaryFileBytes;
         }
 
         public string Namespace { get; }
@@ -476,6 +478,7 @@ internal static class EmbeddedConstantsGeneratorTask
         public string ClassVisibility { get; }
         public string MemberVisibility { get; }
         public string? ProjectDirectory { get; }
+        public int MaxBinaryFileBytes { get; }
 
         public void AddErrors(List<ValidationError> errors)
         {
@@ -544,7 +547,7 @@ internal static class EmbeddedConstantsGeneratorTask
         public byte[] Bytes { get; }
         public IReadOnlyList<ValidationError> Errors { get; }
 
-        public static EmbeddedFile Create(InputFile file)
+        public static EmbeddedFile Create(InputFile file, int maxBinaryFileBytes)
         {
             var errors = new List<ValidationError>();
             if (string.IsNullOrWhiteSpace(file.Kind))
@@ -572,6 +575,13 @@ internal static class EmbeddedConstantsGeneratorTask
 
             if (kind == EmbeddedConstantKind.Binary)
             {
+                // Every byte costs six characters of generated source, so a large file makes the build unusable
+                if (bytes.Length > maxBinaryFileBytes)
+                {
+                    errors.Add(ValidationError.BinaryFileTooLarge(file.FullPath, maxBinaryFileBytes));
+                    return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, text: null, Array.Empty<byte>(), errors);
+                }
+
                 return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, text: null, bytes, errors);
             }
 
@@ -673,6 +683,11 @@ internal static class EmbeddedConstantsGeneratorTask
         public static ValidationError TextFileTooLarge(string filePath, int maxSize)
         {
             return new ValidationError("MFECG0008", string.Create(CultureInfo.InvariantCulture, $"Embedded constant text file is too large to embed as a const string. The maximum supported text file size is {maxSize} bytes."), filePath);
+        }
+
+        public static ValidationError BinaryFileTooLarge(string filePath, int maxSize)
+        {
+            return new ValidationError("MFECG0012", string.Create(CultureInfo.InvariantCulture, $"Embedded constant binary file is too large to embed as a byte array. The maximum supported binary file size is {maxSize} bytes. Raise the 'EmbeddedConstantsMaxBinaryFileSize' property, or use EmbeddedResource for assets this size."), filePath);
         }
 
         public static ValidationError InvalidVisibility(string visibility)

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/GenerateEmbeddedConstantsTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/GenerateEmbeddedConstantsTask.cs
@@ -22,9 +22,11 @@ public sealed class GenerateEmbeddedConstantsTask : Microsoft.Build.Utilities.Ta
 
     public string? ProjectDirectory { get; set; }
 
+    public int MaxBinaryFileSize { get; set; } = EmbeddedConstantsGeneratorTask.DefaultMaxBinaryFileBytes;
+
     public override bool Execute()
     {
-        var options = new EmbeddedConstantsGeneratorTask.GeneratorOptions(Namespace, ClassName, ClassVisibility, MemberVisibility, ProjectDirectory);
+        var options = new EmbeddedConstantsGeneratorTask.GeneratorOptions(Namespace, ClassName, ClassVisibility, MemberVisibility, ProjectDirectory, MaxBinaryFileSize);
         var files = EmbeddedConstants
             .Select(item => new EmbeddedConstantsGeneratorTask.InputFile(
                 item.ItemSpec,

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/build/Meziantou.Framework.EmbeddedConstantsGenerator.targets
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/build/Meziantou.Framework.EmbeddedConstantsGenerator.targets
@@ -7,12 +7,14 @@
     <Meziantou_EmbeddedConstantsClassVisibility Condition="'$(Meziantou_EmbeddedConstantsClassVisibility)' == '' and '$(EmbeddedConstantsClassVisibility)' != ''">$(EmbeddedConstantsClassVisibility)</Meziantou_EmbeddedConstantsClassVisibility>
     <Meziantou_EmbeddedConstantsMemberVisibility Condition="'$(Meziantou_EmbeddedConstantsMemberVisibility)' == '' and '$(EmbeddedConstantsMemberVisibility)' != ''">$(EmbeddedConstantsMemberVisibility)</Meziantou_EmbeddedConstantsMemberVisibility>
     <Meziantou_EmbeddedConstantsOutputPath Condition="'$(Meziantou_EmbeddedConstantsOutputPath)' == '' and '$(EmbeddedConstantsOutputPath)' != ''">$(EmbeddedConstantsOutputPath)</Meziantou_EmbeddedConstantsOutputPath>
+    <Meziantou_EmbeddedConstantsMaxBinaryFileSize Condition="'$(Meziantou_EmbeddedConstantsMaxBinaryFileSize)' == '' and '$(EmbeddedConstantsMaxBinaryFileSize)' != ''">$(EmbeddedConstantsMaxBinaryFileSize)</Meziantou_EmbeddedConstantsMaxBinaryFileSize>
 
     <Meziantou_EmbeddedConstantsNamespace Condition="'$(Meziantou_EmbeddedConstantsNamespace)' == '' and '$(RootNamespace)' != ''">$(RootNamespace)</Meziantou_EmbeddedConstantsNamespace>
     <Meziantou_EmbeddedConstantsNamespace Condition="'$(Meziantou_EmbeddedConstantsNamespace)' == ''">$(MSBuildProjectName)</Meziantou_EmbeddedConstantsNamespace>
     <Meziantou_EmbeddedConstantsClassName Condition="'$(Meziantou_EmbeddedConstantsClassName)' == ''">EmbeddedConstants</Meziantou_EmbeddedConstantsClassName>
     <Meziantou_EmbeddedConstantsClassVisibility Condition="'$(Meziantou_EmbeddedConstantsClassVisibility)' == ''">internal</Meziantou_EmbeddedConstantsClassVisibility>
     <Meziantou_EmbeddedConstantsMemberVisibility Condition="'$(Meziantou_EmbeddedConstantsMemberVisibility)' == ''">public</Meziantou_EmbeddedConstantsMemberVisibility>
+    <Meziantou_EmbeddedConstantsMaxBinaryFileSize Condition="'$(Meziantou_EmbeddedConstantsMaxBinaryFileSize)' == ''">1048576</Meziantou_EmbeddedConstantsMaxBinaryFileSize>
     <Meziantou_EmbeddedConstantsOutputPath Condition="'$(Meziantou_EmbeddedConstantsOutputPath)' == ''">$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'Meziantou.Framework.EmbeddedConstantsGenerator', 'EmbeddedConstants.g.cs'))</Meziantou_EmbeddedConstantsOutputPath>
 
     <_EmbeddedConstantsGeneratedCodePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(Meziantou_EmbeddedConstantsOutputPath)'))</_EmbeddedConstantsGeneratedCodePath>
@@ -34,7 +36,8 @@
                                    ClassName="$(Meziantou_EmbeddedConstantsClassName)"
                                    ClassVisibility="$(Meziantou_EmbeddedConstantsClassVisibility)"
                                    MemberVisibility="$(Meziantou_EmbeddedConstantsMemberVisibility)"
-                                   ProjectDirectory="$(MSBuildProjectDirectory)" />
+                                   ProjectDirectory="$(MSBuildProjectDirectory)"
+                                   MaxBinaryFileSize="$(Meziantou_EmbeddedConstantsMaxBinaryFileSize)" />
 
     <ItemGroup>
       <Compile Include="$(_EmbeddedConstantsGeneratedCodePath)" AutoGen="true" DesignTime="true" Visible="false" />

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
@@ -47,6 +47,7 @@ internal static partial class EmbeddedFiles
 | `EmbeddedConstantsClassName` | `EmbeddedConstants` | Name of the generated class |
 | `EmbeddedConstantsClassVisibility` | `internal` | Generated class visibility: `internal` or `public` |
 | `EmbeddedConstantsMemberVisibility` | `public` | Generated member visibility: `internal` or `public` |
+| `EmbeddedConstantsMaxBinaryFileSize` | `1048576` (1 MiB) | Largest binary file that may be embedded, in bytes |
 | `EmbeddedConstantsOutputPath` | `$(IntermediateOutputPath)\Meziantou.Framework.EmbeddedConstantsGenerator\EmbeddedConstants.g.cs` | Generated C# file path |
 
 The prefixed forms `Meziantou_EmbeddedConstantsNamespace`, `Meziantou_EmbeddedConstantsClassName`, `Meziantou_EmbeddedConstantsClassVisibility`, `Meziantou_EmbeddedConstantsMemberVisibility`, and `Meziantou_EmbeddedConstantsOutputPath` are also supported and take precedence over the shorter aliases.
@@ -80,7 +81,9 @@ If two implicit names collide, the generator tries a path-based name. Remaining 
 
 Text files must be valid UTF-8. An optional UTF-8 BOM is ignored. Binary files are embedded as-is.
 
-Text files larger than 1 MiB are rejected to avoid producing impractically large generated source. Binary files are emitted as byte arrays and should also be kept reasonably small.
+Text files larger than 1 MiB are rejected to avoid producing impractically large generated source.
+
+Binary files are emitted as byte arrays, which cost about six characters of C# per byte. A 4 MiB asset produces roughly 26 MiB of generated source and takes about a minute to compile, so binary files larger than 1 MiB are rejected too. Raise `EmbeddedConstantsMaxBinaryFileSize` if you really need a larger one, or use `EmbeddedResource` instead. Files marked as `Both` are bound by the text limit, because they also produce a `const string`.
 
 ## MSBuild Errors
 
@@ -95,3 +98,4 @@ Text files larger than 1 MiB are rejected to avoid producing impractically large
 | `MFECG0007` | Embedded constant text file is not valid UTF-8 |
 | `MFECG0008` | Embedded constant text file is too large |
 | `MFECG0009` | Embedded constants visibility is invalid |
+| `MFECG0012` | Embedded constant binary file is too large |

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -199,6 +199,27 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         Assert.Contains("MFECG0005", string.Join('\n', result.Output));
     }
 
+    [Fact]
+    public async Task GenerateOnBuild_BinaryFileTooLarge_FailsBuildUntilTheLimitIsRaised()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("large-binary");
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile("large-binary/Sample.csproj", CreateProjectFile(fixture, """
+                <EmbeddedConstant Include="Assets/large.bin" Kind="Binary" />
+            """));
+        CreateBinaryFile(projectDirectory / "Assets" / "large.bin", new byte[(1024 * 1024) + 1]);
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        Assert.Contains("MFECG0012", string.Join('\n', result.Output));
+
+        await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo", "/p:EmbeddedConstantsMaxBinaryFileSize=4194304"], expectedExitCode: 0);
+    }
+
     private static string CreateProjectFile(EmbeddedConstantsGeneratorPackageFixture fixture, string embeddedConstants)
     {
         return $$"""

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
@@ -68,6 +68,40 @@ public sealed class EmbeddedConstantsGeneratorUnitTests
     }
 
     [Fact]
+    public async Task Create_BinaryFileExceedsMaximumSize_ReportsError()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        File.WriteAllBytes(temporaryDirectory.FullPath / "big.bin", new byte[Generator.DefaultMaxBinaryFileBytes + 1]);
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "big.bin", kind: "Binary")]);
+
+        Assert.Equal(["MFECG0012"], ErrorCodes(result));
+    }
+
+    [Fact]
+    public async Task Create_BinaryFileExceedsMaximumSizeButTheLimitIsRaised_Succeeds()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        File.WriteAllBytes(temporaryDirectory.FullPath / "big.bin", new byte[Generator.DefaultMaxBinaryFileBytes + 1]);
+
+        var options = CreateOptions(temporaryDirectory.FullPath, maxBinaryFileBytes: Generator.DefaultMaxBinaryFileBytes * 2);
+        var result = Generator.Create(options, [TextFile(temporaryDirectory, "big.bin", kind: "Binary")]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task Create_BinaryFileAtTheMaximumSize_Succeeds()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        File.WriteAllBytes(temporaryDirectory.FullPath / "exact.bin", new byte[Generator.DefaultMaxBinaryFileBytes]);
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "exact.bin", kind: "Binary")]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public async Task GenerateSource_TextWithCharactersThatNeedEscaping_ProducesAValidLiteral()
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
@@ -145,9 +179,9 @@ public sealed class EmbeddedConstantsGeneratorUnitTests
         Assert.True(source.IndexOf("AppleText", StringComparison.Ordinal) < source.IndexOf("ZebraText", StringComparison.Ordinal));
     }
 
-    private static Options CreateOptions(string projectDirectory, string ns = "Demo", string className = "EmbeddedFiles", string classVisibility = "internal", string memberVisibility = "public")
+    private static Options CreateOptions(string projectDirectory, string ns = "Demo", string className = "EmbeddedFiles", string classVisibility = "internal", string memberVisibility = "public", int maxBinaryFileBytes = Generator.DefaultMaxBinaryFileBytes)
     {
-        return new Options(ns, className, classVisibility, memberVisibility, projectDirectory);
+        return new Options(ns, className, classVisibility, memberVisibility, projectDirectory, maxBinaryFileBytes);
     }
 
     private static InputFile TextFile(TemporaryDirectory temporaryDirectory, string relativePath, string kind = "Text", string? name = null)


### PR DESCRIPTION
**Stack 2 of 4** · merges into #2776 · must merge after #2776, before #2778 and #2779

This is the one finding from the review rated **High**: a binary asset can make a consumer's build unusable with no diagnostic explaining why.

## The finding

`EmbeddedConstantsGeneratorTask.cs:573-583` — the `MaxTextFileBytes` check at line 579 is only reached after the `kind == Binary` early return at line 573. So text files are capped at 1 MiB and binary files are not capped at all.

Each byte costs six characters of generated source (`0x1F, `). Measured against the real generator:

| input | generated C# | task time | `dotnet build` of a project containing only that file |
| -- | -- | -- | -- |
| 1 MiB binary | 6.6 MiB | 30 ms | — |
| 4 MiB binary | 26.3 MiB | ~110 ms | **56 s** |
| 8 MiB binary | 52.5 MiB | 230 ms | — |
| 32 MiB binary | 210.0 MiB | 834 ms | — |

No error, no warning, no message — the build just gets slow, and past a few tens of MiB Roslyn runs out of memory. `<EmbeddedConstant Include="Assets/**" Kind="Binary" />` is the obvious way to use this package and is exactly what triggers it.

The readme does say binary files "should also be kept reasonably small", but guidance without enforcement or a diagnostic does not help someone who has already tripped it.

## The change

Reject binary files over a limit with `MFECG0012`, and make the limit configurable through `EmbeddedConstantsMaxBinaryFileSize` (default 1 MiB, the same as the text limit). The message names the property and points at `EmbeddedResource` for genuinely large assets.

Configurable rather than hard-coded because, unlike text, there is no `const string` metadata limit forcing a particular ceiling — the constraint is compile time, which is a judgement call.

## Behaviour change

A project embedding a binary larger than 1 MiB fails to build until it sets `EmbeddedConstantsMaxBinaryFileSize`. That is deliberate — the alternative is the silent multi-minute build above — but it is a breaking change for existing consumers and may warrant a version bump beyond the current `1.0.2`. I left `<Version>` alone since the repo appears to manage that separately.

## Verification

- Three unit tests: over the limit reports `MFECG0012`, exactly at the limit succeeds, over the limit with a raised limit succeeds.
- One end-to-end test: a 1 MiB + 1 byte asset fails the real build with `MFECG0012`, then the same build succeeds with `/p:EmbeddedConstantsMaxBinaryFileSize=4194304`.

21/21 pass.
