### PR TITLE
Compare boxed Memory values by content in Assert.NotEqual

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.Equality.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equality.cs
@@ -21,6 +21,17 @@ public partial class Assert
         return false;
     }
 
+    private static bool TryNotEqualMemory<TExpected, TActual>(TExpected expected, TActual actual, string? message, string? actualExpression, string? expectedExpression)
+    {
+        if (TryGetMemoryItems(expected, out var expectedItems) && TryGetMemoryItems(actual, out var actualItems))
+        {
+            NotEqual(expectedItems, actualItems, message, actualExpression, expectedExpression);
+            return true;
+        }
+
+        return false;
+    }
+
     private static bool TryGetMemoryItems<T>(T value, [NotNullWhen(true)] out System.Collections.IEnumerable? items)
     {
         items = null;

--- a/src/Meziantou.Framework.Assertions/Assert.NotEqual.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEqual.cs
@@ -48,6 +48,11 @@ public partial class Assert
 
     public static void NotEqual<T>(T expected, T? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
+        // Memory<T> and ReadOnlyMemory<T> compare by backing object, index and length, so a boxed pair holding equal
+        // content has to be unwrapped and compared element by element, exactly as Assert.Equal does.
+        if (TryNotEqualMemory(expected, actual, message, actualExpression, expectedExpression))
+            return;
+
         if (ValuesEqual(expected, actual))
         {
             throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<T, T?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
@@ -57,6 +62,9 @@ public partial class Assert
     [OverloadResolutionPriority(-1)]
     public static void NotEqual<TExpected, TActual>(TExpected expected, TActual? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
+        if (TryNotEqualMemory(expected, actual, message, actualExpression, expectedExpression))
+            return;
+
         if (ValuesEqual(expected, actual))
         {
             throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<TExpected, TActual?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -983,4 +983,24 @@ public sealed class AssertEqualTests
 
         public override int GetHashCode() => _value;
     }
+
+    [Fact]
+    public void BoxedReadOnlyMemory_EqualAndNotEqualDisagree()
+    {
+        object expected = new ReadOnlyMemory<int>([1, 2, 3]);
+        object actual = new ReadOnlyMemory<int>([1, 2, 3]);
+
+        AssertionsAssert.Equal(expected, actual);
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.NotEqual(expected, actual));
+    }
+
+    [Fact]
+    public void BoxedReadOnlyMemory_NotEqualSucceedsForDifferentContent()
+    {
+        object expected = new ReadOnlyMemory<int>([1, 2, 3]);
+        object actual = new ReadOnlyMemory<int>([1, 2, 4]);
+
+        AssertionsAssert.NotEqual(expected, actual);
+    }
+
 }


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before #2814

## Problem

`Assert.Equal` runs `TryEqualEnumerables` and then `TryEqualMemory` before falling through to `ValuesEqual` (`Assert.Equal.cs:51-78`). `Assert.NotEqual` calls only `ValuesEqual` (`Assert.NotEqual.cs:49-64`).

`ValuesEqual` has no memory path — `ReadOnlyMemory<T>` is not `IEnumerable`, so `TryCompareEnumerableValues` never matches it, and its own `Equals` compares the backing object reference, index and length rather than the content. `TryEqualMemory` is referenced nowhere except the two `Assert.Equal.cs` sites, even though `MemoryCandidate<T>.IsPossible` is deliberately true for `typeof(T) == typeof(object)` — the boxed case was explicitly designed for.

The result is a **negative assertion that cannot fail**:

```csharp
object expected = new ReadOnlyMemory<int>([1, 2, 3]);
object actual = new ReadOnlyMemory<int>([1, 2, 3]);

Assert.Equal(expected, actual);     // passes - content is equal
Assert.NotEqual(expected, actual);  // ALSO passes - the two contradict each other
```

`NotEqual` does carry a dedicated statically-typed `ReadOnlyMemory` overload (`Assert.NotEqual.cs:83`), so the case was considered on one side only — an oversight rather than a decision.

## Change

A `TryNotEqualMemory` mirroring `TryEqualMemory`: it unwraps both operands with the existing `TryGetMemoryItems` and delegates to the sequence `NotEqual`. Both scalar `NotEqual` overloads call it before `ValuesEqual`, exactly where `Equal` calls its counterpart.

## Verification

Two new tests in `AssertEqualTests`:

| test | before | after |
| --- | --- | --- |
| `BoxedReadOnlyMemory_EqualAndNotEqualDisagree` | **`NotEqual` did not throw (bug)** | passes — the pair can no longer both succeed |
| `BoxedReadOnlyMemory_NotEqualSucceedsForDifferentContent` | passes | passes (unchanged) |

The first was confirmed to fail against `origin/main` with `Expected exception type: AssertionException`.

Full suite: **832/832 passing** on net10.0 and net11.0 with `-p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` reports no drift; no public API change.

Found by a project review of `Meziantou.Framework.Assertions`.
