### PR TITLE
Drop the redundant RegexOptions.Compiled from the URL patterns

### DIFF
--- a/src/Meziantou.Framework.HtmlSanitizer/UrlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/UrlSanitizer.cs
@@ -39,11 +39,11 @@ public static partial class UrlSanitizer
      *
      * This regular expression was taken from the Closure sanitization library.
      */
-    [GeneratedRegex("^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))", RegexOptions.IgnoreCase | RegexOptions.Compiled, matchTimeoutMilliseconds: 10000)]
+    [GeneratedRegex("^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 10000)]
     private static partial Regex SafeUrlRegex();
 
     /** A pattern that matches safe data URLs. Only matches image, video and audio types. */
-    [GeneratedRegex("^data:(?:image/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video/(?:mpeg|mp4|ogg|webm)|audio/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$", RegexOptions.IgnoreCase | RegexOptions.Compiled, matchTimeoutMilliseconds: 10000)]
+    [GeneratedRegex("^data:(?:image/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video/(?:mpeg|mp4|ogg|webm)|audio/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 10000)]
     private static partial Regex DataUrlPattern();
 
     private static readonly char[] Whitespaces = ['\t', '\r', '\n', ' ', '\f'];


### PR DESCRIPTION
`RegexOptions.Compiled` does nothing on a `[GeneratedRegex]` and only makes the two patterns look more expensive than they are.

The source generator emits a `Regex` subclass with its own `RegexRunnerFactory` and a hand-written `TryMatchAtCurrentPosition`, so `RegexCompiler` is never involved. The flag is simply stored in `base.roptions`.

Diffing the generated file before and after removing it, the matching code is identical — the only changes are the field and a doc comment:

```
-        /// <code>RegexOptions.IgnoreCase | RegexOptions.Compiled</code><br/>
+        /// <code>RegexOptions.IgnoreCase</code><br/>
-            base.roptions = RegexOptions.IgnoreCase | RegexOptions.Compiled;
+            base.roptions = RegexOptions.IgnoreCase;
```

`matchTimeoutMilliseconds: 10000` is kept. I had expected to drop it too, on the grounds that both patterns are anchored and backtrack-free so the bound can never be reached. Two things say otherwise: the generator emits its `CheckTimeout` calls either way, so the timeout was not costing anything to begin with, and `MA0009` — the repo's own analyzer rule — requires a match timeout and fails the build without one.

All 336 tests pass (`Meziantou.Framework.HtmlSanitizer.Tests`, both target frameworks) and `dotnet run ./eng/update-all.cs` reports no further changes.

Found during a review of `Meziantou.Framework.HtmlSanitizer`.
