### PR TITLE
Remove raw text elements even when they are in ValidElements

### DIFF
--- a/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
@@ -111,17 +111,17 @@ public sealed class HtmlSanitizer
             {
                 switch (parent.ChildNodes[i])
                 {
+                    // Blocked elements, and elements whose content is raw text rather than markup, are removed with
+                    // their content. The content of a raw text element (script, style, title, textarea, …) is
+                    // written back verbatim, so neither keeping it nor promoting it to the parent can be made safe.
+                    // This is checked before ValidElements on purpose: adding such an element to the allow list
+                    // would otherwise write its content straight through without ever sanitizing it.
+                    case HtmlElement element when BlockedElements.Contains(element.Name) || HasRawTextContent(element):
+                        element.Remove();
+                        break;
+
                     case HtmlElement element when !IsValidNode(element.Name):
                     {
-                        // Blocked elements, and elements whose content is raw text rather than markup, are removed
-                        // with their content. The content of a raw text element (script, style, title, textarea, …)
-                        // is written back verbatim, so promoting it to the parent would re-inject markup.
-                        if (BlockedElements.Contains(element.Name) || HasRawTextContent(element))
-                        {
-                            element.Remove();
-                            break;
-                        }
-
                         // The element is not allowed but its content is, so only the tag is dropped.
                         var promotedCount = element.ChildNodes.Count;
                         element.Remove(keepChildren: true);

--- a/src/Meziantou.Framework.HtmlSanitizer/readme.md
+++ b/src/Meziantou.Framework.HtmlSanitizer/readme.md
@@ -85,6 +85,10 @@ var sanitizer = new HtmlSanitizer();
 // Add custom elements
 sanitizer.ValidElements.Add("custom-element");
 
+// Has no effect: the content of a raw text element is never sanitized, so the element is
+// removed with its content whether or not it is in ValidElements
+sanitizer.ValidElements.Add("iframe");
+
 // Remove elements from allowed list
 sanitizer.ValidElements.Remove("img");
 
@@ -122,8 +126,8 @@ By default, the sanitizer allows:
 
 An element is handled in one of three ways:
 
-- It is in `ValidElements` (and not in `BlockedElements`): the element and its content are kept, and its attributes are sanitized.
-- It is in `BlockedElements`, or its content is raw text rather than markup (`script`, `style`, `title`, `textarea`, `iframe`, `noscript`, `noembed`, `noframes`, `plaintext`, `xmp`): the element is removed **with its content**.
+- It is in `BlockedElements`, or its content is raw text rather than markup (`script`, `style`, `title`, `textarea`, `iframe`, `noscript`, `noembed`, `noframes`, `plaintext`, `xmp`): the element is removed **with its content**. This takes precedence over `ValidElements` — the content of a raw text element is written back exactly as it was read, so it can never be sanitized and adding such an element to `ValidElements` has no effect.
+- Otherwise, it is in `ValidElements`: the element and its content are kept, and its attributes are sanitized.
 - Otherwise the element is unwrapped: the tag is dropped but its content is kept and sanitized.
 
 ```csharp

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -270,6 +270,44 @@ public class HtmlSanitizerTests
         Assert.Equal("", sanitizer.SanitizeHtmlFragment("<script>alert(1)</script>"));
     }
 
+    [Theory]
+    // The content of these elements is raw text: the parser never reads it as markup and the writer puts it back
+    // exactly as it was, so allowing the element would write unsanitized markup straight through.
+    [InlineData("iframe")]
+    [InlineData("title")]
+    [InlineData("textarea")]
+    [InlineData("noscript")]
+    [InlineData("noembed")]
+    [InlineData("noframes")]
+    [InlineData("xmp")]
+    [InlineData("plaintext")]
+    public void Sanitize_AllowedRawTextElementIsStillRemoved(string name)
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidElements.Add(name);
+
+        Assert.Equal("", sanitizer.SanitizeHtmlFragment($"<{name}><img src=x onerror=alert(1)></{name}>"));
+    }
+
+    [Fact]
+    public void Sanitize_AllowedAndUnblockedRawTextElementIsStillRemoved()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.BlockedElements.Remove("script");
+        sanitizer.ValidElements.Add("script");
+
+        Assert.Equal("<p>ab</p>", sanitizer.SanitizeHtmlFragment("<p>a<script>alert(1)</script>b</p>"));
+    }
+
+    [Fact]
+    public void Sanitize_AllowedRawTextElementIsRemovedWithItsContent()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidElements.Add("title");
+
+        Assert.Equal("<p>ab</p>", sanitizer.SanitizeHtmlFragment("<p>a<title><img src=x onerror=alert(1)></title>b</p>"));
+    }
+
     [Fact]
     public void Sanitize_CanAllowAdditionalAttributes()
     {


### PR DESCRIPTION
Adding a raw text element to `ValidElements` makes the sanitizer write its content out unsanitized.

### The failure

`HasRawTextContent` was only consulted inside the "element is not allowed" branch, so an element that was in `ValidElements` and not in `BlockedElements` skipped the check entirely and was kept along with its content:

```csharp
var sanitizer = new HtmlSanitizer();
sanitizer.ValidElements.Add("iframe");
sanitizer.SanitizeHtmlFragment("<iframe><img src=x onerror=alert(1)></iframe>");
// -> "<iframe><img src=x onerror=alert(1)></iframe>"   (verbatim, never sanitized)
```

The same holds for `title`, `textarea`, `noscript`, `noembed`, `noframes`, `xmp` and `plaintext`. The content of these elements is never parsed as markup and the writer puts it back exactly as it was read, so nothing in the subtree is ever walked, let alone cleaned. Combining `BlockedElements.Remove("script")` with `ValidElements.Add("script")` produced a live `<script>` in the output.

Most of these are not directly exploitable in a current browser — `<iframe>` and `<noscript>` fallback content is not rendered, and `title`/`textarea`/`xmp` are raw text there too. What makes it worth fixing is that the readme presents `ValidElements.Add(...)` as *the* customization story without saying that some names silently turn sanitization off for the subtree. Someone allowing `title` reasonably expects the content to still be cleaned.

The existing `Sanitize_UnblockedRawTextElementIsStillNotUnwrapped` test covered only `BlockedElements.Remove("script")`, which still hit the unwrap branch and so still removed the element.

### The change

The raw text check moves ahead of the allow list, into its own `case`:

```csharp
case HtmlElement element when BlockedElements.Contains(element.Name) || HasRawTextContent(element):
    element.Remove();
    break;
```

Removal with content is now unconditional for those elements. `ValidElements` no longer has a say, which is the only safe answer while the writer emits their content verbatim.

The readme's element-handling rules are reordered to match, and the customization example now shows that allowing `iframe` has no effect.

### Verification

Ten new cases in `HtmlSanitizerTests` — one per raw text element, plus the allow-list-and-unblock combination and one checking the element is removed *with* its content rather than leaving it behind. All ten fail on `main`.

All 356 tests pass after the change (`Meziantou.Framework.HtmlSanitizer.Tests`, both target frameworks), and `dotnet run ./eng/update-all.cs` reports no further changes.

Found during a review of `Meziantou.Framework.HtmlSanitizer`.
