### PR TITLE
Make byte members mirror the file for every kind

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
@@ -585,7 +585,9 @@ internal static class EmbeddedConstantsGeneratorTask
             try
             {
                 var content = Utf8NoBomThrowOnInvalidBytes.GetString(textBytes, 0, textBytes.Length);
-                return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, content, textBytes, errors);
+
+                // The byte member mirrors the file exactly. Only the text member drops the byte order mark.
+                return new EmbeddedFile(file.FullPath, kind, file.ExplicitName, content, bytes, errors);
             }
             catch (DecoderFallbackException)
             {

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
@@ -78,7 +78,9 @@ If two implicit names collide, the generator tries a path-based name. Remaining 
 
 ## Text Encoding
 
-Text files must be valid UTF-8. An optional UTF-8 BOM is ignored. Binary files are embedded as-is.
+Text files must be valid UTF-8. An optional UTF-8 BOM is stripped from the generated `const string`.
+
+Byte members always mirror the file exactly, for every `Kind`. A file marked as `Both` whose content starts with a BOM therefore produces a `Text` member without the BOM and a `Bytes` member with it.
 
 Text files larger than 1 MiB are rejected to avoid producing impractically large generated source. Binary files are emitted as byte arrays and should also be kept reasonably small.
 

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -140,6 +140,38 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         Assert.Contains("public static global::System.ReadOnlySpan<byte> ConfigJsonBytes => new byte[]", generatedSource);
     }
 
+    [Theory]
+    [InlineData("Binary")]
+    [InlineData("Both")]
+    public async Task GenerateOnBuild_FileStartsWithByteOrderMark_ByteMemberKeepsIt(string kind)
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("bom-" + kind);
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile($"bom-{kind}/Sample.csproj", CreateProjectFile(fixture, $"""
+                <EmbeddedConstant Include="Assets/config.json" Kind="{kind}" />
+            """));
+
+        // A UTF-8 byte order mark followed by {}
+        CreateBinaryFile(projectDirectory / "Assets" / "config.json", [0xEF, 0xBB, 0xBF, (byte)'{', (byte)'}']);
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+
+        var generatedSource = await File.ReadAllTextAsync(GetGeneratedFilePath(projectDirectory), XunitCancellationToken);
+
+        // The byte member is the file, byte for byte, whichever Kind asked for it
+        Assert.Contains("0xEF, 0xBB, 0xBF, 0x7B, 0x7D", generatedSource);
+
+        if (kind is "Both")
+        {
+            // Only the text member drops the byte order mark
+            Assert.Contains("public const string ConfigText = \"{}\";", generatedSource);
+        }
+    }
+
     [Fact]
     public async Task GenerateOnBuild_UnsupportedKind_FailsBuild()
     {


### PR DESCRIPTION
The same file produces different bytes depending on its `Kind`.

Recreated from #2778, rebased onto `main` after #2776 and #2777 were closed. The diff is smaller than the original: it no longer carries the binary size check that came from #2777, and the test is end-to-end rather than a unit test, since the test infrastructure from #2776 is no longer there.

## The finding

`EmbeddedConstantsGeneratorTask.cs:588` passes `textBytes` (byte order mark removed) as the `bytes` argument, whereas the binary path at `:575` passes the raw `bytes`.

Verified. For a `config.json` whose bytes are `EF BB BF 7B 7D`:

- `Kind="Binary"` produces `ConfigBytes => new byte[] { 0xEF, 0xBB, 0xBF, 0x7B, 0x7D }`
- `Kind="Both"` produces `ConfigBytes => new byte[] { 0x7B, 0x7D }`

Same file, same member name, different content, no diagnostic and no documentation of the difference.

The readme states flatly that "Binary files are embedded as-is" and scopes BOM removal to the Text section. Anyone who switches a file from `Binary` to `Both` to also get the text form silently changes the bytes underneath them — a hash comparison, a length assertion, or a byte-for-byte round trip to disk breaks with no visible cause. It also means `XBytes` is not a faithful copy of the file, which is the one property a "bytes" member should have.

## The change

One line: the byte member now mirrors the file exactly for every `Kind`. Only the `const string` drops the BOM, which is what a C# consumer wants from text.

The readme's Text Encoding section is rewritten to state the rule directly rather than leaving it implied.

## Verification

New theory `GenerateOnBuild_FileStartsWithByteOrderMark_ByteMemberKeepsIt` over `Binary` and `Both`: it builds a real project against the packed package and asserts the generated byte member contains `0xEF, 0xBB, 0xBF, 0x7B, 0x7D` for both, and that the `Both` case still produces `ConfigText = "{}"` without the BOM.

Checked it is not vacuous: with the generator reverted to `main`, the `Both` case fails and the `Binary` case passes — which is exactly the asymmetry being fixed. Full suite 8/8, and the project builds clean under `Release` + `IsOfficialBuild=true` + `TreatsWarningsAsErrors=true` so the repo analyzers are active.
