### PR TITLE
Update Meziantou.NET.Sdk to 1.0.160 and keep the local CultureInsensitiveType attribute

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "4.1.82",
-    "Meziantou.NET.Sdk": "1.0.158",
-    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.158",
-    "Meziantou.NET.Sdk.Razor": "1.0.158",
-    "Meziantou.NET.Sdk.Test": "1.0.158",
-    "Meziantou.NET.Sdk.Web": "1.0.158",
-    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.158"
+    "Meziantou.NET.Sdk": "1.0.160",
+    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.160",
+    "Meziantou.NET.Sdk.Razor": "1.0.160",
+    "Meziantou.NET.Sdk.Test": "1.0.160",
+    "Meziantou.NET.Sdk.Web": "1.0.160",
+    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.160"
   }
 }

--- a/src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj
+++ b/src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--
+      The attribute shipped by Meziantou.Analyzer.Annotations is [Conditional], so the compiler does not emit
+      its usages into the assembly and consumers of this package cannot see the annotation. Compile a local,
+      non-conditional copy instead, and drop the package's compile assets to avoid the type conflict (CS0436).
+    -->
+    <PackageReference Update="Meziantou.Analyzer.Annotations" ExcludeAssets="compile" />
     <Compile Include="../../common/CultureInsensitiveTypeAttribute.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Supersedes #2798, which fails nearly every CI job.

## Why #2798 fails

`Meziantou.NET.Sdk` 1.0.160 adds an automatic reference to `Meziantou.Analyzer.Annotations` 1.8.0. Its `CultureInsensitiveTypeAttribute` collides with the copy compiled into `Meziantou.Framework.Versioning`:

```
src/Meziantou.Framework.Versioning/SemanticVersion.cs(29,33): error CS0436:
The type 'CultureInsensitiveTypeAttribute' in '.../common/CultureInsensitiveTypeAttribute.cs'
conflicts with the imported type 'CultureInsensitiveTypeAttribute' in
'Meziantou.Analyzer.Annotations, Version=1.8.0.0'
```

Under warnings-as-errors that is fatal, so `build_and_test`, `create_nuget`, `validate_generated_files`, `test_trimming` and CodeQL all fail for the same reason.

## Why simply deleting the local copy does not work

Dropping `common/CultureInsensitiveTypeAttribute.cs` and using the package type builds the Versioning project, but then 9 new `MA0011` errors appear in the tests and the generator tools, on `SemanticVersion.ToString()` and `SemanticVersionRange.ToString()` calls.

The package attribute is marked `[Conditional]`, so the compiler does not emit its usages into the assembly. Reading the attributes back out of the built `Meziantou.Framework.Versioning.dll`:

| Build | Attribute on `SemanticVersion` |
|---|---|
| local copy compiled in | `typedef Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute in [THIS ASSEMBLY]` |
| package type used | *absent* |

The annotation only survives within its own compilation, so consumers of the package stop honoring it. The local, non-conditional copy exists precisely so the annotation reaches other assemblies.

## Fix

Keep compiling the local copy and drop the package's compile assets for that one project, so only one definition is in scope:

```xml
<PackageReference Update="Meziantou.Analyzer.Annotations" ExcludeAssets="compile" />
<Compile Include="../../common/CultureInsensitiveTypeAttribute.cs" />
```

## Validation

- `dotnet build eng/build.proj /p:TreatsWarningsAsErrors=true` - 0 warnings, 0 errors
- `dotnet build eng/build.proj -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` - clean, no `ref/` changes
- `dotnet run ./eng/update-all.cs` - exit 0, no generated-file changes
- `Meziantou.Framework.Versioning.Tests` - 704/704 pass
- Full suite: 42804 tests, 42267 passed, 522 skipped, 15 failed. All 15 are pre-existing local environment failures, confirmed by running the same projects on `main`: `AmsiTests` (8, Windows-only API), `DiffEngine` (2, needs a diff tool installed), `TemporaryContainers` (5 here vs 11 on `main`, needs the container service). No regression.
- Verified the annotation is emitted into the assembly again after the fix.