### PR TITLE
Make byte members mirror the file for every kind

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
@@ -573,15 +573,15 @@ internal static class EmbeddedConstantsGeneratorTask
                 return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, text: null, Array.Empty<byte>(), errors);
             }
 
+            // Every byte costs six characters of generated source, so a large file makes the build unusable
+            if (kind.HasFlag(EmbeddedConstantKind.Binary) && bytes.Length > maxBinaryFileBytes)
+            {
+                errors.Add(ValidationError.BinaryFileTooLarge(file.FullPath, maxBinaryFileBytes));
+                return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, text: null, Array.Empty<byte>(), errors);
+            }
+
             if (kind == EmbeddedConstantKind.Binary)
             {
-                // Every byte costs six characters of generated source, so a large file makes the build unusable
-                if (bytes.Length > maxBinaryFileBytes)
-                {
-                    errors.Add(ValidationError.BinaryFileTooLarge(file.FullPath, maxBinaryFileBytes));
-                    return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, text: null, Array.Empty<byte>(), errors);
-                }
-
                 return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, text: null, bytes, errors);
             }
 
@@ -595,7 +595,9 @@ internal static class EmbeddedConstantsGeneratorTask
             try
             {
                 var content = Utf8NoBomThrowOnInvalidBytes.GetString(textBytes, 0, textBytes.Length);
-                return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, content, textBytes, errors);
+
+                // The byte member mirrors the file exactly. Only the text member drops the byte order mark.
+                return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, content, bytes, errors);
             }
             catch (DecoderFallbackException)
             {

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
@@ -79,7 +79,9 @@ If two implicit names collide, the generator tries a path-based name. Remaining 
 
 ## Text Encoding
 
-Text files must be valid UTF-8. An optional UTF-8 BOM is ignored. Binary files are embedded as-is.
+Text files must be valid UTF-8. An optional UTF-8 BOM is stripped from the generated `const string`.
+
+Byte members always mirror the file exactly, for every `Kind`. A file marked as `Both` whose content starts with a BOM therefore produces a `Text` member without the BOM and a `Bytes` member with it.
 
 Text files larger than 1 MiB are rejected to avoid producing impractically large generated source.
 

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
@@ -120,7 +120,7 @@ public sealed class EmbeddedConstantsGeneratorUnitTests
     }
 
     [Fact]
-    public async Task Create_TextFileStartsWithByteOrderMark_RemovesIt()
+    public async Task Create_TextFileStartsWithByteOrderMark_RemovesItFromTheTextMember()
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
         File.WriteAllBytes(temporaryDirectory.FullPath / "bom.txt", [0xEF, 0xBB, 0xBF, (byte)'{', (byte)'}']);
@@ -129,6 +129,23 @@ public sealed class EmbeddedConstantsGeneratorUnitTests
         var source = Generator.GenerateSource(result.Options, result.Entries);
 
         Assert.Contains("""public const string BomText = "{}";""", source);
+    }
+
+    [Theory]
+    [InlineData("Binary")]
+    [InlineData("Both")]
+    public async Task Create_FileStartsWithByteOrderMark_ByteMemberKeepsIt(string kind)
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        File.WriteAllBytes(temporaryDirectory.FullPath / "bom.json", [0xEF, 0xBB, 0xBF, (byte)'{', (byte)'}']);
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath), [TextFile(temporaryDirectory, "bom.json", kind: kind)]);
+        Assert.Empty(result.Errors);
+
+        var source = Generator.GenerateSource(result.Options, result.Entries);
+
+        // The byte member is the file, byte for byte, whichever Kind asked for it
+        Assert.Contains("0xEF, 0xBB, 0xBF, 0x7B, 0x7D", source);
     }
 
     [Fact]


### PR DESCRIPTION
**Stack 3 of 4** · merges into #2777 · must merge after #2776 and #2777, before #2779

The same file produces different bytes depending on its `Kind`.

## The finding

`EmbeddedConstantsGeneratorTask.cs:578` and `:588` — the text path passes `textBytes` (byte order mark removed) as the `bytes` argument, whereas the binary path at `:575` passes the raw `bytes`.

Verified. For a `config.json` whose bytes are `EF BB BF 7B 7D`:

- `Kind="Binary"` produces `ConfigBytes => new byte[] { 0xEF, 0xBB, 0xBF, 0x7B, 0x7D }`
- `Kind="Both"` produces `ConfigBytes => new byte[] { 0x7B, 0x7D }`

Same file, same member name, different content, no diagnostic and no documentation of the difference.

The readme states flatly that "Binary files are embedded as-is" and scopes BOM removal to the Text section. Anyone who switches a file from `Binary` to `Both` to also get the text form silently changes the bytes underneath them — a hash comparison, a length assertion, or a byte-for-byte round trip to disk breaks with no visible cause. It also means `XBytes` is not a faithful copy of the file, which is the one property a "bytes" member should have.

## The change

The byte member now mirrors the file exactly for every `Kind`. Only the `const string` drops the BOM, which is what a C# consumer wants from text.

Also moves the binary size check from #2777 so it applies whenever the `Binary` flag is set, including `Both` — previously `Both` was bounded only by the text limit, and now that its byte member carries the raw bytes it should answer to the binary limit as well.

The readme's Text Encoding section is rewritten to state the rule directly rather than leaving it implied.

## Verification

New theory over `Binary` and `Both` asserting the byte member contains `0xEF, 0xBB, 0xBF, 0x7B, 0x7D` for both. The existing test that the text member drops the BOM is kept and renamed to say which member it is about.

23/23 pass.
