### PR TITLE
Escape the tag start of text nodes when sanitizing HTML

### DIFF
--- a/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
@@ -147,6 +147,14 @@ public sealed class HtmlSanitizer
                         text.IsCData = false;
                         text.Value = EscapeText(text.Value);
                         break;
+
+                    case HtmlText text:
+                        // A "<" this parser kept as text is not necessarily text to a browser. An unterminated
+                        // "<!--" puts it in comment state for the rest of the page, and "<!x", "<?x" or "</0" start
+                        // a bogus comment that swallows everything up to the next ">". Text is written back exactly
+                        // as it was read, so the "<" would reach the browser intact.
+                        text.Value = EscapeTagStart(text.Value);
+                        break;
                 }
             }
         }
@@ -184,6 +192,16 @@ public sealed class HtmlSanitizer
     {
         var options = element.OwnerDocument?.Options.GetElementReadOptions(element.Name) ?? HtmlElementReadOptions.None;
         return (options & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw;
+    }
+
+    // Only "<" is escaped: a text node keeps the entities of the source, so escaping "&" as well would turn an
+    // already encoded "&lt;" into a visible "&lt;".
+    private static string? EscapeTagStart(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        return text.Replace("<", "&lt;", StringComparison.Ordinal);
     }
 
     private static string EscapeText(string? text)

--- a/src/Meziantou.Framework.HtmlSanitizer/readme.md
+++ b/src/Meziantou.Framework.HtmlSanitizer/readme.md
@@ -64,6 +64,25 @@ var result = sanitizer.SanitizeHtmlFragment("<img srcset='https://example.com/im
 // Result: "<img srcset='https://example.com/img1.jpg 300w, https://example.com/img2.jpg 600w'>"
 ```
 
+### Text
+
+Text keeps the entities it was written with, so already encoded markup stays encoded and is not encoded a
+second time. A literal `<` is re-encoded as `&lt;`, because a `<` the parser gave up on is still markup to a
+browser — an unterminated `<!--` would put the rest of the page in comment state.
+
+```csharp
+var sanitizer = new HtmlSanitizer();
+
+sanitizer.SanitizeHtmlFragment("<p>&lt;script&gt;</p>");
+// Result: "<p>&lt;script&gt;</p>"
+
+sanitizer.SanitizeHtmlFragment("<p>a < b</p>");
+// Result: "<p>a &lt; b</p>"
+
+sanitizer.SanitizeHtmlFragment("<b><!--");
+// Result: "<b>&lt;!--</b>"
+```
+
 ### Keeping Comments
 
 Comments are removed by default: downlevel-hidden conditional comments (`<!--[if IE]><script>...</script><![endif]-->`)

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Meziantou.Framework.Sanitizers.Tests;
 
 public class HtmlSanitizerTests
@@ -139,11 +141,94 @@ public class HtmlSanitizerTests
     [InlineData("<p>&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;</p>", "<p>&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;</p>")]
     [InlineData("a &amp; b", "a &amp; b")]
     [InlineData("a & b", "a & b")]
-    [InlineData("<p>a < b</p>", "<p>a < b</p>")]
+    // "<" is the one character that is re-encoded, see Sanitize_EscapesMarkupStartInText
+    [InlineData("<p>a < b</p>", "<p>a &lt; b</p>")]
     public void Sanitize_KeepsTextAsIs(string html, string expectedResult)
     {
         var sanitizer = new HtmlSanitizer();
         Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // A "<" that the parser gave up on and kept as text is still markup to a browser. An unterminated comment
+    // puts the rest of the host page in comment state; "<!x", "<?x" and "</0" are bogus comments that swallow
+    // everything up to the next ">". None of them may be written back with the "<" intact.
+    [InlineData("<b><!--", "<b>&lt;!--</b>")]
+    [InlineData("<p>a<!--b", "<p>a&lt;!--b</p>")]
+    [InlineData("<!--", "&lt;!--")]
+    [InlineData("<b><!x", "<b>&lt;!x</b>")]
+    [InlineData("<b><?x", "<b>&lt;?x</b>")]
+    [InlineData("<b></0", "<b>&lt;/0</b>")]
+    [InlineData("<b><", "<b>&lt;</b>")]
+    [InlineData("<p>a</0 onerror=alert(1)>b</p>", "<p>a&lt;/0 onerror=alert(1)>b</p>")]
+    [InlineData("<p>a<1 onerror=alert(1)>b</p>", "<p>a&lt;1 onerror=alert(1)>b</p>")]
+    [InlineData("<p>a<%img src=x onerror=alert(1)>b</p>", "<p>a&lt;%img src=x onerror=alert(1)>b</p>")]
+    [InlineData("<p>a<//script>b</p>", "<p>a&lt;//script>b</p>")]
+    // Already encoded text is not encoded a second time
+    [InlineData("<p>&lt;script&gt;</p>", "<p>&lt;script&gt;</p>")]
+    [InlineData("<p>a &amp; b</p>", "<p>a &amp; b</p>")]
+    public void Sanitize_EscapesMarkupStartInText(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Fact]
+    public void Sanitize_IsIdempotent()
+    {
+        // Sanitizing something already sanitized must be a no-op: an output that the parser reads back
+        // differently from the way it was written is how mutation XSS gets started.
+        string[] fragments =
+        [
+            "<b><!--", "<p>a<!--b", "<b><!x", "<b><?x", "<b></0", "<b></", "<b><",
+            "-->", "--><img src=x onerror=alert(1)>", "<p>a</b <img src=x onerror=alert(1)>b</p>",
+            "0\"?</<s->s\"\" 7v1v", "<td>]]></style></title><?x", "<table><!--", "<p><!x]]><!--<style>",
+            "<![CDATA[a><script>alert(1)</script>]]>", "<p>a < b</p>", "<p>&lt;script&gt;</p>",
+            "<svg><table></0<!--", "<a href='javascript:alert(1)'></td><!--<script>>",
+            "<noscript><p title=\"</noscript><img src=x onerror=alert(1)>\">",
+            "<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
+            "<form><p>a</p>b<span>c</span></form>", "<p title=a\"b'c>x</p>",
+        ];
+
+        foreach (var fragment in fragments)
+        {
+            var once = new HtmlSanitizer().SanitizeHtmlFragment(fragment);
+            var twice = new HtmlSanitizer().SanitizeHtmlFragment(once);
+            Assert.Equal(once, twice);
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Generating test inputs, and the fixed seed keeps the cases reproducible.")]
+    public void Sanitize_IsIdempotent_Fuzz()
+    {
+        // Elements whose end tag is optional (p, td, table, …) are left out on purpose. They can still nest in
+        // the output in a way the parser reads back differently, which is a separate defect in how the writer
+        // and the implied-end-tag rules line up rather than anything to do with how text is written. Over
+        // 200_000 fragments drawn from the full token set, every remaining violation involved one of them.
+        string[] tokens =
+        [
+            "<b>", "</b>", "<script>", "</script>", "<img src=x onerror=alert(1)>",
+            "<!--", "-->", "<![CDATA[", "]]>", "<svg>", "</svg>", "<style>", "</style>", "<form>", "</form>",
+            "<a href='javascript:alert(1)'>", "</a>", "a", "<", ">", "\"", "'", "=", "/", "</0", "<?x", "<!x",
+            "<title>", "</title>", "<textarea>", "</textarea>", "<noscript>", "</noscript>", "<plaintext>",
+            "<math>", "<div>", "</div>", "<span title=\"", "\">", "<iframe>", "</iframe>",
+        ];
+
+        var random = new Random(Seed: 20260827);
+        for (var i = 0; i < 50_000; i++)
+        {
+            var builder = new StringBuilder();
+            for (var j = random.Next(1, 6); j > 0; j--)
+            {
+                builder.Append(tokens[random.Next(tokens.Length)]);
+            }
+
+            var fragment = builder.ToString();
+            var once = new HtmlSanitizer().SanitizeHtmlFragment(fragment);
+            var twice = new HtmlSanitizer().SanitizeHtmlFragment(once);
+            Assert.Equal(once, twice, message: $"Not idempotent for {fragment}");
+        }
     }
 
     [Theory]


### PR DESCRIPTION
The sanitized output can contain a raw `<` that a browser reads as markup, letting a fragment comment out the rest of the page it is embedded in.

### The failure

When the reader cannot make sense of a `<`, it keeps the characters as a text node, and text is written back exactly as it was read. So with the default `AllowComments = false`:

| input | output on `main` |
|---|---|
| `<b><!--` | `<b><!--</b>` |
| `<b><!x` | `<b><!x</b>` |
| `<b><?x` | `<b><?x</b>` |
| `<b></0` | `<b></0</b>` |

A browser reading `<b><!--</b>` enters comment state at the `<!--` and stays there until it finds a `-->` or the end of the input — so the `</b>` and **everything the host page emits after the sanitized fragment** disappears into a comment. The `<!x` / `<?x` / `</0` forms are bogus comments and swallow everything up to the next `>`, which is enough to eat the host's closing `</div>`.

A post ending in `<!--` therefore blanks out whatever follows it on the page: a moderation banner, a security notice, the rest of a thread. I could not turn this into script execution on its own, since anything after the `-->` is itself sanitized — but "the sanitizer emits an unclosed comment" is not a property a sanitizer should have, and it is the shape mutation-XSS chains are built from.

The same root cause made sanitizing non-idempotent: `sanitize(sanitize(x)) != sanitize(x)` for a large family of inputs, and some of them lost content outright (`0"?</<s->s"" 7v1v` → `0"?</s"" 7v1v` → `0"?</s"">`).

### The change

Text nodes now have their `<` written as `&lt;`.

Only `<` is escaped. A text node keeps the entities of the source — that is what makes `&lt;script&gt;` survive as `&lt;script&gt;` today — so escaping `&` as well would turn already-encoded markup into a visible `&lt;`. The `<![CDATA[…]]>` path is unchanged: its content is literal, so it still goes through the full `&`/`<`/`>` escape.

One existing expectation changes: `<p>a < b</p>` now produces `<p>a &lt; b</p>` instead of `<p>a < b</p>`. It renders identically.

### Verification

- `Sanitize_EscapesMarkupStartInText` — 13 cases covering the comment and bogus-comment vectors, plus two that pin down that already-encoded text is not encoded a second time.
- `Sanitize_IsIdempotent` — a curated corpus, including the content-losing case above.
- `Sanitize_IsIdempotent_Fuzz` — 50 000 generated fragments.

14 of these fail on `main`, including both idempotence tests. All 366 pass after the change (`Meziantou.Framework.HtmlSanitizer.Tests`, both target frameworks), and `dotnet run ./eng/update-all.cs` reports no further changes.

### Known gap

The fuzz alphabet deliberately leaves out elements whose end tag is optional (`p`, `td`, `table`, …). Those can still nest in the output in a way the parser reads back differently — for example `<td></title><form><td>` sanitizes to `<td>&lt;/title><td /></td>`, which re-sanitizes to `<td>&lt;/title></td><td />&lt;/td>`. That is a separate defect in how the writer and the implied-end-tag rules line up, not in how text is written, and it is not addressed here. Over 200 000 fragments drawn from the full token set, all 5 remaining violations involved one of those elements and none involved anything else. The exclusion is commented in the test.

Found during a review of `Meziantou.Framework.HtmlSanitizer`.
