### PR TITLE
Document the AuthenticationType of Identity-issued principals

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md
@@ -70,6 +70,15 @@ builder.Services
     });
 ```
 
+The principal is built by `SignInManager<TUser>.CreateUserPrincipalAsync`, so `User.Identity.AuthenticationType` is Identity's own `"Identity.Application"`, not the Basic scheme name:
+
+```csharp
+app.MapGet("/", (ClaimsPrincipal user) => user.Identity?.AuthenticationType);
+// => "Identity.Application"
+```
+
+Authorization policies are keyed on the authentication *scheme*, so `RequireAuthorization` and `AddAuthenticationSchemes(...)` behave as expected. Only code that branches on `AuthenticationType` is affected — audit logging, "how did this user sign in" checks, or an application that mixes cookie and Basic authentication would attribute these requests to the cookie scheme. Use the scheme name from the authentication ticket if you need to tell them apart.
+
 ## Security options
 
 - `MaxCredentialLength` limits the size (in characters) of the Base64 credential payload in the `Authorization` header.


### PR DESCRIPTION
## Finding

`HttpBasicAuthenticationIdentityExtensions.cs:85` builds the principal with `signInManager.CreateUserPrincipalAsync(user)`, which stamps Identity's own application scheme onto the identity. A request authenticated through `AddHttpBasicIdentity` reports:

```
GET / with valid Basic credentials => 200  alice|authType=Identity.Application
```

even though the authentication ticket's scheme is `Basic`. Nothing documented this.

Authorization policies are keyed on the *scheme*, so `RequireAuthorization` and `AddAuthenticationSchemes(...)` work correctly — this is not a security hole. But application code that branches on `AuthenticationType` (audit logging, "how did this user sign in" checks, an app mixing cookie and Basic auth) will misattribute Basic requests as cookie sign-ins.

## Why documentation rather than a code change

The review offered two directions: document it, or rebuild the principal with a `ClaimsIdentity` carrying the Basic scheme name.

I went with documentation. Rebuilding the principal means copying claims out of whatever `CreateUserPrincipalAsync` produced and reassembling them, which silently discards anything a custom `UserClaimsPrincipalFactory<TUser>` attached to the identity itself (as opposed to the claim list) — and it would be a behaviour change for anyone already relying on the current value. The surprise is cheap to document and expensive to "fix" wrongly.

If you would rather change the behaviour, say so and I will open that as a separate PR against the next major version.

## What changed

Nine lines in the Identity section of the readme: what the value is, a snippet showing it, what is *not* affected (authorization policies), and what is (code branching on `AuthenticationType`).

Documentation only — no code, no API, no test changes.

## Verification

Markdown only. `dotnet run ./eng/update-all.cs` reports no changes.

Note: touches the same file as #2785, in a different section — whichever merges second may need a trivial rebase.
