### PR TITLE
Emit non-BMP characters as \U escapes instead of malformed \x escapes

### DIFF
--- a/src/Meziantou.Framework.Yaml/Emitter.cs
+++ b/src/Meziantou.Framework.Yaml/Emitter.cs
@@ -1199,7 +1199,7 @@ public partial class Emitter : IEmitter
                         break;
 
                     default:
-                        short code = (short)character;
+                        int code = character;
                         if (code <= 0xFF)
                         {
                             Write('x');

--- a/tests/Meziantou.Framework.Yaml.Tests/EmitterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/EmitterTests.cs
@@ -127,7 +127,58 @@ public class EmitterTests : YamlTest
             emitter.Emit(new DocumentEnd(true));
         }
         var result = encoding.GetString(stream.ToArray()).Trim();
-        Assert.Equal("\"Test\\xD802\\xDD05Yo♥\"", result);
+        Assert.Equal("\"Test\\U00010905Yo♥\"", result);
+    }
+
+    [Theory]
+    [InlineData("\U0001F600")]
+    [InlineData("\U00020000")]
+    [InlineData("\U00010905")]
+    [InlineData("a\U0001F600b")]
+    [InlineData("\U0001F600\U0001F601")]
+    [InlineData("♥\U00010905中")]
+    public void EmitNonBmpCharacters_RoundTrips(string input)
+    {
+        var yaml = EmitDoubleQuotedScalar(input);
+
+        Assert.Equal(input, ParseSingleScalarValue(yaml));
+    }
+
+    [Fact]
+    public void EmitNonBmpCharacter_UsesEightDigitEscape()
+    {
+        Assert.Equal("\"\\U0001F600\"", EmitDoubleQuotedScalar("\U0001F600").Trim());
+    }
+
+    [Fact]
+    public void EmitBmpCharacterAboveShortMaxValue_UsesFourDigitEscape()
+    {
+        // U+FFFE is above short.MaxValue and is not printable, so it must use the 4-digit escape.
+        Assert.Equal("\"\\uFFFE\"", EmitDoubleQuotedScalar("\uFFFE").Trim());
+    }
+
+    private static string EmitDoubleQuotedScalar(string value)
+    {
+        using var output = new StringWriter();
+        var emitter = new Emitter(output);
+        emitter.Emit(new StreamStart());
+        emitter.Emit(new DocumentStart(null, null, true));
+        emitter.Emit(new Scalar(value, ScalarStyle.DoubleQuoted));
+        emitter.Emit(new DocumentEnd(true));
+        emitter.Emit(new StreamEnd());
+        return output.ToString();
+    }
+
+    private static string? ParseSingleScalarValue(string yaml)
+    {
+        var parser = Parser.CreateParser(new StringReader(yaml));
+        while (parser.MoveNext())
+        {
+            if (parser.Current is Scalar scalar)
+                return scalar.Value;
+        }
+
+        return null;
     }
 
     private static void ParseAndEmit(string name)


### PR DESCRIPTION
`Emitter` silently corrupted every non-BMP character — all emoji, CJK extension characters, and anything else outside the BMP.

## The defect

`Emitter.cs:1202`, in the double-quoted scalar escape path:

```csharp
short code = (short)character;
if (code <= 0xFF) { Write('x'); Write(code.ToString("X02", …)); }
else if (CharHelper.IsHighSurrogate(character)) { … Write('U'); … }   // unreachable
```

`char` is unsigned 16-bit, `short` is signed. Any character at or above U+8000 casts to a **negative** `short`, so `code <= 0xFF` is true and the surrogate branch is never reached. High surrogates are U+D800–U+DBFF, all ≥ U+8000, so that `else if` was dead code.

`(short)'\uD83D'` is `-10179`, and `(-10179).ToString("X02")` yields `D83D` — so the emitter wrote `\xD83D`. YAML's `\x` escape takes exactly two hex digits, so re-parsing reads `\xD8` (`Ø`) followed by a literal `3D`.

## Failure scenario

Round-trip through `YamlNode.ToString()` / `WriteTo()`, measured before this change:

| Input | Emitted | Read back |
| --- | --- | --- |
| `"😀"` (U+1F600) | `"\xD83D\xDE00"` | `Ø3DÞ00` |
| `"𠀀"` (U+20000) | `"\xD840\xDC00"` | `Ø403DÜ00` |
| `"中"` (U+4E2D) | `中` | `中` ✓ |

No exception, no warning — silent data corruption, and the emitted document is not valid YAML 1.2, so other parsers disagree about it too.

The escape path is only entered for non-printable characters (`IsPrintable`, `Emitter.cs:1030`), and among those only surrogates exceed U+7FFF, so the blast radius is exactly *non-BMP characters emitted through `Emitter`*. This reaches users via `YamlNode.ToString()`, `YamlNode.WriteTo()`, and `YamlNode.ToObject()` (which routes through `ToString()`).

`YamlSerializer.Serialize` uses `YamlWriter`, not `Emitter`, and was **not** affected — verified emoji round-trip correctly there both before and after.

## The change

`short code = (short)character` → `int code = character`. That makes the `<= 0xFF` test mean what it reads as, and the existing (correct) `IsHighSurrogate` branch becomes reachable and emits `\U0001F600`.

## Tests

`EmitterTests.EmitUnicodeEscapes` previously asserted the corrupted output:

```csharp
Assert.Equal("\"Test\\xD802\\xDD05Yo♥\"", result);   // before
Assert.Equal("\"Test\\U00010905Yo♥\"", result);      // after
```

Because it asserted the exact broken bytes, it passed on the buggy code and would have kept passing after any correct fix was reverted — it could never catch this. Replaced with the correct expectation, and added tests that assert on behaviour rather than literal output:

- `EmitNonBmpCharacters_RoundTrips` — 6 cases (emoji, CJK ext-B, Phoenician, mixed BMP/non-BMP, adjacent pairs) asserting emit → parse → equals original.
- `EmitNonBmpCharacter_UsesEightDigitEscape` — pins the `\U` form.
- `EmitBmpCharacterAboveShortMaxValue_UsesFourDigitEscape` — covers U+FFFE, above `short.MaxValue` but not a surrogate, which must still use the 4-digit `\u` escape. This is the case that would catch an over-broad fix.

`dotnet test` on `Meziantou.Framework.Yaml.Tests`: **888 passed, 0 failed** (Release, net10.0). Confirmed the 6 new round-trip cases and the corrected assertion actually execute.

Found during a project review of `Meziantou.Framework.Yaml`.
