### PR TITLE
Reject conversion types that cannot be instantiated

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/ConvertUtilities.cs
+++ b/src/Meziantou.Framework.TypeConverter/ConvertUtilities.cs
@@ -23,6 +23,12 @@ namespace Meziantou.Framework;
 /// </summary>
 public static class ConvertUtilities
 {
+    /// <summary>Gets a value indicating whether an instance of the type can be created.</summary>
+    internal static bool IsInstantiable(Type type)
+    {
+        return type != typeof(void) && !type.ContainsGenericParameters && !type.IsByRef && !type.IsPointer;
+    }
+
     /// <summary>Gets the default converter instance used by the utility methods.</summary>
     public static IConverter DefaultConverter { get; } = new DefaultConverter();
 
@@ -217,7 +223,7 @@ public static class ConvertUtilities
 
         ArgumentNullException.ThrowIfNull(conversionType);
 
-        if (defaultValue is null && conversionType.IsValueType)
+        if (defaultValue is null && conversionType.IsValueType && IsInstantiable(conversionType))
         {
             defaultValue = Activator.CreateInstance(conversionType);
         }

--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -942,6 +942,13 @@ public class DefaultConverter : IConverter
     {
         ArgumentNullException.ThrowIfNull(conversionType);
 
+        // No instance of these types can be created, so there is nothing to convert to
+        if (!ConvertUtilities.IsInstantiable(conversionType))
+        {
+            value = null;
+            return false;
+        }
+
         if (conversionType == typeof(object))
         {
             value = input;

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ConversionType.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ConversionType.cs
@@ -1,0 +1,59 @@
+namespace Meziantou.Framework.Tests;
+
+public sealed class DefaultConverterTests_ConversionType
+{
+    public static TheoryData<Type> NonInstantiableTypes() => new()
+    {
+        typeof(void),
+        typeof(List<>),
+        typeof(Dictionary<,>),
+        typeof(int).MakeByRefType(),
+        typeof(int).MakePointerType(),
+    };
+
+    // typeof(void).IsValueType is true, so Activator.CreateInstance used to throw NotSupportedException
+    [Theory]
+    [MemberData(nameof(NonInstantiableTypes))]
+    public void TryConvert_NonInstantiableConversionType_ReturnsFalse(Type conversionType)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        var converted = converter.TryChangeType(1, conversionType, cultureInfo, out var value);
+        Assert.False(converted);
+        Assert.Null(value);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonInstantiableTypes))]
+    public void TryConvert_NonInstantiableConversionType_NullInput_ReturnsFalse(Type conversionType)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        var converted = converter.TryChangeType(input: null, conversionType, cultureInfo, out var value);
+        Assert.False(converted);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void ChangeType_NonInstantiableConversionType_ReturnsDefaultValue()
+    {
+        var converter = new DefaultConverter();
+
+        Assert.Null(converter.ChangeType(1, typeof(void)));
+        Assert.Null(converter.ChangeType(1, typeof(List<>)));
+    }
+
+    // A closed generic type is still convertible, so the guard must not be too broad
+    [Fact]
+    public void TryConvert_ClosedGenericConversionType_IsNotRejected()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        var converted = converter.TryChangeType("42", typeof(int?), cultureInfo, out var value);
+        Assert.True(converted);
+        Assert.Equal(42, value);
+    }
+}


### PR DESCRIPTION
`TryChangeType(input, typeof(void), out _)` threw `NotSupportedException`.

## The bug

`typeof(void).IsValueType` is `true`, so both code paths that materialise a default value reached `Activator.CreateInstance(typeof(void))`, which throws:

```
ConvertUtilities.TryChangeType(1, typeof(void), out var v)
  → NotSupportedException: Cannot dynamically create an instance of System.Void
```

By-ref types and open generics were already handled gracefully (both return `false`), so `void` was the odd one out.

This is only reachable through the `Type`-taking overloads, and only with a `Type` a caller would rarely write deliberately — but reflection-driven callers mapping a `MethodInfo.ReturnType` or a `PropertyInfo.PropertyType` can produce it, and being safe with a runtime `Type` is the whole point of that overload.

## What changed

One shared predicate, used at both throw sites:

```csharp
internal static bool IsInstantiable(Type type)
    => type != typeof(void) && !type.ContainsGenericParameters && !type.IsByRef && !type.IsPointer;
```

- `DefaultConverter.TryConvert(object?, Type, …)` returns `false` with a null value for such types before doing any work.
- `ConvertUtilities.ChangeType(…)` guards its `Activator.CreateInstance(conversionType)` call with the same predicate.

**The second location is the interesting one.** I initially guarded only `DefaultConverter`, and the new test for `ChangeType` still failed — `ConvertUtilities.ChangeType` computes its `defaultValue` *before* delegating to the converter, so it threw without ever reaching the guard. Both are the same defect; fixing one and shipping it would have left the bug reachable through the more convenient API.

For by-ref types, pointer types and open generics the observable result is unchanged (they already returned `false`); the guard just makes the reason explicit and cheap.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **140 passed, 0 failed** (was 116; 12 new cases per target framework, net10.0 and net11.0).

Reverting both source files and re-running reproduces the original defect: `System.NotSupportedException : Cannot dynamically create an instance of System.Void`.

New tests run `void`, `List<>`, `Dictionary<,>`, `int&` and `int*` through `TryChangeType` with both a non-null and a null input, and through `ChangeType`. One test deliberately pins the opposite direction — `TryChangeType("42", typeof(int?))` still returns `42` — so the guard cannot silently grow too broad and start rejecting closed generic types.

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — `IsInstantiable` is `internal`.

## Note for review

New test file, `DefaultConverterTests_ConversionType.cs`. `AGENTS.md` asks to prefer existing files, but the existing ones are organised by *source* type (`…_StringTo`, `…_Int32To`, `…_ByteArrayTo`) or by feature (`…_TypeDescriptor`, `…_ImplicitConverter`), and this is about validating the `conversionType` argument. It follows the feature-named pattern; happy to fold it into another file if you would rather.

Found by a project review of `Meziantou.Framework.TypeConverter`.
