### PR TITLE
Correct the srcset samples and document URL validation in the sanitizer readme

### DIFF
--- a/src/Meziantou.Framework.HtmlSanitizer/readme.md
+++ b/src/Meziantou.Framework.HtmlSanitizer/readme.md
@@ -57,11 +57,11 @@ var sanitizer = new HtmlSanitizer();
 
 // Blocks srcset with dangerous URLs
 var result = sanitizer.SanitizeHtmlFragment("<img srcset='javascript:alert() 300w, https://example.com 600w'>");
-// Result: "<img srcset=''>"
+// Result: "<img srcset='' />"
 
 // Allows safe srcset
 var result = sanitizer.SanitizeHtmlFragment("<img srcset='https://example.com/img1.jpg 300w, https://example.com/img2.jpg 600w'>");
-// Result: "<img srcset='https://example.com/img1.jpg 300w, https://example.com/img2.jpg 600w'>"
+// Result: "<img srcset='https://example.com/img1.jpg 300w, https://example.com/img2.jpg 600w' />"
 ```
 
 ### Keeping Comments
@@ -108,6 +108,26 @@ sanitizer.ValidAttributes.Remove("target");
 // Add attributes that should be URL-validated
 sanitizer.UriAttributes.Add("data-url");
 ```
+
+`ValidAttributes` and `UriAttributes` are separate sets, and only `UriAttributes` triggers URL validation.
+Adding an attribute to `ValidAttributes` alone lets any value through unchecked:
+
+```csharp
+var sanitizer = new HtmlSanitizer();
+sanitizer.ValidAttributes.Add("data-url");
+
+sanitizer.SanitizeHtmlFragment("<p data-url='javascript:alert(1)'>test</p>");
+// Result: "<p data-url='javascript:alert(1)'>test</p>"   (the value is not validated)
+
+sanitizer.UriAttributes.Add("data-url");
+sanitizer.SanitizeHtmlFragment("<p data-url='javascript:alert(1)'>test</p>");
+// Result: "<p data-url=''>test</p>"
+```
+
+Add any attribute that a browser resolves as a URL to both sets — `action`, `formaction`, `poster`, `data`,
+`srcdoc`, `dynsrc` and `lowsrc` among them. The same applies in reverse: removing an attribute from
+`UriAttributes` while leaving it in `ValidAttributes` stops its value from being checked. Removing it from
+`ValidAttributes` alone is safe, since the attribute is then dropped.
 
 ## Default Configuration
 
@@ -176,6 +196,10 @@ The URL sanitizer allows:
 - `file:`
 - Relative URLs (no protocol)
 - Safe data URLs (base64-encoded images, videos, and audio)
+
+A URL is rejected when it contains a `&` before the first `/`, `?` or `#`. This is what stops an entity from
+masking the scheme, as in `java&#115;cript:alert(1)` or `javascript&#58;alert(1)`. It also rejects the rare
+relative URL whose first segment contains a literal `&`, such as `q&a.html` — encode it as `q%26a.html`.
 
 ## Implementation Details
 


### PR DESCRIPTION
Three corrections to the `Meziantou.Framework.HtmlSanitizer` readme. Documentation only — no code change.

**The `srcset` samples showed the wrong output.** Both claimed `<img srcset='…'>` where the sanitizer actually writes the self-closing `<img srcset='…' />`, as `UrlSanitizerTests.Sanitize_Srcset` has always asserted.

**Allowing an attribute did not obviously skip URL validation.** `ValidAttributes` and `UriAttributes` are independent sets and only the latter triggers validation, so the `sanitizer.ValidAttributes.Add(...)` one-liner the readme leads with silently accepts any value:

```csharp
sanitizer.ValidAttributes.Add("data-url");
sanitizer.SanitizeHtmlFragment("<p data-url='javascript:alert(1)'>test</p>");
// Result: "<p data-url='javascript:alert(1)'>test</p>"   (the value is not validated)
```

The readme now spells that out, names the URL-bearing attributes worth adding to both sets (`action`, `formaction`, `poster`, `data`, `srcdoc`, `dynsrc`, `lowsrc`), and notes that the reverse mistake — adding to `UriAttributes` only — fails safe because the attribute is dropped.

**The `&` rule was undocumented.** `IsSafeUrl` rejects any URL with a `&` before the first `/`, `?` or `#`. That is deliberate and load-bearing: it is what stops `java&#115;cript:alert(1)` and `javascript&#58;alert(1)`. It also rejects the occasional legitimate relative URL such as `q&a.html`, which previously looked like a bug. Documented, with `q%26a.html` as the way out.

### Verification

Every sample in the readme was run against the library. The two `srcset` outputs were the only ones that did not match; the rest are unchanged because they were already correct. The two new samples were run as well and their comments show the exact output.

Found during a review of `Meziantou.Framework.HtmlSanitizer`.
