### PR TITLE
Bump the shipping package version when only its analyzer changes

### DIFF
--- a/eng/update-versions.cs
+++ b/eng/update-versions.cs
@@ -56,15 +56,8 @@ var changesPerCsproj = new Dictionary<string, CsprojInfo>(StringComparer.Ordinal
 var allCsprojFiles = new List<string>();
 var packableProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-// Every project under src, packable or not. Non-packable projects (analyzers, code fixes, source
-// generators) ship inside a packable package, so they must take part in the dependency graph even
-// though they never carry a version of their own.
-var allProjectFiles = new List<string>();
-
 foreach (var file in Directory.EnumerateFiles(srcPath, "*.csproj", SearchOption.AllDirectories))
 {
-    allProjectFiles.Add(file);
-
     var isPackable = IsPackableProject(file);
     if (isPackable)
     {
@@ -86,13 +79,13 @@ Console.WriteLine("Building dependency graph...");
 var dependencyGraph = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 var reverseDependencyGraph = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-foreach (var csproj in allProjectFiles)
+foreach (var csproj in allCsprojFiles)
 {
     dependencyGraph[csproj] = GetProjectReferences(csproj);
     reverseDependencyGraph[csproj] = [];
 }
 
-foreach (var csproj in allProjectFiles)
+foreach (var csproj in allCsprojFiles)
 {
     foreach (var dependency in dependencyGraph[csproj])
     {
@@ -100,6 +93,27 @@ foreach (var csproj in allProjectFiles)
         {
             list.Add(csproj);
         }
+    }
+}
+
+// A project that is not packable (an analyzer, a code fix, a source generator) carries no version of its own: it
+// ships inside the packable projects that reference it with ProjectReference/ReferenceOutputAssembly=false. Map it
+// to those packages so that a change confined to it still bumps the version of the package that ships it.
+var shippedByPackages = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+foreach (var csproj in allCsprojFiles)
+{
+    foreach (var dependency in GetProjectReferences(csproj))
+    {
+        if (packableProjects.Contains(dependency))
+            continue;
+
+        if (!shippedByPackages.TryGetValue(dependency, out var packages))
+        {
+            packages = [];
+            shippedByPackages[dependency] = packages;
+        }
+
+        packages.Add(csproj);
     }
 }
 
@@ -164,13 +178,16 @@ foreach (var commit in commits)
             if (csproj is null)
                 continue;
 
-            if (!changesPerCsproj.TryGetValue(csproj, out var info))
+            foreach (var versionedProject in GetVersionedProjects(csproj))
             {
-                info = new CsprojInfo();
-                changesPerCsproj[csproj] = info;
-            }
+                if (!changesPerCsproj.TryGetValue(versionedProject, out var info))
+                {
+                    info = new CsprojInfo();
+                    changesPerCsproj[versionedProject] = info;
+                }
 
-            info.StopProcessing = true;
+                info.StopProcessing = true;
+            }
         }
     }
 
@@ -180,16 +197,19 @@ foreach (var commit in commits)
         if (csproj is null)
             continue;
 
-        if (!changesPerCsproj.TryGetValue(csproj, out var info))
+        foreach (var versionedProject in GetVersionedProjects(csproj))
         {
-            info = new CsprojInfo();
-            changesPerCsproj[csproj] = info;
+            if (!changesPerCsproj.TryGetValue(versionedProject, out var info))
+            {
+                info = new CsprojInfo();
+                changesPerCsproj[versionedProject] = info;
+            }
+
+            if (info.StopProcessing)
+                continue;
+
+            info.Commits.Add(commit);
         }
-
-        if (info.StopProcessing)
-            continue;
-
-        info.Commits.Add(commit);
     }
 }
 
@@ -205,33 +225,21 @@ if (forceBumpAll)
     }
 }
 
-// First pass: identify projects with direct changes. A non-packable project carries no version of
-// its own, so it is never updated directly; the package shipping it is updated in the second pass.
+// First pass: identify projects with direct changes
 foreach (var (csproj, info) in changesPerCsproj.OrderBy(kv => kv.Key, StringComparer.Ordinal))
 {
-    if (info.Commits.Count > 0 && packableProjects.Contains(csproj))
+    if (info.Commits.Count > 0)
     {
         projectsToUpdate[csproj] = new ProjectUpdateInfo { Commits = info.Commits };
     }
 }
 
-// Second pass: identify transitive dependents. Seeded from every changed project, including the
-// non-packable ones, so that a change confined to an analyzer still bumps the package shipping it.
-var changedProjects = changesPerCsproj
-    .Where(kv => kv.Value.Commits.Count > 0)
-    .Select(kv => kv.Key)
-    .Union(projectsToUpdate.Keys, StringComparer.OrdinalIgnoreCase)
-    .OrderBy(csproj => csproj, StringComparer.Ordinal)
-    .ToList();
-
-foreach (var csproj in changedProjects)
+// Second pass: identify transitive dependents
+foreach (var csproj in projectsToUpdate.Keys.ToList())
 {
     var dependents = GetTransitiveDependents(csproj);
     foreach (var dependent in dependents)
     {
-        if (!packableProjects.Contains(dependent))
-            continue;
-
         if (!projectsToUpdate.TryGetValue(dependent, out var existingInfo) || existingInfo.ForceUpdated)
         {
             Console.WriteLine($"Project {dependent} will be updated due to dependency on {csproj}");
@@ -412,6 +420,29 @@ string? GetCsproj(string relativePath)
     }
 
     return null;
+}
+
+// Returns the projects whose version a change to csproj must bump: the project itself when it is packable,
+// otherwise the packable projects that ship it through an explicit ProjectReference.
+List<string> GetVersionedProjects(string csproj, HashSet<string>? visited = null)
+{
+    if (packableProjects.Contains(csproj))
+        return [csproj];
+
+    if (!shippedByPackages.TryGetValue(csproj, out var packages))
+        return [];
+
+    visited ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (!visited.Add(csproj))
+        return [];
+
+    var result = new List<string>();
+    foreach (var package in packages)
+    {
+        result.AddRange(GetVersionedProjects(package, visited));
+    }
+
+    return result.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 }
 
 List<string> GetProjectReferences(string csprojPath)

--- a/eng/update-versions.cs
+++ b/eng/update-versions.cs
@@ -56,8 +56,15 @@ var changesPerCsproj = new Dictionary<string, CsprojInfo>(StringComparer.Ordinal
 var allCsprojFiles = new List<string>();
 var packableProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+// Every project under src, packable or not. Non-packable projects (analyzers, code fixes, source
+// generators) ship inside a packable package, so they must take part in the dependency graph even
+// though they never carry a version of their own.
+var allProjectFiles = new List<string>();
+
 foreach (var file in Directory.EnumerateFiles(srcPath, "*.csproj", SearchOption.AllDirectories))
 {
+    allProjectFiles.Add(file);
+
     var isPackable = IsPackableProject(file);
     if (isPackable)
     {
@@ -79,13 +86,13 @@ Console.WriteLine("Building dependency graph...");
 var dependencyGraph = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 var reverseDependencyGraph = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-foreach (var csproj in allCsprojFiles)
+foreach (var csproj in allProjectFiles)
 {
     dependencyGraph[csproj] = GetProjectReferences(csproj);
     reverseDependencyGraph[csproj] = [];
 }
 
-foreach (var csproj in allCsprojFiles)
+foreach (var csproj in allProjectFiles)
 {
     foreach (var dependency in dependencyGraph[csproj])
     {
@@ -159,9 +166,6 @@ foreach (var commit in commits)
 
             if (!changesPerCsproj.TryGetValue(csproj, out var info))
             {
-                if (!packableProjects.Contains(csproj))
-                    continue;
-
                 info = new CsprojInfo();
                 changesPerCsproj[csproj] = info;
             }
@@ -178,9 +182,6 @@ foreach (var commit in commits)
 
         if (!changesPerCsproj.TryGetValue(csproj, out var info))
         {
-            if (!packableProjects.Contains(csproj))
-                continue;
-
             info = new CsprojInfo();
             changesPerCsproj[csproj] = info;
         }
@@ -204,21 +205,33 @@ if (forceBumpAll)
     }
 }
 
-// First pass: identify projects with direct changes
+// First pass: identify projects with direct changes. A non-packable project carries no version of
+// its own, so it is never updated directly; the package shipping it is updated in the second pass.
 foreach (var (csproj, info) in changesPerCsproj.OrderBy(kv => kv.Key, StringComparer.Ordinal))
 {
-    if (info.Commits.Count > 0)
+    if (info.Commits.Count > 0 && packableProjects.Contains(csproj))
     {
         projectsToUpdate[csproj] = new ProjectUpdateInfo { Commits = info.Commits };
     }
 }
 
-// Second pass: identify transitive dependents
-foreach (var csproj in projectsToUpdate.Keys.ToList())
+// Second pass: identify transitive dependents. Seeded from every changed project, including the
+// non-packable ones, so that a change confined to an analyzer still bumps the package shipping it.
+var changedProjects = changesPerCsproj
+    .Where(kv => kv.Value.Commits.Count > 0)
+    .Select(kv => kv.Key)
+    .Union(projectsToUpdate.Keys, StringComparer.OrdinalIgnoreCase)
+    .OrderBy(csproj => csproj, StringComparer.Ordinal)
+    .ToList();
+
+foreach (var csproj in changedProjects)
 {
     var dependents = GetTransitiveDependents(csproj);
     foreach (var dependent in dependents)
     {
+        if (!packableProjects.Contains(dependent))
+            continue;
+
         if (!projectsToUpdate.TryGetValue(dependent, out var existingInfo) || existingInfo.ForceUpdated)
         {
             Console.WriteLine($"Project {dependent} will be updated due to dependency on {csproj}");


### PR DESCRIPTION
## Problem

`eng/update-versions.cs` skips every non-packable project before it builds the dependency graph:

```csharp
var isPackable = IsPackableProject(file);
if (!isPackable)
{
    continue;   // never reaches allCsprojFiles / changesPerCsproj / the graph
}
```

`Meziantou.Framework.Assertions.Analyzer` and `.CodeFix` both set `IsPackable=false` — they ship *inside* the `Meziantou.Framework.Assertions` package via `<None Include ... PackagePath="analyzers/dotnet/cs" />`, and the package declares that dependency explicitly with `ProjectReference` + `ReferenceOutputAssembly="false"`.

`GetProjectReferences` already reads every `ProjectReference` regardless of `ReferenceOutputAssembly`, so the dependency was always visible to the script. But because the analyzer was never added to the graph, `reverseDependencyGraph[analyzer]` did not exist, so a commit touching only `src/Meziantou.Framework.Assertions.Analyzer/**`:

1. mapped via `GetCsproj()` to the analyzer csproj,
2. failed the `packableProjects.Contains(csproj)` check and was dropped,
3. and was never picked up by the transitive-dependents pass either.

The version stayed put, `create_nuget` repacked a package containing the **new** analyzer DLL, and the push ran with `--skip-duplicate`, which silently no-ops against the already-published version. CI stayed green and the fix never reached users.

## Change

Follow the explicit `ProjectReference`, without touching the existing graph or passes.

- One new map, built from the packable projects' own `ProjectReference`s: non-packable project → the packable projects that ship it.
- One resolver, `GetVersionedProjects(csproj)`: the project itself when it is packable, otherwise the packages that reference it. Recursive, so an analyzer sitting behind another non-packable project still resolves.
- The two change-attribution loops resolve through it.

`allCsprojFiles`, the dependency graph, the direct-change pass and the transitive-dependent pass are all unchanged. A non-packable project can never enter `projectsToUpdate`, so it never gains a `<Version>` element. Test projects keep the previous behavior: `GetVersionedProjects` returns an empty list for a project that is neither packable nor shipped by one.

The analyzer's commits are attributed **directly** to the shipping package, so the generated bump PR lists the real commit messages rather than `Updated due to dependency on ...`.

## Scope

I checked every package that packs an analyzer. FullPath, FastEnumGenerator and Yaml all `ProjectReference` what they pack; ResxSourceGenerator, FixedStringBuilder.Generator and ServiceDefaults.AutoRegister pack their own `$(AssemblyName).dll` and so have no cross-project dependency to declare. No csproj needs a new `ProjectReference`.

## Verification

Synthetic analyzer-only commit, run with `--since "10 minutes ago"` and no `--create-pull-request`:

| | `Meziantou.Framework.Assertions` version |
| --- | --- |
| `main` | `2.0.5` — unchanged |
| this branch | **`2.0.6`**, listed with the analyzer's own commit |

Both `Meziantou.Framework.Assertions.Analyzer.csproj` and `.CodeFix.csproj` still contain zero `<Version>` elements, confirming non-packable projects are not versioned. `dotnet build eng/update-versions.cs` succeeds.

Found by a project review of `Meziantou.Framework.Assertions`.
