### PR TITLE
Document the security characteristics of HTTP Basic authentication

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md
@@ -2,6 +2,9 @@
 
 ASP.NET Core authentication handler for HTTP Basic authentication.
 
+> [!WARNING]
+> HTTP Basic sends the password on **every** request, encoded with Base64, which is reversible and not encryption. Serve these endpoints over HTTPS only. Unlike a session cookie, a leaked Basic credential is the password itself and stays replayable until it is changed.
+
 Credential validation is delegate-based through `options.ValidateCredentials`, which returns a `ClaimsPrincipal` for valid credentials and `null` for invalid credentials.
 
 You can also integrate with ASP.NET Core Identity using `AddHttpBasicIdentity<TUser>()`.
@@ -72,4 +75,26 @@ builder.Services
 
 ## Security options
 
-- `MaxCredentialLength` limits the size (in characters) of the Base64 credential payload in the `Authorization` header.
+- `MaxCredentialLength` limits the size (in characters) of the Base64 credential payload in the `Authorization` header. The limit is applied before the payload is decoded.
+
+### Use HTTPS
+
+Credentials travel in cleartext on every request. Do not expose a Basic endpoint over plain HTTP outside of loopback.
+
+### Rate limit the endpoint
+
+HTTP Basic is an easy brute-force target: there is no CSRF token, no session, and no interactive step, so an attacker can replay guesses as fast as the server answers. Put the endpoint behind [ASP.NET Core rate limiting](https://learn.microsoft.com/aspnet/core/performance/rate-limit).
+
+This matters for throughput too. Credentials are revalidated from scratch on every request, and with ASP.NET Core Identity that means a full password hash each time — on the order of tens of milliseconds of CPU per request. A single client can consume a disproportionate amount of CPU.
+
+### Account lockout with ASP.NET Core Identity
+
+`AddHttpBasicIdentity<TUser>` does **not** record failed sign-in attempts by default, so Identity's lockout never triggers no matter how `IdentityOptions.Lockout` is configured. Pass `lockoutOnFailure: true` to opt in:
+
+```csharp
+builder.Services
+    .AddAuthentication(HttpBasicAuthenticationDefaults.AuthenticationScheme)
+    .AddHttpBasicIdentity<IdentityUser>(options => options.Realm = "My application", lockoutOnFailure: true);
+```
+
+The default is `false` because lockout on an endpoint with no interactive step lets a third party lock accounts out on purpose simply by sending bad passwords. Neither default is safe on its own: choose `lockoutOnFailure: true` to bound guessing per account, or keep `false` and rely on rate limiting to bound guessing per caller. Doing neither leaves an unthrottled password oracle.


### PR DESCRIPTION
## Finding

The readme's "Security options" section listed a single bullet (`MaxCredentialLength`) and said nothing about the three things that actually determine whether a Basic-auth deployment is safe. This PR is **documentation only** — no behaviour changes.

It consolidates three review findings that all land in the same section. They were split into separate findings but would have been three PRs editing the same handful of lines, conflicting pairwise for no reviewer benefit.

### 1. Transport (was: Low)

Basic auth transmits reusable credentials as trivially reversible Base64 on **every** request, and nothing in the readme said so. It is the single most important operational fact about the scheme, and a developer skimming the page would not have encountered it. Unlike a session cookie, a leaked Basic credential is the password itself and stays replayable until changed.

Added as a `> [!WARNING]` callout at the top, where it cannot be missed, plus a "Use HTTPS" subsection.

### 2. Brute force and lockout (was: High)

`AddHttpBasicIdentity<TUser>` does not record failed sign-in attempts by default, so Identity's lockout never triggers regardless of how `IdentityOptions.Lockout` is configured. Confirmed by measurement — 25 consecutive wrong passwords left `AccessFailedCount` at 0 with the account still usable:

```
AccessFailedCount before=0   after 25 bad attempts=0   LockoutEnd=null
correct password still authenticates => 200
```

The readme's Identity example used the affected overload and never mentioned `lockoutOnFailure`.

The default stays `false` — that was a deliberate call, since lockout on an endpoint with no interactive step lets a third party lock accounts out on purpose. The fix here is to make the trade visible rather than silent, with a worked example of opting in and an explicit statement that **neither** default is safe alone: bound guessing per account with `lockoutOnFailure: true`, or bound it per caller with rate limiting, but doing neither leaves an unthrottled password oracle.

### 3. Cost per request (was: Medium)

Credentials are revalidated from scratch on every request. With Identity that is a full password hash each time — **41.8 ms of PBKDF2 per request** measured locally, so roughly 24 requests/second saturates a core, at a cost to the attacker of one cheap HTTP call. Documented alongside the rate-limiting guidance, since that is the mitigation.

## Not included

The `Realm` ASCII restriction belongs to #2724 and is documented there instead — it does not exist on `main` yet, so documenting it here would have made this PR describe behaviour that has not shipped, and would have created a merge-order dependency between two PRs that are otherwise independent.

## Verification

Markdown only. `dotnet run ./eng/update-all.cs` reports no changes, so the readme is not mirrored or generated anywhere that needs updating.
