### PR TITLE
Make HashCodeExtensions.AddValues actually update the caller's HashCode

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -253,9 +253,9 @@ namespace Meziantou.Framework
 
     public static class HashCodeExtensions
     {
-        public static void AddValues<T>(this System.HashCode hashCode, T[] values, System.Collections.Generic.IEqualityComparer<T>? equalityComparer = null) { }
-        public static void AddValues<T>(this System.HashCode hashCode, System.ReadOnlySpan<T> values, System.Collections.Generic.IEqualityComparer<T>? equalityComparer = null) { }
-        public static void AddValues<T>(this System.HashCode hashCode, System.Collections.Generic.IEnumerable<T> values, System.Collections.Generic.IEqualityComparer<T>? equalityComparer = null) { }
+        public static void AddValues<T>(this ref System.HashCode hashCode, T[] values, System.Collections.Generic.IEqualityComparer<T>? equalityComparer = null) { }
+        public static void AddValues<T>(this ref System.HashCode hashCode, System.ReadOnlySpan<T> values, System.Collections.Generic.IEqualityComparer<T>? equalityComparer = null) { }
+        public static void AddValues<T>(this ref System.HashCode hashCode, System.Collections.Generic.IEnumerable<T> values, System.Collections.Generic.IEqualityComparer<T>? equalityComparer = null) { }
     }
 
     public interface ICachedAsyncEnumerable<T> : System.Collections.Generic.IAsyncEnumerable<T>, System.IAsyncDisposable

--- a/src/Meziantou.Framework/HashCodeExtensions.cs
+++ b/src/Meziantou.Framework/HashCodeExtensions.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Framework;
 public static class HashCodeExtensions
 {
     /// <summary>Adds all values from an array to the hash code.</summary>
-    public static void AddValues<T>(this HashCode hashCode, T[] values, IEqualityComparer<T>? equalityComparer = null)
+    public static void AddValues<T>(this ref HashCode hashCode, T[] values, IEqualityComparer<T>? equalityComparer = null)
     {
         if (values is null)
         {
@@ -19,7 +19,7 @@ public static class HashCodeExtensions
     }
 
     /// <summary>Adds all values from a span to the hash code.</summary>
-    public static void AddValues<T>(this HashCode hashCode, ReadOnlySpan<T> values, IEqualityComparer<T>? equalityComparer = null)
+    public static void AddValues<T>(this ref HashCode hashCode, ReadOnlySpan<T> values, IEqualityComparer<T>? equalityComparer = null)
     {
         foreach (var value in values)
         {
@@ -28,7 +28,7 @@ public static class HashCodeExtensions
     }
 
     /// <summary>Adds all values from an enumerable to the hash code.</summary>
-    public static void AddValues<T>(this HashCode hashCode, IEnumerable<T> values, IEqualityComparer<T>? equalityComparer = null)
+    public static void AddValues<T>(this ref HashCode hashCode, IEnumerable<T> values, IEqualityComparer<T>? equalityComparer = null)
     {
         foreach (var value in values)
         {

--- a/tests/Meziantou.Framework.Tests/HashCodeExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/HashCodeExtensionsTests.cs
@@ -1,0 +1,69 @@
+namespace Meziantou.Framework.Tests;
+
+public sealed class HashCodeExtensionsTests
+{
+    [Fact]
+    public void AddValues_Array_ContributesToTheHashCode()
+    {
+        var hashCode = new HashCode();
+        hashCode.AddValues([1, 2, 3]);
+
+        Assert.NotEqual(new HashCode().ToHashCode(), hashCode.ToHashCode());
+    }
+
+    [Fact]
+    public void AddValues_Span_ContributesToTheHashCode()
+    {
+        var hashCode = new HashCode();
+        hashCode.AddValues(new ReadOnlySpan<int>([1, 2, 3]));
+
+        Assert.NotEqual(new HashCode().ToHashCode(), hashCode.ToHashCode());
+    }
+
+    [Fact]
+    public void AddValues_Enumerable_ContributesToTheHashCode()
+    {
+        var hashCode = new HashCode();
+        hashCode.AddValues(Enumerable.Range(1, 3));
+
+        Assert.NotEqual(new HashCode().ToHashCode(), hashCode.ToHashCode());
+    }
+
+    [Fact]
+    public void AddValues_MatchesAddingTheValuesOneByOne()
+    {
+        var actual = new HashCode();
+        actual.AddValues([1, 2, 3]);
+
+        var expected = new HashCode();
+        expected.Add(1);
+        expected.Add(2);
+        expected.Add(3);
+
+        Assert.Equal(expected.ToHashCode(), actual.ToHashCode());
+    }
+
+    [Fact]
+    public void AddValues_DifferentValuesProduceDifferentHashCodes()
+    {
+        var first = new HashCode();
+        first.AddValues([1, 2, 3]);
+
+        var second = new HashCode();
+        second.AddValues([4, 5, 6]);
+
+        Assert.NotEqual(first.ToHashCode(), second.ToHashCode());
+    }
+
+    [Fact]
+    public void AddValues_UsesTheEqualityComparer()
+    {
+        var withComparer = new HashCode();
+        withComparer.AddValues(["A"], StringComparer.OrdinalIgnoreCase);
+
+        var expected = new HashCode();
+        expected.Add("a", StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal(expected.ToHashCode(), withComparer.ToHashCode());
+    }
+}


### PR DESCRIPTION
## The bug

`HashCodeExtensions.AddValues` takes its receiver as `this HashCode hashCode` — **by value**.
`HashCode` is a mutable struct, so every call mutated a copy that was discarded on return. All three
overloads were no-ops: the caller's `HashCode` was never touched.

```csharp
var hc = new HashCode();
hc.AddValues([1, 2, 3]);
hc.ToHashCode();   // identical to new HashCode().ToHashCode()
```

Measured before this change — every input produced the empty-`HashCode` constant:

```
empty HashCode          = -1863804162
AddValues([1,2,3])      = -1863804162
AddValues([9,9,9,9,9])  = -1863804162
AddValues(['x','y'])    = -1863804162
AddValues(span [7])     = -1863804162
manual Add(1);Add(2);.. = -1857043520   <- what it should have produced
```

Any type using `AddValues` in its `GetHashCode()` returns a constant for every instance, so every
value collides and any `Dictionary`/`HashSet` keyed on it degrades to a linear scan with full
`Equals` comparisons. It never throws and never logs, and there was no test covering it.

## The change

`this HashCode` → `this ref HashCode` on all three overloads, plus the regenerated
`ref/Meziantou.Framework.cs`.

## Compatibility

This is a **binary-breaking** change to shipped API (`Meziantou.Framework` 6.0.2). It is source
compatible for the normal `hashCode.AddValues(...)` call on an addressable variable, which is the
only way the method was ever meant to be used; it will now correctly reject calls on r-values.

There is no behaviour to preserve — the previous signature could not work at all. `<Version>` is
deliberately left at `6.0.2` here; the release story is a separate call.

## Verification

Six regression tests added in `HashCodeExtensionsTests`. Confirmed they fail on the old signature
(6/6 failed) and pass with the fix (6/6 passed).
