### PR TITLE
Only read quoted attribute names in doctypes and processing instructions

### DIFF
--- a/src/Meziantou.Framework.Html/HtmlReader.cs
+++ b/src/Meziantou.Framework.Html/HtmlReader.cs
@@ -172,6 +172,13 @@ sealed class HtmlReader
         return character is '"' or '\'';
     }
 
+    // "<!DOCTYPE …>" and "<?php … ?>" are not elements: they carry quoted text rather than attributes, and the
+    // public and system identifiers of a doctype are read back from the names of its attributes.
+    private static bool CanHaveQuotedAttributeNames(string? elementName)
+    {
+        return elementName is ['!' or '?', ..];
+    }
+
     public static bool IsWhiteSpace(int character)
     {
         return character is 10 or 13 or 32 or 9;
@@ -553,19 +560,13 @@ sealed class HtmlReader
                     break;
 
                 case HtmlParserState.AttName:
-                    // quoted named are essentially useful for !DOCTYPE tags
                     if (Value.Length == 1) // first char?
                     {
-                        if (IsAnyQuote(Value[0]))
-                        {
-                            // quoted
-                            QuoteChar = Value[0];
-                        }
-                        else
-                        {
-                            // not quoted
-                            QuoteChar = '\0';
-                        }
+                        // A quoted name only means something in a !DOCTYPE or a processing instruction. Everywhere
+                        // else the HTML tokenizer treats a quote as an ordinary attribute name character, and
+                        // ending the name at the closing quote dropped the value that followed it - and, when
+                        // that value contained a quote of the other kind, the content of the element as well.
+                        QuoteChar = IsAnyQuote(Value[0]) && CanHaveQuotedAttributeNames(_currentElement) ? Value[0] : '\0';
                     }
 
                     // quoted name?

--- a/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
@@ -589,6 +589,38 @@ public class HtmlParserTests
         Assert.Equal(expectedLine, states[^1].Line);
     }
 
+    [Theory]
+    // An attribute name that starts with a quote used to end at the closing quote, which dropped the value that
+    // followed it. When that value contained a quote of the other kind, the rest of the tag went with it and the
+    // content of the element was lost. A browser treats the quote as an ordinary attribute name character.
+    [InlineData("<p 'class'='a'>x</p>", "<p class='a'>x</p>")]
+    [InlineData("<p \"class\"=\"a\">x</p>", "<p class=\"a\">x</p>")]
+    [InlineData("<p 'title'='a\" onmouseover=\"alert(1)'>x</p>", "<p title='a\" onmouseover=\"alert(1)'>x</p>")]
+    [InlineData("<p 'class'='a'>x<b>y</b></p>", "<p class='a'>x<b>y</b></p>")]
+    // A doctype and a processing instruction carry quoted text rather than attributes, so they keep it
+    [InlineData("<!DOCTYPE html><p>a</p>", "<!DOCTYPE html><p>a</p>")]
+    // The space before "?>" is how a processing instruction has always been written back
+    [InlineData("<?xml version='1.0'?><p>a</p>", "<?xml version='1.0' ?><p>a</p>")]
+    public void HtmlParser_QuotedAttributeNames(string html, string expected)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        Assert.Equal(expected, document.OuterHtml);
+    }
+
+    [Fact]
+    public void HtmlParser_DoctypeKeepsItsPublicAndSystemIdentifiers()
+    {
+        const string Html = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"><p>a</p>";
+        var document = new HtmlDocument();
+        document.LoadHtml(Html);
+
+        Assert.Equal(Html, document.OuterHtml);
+        Assert.NotNull(document.DocumentType);
+        Assert.Equal(["html", "PUBLIC", "-//W3C//DTD XHTML 1.0 Strict//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"], document.DocumentType!.Attributes.Select(a => a.Name));
+    }
+
     private static List<HtmlReaderState> ReadAll(string html)
     {
         var reader = new HtmlReader(new StringReader(html));


### PR DESCRIPTION
An attribute name that starts with a quote loses its value, and sometimes the content of the element with it.

### The failure

`HtmlParserState.AttName` treated a leading quote as opening a *quoted attribute name* and ended the attribute at the closing quote — in every tag, not only in the `!DOCTYPE` the comment said it was there for. The `=value` that followed was then read as something else entirely:

| input | before | a browser sees |
|---|---|---|
| `<p 'class'='a'>x</p>` | `<p 'class'>x</p>` | attribute named `'class'`, value `a` |
| `<p "class"="a">x</p>` | `<p "class">x</p>` | attribute named `"class"`, value `a` |
| `<p 'title'='a" onmouseover="alert(1)'>x</p>` | `<p 'title' />` | attribute named `'title'` |

The third row is the bad one: the value contained a quote of the other kind, so the rest of the tag was swallowed and **the text `x` disappeared**. For anything rendering user content through `Meziantou.Framework.HtmlSanitizer`, that is a post that silently vanishes rather than one that gets cleaned.

### The change

A quoted attribute name is now only recognised where it means something — a `!DOCTYPE`, whose public and system identifiers are read back from the names of its attributes (`HtmlDocument.WriteDocType`), and a processing instruction, which carries quoted text rather than attributes. Both are detected by the `!` or `?` that starts their name. Everywhere else the quote is an ordinary attribute name character, which is what the HTML tokenizer does.

I first restricted this to `!DOCTYPE` alone, which broke `<?php echo '<script>…</script>'; ?>` — the PI stopped containing its own quoted text and leaked it into the document as text. Including processing instructions keeps that working; the sanitizer test that covers it passes unchanged.

### Verification

Five parser tests in `HtmlParserTests` for the quoted-name cases, plus one pinning down that a full `<!DOCTYPE html PUBLIC "…" "…">` still round-trips and still exposes its identifiers as attribute names. Four of them fail on `main`.

No existing expectation changed anywhere:

| project | tests |
|---|---|
| `Meziantou.Framework.Html.Tests` | 284 |
| `Meziantou.Framework.HtmlSanitizer.Tests` | 336 |
| `Meziantou.Framework.HtmlToMarkdown.Tests` | 1698 |
| `Meziantou.Framework.Html.Tool.Tests` | 12 |
| `Meziantou.Framework.Templating.Html.Tests` | 18 |

`dotnet run ./eng/update-all.cs` reports no further changes, and there is no public API change.

### What this does not change

`HtmlReaderState.Value` still strips a surrounding pair of quotes from an attribute name, so `<p 'class'='a'>` is reported as `class`, where a browser reports a junk attribute literally named `'class'`. That is pre-existing and untouched here. It matters only for fidelity: the sanitizer now evaluates the *unquoted* name against its allow list, which is the stricter reading — `<p 'onclick'='alert(1)'>x</p>` sanitizes to `<p>x</p>`.

Found during a review of `Meziantou.Framework.HtmlSanitizer`.
