### PR TITLE
Document which components IgnoreCase actually affects

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPatternOptions.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPatternOptions.cs
@@ -7,10 +7,19 @@ namespace Meziantou.Framework;
 /// </remarks>
 public sealed class UrlPatternOptions
 {
-    /// <summary>Gets or sets whether the pattern matching should be case-insensitive.</summary>
+    /// <summary>Gets or sets whether the pathname, search and hash should be matched case-insensitively.</summary>
     /// <remarks>
-    /// If <see langword="true"/>, all matching operations will be case-insensitive.
-    /// If <see langword="false"/> (default), matching is case-sensitive.
+    /// <para>
+    /// If <see langword="true"/>, the pathname, search and hash are matched case-insensitively.
+    /// If <see langword="false"/> (default), they are matched case-sensitively.
+    /// </para>
+    /// <para>
+    /// The option does not reach the protocol, username, password, hostname and port components, which the
+    /// spec always compiles with the default options. In practice the protocol and hostname are still matched
+    /// case-insensitively, because both the pattern and the URL are lower-cased before they are compared; the
+    /// username, password and port are always case-sensitive.
+    /// </para>
+    /// <see href="https://urlpattern.spec.whatwg.org/#create">WHATWG URL Pattern Spec - Create</see>
     /// </remarks>
     public bool IgnoreCase { get; set; }
 }

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -176,6 +176,34 @@ public sealed class UrlPatternTests
         Assert.True(pattern.IsMatch("https://example.com/Books/123"));
     }
 
+    [Fact]
+    public void IsMatch_IgnoreCase_AppliesToThePathnameSearchAndHash()
+    {
+        var options = new UrlPatternOptions { IgnoreCase = true };
+
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Pathname = "/Books" }, options)
+            .IsMatch("https://example.com/books"));
+
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Search = "Foo=Bar" }, options)
+            .IsMatch("https://example.com?foo=bar"));
+
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Hash = "Section" }, options)
+            .IsMatch("https://example.com#section"));
+    }
+
+    [Fact]
+    public void IsMatch_IgnoreCase_DoesNotApplyToTheUsernamePasswordOrPort()
+    {
+        // Per the spec, ignoreCase only reaches the pathname, search and hash components
+        var options = new UrlPatternOptions { IgnoreCase = true };
+
+        Assert.False(UrlPattern.Create(new UrlPatternInit { Username = "Admin" }, options)
+            .IsMatch(new UrlPatternInit { Username = "admin" }));
+
+        Assert.False(UrlPattern.Create(new UrlPatternInit { Password = "Secret" }, options)
+            .IsMatch(new UrlPatternInit { Password = "secret" }));
+    }
+
     // Full URL pattern string
     [Fact]
     public void Create_WithFullUrlPatternString_ShouldParse()


### PR DESCRIPTION
`UrlPatternOptions.IgnoreCase` was documented as *"all matching operations will be case-insensitive"*. It reaches only three of the eight components.

[The spec's `create` algorithm](https://urlpattern.spec.whatwg.org/#create) compiles the protocol, username, password, hostname and port with the plain default options, and threads `ignoreCase` into the compile options used for the pathname, search and hash only. This implementation follows the spec exactly (`UrlPattern.cs:266-280`) — the documentation is what was wrong:

```csharp
var options = new UrlPatternOptions { IgnoreCase = true };
UrlPattern.Create(new UrlPatternInit { Username = "Admin" }, options)
          .IsMatch(new UrlPatternInit { Username = "admin" });  // false
```

## What changed

Documentation only; no behaviour change. The remark now names the three components the option affects, and explains why the picture is not as stark as it sounds: the protocol and hostname end up case-insensitive anyway because both sides are lower-cased before comparison, while the username, password and port are genuinely case-sensitive regardless of the flag. The `<summary>` names the scope too, since that is the line most tooling shows.

## Verification

Two new cases in `UrlPatternTests`, both passing before and after — they pin behaviour that was already correct, so the documentation cannot drift back:

- `IsMatch_IgnoreCase_AppliesToThePathnameSearchAndHash`
- `IsMatch_IgnoreCase_DoesNotApplyToTheUsernamePasswordOrPort`

Full suite: 532 passed, 0 failed, both target frameworks, no warnings. `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `src/Meziantou.Framework.Uri`.
