### PR TITLE
Extract the shared URL-to-components split from MatchUrl and IsMatchUrl

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -402,16 +402,28 @@ public sealed class UrlPattern
 
     private UrlPatternResult? MatchUrl(Uri url, string originalInput)
     {
-        var protocol = url.Scheme;
-        var username = Uri.UnescapeDataString(url.UserInfo.Split(':').FirstOrDefault() ?? "");
-        var password = url.UserInfo.Contains(':', StringComparison.Ordinal) ? Uri.UnescapeDataString(url.UserInfo[(url.UserInfo.IndexOf(':', StringComparison.Ordinal) + 1)..]) : "";
-        var hostname = url.Host;
-        var port = url.IsDefaultPort ? "" : url.Port.ToString(CultureInfo.InvariantCulture);
-        var pathname = url.AbsolutePath;
-        var search = url.Query.TrimStart('?');
-        var hash = url.Fragment.TrimStart('#');
+        var (protocol, username, password, hostname, port, pathname, search, hash) = GetUrlComponents(url);
 
         return MatchComponents(protocol, username, password, hostname, port, pathname, search, hash, originalInput);
+    }
+
+    /// <summary>Splits the URL into the eight component values that are matched against the pattern.</summary>
+    private static (string Protocol, string Username, string Password, string Hostname, string Port, string Pathname, string Search, string Hash) GetUrlComponents(Uri url)
+    {
+        var userInfo = url.UserInfo;
+        var separatorIndex = userInfo.IndexOf(':', StringComparison.Ordinal);
+        var username = separatorIndex == -1 ? userInfo : userInfo[..separatorIndex];
+        var password = separatorIndex == -1 ? "" : userInfo[(separatorIndex + 1)..];
+
+        return (
+            url.Scheme,
+            Uri.UnescapeDataString(username),
+            Uri.UnescapeDataString(password),
+            url.Host,
+            url.IsDefaultPort ? "" : url.Port.ToString(CultureInfo.InvariantCulture),
+            url.AbsolutePath,
+            url.Query.TrimStart('?'),
+            url.Fragment.TrimStart('#'));
     }
 
     private UrlPatternResult? MatchInit(UrlPatternInit init)
@@ -515,14 +527,7 @@ public sealed class UrlPattern
 
     private bool IsMatchUrl(Uri url)
     {
-        var protocol = url.Scheme;
-        var username = Uri.UnescapeDataString(url.UserInfo.Split(':').FirstOrDefault() ?? "");
-        var password = url.UserInfo.Contains(':', StringComparison.Ordinal) ? Uri.UnescapeDataString(url.UserInfo[(url.UserInfo.IndexOf(':', StringComparison.Ordinal) + 1)..]) : "";
-        var hostname = url.Host;
-        var port = url.IsDefaultPort ? "" : url.Port.ToString(CultureInfo.InvariantCulture);
-        var pathname = url.AbsolutePath;
-        var search = url.Query.TrimStart('?');
-        var hash = url.Fragment.TrimStart('#');
+        var (protocol, username, password, hostname, port, pathname, search, hash) = GetUrlComponents(url);
 
         return IsMatchComponents(protocol, username, password, hostname, port, pathname, search, hash);
     }

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -670,6 +670,22 @@ public sealed class UrlPatternTests
         Assert.True(pattern.IsMatch("https://user:secret@example.com/path"));
     }
 
+    [Theory]
+    // url, expected username, expected password
+    [InlineData("https://example.com/path", "", "")]
+    [InlineData("https://john@example.com/path", "john", "")]
+    [InlineData("https://john:secret@example.com/path", "john", "secret")]
+    [InlineData("https://:secret@example.com/path", "", "secret")]
+    [InlineData("https://john:pa:ss@example.com/path", "john", "pa:ss")]
+    public void Match_SplitsTheUserInfoIntoUsernameAndPassword(string url, string expectedUsername, string expectedPassword)
+    {
+        var result = UrlPattern.Create(new UrlPatternInit()).Match(url);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedUsername, result.Username.Input);
+        Assert.Equal(expectedPassword, result.Password.Input);
+    }
+
     // Trailing slash handling
     [Fact]
     public void IsMatch_TrailingSlash()


### PR DESCRIPTION
`MatchUrl` and `IsMatchUrl` held the same eight lines of `Uri`-to-components code, duplicated verbatim. The copy-paste is the risk — any future fix to how a component is derived has to be made twice, and the two would diverge silently.

The user-info handling in both copies also did more work than it needed to:

```csharp
var username = Uri.UnescapeDataString(url.UserInfo.Split(':').FirstOrDefault() ?? "");
var password = url.UserInfo.Contains(':', StringComparison.Ordinal)
    ? Uri.UnescapeDataString(url.UserInfo[(url.UserInfo.IndexOf(':', StringComparison.Ordinal) + 1)..])
    : "";
```

`Split(':')` allocates a `string[]` — and for `user:pass` a second string too — only to take the first element, and the string is then scanned twice more by `Contains` and `IndexOf`.

## What changed

One `GetUrlComponents(Uri)` helper returning the eight values as a named tuple; both methods call it. The user-info split is a single `IndexOf` plus two slices, so the array and the redundant scans are gone.

Behaviour is identical, including the corner cases: no user-info gives two empty strings, `:secret` gives an empty username, and a password containing a further `:` keeps it (only the first `:` separates).

## Verification

`Match_SplitsTheUserInfoIntoUsernameAndPassword` — five theory cases covering no user info, username only, username and password, empty username, and a password containing a `:`. These are characterization tests: they pass on `main` and after the change, which is what makes them useful for a refactor. I ran them against `main`'s `UrlPattern.cs` with the new test file to confirm — 5 passed there too.

Full suite: 538 passed, 0 failed, both target frameworks, no warnings. `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `src/Meziantou.Framework.Uri`.
