### PR TITLE
Do not drop log messages when the queue is full and QueueFullMode is Wait

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
@@ -163,20 +163,26 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
         if (channel is null)
             return;
 
+        var logMessage = new LogMessage(message, flushCompletion: null);
+
         // Try to write to the channel - this will succeed as long as there's space
         // and the channel hasn't been completed yet
-        if (channel.Writer.TryWrite(new LogMessage(message, flushCompletion: null)))
+        if (channel.Writer.TryWrite(logMessage))
             return;
 
         // TryWrite failed - the channel is full (need backpressure) or completed (disposal)
         try
         {
+            // Another thread can take the room freed between WaitToWriteAsync and TryWrite, so keep
+            // trying until the message is queued. Otherwise the message would be dropped even though
+            // the caller asked to wait for room.
             // WaitToWriteAsync returns false if the channel is completed
             // This is cheaper than catching ChannelClosedException from WriteAsync
-            if (!channel.Writer.WaitToWriteAsync().AsTask().GetAwaiter().GetResult())
-                return;
-
-            channel.Writer.TryWrite(new LogMessage(message, flushCompletion: null));
+            while (channel.Writer.WaitToWriteAsync().AsTask().GetAwaiter().GetResult())
+            {
+                if (channel.Writer.TryWrite(logMessage))
+                    return;
+            }
         }
         catch (ChannelClosedException)
         {
@@ -256,20 +262,19 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
 
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var message = new LogMessage(message: null, completion);
-        if (!channel.Writer.TryWrite(message))
+        try
         {
-            try
+            // Another thread can take the room freed between WaitToWriteAsync and TryWrite, so keep
+            // trying until the flush request is queued
+            while (!channel.Writer.TryWrite(message))
             {
                 if (!await channel.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false))
                     return;
-
-                if (!channel.Writer.TryWrite(message))
-                    return;
             }
-            catch (ChannelClosedException)
-            {
-                return;
-            }
+        }
+        catch (ChannelClosedException)
+        {
+            return;
         }
 
         await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -489,6 +489,41 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task WaitQueueFullModeDoesNotDropMessages()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            MaxQueueLength = 1,
+            QueueFullMode = FileLoggerQueueFullMode.Wait,
+            TimestampFormat = null,
+            IncludeLogLevel = false,
+            IncludeCategory = false,
+        });
+
+        const int ThreadCount = 8;
+        const int MessagesPerThread = 500;
+
+        var logger = provider.CreateLogger("Test");
+
+        // Dedicated threads, so the producers cannot starve the thread pool the writer runs on
+        await Task.WhenAll(Enumerable.Range(0, ThreadCount).Select(_ => Task.Factory.StartNew(
+            () =>
+            {
+                for (var i = 0; i < MessagesPerThread; i++)
+                {
+                    logger.LogInformation("Message");
+                }
+            }, TestContext.Current.CancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default)));
+
+        await provider.DisposeAsync();
+
+        var lines = await File.ReadAllLinesAsync(provider.LogFilePath!, TestContext.Current.CancellationToken);
+        Assert.HasCount(ThreadCount * MessagesPerThread, lines);
+    }
+
+    [Fact]
     public async Task DropWriteDoesNotBlock()
     {
         using var tempDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
`WriteLog` tries `TryWrite`, and on failure awaits `WaitToWriteAsync` and then calls `TryWrite` **once** more (`FileLoggerProvider.cs:160-185`). Between those two calls another thread can take the freed slot, so the second `TryWrite` returns `false` and the message is discarded — with no error, no counter and no warning.

That happens in the mode whose documented behavior is *"Blocks the thread that logs the message until the queue has room for it"* (`FileLoggerQueueFullMode.cs:6-7`), which is also the default.

### Failure scenario

Measured against the current code with `QueueFullMode.Wait`, 32 threads x 20,000 messages:

| `MaxQueueLength` | logged | lost |
| --- | --- | --- |
| 1024 (default) | 640,000 | 1,101 (0.2%) |
| 256 | 8,000 | 6 |
| 16 | 8,000 | 642 |
| 1 | 8,000 | 5,092 (64%) |

A single producer loses nothing at any queue length, which confirms this is the multi-writer race and not backpressure working as intended. Loss scales with pressure, so it is worst exactly when the log matters most — and callers who chose `Wait` are the ones who explicitly accepted latency in order not to lose entries.

### What changed

Both queueing paths now retry until the message is actually accepted, instead of giving up after one attempt:

- `WriteLog` loops `while (WaitToWriteAsync()) { if (TryWrite(...)) return; }`
- `FlushAsync` loops `while (!TryWrite(...)) { if (!await WaitToWriteAsync(ct)) return; }`

The loop only ever spins in `Wait` mode: with `DropWrite`/`DropOldest` the channel accepts the write and applies its own drop policy, so `TryWrite` succeeds on the first attempt and the behavior of those modes is unchanged. Exiting on `WaitToWriteAsync` returning `false` keeps the existing disposal behavior — a completed channel still returns immediately rather than blocking.

The message struct is now built once before the loop rather than allocated per attempt.

### Verification

New test `WaitQueueFullModeDoesNotDropMessages` drives 8 threads x 500 messages through a 1-slot queue in `Wait` mode and asserts every message reaches the file. Producers run on dedicated threads so they cannot starve the thread pool the writer currently runs on.

- Without the source change: fails 3/3 runs, both target frameworks.
- With it: passes 5/5 runs, both target frameworks — checked repeatedly because a concurrency test that flakes in CI is worse than no test.

Full suite 57/57 green on net10.0 and net11.0; `dotnet run ./eng/update-all.cs` reports no changes.
