### PR TITLE
Build negative assertion failure messages from the snapshot

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.DoesNotContain.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.DoesNotContain.cs
@@ -36,12 +36,14 @@ public partial class Assert
             return;
 
         comparer ??= EqualityComparer<T>.Default;
-        foreach (var item in actual)
+        using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
+        for (var index = 0; actualSnapshot.TryGetItem(index, out var item); index++)
         {
             if (!comparer.Equals(expected, item))
                 continue;
 
-            throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<T, IEnumerable<T>>("Not expected item", expected, actual, actualExpression, expectedExpression, message)));
+            actualSnapshot.EnsureComplete();
+            throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<T, IReadOnlyList<T>>("Not expected item", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
         }
     }
 
@@ -65,12 +67,14 @@ public partial class Assert
             return;
 
         comparer ??= EqualityComparer<TKey>.Default;
-        foreach (var item in actual)
+        using var actualSnapshot = CollectionSnapshot.Create<KeyValuePair<TKey, TValue>>(actual);
+        for (var index = 0; actualSnapshot.TryGetItem(index, out var item); index++)
         {
             if (!comparer.Equals(expected, item.Key))
                 continue;
 
-            throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<TKey, IEnumerable<KeyValuePair<TKey, TValue>>>("Not expected key", expected, actual, actualExpression, expectedExpression, message)));
+            actualSnapshot.EnsureComplete();
+            throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<TKey, IReadOnlyList<KeyValuePair<TKey, TValue>>>("Not expected key", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
         }
     }
 
@@ -93,12 +97,14 @@ public partial class Assert
         if (actual is null)
             return;
 
-        foreach (var item in actual)
+        using var actualSnapshot = CollectionSnapshot.Create(actual);
+        for (var index = 0; actualSnapshot.TryGetItem(index, out var item); index++)
         {
             if (!object.Equals(expected, item))
                 continue;
 
-            throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<object?, System.Collections.IEnumerable>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+            actualSnapshot.EnsureComplete();
+            throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<object?, IReadOnlyList<object?>>("Not expected", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
         }
     }
 
@@ -177,6 +183,6 @@ public partial class Assert
         if (!ContainsSubsequence(expectedSnapshot.Items, actualSnapshot.Items, comparer))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotContainAssertionError<IReadOnlyList<object?>, IReadOnlyList<object?>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.DoesNotEndWith.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.DoesNotEndWith.cs
@@ -26,7 +26,7 @@ public partial class Assert
             return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotEndWithAssertionError<T, IEnumerable<T>>("Not expected suffix", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotEndWithAssertionError<T, IReadOnlyList<T>>("Not expected suffix", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 
     public static void DoesNotEndWith(object? expected, System.Collections.IEnumerable? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -41,7 +41,7 @@ public partial class Assert
             return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotEndWithAssertionError<object?, System.Collections.IEnumerable>("Not expected suffix", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotEndWithAssertionError<object?, IReadOnlyList<object?>>("Not expected suffix", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 
     public static void DoesNotEndWith<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -103,6 +103,6 @@ public partial class Assert
         if (GetFirstSuffixDifferenceIndex(expectedSnapshot.Items, actualSnapshot.Items, comparer) is not null)
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotEndWithAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable>("Not expected suffix", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotEndWithAssertionError<IReadOnlyList<object?>, IReadOnlyList<object?>>("Not expected suffix", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.DoesNotHaveCount.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.DoesNotHaveCount.cs
@@ -27,7 +27,7 @@ public partial class Assert
         if (actualSnapshot.Items.Count != expectedCount)
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NegativeCountAssertionError<IEnumerable<T>>(nameof(DoesNotHaveCount), expectedCount, actualSnapshot.Items.Count, actual, actualExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NegativeCountAssertionError<IReadOnlyList<T>>(nameof(DoesNotHaveCount), expectedCount, actualSnapshot.Items.Count, actualSnapshot.Items, actualExpression, message)));
     }
 
     public static void DoesNotHaveCount(int expectedCount, System.Collections.IEnumerable actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
@@ -37,7 +37,7 @@ public partial class Assert
         if (actualSnapshot.Items.Count != expectedCount)
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NegativeCountAssertionError<System.Collections.IEnumerable>(nameof(DoesNotHaveCount), expectedCount, actualSnapshot.Items.Count, actual, actualExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NegativeCountAssertionError<IReadOnlyList<object?>>(nameof(DoesNotHaveCount), expectedCount, actualSnapshot.Items.Count, actualSnapshot.Items, actualExpression, message)));
     }
 
     public static async Task DoesNotHaveCount<T>(int expectedCount, IAsyncEnumerable<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)

--- a/src/Meziantou.Framework.Assertions/Assert.DoesNotStartWith.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.DoesNotStartWith.cs
@@ -25,7 +25,8 @@ public partial class Assert
             return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotStartWithAssertionError<T, IEnumerable<T>>("Not expected prefix", expected, actual, actualExpression, expectedExpression, message)));
+        actualSnapshot.EnsureComplete();
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotStartWithAssertionError<T, IReadOnlyList<T>>("Not expected prefix", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 
     public static void DoesNotStartWith(object? expected, System.Collections.IEnumerable? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -39,7 +40,8 @@ public partial class Assert
             return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotStartWithAssertionError<object?, System.Collections.IEnumerable>("Not expected prefix", expected, actual, actualExpression, expectedExpression, message)));
+        actualSnapshot.EnsureComplete();
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotStartWithAssertionError<object?, IReadOnlyList<object?>>("Not expected prefix", expected, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 
     public static void DoesNotStartWith<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -107,6 +109,8 @@ public partial class Assert
                 return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new DoesNotStartWithAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable>("Not expected prefix", expected, actual, actualExpression, expectedExpression, message)));
+        expectedSnapshot.EnsureComplete();
+        actualSnapshot.EnsureComplete();
+        throw new AssertionException(ErrorFormatter.Format(new DoesNotStartWithAssertionError<IReadOnlyList<object?>, IReadOnlyList<object?>>("Not expected prefix", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.NotDistinct.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotDistinct.cs
@@ -31,7 +31,8 @@ public partial class Assert
                 return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new NegativeActualValueAssertionError<IEnumerable<T>>(nameof(NotDistinct), "all distinct items", actual, actualExpression, message)));
+        actualSnapshot.EnsureComplete();
+        throw new AssertionException(ErrorFormatter.Format(new NegativeActualValueAssertionError<IReadOnlyList<T>>(nameof(NotDistinct), "all distinct items", actualSnapshot.Items, actualExpression, message)));
     }
 
     public static void NotDistinct(System.Collections.IEnumerable actual, System.Collections.IEqualityComparer? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
@@ -43,7 +44,8 @@ public partial class Assert
                 return;
         }
 
-        throw new AssertionException(ErrorFormatter.Format(new NegativeActualValueAssertionError<System.Collections.IEnumerable>(nameof(NotDistinct), "all distinct items", actual, actualExpression, message)));
+        actualSnapshot.EnsureComplete();
+        throw new AssertionException(ErrorFormatter.Format(new NegativeActualValueAssertionError<IReadOnlyList<object?>>(nameof(NotDistinct), "all distinct items", actualSnapshot.Items, actualExpression, message)));
     }
 
     public static async Task NotDistinct<T>(IAsyncEnumerable<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertContainsTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertContainsTests.cs
@@ -534,4 +534,13 @@ public sealed class AssertContainsTests
             Actual:           [[a, 1]]
             """);
     }
+
+    [Fact]
+    public void DoesNotContain_EnumeratesASingleUseSequenceOnlyOnce()
+    {
+        var actual = AssertionTestHelpers.SingleUse(1, 2, 3);
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.DoesNotContain(2, actual));
+    }
+
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertCountTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertCountTests.cs
@@ -259,4 +259,13 @@ public sealed class AssertCountTests
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
+
+    [Fact]
+    public void DoesNotHaveCount_EnumeratesASingleUseSequenceOnlyOnce()
+    {
+        var actual = AssertionTestHelpers.SingleUse(1, 2, 3);
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.DoesNotHaveCount(3, actual));
+    }
+
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertDistinctTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertDistinctTests.cs
@@ -233,4 +233,13 @@ public sealed class AssertDistinctTests
             Actual:       [1, 2, 3]
             """);
     }
+
+    [Fact]
+    public void NotDistinct_EnumeratesASingleUseSequenceOnlyOnce()
+    {
+        var actual = AssertionTestHelpers.SingleUse(1, 2, 3);
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.NotDistinct(actual));
+    }
+
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEndsWithTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEndsWithTests.cs
@@ -300,4 +300,13 @@ public sealed class AssertEndsWithTests
             Actual:              [1, 2, 3]
             """);
     }
+
+    [Fact]
+    public void DoesNotEndWith_EnumeratesASingleUseSequenceOnlyOnce()
+    {
+        var actual = AssertionTestHelpers.SingleUse(1, 2, 3);
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.DoesNotEndWith(3, actual));
+    }
+
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertStartsWithTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertStartsWithTests.cs
@@ -323,4 +323,13 @@ public sealed class AssertStartsWithTests
             Actual:              [1, 2, 3]
             """);
     }
+
+    [Fact]
+    public void DoesNotStartWith_EnumeratesASingleUseSequenceOnlyOnce()
+    {
+        var actual = AssertionTestHelpers.SingleUse(1, 2, 3);
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.DoesNotStartWith(1, actual));
+    }
+
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertionTestHelpers.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertionTestHelpers.cs
@@ -28,6 +28,28 @@ internal static class AssertionTestHelpers
         AssertionsAssert.Equal(expectedMessage, exception.Message);
     }
 
+    /// <summary>
+    /// A sequence that can only be enumerated once, so an assertion that walks it a second time to build its failure
+    /// message fails loudly instead of silently reporting different data.
+    /// </summary>
+    public static IEnumerable<T> SingleUse<T>(params T[] items) => new SingleUseEnumerable<T>(items);
+
+    private sealed class SingleUseEnumerable<T>(T[] items) : IEnumerable<T>
+    {
+        private int _enumerationCount;
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            _enumerationCount++;
+            if (_enumerationCount > 1)
+                throw new InvalidOperationException("The sequence was enumerated more than once.");
+
+            return ((IEnumerable<T>)items).GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
     public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> items)
     {
         foreach (var item in items)


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before #2811

## Problem

Every negative collection assertion hands the caller's **raw** `IEnumerable` to the error record after having already enumerated it. `AssertionFormatter.FormatValue` (`AssertionFormatter.cs:1202`) then enumerates whatever it is given, so the source is walked a **second time**, on the failure path.

Every *positive* assertion does this correctly — `Contains` passes `actualSnapshot`, which is exactly why `CollectionSnapshot` exists.

Against a sequence that can only be enumerated once (a consumed generator, a reader-backed sequence, a DB query), the two directions diverge sharply:

```
Contains / HasCount / Distinct                 -> AssertionException          (correct)
DoesNotContain / DoesNotHaveCount /
NotDistinct / DoesNotStartWith / DoesNotEndWith -> InvalidOperationException   (masks the real failure)
```

The silent variant is worse. A generator yielding `[0,1,2]` and then `[10,11,12]` produces:

```
Assert.DoesNotContain() assertion failed.
Not expected item: 0
Actual:            [10, 11, 12]     <- data the assertion never looked at
```

A wrong or exception-throwing failure message on a real test failure is the worst possible moment for the library to misbehave.

## Change

Five files, one shape: build the failure message from the snapshot instead of the raw argument.

- `DoesNotContain` had no snapshot at all in three overloads (a bare `foreach`) — these now use `CollectionSnapshot` and iterate with `TryGetItem`, mirroring `Contains`.
- `DoesNotStartWith`, `DoesNotEndWith`, `NotDistinct`, `DoesNotHaveCount` already had a snapshot and simply passed the wrong value; they now pass `actualSnapshot.Items`, with `EnsureComplete()` on the failure path so the message shows the whole collection rather than only the items the check happened to observe.

The error records' `TActual` moves from `IEnumerable<T>`/`IEnumerable` to `IReadOnlyList<T>`/`IReadOnlyList<object?>`. These records are `internal`, so there is no public API change — `dotnet run ./eng/update-all.cs` confirms no `ref/` drift.

## Verification

New `AssertionTestHelpers.SingleUse<T>()` returns a sequence that throws on a second enumeration. Five new tests, one per affected family, all confirmed to **fail without the fix** with `The sequence was enumerated more than once.` and pass with it.

Full suite: **838/838 passing** on net10.0 and net11.0 with `-p:TreatsWarningsAsErrors=true`. No pinned failure-message expectation changed.

## Scope

`Assert.NotEqualUnordered.cs` has the same defect but is deliberately left out — #2808 already modifies that file a few lines away, and splitting it here would guarantee a merge conflict. It is fixed in that PR instead.

Found by a project review of `Meziantou.Framework.Assertions`.
