### PR TITLE
Guard FileEditor's cross-file edit log against concurrent updates

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs
@@ -13,8 +13,11 @@ internal static class FileEditor
     private static readonly ConcurrentDictionary<FullPath, Lock> FileLocks = new();
     private static readonly ConcurrentDictionary<FullPath, FullPath> TempFiles = new();
 
-    private static readonly Dictionary<FullPath, List<FileEdit>> Changes = [];
-    private static readonly HashSet<FullPath> Errors = [];
+    // Concurrent because the lock above is per file: two threads updating snapshots in two different files
+    // hold two different locks and would otherwise mutate these two collections at the same time.
+    // The List<FileEdit> of a given file is only ever touched under that file's lock, so it stays a plain list.
+    private static readonly ConcurrentDictionary<FullPath, List<FileEdit>> Changes = new();
+    private static readonly ConcurrentDictionary<FullPath, byte> Errors = new();
 
     private static int GetActualLine(FullPath fullPath, int startLine)
     {
@@ -64,7 +67,7 @@ internal static class FileEditor
         var lockObject = FileLocks.GetOrAdd(context.FilePath, _ => new());
         lock (lockObject)
         {
-            if (Errors.Contains(context.FilePath))
+            if (Errors.ContainsKey(context.FilePath))
                 throw new InlineSnapshotException("The previous merged cannot be resolved. Restart the tests to update this snapshot.");
 
             var tempPath = TempFiles.GetOrAdd(context.FilePath, _ => FullPath.GetTempPath() / (Guid.NewGuid().ToString("N") + ".cs"));
@@ -185,7 +188,7 @@ internal static class FileEditor
                 var potentialMergedExpressions = mergedRoot.DescendantNodesAndSelf(textSpan).OfType<InvocationExpressionSyntax>().ToArray();
                 if (potentialMergedExpressions.Length == 0)
                 {
-                    Errors.Add(context.FilePath);
+                    Errors.TryAdd(context.FilePath, value: default);
                     return;
                 }
 
@@ -205,11 +208,7 @@ internal static class FileEditor
             context.LineNumber,
             invocationSpan.EndLinePosition.Line - invocationSpan.StartLinePosition.Line,
             newInvocationSpan.EndLinePosition.Line - newInvocationSpan.StartLinePosition.Line);
-        if (!Changes.TryGetValue(context.FilePath, out var fileEdits))
-        {
-            fileEdits = [];
-            Changes.Add(context.FilePath, fileEdits);
-        }
+        var fileEdits = Changes.GetOrAdd(context.FilePath, _ => []);
 
         fileEdits.Add(fileEdit);
         fileEdits.Sort((a, b) => a.StartLine - b.StartLine);


### PR DESCRIPTION
## Problem

`FileEditor.UpdateFile` takes a lock **per source file**:

```csharp
var lockObject = FileLocks.GetOrAdd(context.FilePath, _ => new());
lock (lockObject)
```

but inside that lock it reads and writes `Changes` (a plain `Dictionary<FullPath, List<FileEdit>>`) and `Errors` (a plain `HashSet<FullPath>`), which are **process-global**. Two threads updating snapshots in two *different* source files hold two different locks and mutate those two collections concurrently.

That is the ordinary configuration, not an exotic one: xUnit, NUnit and MSTest all run separate test classes in parallel by default, and separate test classes normally live in separate files.

Reproduced on `main` with six threads updating six source files (`OverwriteWithoutFailure` + `ForceUpdateSnapshots`), roughly one run in five:

```
System.InvalidOperationException: Operations that change non-concurrent collections must have
exclusive access. A concurrent update was performed on this collection and corrupted its state.
The collection's state is no longer correct.
```

The symptoms are nondeterministic: a hard `InvalidOperationException` thrown from inside an assertion, a corrupted `Errors` set that makes unrelated files report *"The previous merged cannot be resolved. Restart the tests to update this snapshot."*, or lost `Changes` entries — which makes `GetActualLine` compute the wrong line offset and edit the wrong snapshot.

## Change

Make the two shared containers `ConcurrentDictionary`. The `List<FileEdit>` for a given file is still a plain list, because it is only ever touched under that file's own lock — only the dictionaries were being shared across locks.

No behavior change on the single-threaded path.

## Verification

- The six-thread stress repro above: 8 consecutive runs clean on this branch, against ~1-in-5 failures on `main`.
- Full test project: 131/131 passing with `/p:TreatWarningsAsErrors=true`.

No unit test is included: the failure is a nondeterministic data race, so a test for it would either be flaky or would pass for the wrong reason. The stress program above is the honest reproduction.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
