### PR TITLE
Remove the unused ToHexa offset overload and its incomplete validation

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -141,22 +141,7 @@ public class DefaultConverter : IConverter
         if (bytes is null)
             return "";
 
-        return ToHexa(bytes, 0, bytes.Length);
-    }
-
-    private static string ToHexa(byte[]? bytes, int offset, int count)
-    {
-        if (bytes is null)
-            return "";
-
-        ArgumentOutOfRangeException.ThrowIfNegative(offset);
-        ArgumentOutOfRangeException.ThrowIfNegative(count);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, bytes.Length);
-
-        if (offset >= bytes.Length)
-            return "";
-
-        return Convert.ToHexString(bytes, offset, count);
+        return Convert.ToHexString(bytes);
     }
 
     private static byte[]? FromHexa(string hex)


### PR DESCRIPTION
Dead-code removal. **No behaviour change** — see the note at the bottom about tests.

## What was there

`ToHexa(byte[]?, int offset, int count)` validated `offset` but never checked that the range actually fits:

```csharp
ArgumentOutOfRangeException.ThrowIfNegative(offset);
ArgumentOutOfRangeException.ThrowIfNegative(count);
ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, bytes.Length);
```

Nothing constrains `offset + count`, so `ToHexa(new byte[4], 2, 10)` would sail past all three guards into `Convert.ToHexString`, which throws with a message pointing at the BCL rather than at the caller.

It is unreachable today: the overload is `private static` with exactly one caller, `ToHexa(byte[]?)`, which always passes `0, bytes.Length`. The reason it is worth touching at all is that the three guards *read* as complete — the next person to add a call site would reasonably assume the range was checked.

## What changed

Rather than adding a fourth guard to code nothing calls, the overload is deleted and its only caller now calls `Convert.ToHexString(bytes)` directly:

```csharp
private static string ToHexa(byte[]? bytes)
{
    if (bytes is null)
        return "";

    return Convert.ToHexString(bytes);
}
```

16 lines removed, 1 added. `Convert.ToHexString(byte[])` does its own argument validation, so nothing is lost.

I deliberately stopped there. `ToHexa` itself is now a thin wrapper whose null check is unreachable — both call sites pass the non-nullable `byte[] input` parameter of `TryConvert` — so it could be inlined away entirely, but that is a separate judgment call from the finding and did not belong in this diff.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **116 passed, 0 failed**, unchanged from the baseline.

**No new tests.** `CONTRIBUTING.md` asks for a test with every fix, and I want to be explicit rather than quietly skip it: there is no observable behaviour to test here. The removed overload was private and unreachable, and the surviving path is already covered by `TryConvert_ByteArrayToString_Base16WithoutPrefix` and `TryConvert_ByteArrayToString_Base16WithPrefix`, which both still pass. Writing a test for `Convert.ToHexString` would be testing the BCL. If you would rather see this shipped with the fourth guard added instead of the overload deleted, that version can have a test — say the word.

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — everything removed was private.

Found by a project review of `Meziantou.Framework.TypeConverter`.
