### PR TITLE
Stop INLINESNAPSHOTTESTING_STRATEGY=Default from recursing into itself

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategy.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategy.cs
@@ -7,7 +7,11 @@ namespace Meziantou.Framework.InlineSnapshotTesting;
 public abstract class SnapshotUpdateStrategy
 {
     private const string SnapshotUpdateStrategyEnvironmentVariableName = "INLINESNAPSHOTTESTING_STRATEGY";
-    private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties = typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
+    // Default is excluded on purpose: its getter calls GetStrategyFromEnvironmentVariable, so resolving it from
+    // here would re-enter the getter and recurse until the process died with an uncatchable StackOverflowException.
+    private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties =
+        [.. typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static).Where(property => property.Name is not nameof(Default))];
 
     /// <summary>Do not update the snapshots and fail the tests if the snapshots are different.</summary>
     public static SnapshotUpdateStrategy Disallow { get; } = new DisallowStrategy();

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -87,6 +87,16 @@ public sealed class InlineSnapshotSettingsTests
     }
 
     [Fact]
+    public void SnapshotUpdateStrategy_Default_EnvironmentVariableNamingDefault_FallsBackToDisallow()
+    {
+        // "Default" is one of the static property names, so resolving it by reflection used to re-enter the
+        // Default getter and kill the process with a StackOverflowException instead of failing this assertion.
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, nameof(SnapshotUpdateStrategy.Default));
+
+        Assert.Same(SnapshotUpdateStrategy.Disallow, SnapshotUpdateStrategy.Default);
+    }
+
+    [Fact]
     public void SnapshotUpdateStrategy_ExplicitSetting_HasPriorityOverEnvironmentVariable()
     {
         using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, nameof(SnapshotUpdateStrategy.Overwrite));


### PR DESCRIPTION
## Problem

`SnapshotUpdateStrategy.Default` resolves `INLINESNAPSHOTTESTING_STRATEGY` by reflecting over the public static properties of `SnapshotUpdateStrategy`:

```csharp
private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties =
    typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static);
```

That set includes `Default` itself. So when the variable is set to `Default`, `GetStrategyFromEnvironmentVariable` matches the `Default` property and calls `property.GetValue(null)`, which re-enters the `Default` getter, which calls `GetStrategyFromEnvironmentVariable` again — unbounded recursion.

Reproduced on `main`:

```
INLINESNAPSHOTTESTING_STRATEGY=Default
  at ...SnapshotUpdateStrategy.GetStrategyFromEnvironmentVariable()
  at ...SnapshotUpdateStrategy.get_Default()
  at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(...)
  ... repeats until StackOverflowException
```

`StackOverflowException` cannot be caught, so the test host dies with no results and a stack trace that points at reflection rather than at the environment variable. `Default` is not an exotic value either — the readme says the value "must match one of the `SnapshotUpdateStrategy` static property names", and `Default` is one of them.

## Change

Exclude `Default` from the reflected property list, with a comment explaining why it must stay excluded.

Every other accepted value (`Disallow`, `MergeTool`, `MergeToolSync`, `Overwrite`, `OverwriteWithoutFailure`) behaves exactly as before, including the case-insensitive match and the fallback to `Disallow` for unrecognised values.

## Verification

- Added `SnapshotUpdateStrategy_Default_EnvironmentVariableNamingDefault_FallsBackToDisallow`. On `main` this test does not fail — it kills the test process — which is why the existing `[Theory]` never covered the value.
- `dotnet test --filter-class ...InlineSnapshotSettingsTests /p:TreatWarningsAsErrors=true` → 9/9 passing (8 before).
- `dotnet run ./eng/update-all.cs` → no changes.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
