### PR TITLE
Make the MaximumLength property tests two-sided

### DIFF
--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -389,31 +389,125 @@ public class SlugTests
         Assert.Equal("\u00E9\u00E9\u00E9\u00E9", slug);
     }
 
-    [Fact]
-    public void Slug_MaximumLength_IsNeverExceededOnComposingInput()
+    [Theory]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    [InlineData("\u00E9\u00E9\u00E9\u00E9", "\u00E9\u00E9\u00E9\u00E9")]
+    [InlineData("caf\u00E9 cr\u00E8me br\u00FBl\u00E9e", "caf\u00E9 cr\u00E8me br\u00FBl\u00E9e")]
+    [InlineData("\uAC00\uAC01\uAC02", "\uAC00\uAC01\uAC02")]
+    [InlineData("a\u0301\u0302\u0303\u0304b", "\u00E1\u0302\u0303\u0304b")]
+    [InlineData("  \u00E9 \u00E9  ", "  \u00E9 \u00E9  ")]
+    [InlineData("\U0001F600\u00E9\U0001F600", "\U0001F600\u00E9\U0001F600")]
+    [InlineData("Ti\u1EBFng Vi\u1EC7t", "Ti\u1EBFng Vi\u1EC7t")]
+    [InlineData("a-b--c", "a-b--c")]
+    public void Slug_MaximumLength_Unlimited_KeepsEveryAllowedCharacter(string text, string expected)
     {
-        string[] inputs =
+        var options = new SlugOptions { MaximumLength = 0 };
+        options.AllowedRanges.Clear();
+
+        var slug = Slug.Create(text, options);
+
+        Assert.Equal(expected, slug);
+    }
+
+    [Fact]
+    public void Slug_MaximumLength_Properties_WithoutNormalization()
+    {
+        // Normalization is a no-op under InvariantGlobalization, so these inputs keep the limit logic covered in
+        // both modes. The cases that depend on composing are in Slug_MaximumLength_Properties.
+        string[] texts = ["hello world this is long", "a-b--c", "a  b", "!!!", "A", "ab cdef"];
+
+        foreach (var text in texts)
+        {
+            foreach (var separator in new[] { "-", "__", "" })
+            {
+                foreach (var canEndWithSeparator in new[] { true, false })
+                {
+                    SlugOptions CreateOptions(int maximumLength)
+                        => new() { MaximumLength = maximumLength, Separator = separator, CanEndWithSeparator = canEndWithSeparator };
+
+                    var context = $"[{text}] separator '{separator}' canEndWithSeparator={canEndWithSeparator}";
+                    var unlimited = Slug.Create(text, CreateOptions(0));
+                    var previous = "";
+
+                    for (var maximumLength = 1; maximumLength <= 24; maximumLength++)
+                    {
+                        var slug = Slug.Create(text, CreateOptions(maximumLength));
+
+                        Assert.HasCountLessThanOrEqual(maximumLength, slug, $"{context} with limit {maximumLength} exceeded the limit");
+                        Assert.StartsWith(previous, slug, message: $"{context}: limit {maximumLength} does not extend the slug from limit {maximumLength - 1}");
+
+                        if (maximumLength >= unlimited.Length)
+                        {
+                            Assert.Equal(unlimited, slug);
+                        }
+
+                        previous = slug;
+                    }
+                }
+            }
+        }
+    }
+
+    [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void Slug_MaximumLength_Properties()
+    {
+        string[] texts =
         [
             "\u00E9\u00E9\u00E9\u00E9",
             "caf\u00E9 cr\u00E8me br\u00FBl\u00E9e",
             "\uAC00\uAC01\uAC02",
+            "a\u0301\u0302\u0303\u0304b",
             "  \u00E9 \u00E9  ",
             "\U0001F600\u00E9\U0001F600",
+            "Ti\u1EBFng Vi\u1EC7t",
+            "a-b--c",
+            "_b\u00C1\u11A8--__a!",
         ];
 
-        foreach (var input in inputs)
+        foreach (var text in texts)
         {
-            for (var maximumLength = 1; maximumLength <= 24; maximumLength++)
+            foreach (var separator in new[] { "-", "__", "" })
             {
-                foreach (var separator in new[] { "-", "__", "" })
+                foreach (var clearAllowedRanges in new[] { true, false })
                 {
-                    var options = new SlugOptions { MaximumLength = maximumLength, Separator = separator };
-                    options.AllowedRanges.Clear();
+                    foreach (var canEndWithSeparator in new[] { true, false })
+                    {
+                        SlugOptions CreateOptions(int maximumLength)
+                        {
+                            var options = new SlugOptions { MaximumLength = maximumLength, Separator = separator, CanEndWithSeparator = canEndWithSeparator };
+                            if (clearAllowedRanges)
+                            {
+                                options.AllowedRanges.Clear();
+                            }
 
-                    var slug = Slug.Create(input, options);
+                            return options;
+                        }
 
-                    Assert.HasCountLessThanOrEqual(maximumLength, slug, $"[{input}] with limit {maximumLength} and separator '{separator}'");
-                    Assert.Equal(slug, slug.Normalize(NormalizationForm.FormC));
+                        var context = $"[{text}] separator '{separator}' cleared={clearAllowedRanges} canEndWithSeparator={canEndWithSeparator}";
+                        var unlimited = Slug.Create(text, CreateOptions(0));
+                        var previous = "";
+
+                        for (var maximumLength = 1; maximumLength <= 24; maximumLength++)
+                        {
+                            var slug = Slug.Create(text, CreateOptions(maximumLength));
+
+                            Assert.HasCountLessThanOrEqual(maximumLength, slug, $"{context} with limit {maximumLength} exceeded the limit");
+                            Assert.Equal(slug, slug.Normalize(NormalizationForm.FormC));
+
+                            // Raising the limit only ever appends, so the shorter slug is a prefix of the longer one.
+                            Assert.StartsWith(previous, slug, message: $"{context}: limit {maximumLength} does not extend the slug from limit {maximumLength - 1}");
+
+                            // A limit that can hold the whole slug produces exactly it, so truncation is the only
+                            // thing the limit ever does.
+                            if (maximumLength >= unlimited.Length)
+                            {
+                                Assert.Equal(unlimited, slug);
+                            }
+
+                            previous = slug;
+                        }
+                    }
                 }
             }
         }
@@ -458,19 +552,4 @@ public class SlugTests
         }
     }
 
-    [Fact]
-    public void Slug_MaximumLength_RaisingTheLimitNeverShortensTheSlug()
-    {
-        var previousLength = 0;
-        for (var maximumLength = 1; maximumLength <= 24; maximumLength++)
-        {
-            var options = new SlugOptions { MaximumLength = maximumLength };
-            options.AllowedRanges.Clear();
-
-            var slug = Slug.Create("caf\u00E9 cr\u00E8me br\u00FBl\u00E9e", options);
-
-            Assert.HasCountGreaterThanOrEqual(previousLength, slug, $"limit {maximumLength} produced fewer characters than limit {maximumLength - 1}");
-            previousLength = slug.Length;
-        }
-    }
 }


### PR DESCRIPTION
> **Stack 4 of 4 · base `fix/slug-recovery-one-pass` (#2788) · merge last.**

Tests only. The two tests designated as the guard for the `MaximumLength` logic could not fail.

## The problem

`Slug_MaximumLength_IsNeverExceededOnComposingInput` asserted only `slug.Length <= maximumLength` and `slug == slug.Normalize(FormC)`. `Slug_MaximumLength_RaisingTheLimitNeverShortensTheSlug` asserted only that the length is non-decreasing as the limit rises, starting from `previousLength = 0`, and never compared content.

I ran both bodies verbatim against `static string BrokenCreate(text, options) => "";` — **both pass**, in ICU and invariant mode. Neither ever asserted the slug is non-empty, contains any of the input's characters, or that limit *N*'s output relates to limit *N+1*'s. An implementation capping every slug at one character also passes.

Commit `3becdfbc7` states these two "are what guards the library itself under `InvariantGlobalization`". They guarded nothing — which is how the four truncation defects in #2757, #2766 and #2788 shipped green, including a monotonicity invariant that was *false* of the implementation while this very test claimed to assert it.

## What replaces them

**`Slug_MaximumLength_Unlimited_KeepsEveryAllowedCharacter`** — a theory anchoring the unlimited slug to a concrete expected value for 8 inputs (accented, Vietnamese two-mark, Hangul, a 4-deep mark stack, surrogate pairs, separator-bearing). This is the assertion that makes the suite non-vacuous.

**`Slug_MaximumLength_Properties`** — 9 inputs × 3 separators × cleared/default ranges × both `CanEndWithSeparator` × limits 1–24 (2,592 combinations), asserting four properties:

1. the slug never exceeds the limit;
2. the slug is always NFC;
3. **limit *N*'s slug is a prefix of limit *N+1*'s** — strictly stronger than the old "no shorter", and it pins content rather than just length;
4. **a limit at least as large as the unlimited slug reproduces it exactly** — so truncation is the only thing the limit ever does.

**`Slug_MaximumLength_Properties_WithoutNormalization`** — the same four properties over inputs where normalization is a no-op, so it is *not* `[RunIf(NotInvariant)]` and keeps the limit logic covered in invariant mode. Without it, marking the Unicode property tests `NotInvariant` would have left that CI leg with no coverage of this logic at all — replacing one gap with another.

## Does the new suite actually catch it?

Replaying the bodies against the broken implementations:

| implementation | old test 1 | old test 2 | new anchor | new properties |
|---|---|---|---|---|
| always returns `""` | passes | passes | **fails** | passes |
| caps every slug at 1 char | passes | passes | **fails** | passes |

The anchor theory is what catches both; the property test alone would not, which is why both are here rather than only the property sweep. A degenerate implementation cannot satisfy a concrete expected value.

## Verification

- ICU: 164/164 pass across net10.0 and net11.0.
- `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`: 108 pass, 56 skipped, 0 fail — two more passing than before, from the invariant-safe property test.
- The four properties were validated over 2,592 combinations before being asserted, rather than assumed.
- `dotnet run ./eng/update-all.cs` — no generated files changed.

Found by a project review of `Meziantou.Framework.Slug` (finding H2).
