### PR TITLE
Fill MaximumLength exactly by budgeting composed characters in one pass

### DIFF
--- a/src/Meziantou.Framework.Slug/Slug.cs
+++ b/src/Meziantou.Framework.Slug/Slug.cs
@@ -14,6 +14,9 @@ public static class Slug
     /// <summary>The number of UTF-16 characters needed to encode any single rune.</summary>
     private const int MaxUtf16CharsPerRune = 2;
 
+    /// <summary>Extra buffer room for the character that turns out not to fit and is removed again.</summary>
+    private const int TruncationHeadroom = 8;
+
     // A Hangul syllable decomposes into a leading jamo, a vowel jamo and an optional trailing jamo. Those are
     // letters rather than marks, so the mark test alone does not recognize them as part of the same character.
     private const int HangulLeadingJamoFirst = 0x1100;
@@ -48,50 +51,32 @@ public static class Slug
         var separator = options.Separator;
         var maximumLength = options.MaximumLength > 0 ? options.MaximumLength : int.MaxValue;
 
-        var sb = new StringBuilder(Math.Min(text.Length, maximumLength));
-        var budget = maximumLength;
-        int trailingSeparatorStart;
-        string slug;
-        while (true)
-        {
-            var completed = AppendSlug(sb, text, options, separator, budget, out trailingSeparatorStart);
-            slug = sb.ToString().Normalize(NormalizationForm.FormC);
-            if (completed)
-                break;
-
-            // The slug is built decomposed but returned composed, and composing it merges each combining
-            // mark back into the character it follows. The buffer can therefore be full while the composed
-            // slug is still under the limit. Grant back exactly the characters composition recovered and
-            // rebuild: the limit stays an upper bound on the composed slug, but it is actually filled.
-            var recovered = sb.Length - slug.Length;
-            if (recovered == 0 || maximumLength > int.MaxValue - recovered)
-                break;
-
-            var extendedBudget = maximumLength + recovered;
-            if (extendedBudget <= budget)
-                break;
-
-            budget = extendedBudget;
-        }
+        // AppendSlug writes a character before it can measure it, so the buffer briefly holds one character more
+        // than the limit allows. Sizing for that keeps the common case in a single StringBuilder chunk.
+        var capacity = text.Length <= maximumLength ? text.Length : Math.Min(text.Length, maximumLength + TruncationHeadroom);
+        var sb = new StringBuilder(capacity);
+        AppendSlug(sb, text, options, separator, maximumLength, out var trailingSeparatorStart);
 
         // Only a separator AppendSlug emitted is trimmed. A character that came from the input is content, even
         // when it matches the separator, so CanEndWithSeparator never deletes something the caller typed.
         if (!options.CanEndWithSeparator && separator.Length > 0 && trailingSeparatorStart >= 0)
-        {
             sb.Length = trailingSeparatorStart;
-            slug = sb.ToString().Normalize(NormalizationForm.FormC);
-        }
 
-        return slug;
+        return sb.ToString().Normalize(NormalizationForm.FormC);
     }
 
-    /// <summary>Rebuilds the slug into <paramref name="sb"/>, using at most <paramref name="budget"/> characters.</summary>
+    /// <summary>Builds the slug into <paramref name="sb"/>, keeping the composed result within <paramref name="maximumLength"/>.</summary>
     /// <param name="trailingSeparatorStart">
     /// The offset of the separator this method emitted at the end of <paramref name="sb"/>, or -1 when the buffer does
     /// not end with one. A separator character that came from the input is content and never reported here.
     /// </param>
-    /// <returns><see langword="true"/> if the whole text was consumed; otherwise, <see langword="false"/>.</returns>
-    private static bool AppendSlug(StringBuilder sb, string text, SlugOptions options, string separator, int budget, out int trailingSeparatorStart)
+    /// <remarks>
+    /// The buffer is decomposed while the returned slug is composed, and composing merges each combining mark back into
+    /// the character it follows, so the two have different lengths. The limit applies to the composed slug, so the budget
+    /// is spent in composed characters: each character is measured once it is complete, and dropped whole when it does
+    /// not fit. That keeps the limit an upper bound on the result while still filling it, in a single pass over the text.
+    /// </remarks>
+    private static void AppendSlug(StringBuilder sb, string text, SlugOptions options, string separator, int maximumLength, out int trailingSeparatorStart)
     {
         sb.Clear();
 
@@ -100,7 +85,13 @@ public static class Slug
         var lastSeparatorStart = -1;
         var usesDefaultReplace = options.UsesDefaultReplace;
         Span<char> transformed = stackalloc char[MaxUtf16CharsPerRune];
-        var characterStart = 0;
+
+        // Length of the composed slug built so far, and the character still being accumulated: it is only measured
+        // once the next character starts, because a combining mark can still shorten it.
+        var composedLength = 0;
+        var characterStart = -1;
+        var characterRuneCount = 0;
+        var separatorLength = separator.Length == 0 ? 0 : separator.Normalize(NormalizationForm.FormC).Length;
         var previousRuneWasHangulJamo = false;
 
         foreach (var rune in text.EnumerateRunes())
@@ -128,57 +119,80 @@ public static class Slug
                     replacement = options.Replace(rune);
                 }
 
-                // A continuation belongs to the character before it, so only a rune that is not one starts
-                // a new character.
                 if (!continuesCharacter)
                 {
+                    if (!TryEndCharacter(sb, characterStart, characterRuneCount, maximumLength, ref composedLength))
+                        break;
+
                     characterStart = sb.Length;
+                    characterRuneCount = 0;
                 }
-                else if (characterStart == sb.Length)
+                else if (characterStart < 0 || characterStart == sb.Length)
                 {
-                    // Nothing was written for the current character, so this continuation has no base to attach
-                    // to and would leave a floating accent or a bare jamo at the start of the slug or right
-                    // after a separator. Drop it, the way a disallowed character's marks are dropped below.
+                    // Nothing was written for the current character, so this continuation has no base to attach to
+                    // and would leave a floating accent or a bare jamo at the start of the slug or right after a
+                    // separator. Drop it, the way a disallowed character's marks are dropped below.
                     continue;
                 }
 
-                if (sb.Length + replacement.Length > budget)
-                {
-                    // Keeping a base character while dropping what follows it would silently strip the accent
-                    // off the last character of the slug, or cut a syllable in half. Drop the character instead.
-                    if (continuesCharacter)
-                        sb.Length = characterStart;
-
-                    trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
-                    return false;
-                }
-
                 sb.Append(replacement);
+                characterRuneCount++;
                 appended = true;
             }
             else if (!isCombiningMark)
             {
                 // A disallowed combining mark is dropped rather than emitting a separator, because it is part of
                 // the character before it and not a word boundary.
+                if (!TryEndCharacter(sb, characterStart, characterRuneCount, maximumLength, ref composedLength))
+                    break;
+
+                characterStart = -1;
+                characterRuneCount = 0;
+
                 // A slug never starts with a separator, and separators are never repeated.
                 if (sb.Length == 0 || EndsWithEmittedSeparator(sb, lastSeparatorStart, separator))
                     continue;
 
-                if (sb.Length + separator.Length > budget)
-                {
-                    trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
-                    return false;
-                }
+                if (separatorLength > maximumLength - composedLength)
+                    break;
 
                 lastSeparatorStart = sb.Length;
                 sb.Append(separator);
-                characterStart = sb.Length;
+                composedLength += separatorLength;
             }
 
             previousRuneWasHangulJamo = appended && IsHangulJamo(rune);
         }
 
+        TryEndCharacter(sb, characterStart, characterRuneCount, maximumLength, ref composedLength);
         trailingSeparatorStart = TrailingSeparatorStart(sb, lastSeparatorStart, separator);
+    }
+
+    /// <summary>
+    /// Charges the character accumulated since <paramref name="characterStart"/> to <paramref name="composedLength"/>,
+    /// or removes it from <paramref name="sb"/> when it no longer fits.
+    /// </summary>
+    /// <returns><see langword="true"/> if the character fit; otherwise, <see langword="false"/>.</returns>
+    private static bool TryEndCharacter(StringBuilder sb, int characterStart, int characterRuneCount, int maximumLength, ref int composedLength)
+    {
+        if (characterStart < 0 || characterStart == sb.Length)
+            return true;
+
+        // A character made of a single rune has nothing to compose with, so its composed length is the length it
+        // already occupies. Only the ones carrying combining marks or jamo are worth normalizing to measure.
+        var length = sb.Length - characterStart;
+        if (characterRuneCount > 1)
+        {
+            length = sb.ToString(characterStart, length).Normalize(NormalizationForm.FormC).Length;
+        }
+
+        if (length > maximumLength - composedLength)
+        {
+            sb.Length = characterStart;
+            return false;
+        }
+
+        composedLength += length;
         return true;
     }
 

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -94,10 +94,10 @@ public class SlugTests
 
     [Theory]
     [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
-    [InlineData(1, "")]
-    [InlineData(2, "\uAC00")]
-    [InlineData(3, "\uAC00")]
-    [InlineData(4, "\uAC00\uAC01")]
+    [InlineData(1, "\uAC00")]
+    [InlineData(2, "\uAC00\uAC01")]
+    [InlineData(3, "\uAC00\uAC01\uAC02")]
+    [InlineData(4, "\uAC00\uAC01\uAC02")]
     [InlineData(5, "\uAC00\uAC01\uAC02")]
     public void Slug_MaximumLength_DoesNotSplitHangulSyllables(int maximumLength, string expected)
     {
@@ -348,9 +348,9 @@ public class SlugTests
 
     [Theory]
     [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
-    [InlineData(1, "")]
-    [InlineData(2, "\u00E9")]
-    [InlineData(3, "\u00E9\u00E9")]
+    [InlineData(1, "\u00E9")]
+    [InlineData(2, "\u00E9\u00E9")]
+    [InlineData(3, "\u00E9\u00E9\u00E9")]
     [InlineData(5, "\u00E9\u00E9\u00E9\u00E9")]
     [InlineData(9, "\u00E9\u00E9\u00E9\u00E9")]
     public void Slug_MaximumLength_AppliesToTheComposedSlug(int maximumLength, string expected)
@@ -383,10 +383,10 @@ public class SlugTests
         var options = new SlugOptions { MaximumLength = 4 };
         options.AllowedRanges.Clear();
 
-        var slug = Slug.Create("\u00E9\u00E9\u00E9\u00E9", options);
+        var slug = Slug.Create("\u00E9\u00E9\u00E9\u00E9\u00E9", options);
 
         Assert.DoesNotContain('e', slug);
-        Assert.Equal("\u00E9\u00E9\u00E9", slug);
+        Assert.Equal("\u00E9\u00E9\u00E9\u00E9", slug);
     }
 
     [Fact]
@@ -415,6 +415,45 @@ public class SlugTests
                     Assert.HasCountLessThanOrEqual(maximumLength, slug, $"[{input}] with limit {maximumLength} and separator '{separator}'");
                     Assert.Equal(slug, slug.Normalize(NormalizationForm.FormC));
                 }
+            }
+        }
+    }
+
+    [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void Slug_MaximumLength_IsFilled_NotMerelyRespected()
+    {
+        string[] texts =
+        [
+            "\u00E9\u00E9\u00E9\u00E9\u00E9\u00E9",
+            "\u1EC7\u1EC7\u1EC7\u1EC7",
+            "Ti\u1EBFng Vi\u1EC7t",
+            "\uAC00\uAC01\uAC02",
+            "caf\u00E9 cr\u00E8me br\u00FBl\u00E9e",
+        ];
+
+        foreach (var text in texts)
+        {
+            for (var maximumLength = 1; maximumLength <= 20; maximumLength++)
+            {
+                var options = new SlugOptions { MaximumLength = maximumLength };
+                options.AllowedRanges.Clear();
+
+                var slug = Slug.Create(text, options);
+
+                // The longest prefix of the input whose composed form still fits the limit.
+                var longestThatFits = "";
+                for (var take = 1; take <= text.Length; take++)
+                {
+                    var candidate = text[..take].Normalize(NormalizationForm.FormC);
+                    if (candidate.Length > maximumLength)
+                        break;
+
+                    longestThatFits = candidate;
+                }
+
+                Assert.HasCountLessThanOrEqual(maximumLength, slug, $"[{text}] with limit {maximumLength} exceeded the limit");
+                Assert.Equal(longestThatFits, slug);
             }
         }
     }


### PR DESCRIPTION
> **Stack 3 of 4 · base `fix/slug-character-boundary` (#2766) · merge after #2766.**
> **This changes observable output** — see *Behavior change* below. It is the finding you were unsure about, so the before/after is laid out in full.

## The problem

`Create` budgeted in *decomposed* characters and then tried to recover the difference by rebuilding:

```csharp
var recovered = sb.Length - slug.Length;
if (recovered == 0 || maximumLength > int.MaxValue - recovered) break;
var extendedBudget = maximumLength + recovered;
if (extendedBudget <= budget) break;
```

When truncation lands mid-character, the partial character is rolled back — which removes the very combining marks whose composition would have proven more room existed. `recovered` is then measured on the rolled-back buffer, which is identical to the previous round's, so `extendedBudget <= budget` and the loop settles one character short. Every limit under-filled:

| input | limit | returned | actually fits |
|---|---|---|---|
| `"éééééé"` | 1 | `""` | `"é"` |
| `"éééééé"` | 2…6 | *N−1* chars | *N* chars |
| `"ệệệệ"` (Vietnamese, 2 marks/char) | 2 | `""` | `"ệệ"` |
| `"Tiếng Việt"` | 3 | `"Ti"` | `"Tiế"` |

At limit 1 the result was the **empty string** for any input starting with an accented character. The loop exists specifically to fill the limit, and `Slug_MaximumLength_FillsTheLimitWhenComposingFreesRoom` asserts that it does — it only half-worked.

## What changed

The budget is now spent in **composed** characters, measured in a single pass. `AppendSlug` accumulates one character at a time (a base plus its marks or jamo, using the grouping from #2766) and charges it once it is complete:

- a character made of a single rune has nothing to compose with, so its composed length is the length it already occupies — no normalization, which is the entire default-options path;
- only a character carrying marks or jamo is normalized, and only that character, not the whole buffer.

The `while (true)` loop, the `recovered` arithmetic and the `int.MaxValue` overflow guard are gone, which also resolves L7 — there is no longer a termination argument to write down, because there is no loop. Budget comparisons are written as `length > maximumLength - composedLength` so an unlimited `int.MaxValue` limit cannot overflow.

`AppendSlug` writes a character before it can measure it, so the buffer briefly holds one character more than the limit allows; the `StringBuilder` is sized with 8 characters of headroom so that overshoot stays in one chunk.

## Behavior change

**The limit is now filled exactly.** Verified against the longest prefix whose composed form fits, over 6 inputs × limits 1–20: **0 under-filled and 0 over-limit results** (previously under-filled at nearly every limit).

Three existing expectations encoded the old under-fill and are updated:

| test | limit | was | now |
|---|---|---|---|
| `Slug_MaximumLength_AppliesToTheComposedSlug` | 1 / 2 / 3 | `""` / `"é"` / `"éé"` | `"é"` / `"éé"` / `"ééé"` |
| `Slug_MaximumLength_DoesNotSplitHangulSyllables` (from #2766) | 1 / 2 / 3 | `""` / `"가"` / `"가"` | `"가"` / `"가각"` / `"가각갂"` |
| `Slug_MaximumLength_NeverStripsCombiningMarksFromTheLastCharacter` | 4 | `"ééé"` from `"éééé"` | `"éééé"` from `"ééééé"` |

The third keeps its point — it now uses a 5-character input so truncation still lands mid-character and the test still proves a partial character is dropped rather than stripped of its accent.

**Default options are unaffected**: the default ranges admit no combining mark, so every character was already a single rune and the old loop never ran a second iteration.

## Performance

200,000 `é` with `AllowedRanges` cleared — the case where the old loop re-scanned O(log limit) times:

| limit | before | after |
|---|---|---|
| 320 | 2.3 ms → 319 chars | 2.1 ms → **320** chars |
| 5,120 | 5.9 ms → 5,119 chars | 3.0 ms → **5,120** chars |
| 20,480 | 27.7 ms → 20,479 chars | 6.1 ms → **20,480** chars |

Cost is now flat in the limit instead of growing with it (finding L3). Allocation rises at very large limits with fully-accented input (2.8 → 3.9 MB at limit 20,480), because each accented character is normalized individually; that is the trade for the single pass, and it does not affect default options.

Default options, 203-char title, best-of-7 × 200,000 calls: **0.69 µs/call and 432 bytes/call, versus 0.71 µs and 432 bytes before** — parity.

## Verification

- New `Slug_MaximumLength_IsFilled_NotMerelyRespected`: asserts the slug equals the longest prefix that fits, over 5 inputs × limits 1–20. This is the two-sided property the old tests lacked.
- Fuzz, 30,000 cases: 0 monotonicity violations, 0 over-limit results, 0 non-NFC results.
- `dotnet test -c Release /p:TreatsWarningsAsErrors=true` — 148/148 across net10.0 and net11.0; 110 pass / 38 skip under `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`.

Found by a project review of `Meziantou.Framework.Slug` (findings M2, L3, L7).
