### PR TITLE
Report member names that collide with each other or with the class name

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
@@ -168,7 +168,7 @@ internal static class EmbeddedConstantsGeneratorTask
         }
 
         UsePathBasedNamesForImplicitDuplicates(options, entries);
-        ReportDuplicateMembers(entries, errors);
+        ReportInvalidMemberNames(options, entries, errors);
 
         return entries;
     }
@@ -183,17 +183,39 @@ internal static class EmbeddedConstantsGeneratorTask
 
         foreach (var entry in duplicatedImplicitEntries)
         {
+            // A file outside the project directory has no stable relative path. Naming the member after its
+            // absolute path would make the generated API depend on where the repository is checked out, so
+            // the collision is reported instead and the file needs explicit Name metadata.
             var relativePath = MakeRelativePath(entry.File.FullPath, options.ProjectDirectory);
+            if (relativePath is null)
+                continue;
+
             var pathWithoutExtension = Path.ChangeExtension(relativePath, extension: null);
             entry.BaseName = ToPascalCaseIdentifier(pathWithoutExtension);
         }
     }
 
-    private static void ReportDuplicateMembers(List<EmbeddedConstantEntry> entries, List<ValidationError> errors)
+    private static void ReportInvalidMemberNames(GeneratorOptions options, List<EmbeddedConstantEntry> entries, List<ValidationError> errors)
     {
         foreach (var group in GetDuplicateMemberNames(entries))
         {
-            errors.Add(ValidationError.DuplicateMemberName(group.MemberName));
+            var paths = group.Entries
+                .Select(entry => entry.File.FullPath)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+            errors.Add(ValidationError.DuplicateMemberName(group.MemberName, paths));
+        }
+
+        foreach (var entry in entries)
+        {
+            foreach (var memberName in entry.GetMemberNames())
+            {
+                if (string.Equals(memberName, options.ClassName, StringComparison.Ordinal))
+                {
+                    errors.Add(ValidationError.MemberNameMatchesClassName(memberName, entry.File.FullPath));
+                }
+            }
         }
     }
 
@@ -336,26 +358,35 @@ internal static class EmbeddedConstantsGeneratorTask
         return bytes;
     }
 
-    private static string MakeRelativePath(string path, string? basePath)
+    /// <summary>
+    /// Returns <paramref name="path"/> relative to <paramref name="basePath"/>, or <see langword="null"/>
+    /// when it is not under it. Path.GetRelativePath applies the comparison rules of the current platform.
+    /// </summary>
+    private static string? MakeRelativePath(string path, string? basePath)
     {
         if (string.IsNullOrWhiteSpace(basePath))
-            return path;
+            return null;
 
         try
         {
-            var fullBasePath = Path.GetFullPath(basePath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-            var fullPath = Path.GetFullPath(path);
-            if (fullPath.StartsWith(fullBasePath, StringComparison.OrdinalIgnoreCase))
-            {
-                return fullPath.Substring(fullBasePath.Length);
-            }
+            var relativePath = Path.GetRelativePath(Path.GetFullPath(basePath), Path.GetFullPath(path));
+            if (Path.IsPathRooted(relativePath) || IsParentDirectorySegment(relativePath))
+                return null;
+
+            return relativePath;
         }
         catch (Exception)
         {
-            return path;
+            return null;
         }
+    }
 
-        return path;
+    private static bool IsParentDirectorySegment(string relativePath)
+    {
+        if (!relativePath.StartsWith("..", StringComparison.Ordinal))
+            return false;
+
+        return relativePath.Length is 2 || relativePath[2] == Path.DirectorySeparatorChar || relativePath[2] == Path.AltDirectorySeparatorChar;
     }
 
     private static void AppendStringLiteral(StringBuilder sb, string value)
@@ -667,9 +698,15 @@ internal static class EmbeddedConstantsGeneratorTask
             return new ValidationError("MFECG0004", string.Create(CultureInfo.InvariantCulture, $"Embedded constant file has unsupported Kind value '{kind}'"), filePath);
         }
 
-        public static ValidationError DuplicateMemberName(string memberName)
+        public static ValidationError DuplicateMemberName(string memberName, IReadOnlyList<string> filePaths)
         {
-            return new ValidationError("MFECG0005", string.Create(CultureInfo.InvariantCulture, $"Generated member name '{memberName}' is used by multiple embedded constant files"), filePath: null);
+            var paths = string.Join(", ", filePaths);
+            return new ValidationError("MFECG0005", string.Create(CultureInfo.InvariantCulture, $"Generated member name '{memberName}' is used by multiple embedded constant files ({paths}). Set the Name metadata on all but one of them."), filePaths.Count > 0 ? filePaths[0] : null);
+        }
+
+        public static ValidationError MemberNameMatchesClassName(string memberName, string filePath)
+        {
+            return new ValidationError("MFECG0013", string.Create(CultureInfo.InvariantCulture, $"Generated member name '{memberName}' is the same as the generated class name, which does not compile. Set the Name metadata on this file, or change the 'EmbeddedConstantsClassName' property."), filePath);
         }
 
         public static ValidationError CannotReadFile(string filePath, string message)

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
@@ -75,7 +75,9 @@ Examples:
 | `appsettings.Development.json` | `Both` | `AppsettingsDevelopmentText`, `AppsettingsDevelopmentBytes` |
 | `logo.bin` | `Binary` | `LogoBytes` |
 
-If two implicit names collide, the generator tries a path-based name. Remaining collisions are reported as MSBuild errors.
+If two implicit names collide, the generator tries a name based on the file path relative to the project directory. Files outside the project directory keep their original name, because a name derived from an absolute path would change with the location of the checkout. Remaining collisions are reported as MSBuild errors, and the files involved need explicit `Name` metadata.
+
+A generated member may not have the same name as the generated class, since C# does not allow it. That is reported too.
 
 ## Text Encoding
 
@@ -101,3 +103,4 @@ Binary files are emitted as byte arrays, which cost about six characters of C# p
 | `MFECG0008` | Embedded constant text file is too large |
 | `MFECG0009` | Embedded constants visibility is invalid |
 | `MFECG0012` | Embedded constant binary file is too large |
+| `MFECG0013` | Embedded constant member name is the same as the generated class name |

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorUnitTests.cs
@@ -167,6 +167,58 @@ public sealed class EmbeddedConstantsGeneratorUnitTests
     }
 
     [Fact]
+    public async Task Create_ImplicitNamesCollideOutsideTheProjectDirectory_ReportsErrorInsteadOfUsingTheAbsolutePath()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("project");
+        var outsideDirectory = temporaryDirectory.CreateDirectory("outside");
+        File.WriteAllText(projectDirectory / "shared.txt", "inside");
+        File.WriteAllText(outsideDirectory / "shared.txt", "outside");
+
+        var result = Generator.Create(
+            CreateOptions(projectDirectory),
+            [
+                new InputFile(projectDirectory / "shared.txt", "Text", null, projectDirectory),
+                new InputFile(outsideDirectory / "shared.txt", "Text", null, projectDirectory),
+            ]);
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("MFECG0005", error.Code);
+
+        // Both files keep the colliding name instead of one being renamed after its absolute path
+        Assert.Contains("'SharedText'", error.Message);
+    }
+
+    [Fact]
+    public async Task Create_MemberNameMatchesTheClassName_ReportsError()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        temporaryDirectory.CreateTextFile("Foo.txt", "x");
+
+        var result = Generator.Create(CreateOptions(temporaryDirectory.FullPath, className: "FooText"), [TextFile(temporaryDirectory, "Foo.txt")]);
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("MFECG0013", error.Code);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateMemberName_NamesTheFilesInvolved()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        temporaryDirectory.CreateTextFile("p.txt", "p");
+        temporaryDirectory.CreateTextFile("q.txt", "q");
+
+        var result = Generator.Create(
+            CreateOptions(temporaryDirectory.FullPath),
+            [TextFile(temporaryDirectory, "p.txt", name: "Same"), TextFile(temporaryDirectory, "q.txt", name: "Same")]);
+
+        var error = Assert.Single(result.Errors);
+        Assert.Contains("p.txt", error.Message);
+        Assert.Contains("q.txt", error.Message);
+        Assert.NotNull(error.FilePath);
+    }
+
+    [Fact]
     public async Task Create_ExplicitNamesNormaliseToTheSameIdentifier_ReportsError()
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
**Stack 4 of 4** · merges into #2778 · must merge last

Four related defects in the member-naming pipeline. `CreateEntries` calls `UsePathBasedNamesForImplicitDuplicates` and then `ReportDuplicateMembers`, and those two methods sit one blank line apart (`:189` and `:191`) — they are one mechanism, so they are fixed together rather than as four PRs that all collide.

## Finding 1 — a member name equal to the class name emits uncompilable code, with no diagnostic

`:191-197`. `ReportDuplicateMembers` compares member names against each other, never against `options.ClassName`.

With `<EmbeddedConstantsClassName>FooText</EmbeddedConstantsClassName>` and `<EmbeddedConstant Include="Foo.txt" Kind="Text" />`, `Create` reports zero errors and emits:

```csharp
internal static partial class FooText
{
    public const string FooText = "x";
}
```

which fails with `error CS0542: 'FooText': member names cannot be the same as their enclosing type` (confirmed by compiling it). The user gets a Roslyn error pointing into a generated file they did not write, with no `MFECG` code to search for. Now reported as `MFECG0013`.

## Finding 2 — the name fallback embeds absolute filesystem paths

`:175-189` calling `MakeRelativePath:338-358`, which returns the full path unchanged when the file is not under `ProjectDirectory`.

Verified: two files named `shared.txt`, one in the project and one at `../shared/`, both without explicit `Name`. They collide, the fallback kicks in, and the out-of-project one becomes:

```csharp
public const string VarFoldersL_M8fk0x1s07ngvkcrk8mhhpqh0000gnTEcgOutsideSharedText = "o";
```

On CI the same file sits at a different absolute path, so the member is named something else entirely — code that references it compiles locally and fails on the build server. It also bakes the developer's home directory into shipped IL as a public member name.

Now the fallback is skipped for files outside the project directory, so the collision survives and is reported as `MFECG0005` telling the user to set `Name`. An error is better than a name that depends on where the repository is checked out.

## Finding 3 — `MFECG0005` named the member but not the files

`:658-661`, with `FilePath` passed as `null` at `:195`. With a glob over a large asset tree, finding the two culprits was manual work. The message now lists the participating files and the error is attributed to the first of them so the IDE can navigate to it.

## Finding 4 — `MakeRelativePath` compared paths case-insensitively

`:347` used `StringComparison.OrdinalIgnoreCase`. On Linux, `/src/Project/` and `/src/project/` are different directories, but this treated a file under the latter as being under the former. Replaced with `Path.GetRelativePath`, which applies the current platform's rules and also normalises separators; a result that is rooted or starts with a `..` segment means "not under the base path".

## Verification

Three new unit tests: the class-name collision reports `MFECG0013`; the out-of-project collision reports `MFECG0005` rather than inventing a path-based name; the duplicate message names both files and sets `FilePath`. The existing test that in-project duplicates still get path-based names (`ASettingsText` / `BSettingsText`) continues to pass, which is what keeps finding 2's fix from over-reaching.

26/26 pass on `net10.0` and `net11.0`.
