### PR TITLE
Fix the readme and XML documentation samples

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/ConvertUtilities.cs
+++ b/src/Meziantou.Framework.TypeConverter/ConvertUtilities.cs
@@ -17,7 +17,7 @@ namespace Meziantou.Framework;
 ///
 /// // Convert with culture-specific formatting
 /// var cultureInfo = CultureInfo.GetCultureInfo("fr-FR");
-/// var number = ConvertUtilities.ChangeType<decimal>("1234,56", provider: cultureInfo);
+/// var number = ConvertUtilities.ChangeType<decimal>("1234,56", defaultValue: 0m, provider: cultureInfo);
 /// ]]></code>
 /// </example>
 /// </summary>

--- a/src/Meziantou.Framework.TypeConverter/readme.md
+++ b/src/Meziantou.Framework.TypeConverter/readme.md
@@ -33,7 +33,7 @@ Console.WriteLine(result); // 0
 
 // Convert with culture-specific formatting
 var cultureInfo = CultureInfo.GetCultureInfo("fr-FR");
-var number = ConvertUtilities.ChangeType<decimal>("1234,56", provider: cultureInfo);
+var number = ConvertUtilities.ChangeType<decimal>("1234,56", defaultValue: 0m, provider: cultureInfo);
 Console.WriteLine(number); // 1234.56
 ```
 
@@ -44,7 +44,7 @@ var bytes = new byte[] { 1, 2, 3, 4 };
 
 // Default: Base64
 var converter1 = new DefaultConverter();
-converter1.TryChangeType(bytes, null, out string base64);
+converter1.TryChangeType(bytes, null, out string? base64);
 Console.WriteLine(base64); // "AQIDBA=="
 
 // Hexadecimal without prefix
@@ -52,7 +52,7 @@ var converter2 = new DefaultConverter
 {
     ByteArrayToStringFormat = ByteArrayToStringFormat.Base16
 };
-converter2.TryChangeType(bytes, null, out string hex);
+converter2.TryChangeType(bytes, null, out string? hex);
 Console.WriteLine(hex); // "01020304"
 
 // Hexadecimal with 0x prefix
@@ -60,15 +60,15 @@ var converter3 = new DefaultConverter
 {
     ByteArrayToStringFormat = ByteArrayToStringFormat.Base16Prefixed
 };
-converter3.TryChangeType(bytes, null, out string hexPrefixed);
+converter3.TryChangeType(bytes, null, out string? hexPrefixed);
 Console.WriteLine(hexPrefixed); // "0x01020304"
 
 // Convert from hexadecimal string to byte array
-ConvertUtilities.TryChangeType("0x01020304", out byte[] result);
+ConvertUtilities.TryChangeType("0x01020304", out byte[]? result);
 // result = [1, 2, 3, 4]
 
 // Convert from Base64 string to byte array
-ConvertUtilities.TryChangeType("AQIDBA==", out byte[] result2);
+ConvertUtilities.TryChangeType("AQIDBA==", out byte[]? result2);
 // result2 = [1, 2, 3, 4]
 ```
 


### PR DESCRIPTION
The samples in the readme and in the `ConvertUtilities` XML doc do not compile.

The XML-doc copy surfaces in IntelliSense and on the NuGet page, so it is the first thing a new user tries.

## What was broken

I extracted every ` ```csharp ` block from `readme.md` plus the `<code>` block from the `ConvertUtilities` class doc into a scratch project (nullable enabled, `TreatWarningsAsErrors=true`) and compiled them verbatim. Two distinct problems, 7 diagnostics:

**`ChangeType` called with 2 arguments** — `error CS1501`. There is no `ChangeType<T>(object?, IFormatProvider?)` overload; the one taking a provider also requires `defaultValue`:

```csharp
var number = ConvertUtilities.ChangeType<decimal>("1234,56", provider: cultureInfo);
//                                     ^ CS1501: No overload for method 'ChangeType' takes 2 arguments
```

**Six `error CS8600`** from `out` variables declared non-nullable. `TryChangeType` annotates its out parameter `[MaybeNullWhen(false)]`, so `out string base64` and `out byte[] result` are "converting null literal or possible null value to non-nullable type".

## What changed

Minimal corrections to the samples themselves — no API change:

- `ChangeType<decimal>("1234,56", defaultValue: 0m, provider: cultureInfo)`
- `out string?` in the three byte-array-to-string samples
- `out byte[]?` in the two string-to-byte-array samples

The `ChangeType` fix is applied in both places the sample appears (`readme.md` and the `ConvertUtilities` XML doc).

## Verification

All four blocks — three from the readme, one from the XML doc — now compile clean with nullable enabled and `TreatWarningsAsErrors=true`: **Build succeeded**, no errors, no warnings.

I also *ran* them, to check that the expected-output comments are truthful:

```
--- readme: basic conversions ---     42 · 0 · 1234.56
--- readme: byte arrays ---           AQIDBA== · 01020304 · 0x01020304
--- readme: dictionary extensions --- 25 · 19.99 · default · Age: 25
--- ConvertUtilities XML doc ---      42
```

Every value matches its comment.

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — 116 passed, 0 failed, unchanged. `dotnet run ./eng/update-all.cs` reports no generated-file changes (the readme edit does not propagate to the root readme).

## Two corrections to the review that prompted this

Worth recording, since the review is the source document for this PR:

1. **The "duplicate variable name" claim was wrong.** The review stated the byte-array block "declares the same variable name twice in one block". It does not — `result` and `result2` are distinct, and the compiler raises nothing. Only the nullability of those declarations was a real problem.
2. **CS8600 is a warning, not an error**, in a default project. It only became an error here because I compiled the samples with `TreatWarningsAsErrors=true`. So a user pasting these would have seen six warnings rather than a failed build. The `CS1501` on `ChangeType` is a hard error regardless.

## Note for review

The review suggested two follow-ups I did not take, both of which are yours to call:

- **Adding a `ChangeType<T>(object?, IFormatProvider?)` overload** would let the original sample read as written, and it is arguably the ergonomic gap the sample author assumed existed. It is a public API addition, so it needs `ref/` regeneration and a deliberate decision — not something to slip into a docs fix.
- **Compiling the samples in CI** would stop this recurring. The extraction script I used for this PR is about 15 lines; happy to turn it into a test project if you want it.

Found by a project review of `Meziantou.Framework.TypeConverter`.
