### PR TITLE
Scope the file logger retention policy to the files of the current process

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
@@ -211,6 +211,21 @@ internal sealed class LogFileWriter : IDisposable
         }
     }
 
+    private string[] GetRetentionPatterns()
+    {
+        // A log file is named {prefix}{timestamp}[-{processId}][_{index}]{extension}[{compressionExtension}].
+        // Matching the process id keeps the retention policy from deleting the files that another
+        // process is currently writing in the same directory
+        var prefix = _options.FileNamePrefix + "*";
+        if (_options.IncludeProcessIdInFileName)
+        {
+            prefix += "-" + Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        }
+
+        // The index is added after the process id, so it needs its own pattern
+        return [prefix + _options.FileNameExtension, prefix + "_*" + _options.FileNameExtension];
+    }
+
     private void ApplyRetentionPolicy()
     {
         if (_options.MaxRetainedFiles is not { } maxRetainedFiles)
@@ -219,12 +234,11 @@ internal sealed class LogFileWriter : IDisposable
         try
         {
             var directory = new DirectoryInfo(_directory);
-            var pattern = _options.FileNamePrefix + "*" + _options.FileNameExtension;
 
             // The file names start with the timestamp, so ordering them by name orders them chronologically.
-            // The second pattern matches the compressed files, whatever the algorithm they were compressed with
-            var files = directory.GetFiles(pattern)
-                .Concat(directory.GetFiles(pattern + ".*"))
+            // The '.*' patterns match the compressed files, whatever the algorithm they were compressed with
+            var files = GetRetentionPatterns()
+                .SelectMany(pattern => directory.GetFiles(pattern).Concat(directory.GetFiles(pattern + ".*")))
                 .DistinctBy(file => file.FullName, StringComparer.Ordinal)
                 .OrderByDescending(file => file.Name, StringComparer.Ordinal)
                 .Skip(maxRetainedFiles);

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -271,6 +271,40 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task RetentionPolicyKeepsTheFilesOfTheOtherProcesses()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+
+        // Log files that another process is writing in the same directory. They are older than the
+        // files of this process, so the retention policy would delete them first if it considered them
+        var otherProcessId = (Environment.ProcessId + 1).ToString(CultureInfo.InvariantCulture);
+        string[] otherProcessFiles = [$"2024-01-01-{otherProcessId}.log", $"2024-01-01-{otherProcessId}_001.log"];
+        foreach (var fileName in otherProcessFiles)
+        {
+            await File.WriteAllTextAsync(Path.Combine(tempDirectory.FullPath, fileName), "other process", TestContext.Current.CancellationToken);
+        }
+
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            RollInterval = RollInterval.Daily,
+            MaxRetainedFiles = 2,
+        }, timeProvider);
+
+        var logger = provider.CreateLogger("Test");
+        for (var i = 0; i < 5; i++)
+        {
+            logger.LogInformation("Day {Index}", i);
+            await provider.FlushAsync(TestContext.Current.CancellationToken);
+            timeProvider.Advance(TimeSpan.FromDays(1));
+        }
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal([.. otherProcessFiles, $"2024-01-05-{pid}.log", $"2024-01-06-{pid}.log"], GetFileNames(tempDirectory));
+    }
+
+    [Fact]
     public async Task CompressOnRoll()
     {
         using var tempDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
`ApplyRetentionPolicy` deletes any file in the log directory matching `{FileNamePrefix}*{FileNameExtension}`, sparing only the file this writer currently holds (`LogFileWriter.cs:234`). Files belonging to **other live processes** are ordinary deletion candidates, and because every log file is opened with `FileShare.Delete` (`LogFileWriter.cs:111`) the delete succeeds even on Windows.

### Failure scenario

Two processes log to the same directory, the second one has `MaxRetainedFiles = 1`:

```
provider A (pid 100) -> logs/2024-01-02-100.log   <- open, actively written
provider B (pid 200) rolls -> retention runs -> logs/2024-01-02-100.log DELETED
```

Reproduced before the fix: provider A keeps writing to a handle whose file no longer exists, and on Unix the deletion does not even raise an error.

This is reachable rather than theoretical: `IncludeProcessIdInFileName` defaults to `true`, so the naming scheme explicitly anticipates several processes sharing one directory. On a web farm or any multi-worker host the newest N files win and the older workers silently lose their history mid-run.

### What changed

Retention now enumerates only the files this writer could have produced. When `IncludeProcessIdInFileName` is set, the process id becomes part of the search pattern, so another process's files are never enumerated in the first place:

```
*-{pid}{extension}      and  *-{pid}_*{extension}      (+ the '.*' variants for compressed files)
```

Behavior is unchanged when `IncludeProcessIdInFileName` is `false` — that configuration opts into a shared naming scheme, and narrowing it further would silently stop cleaning up files users expect to be removed.

### Verification

New test `RetentionPolicyKeepsTheFilesOfTheOtherProcesses` seeds the directory with two files carrying a foreign process id, then drives five daily rolls with `MaxRetainedFiles = 2`. It asserts the foreign files survive alongside the two most recent own files.

Confirmed the test fails without the source change (`Assert.Equal() assertion failed: Lengths differ` on both net10.0 and net11.0) and passes with it. Full suite: 57/57 green on both target frameworks, `dotnet run ./eng/update-all.cs` reports no changes.

### Note

One residual case is deliberately left alone: with `IncludeProcessIdInFileName = false` **and** an empty `FileNamePrefix`, the pattern is still `*.log`, which can match `.log` files written by unrelated components sharing the directory. Tightening that changes retention semantics for existing users, so it seemed worth a separate decision rather than riding along here.
