### PR TITLE
Share one special-scheme table between the pattern and the parser

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/ConstructorStringParser.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/ConstructorStringParser.cs
@@ -35,19 +35,6 @@ internal sealed class ConstructorStringParser
         Done,
     }
 
-    /// <summary>
-    /// Special schemes per URL Standard.
-    /// </summary>
-    private static readonly HashSet<string> SpecialSchemes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "ftp",
-        "file",
-        "http",
-        "https",
-        "ws",
-        "wss",
-    };
-
     public ConstructorStringParser(string input)
     {
         _input = input;
@@ -443,7 +430,7 @@ internal sealed class ConstructorStringParser
         try
         {
             var component = UrlPatternComponent.Compile(protocolString, CanonicalizeProtocol, PatternOptions.Default);
-            foreach (var scheme in SpecialSchemes)
+            foreach (var scheme in SpecialSchemes.All)
             {
                 if (component.RegularExpression.IsMatch(scheme))
                 {

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/SpecialSchemes.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/SpecialSchemes.cs
@@ -1,0 +1,29 @@
+using System.Collections.Frozen;
+
+namespace Meziantou.Framework.UrlPatternInternal;
+
+/// <summary>The special schemes of the URL Standard, and the default port of each.</summary>
+/// <remarks>
+/// <see href="https://url.spec.whatwg.org/#special-scheme">URL Standard - Special scheme</see>
+/// </remarks>
+internal static class SpecialSchemes
+{
+    // "file" is a special scheme, but it has no default port
+    private static readonly FrozenDictionary<string, string> DefaultPorts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["ftp"] = "21",
+        ["http"] = "80",
+        ["https"] = "443",
+        ["ws"] = "80",
+        ["wss"] = "443",
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Gets every special scheme.</summary>
+    public static FrozenSet<string> All { get; } = FrozenSet.Create(StringComparer.OrdinalIgnoreCase, "ftp", "file", "http", "https", "ws", "wss");
+
+    /// <summary>Determines whether the scheme is a special scheme.</summary>
+    public static bool Contains(string scheme) => All.Contains(scheme);
+
+    /// <summary>Gets the default port of the scheme, when it has one.</summary>
+    public static bool TryGetDefaultPort(string scheme, [MaybeNullWhen(false)] out string port) => DefaultPorts.TryGetValue(scheme, out port);
+}

--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -36,31 +36,6 @@ public sealed class UrlPattern
     private readonly UrlPatternComponent _searchComponent;
     private readonly UrlPatternComponent _hashComponent;
 
-    /// <summary>
-    /// Special schemes per URL Standard.
-    /// </summary>
-    private static readonly HashSet<string> SpecialSchemes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "ftp",
-        "file",
-        "http",
-        "https",
-        "ws",
-        "wss",
-    };
-
-    /// <summary>
-    /// Default ports for special schemes.
-    /// </summary>
-    private static readonly Dictionary<string, string> DefaultPorts = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["ftp"] = "21",
-        ["http"] = "80",
-        ["https"] = "443",
-        ["ws"] = "80",
-        ["wss"] = "443",
-    };
-
     private UrlPattern(
         UrlPatternComponent protocolComponent,
         UrlPatternComponent usernameComponent,
@@ -238,7 +213,7 @@ public sealed class UrlPattern
 
         // If protocol is a special scheme and port matches its default port, set port to empty string
         if (SpecialSchemes.Contains(processedInit.Protocol) &&
-            DefaultPorts.TryGetValue(processedInit.Protocol, out var defaultPort) &&
+            SpecialSchemes.TryGetDefaultPort(processedInit.Protocol, out var defaultPort) &&
             processedInit.Port == defaultPort)
         {
             processedInit.Port = "";
@@ -699,7 +674,7 @@ public sealed class UrlPattern
 
     private static bool ProtocolMatchesSpecialScheme(UrlPatternComponent protocolComponent)
     {
-        foreach (var scheme in SpecialSchemes)
+        foreach (var scheme in SpecialSchemes.All)
         {
             if (protocolComponent.RegularExpression.IsMatch(scheme))
             {


### PR DESCRIPTION
`UrlPattern` and `ConstructorStringParser` each carried their own `HashSet<string>` of the six URL Standard special schemes, and `UrlPattern` kept a second table of their default ports right next to its copy. Nothing kept the three in sync: `ComputeProtocolMatchesSpecialScheme` in the parser and `ProtocolMatchesSpecialScheme` in `UrlPattern` answer the same question against two independent lists, and the ports table has to agree with the scheme list for the default-port collapse to work at all.

## What changed

One `internal static class SpecialSchemes` in `UrlPattern/Internal`, holding the scheme set and the default ports together, and both files use it. Pure refactor — no behaviour change:

- The scheme set becomes a `FrozenSet<string>`, still `OrdinalIgnoreCase`. `SpecialSchemes.Contains(x)` reads identically at the call sites; iteration becomes `SpecialSchemes.All`.
- The port lookup becomes `SpecialSchemes.TryGetDefaultPort(scheme, out var port)` over a `FrozenDictionary`, replacing `DefaultPorts.TryGetValue`.
- `file` is deliberately still absent from the port table, with a comment saying so — it is a special scheme with no default port, and the default-port collapse depends on the lookup missing for it.

Both collections are built once and never mutated, so `FrozenSet`/`FrozenDictionary` are a better fit than the mutable `HashSet`/`Dictionary` they replace; the package already depends on `System.Collections.Frozen` for the Public Suffix List.

## Verification

No new tests: this moves two tables without changing what they contain, and the existing suite already exercises both call sites — special-scheme detection through `Create_WithFullUrlPatternString_ShouldParse` and the `file` protocol test, and the default-port collapse through the port tests.

Full suite: 528 passed, 0 failed, both target frameworks, no warnings. `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `src/Meziantou.Framework.Uri`.
