### PR TITLE
Report member names that collide with each other or with the class name

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/EmbeddedConstantsGeneratorTask.cs
@@ -167,7 +167,7 @@ internal static class EmbeddedConstantsGeneratorTask
         }
 
         UsePathBasedNamesForImplicitDuplicates(options, entries);
-        ReportDuplicateMembers(entries, errors);
+        ReportInvalidMemberNames(options, entries, errors);
 
         return entries;
     }
@@ -182,17 +182,39 @@ internal static class EmbeddedConstantsGeneratorTask
 
         foreach (var entry in duplicatedImplicitEntries)
         {
+            // A file outside the project directory has no stable relative path. Naming the member after its
+            // absolute path would make the generated API depend on where the repository is checked out, so
+            // the collision is reported instead and the file needs explicit Name metadata.
             var relativePath = MakeRelativePath(entry.File.FullPath, options.ProjectDirectory);
+            if (relativePath is null)
+                continue;
+
             var pathWithoutExtension = Path.ChangeExtension(relativePath, extension: null);
             entry.BaseName = ToPascalCaseIdentifier(pathWithoutExtension);
         }
     }
 
-    private static void ReportDuplicateMembers(List<EmbeddedConstantEntry> entries, List<ValidationError> errors)
+    private static void ReportInvalidMemberNames(GeneratorOptions options, List<EmbeddedConstantEntry> entries, List<ValidationError> errors)
     {
         foreach (var group in GetDuplicateMemberNames(entries))
         {
-            errors.Add(ValidationError.DuplicateMemberName(group.MemberName));
+            var paths = group.Entries
+                .Select(entry => entry.File.FullPath)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+            errors.Add(ValidationError.DuplicateMemberName(group.MemberName, paths));
+        }
+
+        foreach (var entry in entries)
+        {
+            foreach (var memberName in entry.GetMemberNames())
+            {
+                if (string.Equals(memberName, options.ClassName, StringComparison.Ordinal))
+                {
+                    errors.Add(ValidationError.MemberNameMatchesClassName(memberName, entry.File.FullPath));
+                }
+            }
         }
     }
 
@@ -335,26 +357,35 @@ internal static class EmbeddedConstantsGeneratorTask
         return bytes;
     }
 
-    private static string MakeRelativePath(string path, string? basePath)
+    /// <summary>
+    /// Returns <paramref name="path"/> relative to <paramref name="basePath"/>, or <see langword="null"/>
+    /// when it is not under it. Path.GetRelativePath applies the comparison rules of the current platform.
+    /// </summary>
+    private static string? MakeRelativePath(string path, string? basePath)
     {
         if (string.IsNullOrWhiteSpace(basePath))
-            return path;
+            return null;
 
         try
         {
-            var fullBasePath = Path.GetFullPath(basePath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-            var fullPath = Path.GetFullPath(path);
-            if (fullPath.StartsWith(fullBasePath, StringComparison.OrdinalIgnoreCase))
-            {
-                return fullPath.Substring(fullBasePath.Length);
-            }
+            var relativePath = Path.GetRelativePath(Path.GetFullPath(basePath), Path.GetFullPath(path));
+            if (Path.IsPathRooted(relativePath) || IsParentDirectorySegment(relativePath))
+                return null;
+
+            return relativePath;
         }
         catch (Exception)
         {
-            return path;
+            return null;
         }
+    }
 
-        return path;
+    private static bool IsParentDirectorySegment(string relativePath)
+    {
+        if (!relativePath.StartsWith("..", StringComparison.Ordinal))
+            return false;
+
+        return relativePath.Length is 2 || relativePath[2] == Path.DirectorySeparatorChar || relativePath[2] == Path.AltDirectorySeparatorChar;
     }
 
     private static void AppendStringLiteral(StringBuilder sb, string value)
@@ -655,9 +686,15 @@ internal static class EmbeddedConstantsGeneratorTask
             return new ValidationError("MFECG0004", string.Create(CultureInfo.InvariantCulture, $"Embedded constant file has unsupported Kind value '{kind}'"), filePath);
         }
 
-        public static ValidationError DuplicateMemberName(string memberName)
+        public static ValidationError DuplicateMemberName(string memberName, IReadOnlyList<string> filePaths)
         {
-            return new ValidationError("MFECG0005", string.Create(CultureInfo.InvariantCulture, $"Generated member name '{memberName}' is used by multiple embedded constant files"), filePath: null);
+            var paths = string.Join(", ", filePaths);
+            return new ValidationError("MFECG0005", string.Create(CultureInfo.InvariantCulture, $"Generated member name '{memberName}' is used by multiple embedded constant files ({paths}). Set the Name metadata on all but one of them."), filePaths.Count > 0 ? filePaths[0] : null);
+        }
+
+        public static ValidationError MemberNameMatchesClassName(string memberName, string filePath)
+        {
+            return new ValidationError("MFECG0010", string.Create(CultureInfo.InvariantCulture, $"Generated member name '{memberName}' is the same as the generated class name, which does not compile. Set the Name metadata on this file, or change the 'EmbeddedConstantsClassName' property."), filePath);
         }
 
         public static ValidationError CannotReadFile(string filePath, string message)

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/readme.md
@@ -74,7 +74,9 @@ Examples:
 | `appsettings.Development.json` | `Both` | `AppsettingsDevelopmentText`, `AppsettingsDevelopmentBytes` |
 | `logo.bin` | `Binary` | `LogoBytes` |
 
-If two implicit names collide, the generator tries a path-based name. Remaining collisions are reported as MSBuild errors.
+If two implicit names collide, the generator tries a name based on the file path relative to the project directory. Files outside the project directory keep their original name, because a name derived from an absolute path would change with the location of the checkout. Remaining collisions are reported as MSBuild errors, and the files involved need explicit `Name` metadata.
+
+A generated member may not have the same name as the generated class, since C# does not allow it. That is reported too.
 
 ## Text Encoding
 
@@ -95,3 +97,4 @@ Text files larger than 1 MiB are rejected to avoid producing impractically large
 | `MFECG0007` | Embedded constant text file is not valid UTF-8 |
 | `MFECG0008` | Embedded constant text file is too large |
 | `MFECG0009` | Embedded constants visibility is invalid |
+| `MFECG0010` | Embedded constant member name is the same as the generated class name |

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -199,6 +199,89 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         Assert.Contains("MFECG0005", string.Join('\n', result.Output));
     }
 
+    [Fact]
+    public async Task GenerateOnBuild_MemberNameMatchesClassName_FailsBuild()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("member-matches-class");
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        // Foo.txt generates 'FooText', which is also the class name, and C# does not allow that
+        temporaryDirectory.CreateTextFile("member-matches-class/Sample.csproj", $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <EmbeddedConstantsNamespace>Generated</EmbeddedConstantsNamespace>
+                <EmbeddedConstantsClassName>FooText</EmbeddedConstantsClassName>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{{EmbeddedConstantsGeneratorPackageFixture.PackageName}}" Version="{{fixture.PackageVersion}}" PrivateAssets="all" />
+                <EmbeddedConstant Include="Assets/Foo.txt" Kind="Text" />
+              </ItemGroup>
+            </Project>
+            """);
+        temporaryDirectory.CreateTextFile("member-matches-class/Assets/Foo.txt", "x");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        var output = string.Join('\n', result.Output);
+        Assert.Contains("MFECG0010", output);
+
+        // The generator reports it instead of letting the compiler produce CS0542 on generated code
+        Assert.DoesNotContain("CS0542", output);
+    }
+
+    [Fact]
+    public async Task GenerateOnBuild_DuplicateMemberName_NamesTheFilesInvolved()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("duplicate-names-files");
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile("duplicate-names-files/Sample.csproj", CreateProjectFile(fixture, """
+                <EmbeddedConstant Include="Assets/first.txt" Kind="Text" Name="Same" />
+                <EmbeddedConstant Include="Assets/second.txt" Kind="Text" Name="Same" />
+            """));
+        temporaryDirectory.CreateTextFile("duplicate-names-files/Assets/first.txt", "First");
+        temporaryDirectory.CreateTextFile("duplicate-names-files/Assets/second.txt", "Second");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        var output = string.Join('\n', result.Output);
+        Assert.Contains("MFECG0005", output);
+        Assert.Contains("first.txt", output);
+        Assert.Contains("second.txt", output);
+    }
+
+    [Fact]
+    public async Task GenerateOnBuild_ImplicitNamesCollideOutsideTheProjectDirectory_FailsInsteadOfUsingTheAbsolutePath()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("outside-collision");
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        // One shared.txt inside the project, one in a sibling directory outside it
+        temporaryDirectory.CreateTextFile("outside-collision/Sample.csproj", CreateProjectFile(fixture, """
+                <EmbeddedConstant Include="shared.txt" Kind="Text" />
+                <EmbeddedConstant Include="../outside/shared.txt" Kind="Text" />
+            """));
+        temporaryDirectory.CreateTextFile("outside-collision/shared.txt", "inside");
+        temporaryDirectory.CreateTextFile("outside/shared.txt", "outside");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        var output = string.Join('\n', result.Output);
+        Assert.Contains("MFECG0005", output);
+        Assert.Contains("'SharedText'", output);
+    }
+
     private static string CreateProjectFile(EmbeddedConstantsGeneratorPackageFixture fixture, string embeddedConstants)
     {
         return $$"""


### PR DESCRIPTION
Four related defects in the member-naming pipeline. `CreateEntries` calls `UsePathBasedNamesForImplicitDuplicates` and then the duplicate reporter, and those two methods sit one blank line apart — they are one mechanism, so they are fixed together rather than as four PRs that all collide.

Recreated from #2779, rebased onto `main` after #2776 and #2777 were closed. The production diff is unchanged; the tests are end-to-end rather than unit tests, since the test infrastructure from #2776 is no longer there.

## Finding 1 — a member name equal to the class name emits uncompilable code, with no diagnostic

`ReportDuplicateMembers` compares member names against each other, never against `options.ClassName`.

With `<EmbeddedConstantsClassName>FooText</EmbeddedConstantsClassName>` and `<EmbeddedConstant Include="Foo.txt" Kind="Text" />`, `Create` reports zero errors and emits:

```csharp
internal static partial class FooText
{
    public const string FooText = "x";
}
```

which fails with `error CS0542: 'FooText': member names cannot be the same as their enclosing type`. The user gets a Roslyn error pointing into a generated file they did not write, with no `MFECG` code to search for. Now reported as `MFECG0010`.

## Finding 2 — the name fallback embeds absolute filesystem paths

`MakeRelativePath` returned the full path unchanged when the file is not under `ProjectDirectory`.

Two files named `shared.txt`, one in the project and one at `../outside/`, both without explicit `Name`. They collide, the fallback kicks in, and the out-of-project one becomes:

```csharp
public const string VarFoldersL_M8fk0x1s07ngvkcrk8mhhpqh0000gnTEcgOutsideSharedText = "o";
```

On CI the same file sits at a different absolute path, so the member is named something else entirely — code that references it compiles locally and fails on the build server. It also bakes the developer's home directory into shipped IL as a public member name.

The fallback is now skipped for files outside the project directory, so the collision survives and is reported as `MFECG0005` telling the user to set `Name`. An error is better than a name that depends on where the repository is checked out.

## Finding 3 — `MFECG0005` named the member but not the files

`FilePath` was passed as `null`. With a glob over a large asset tree, finding the two culprits was manual work. The message now lists the participating files and the error is attributed to the first of them so the IDE can navigate to it.

## Finding 4 — `MakeRelativePath` compared paths case-insensitively

It used `StringComparison.OrdinalIgnoreCase`. On Linux, `/src/Project/` and `/src/project/` are different directories, but this treated a file under the latter as being under the former. Replaced with `Path.GetRelativePath`, which applies the current platform's rules and normalises separators; a result that is rooted or starts with a `..` segment means "not under the base path".

## Verification

Three end-to-end tests, each building a real project against the packed package:

- `GenerateOnBuild_MemberNameMatchesClassName_FailsBuild` — reports `MFECG0010`, and asserts `CS0542` does *not* appear, i.e. the generator catches it before the compiler does.
- `GenerateOnBuild_DuplicateMemberName_NamesTheFilesInvolved` — the `MFECG0005` output names both `first.txt` and `second.txt`.
- `GenerateOnBuild_ImplicitNamesCollideOutsideTheProjectDirectory_FailsInsteadOfUsingTheAbsolutePath` — reports `MFECG0005` for `'SharedText'` rather than inventing a path-based name.

The existing test that in-project duplicates still get path-based names continues to pass, which is what keeps finding 2's fix from over-reaching.

Checked all three are not vacuous: with the generator reverted to `main` they fail and the other six pass. Full suite 9/9, and the project builds clean under `Release` + `IsOfficialBuild=true` + `TreatsWarningsAsErrors=true` so the repo analyzers are active.

## Note on the diagnostic id

The original #2779 used `MFECG0013`, chosen to avoid clashing with ids in the other PRs from this review. With #2777 closed and #2712 no longer adding a diagnostic, `MFECG0010` is free again, so this uses it — that keeps the sequence contiguous with `MFECG0011` in #2723 and leaves no gaps.
