### PR TITLE
Validate all properties of collection items, not only [Required]

### DIFF
--- a/src/Meziantou.Framework/DataAnnotations/ValidateCollectionItemsAttribute.cs
+++ b/src/Meziantou.Framework/DataAnnotations/ValidateCollectionItemsAttribute.cs
@@ -25,7 +25,7 @@ public sealed class ValidateCollectionItemsAttribute : ValidationAttribute
             {
                 var results = new List<ValidationResult>();
                 var itemValidationContext = new ValidationContext(item);
-                Validator.TryValidateObject(item, itemValidationContext, results);
+                Validator.TryValidateObject(item, itemValidationContext, results, validateAllProperties: true);
                 if (results.Count > 0)
                     return results[0];
             }

--- a/tests/Meziantou.Framework.Tests/DataAnnotations/ValidateCollectionItemsAttributeTests.cs
+++ b/tests/Meziantou.Framework.Tests/DataAnnotations/ValidateCollectionItemsAttributeTests.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+using Meziantou.Framework.DataAnnotations;
+
+namespace Meziantou.Framework.Tests.DataAnnotations;
+
+public sealed class ValidateCollectionItemsAttributeTests
+{
+    [Fact]
+    public void ReportsItemsViolatingNonRequiredAttributes()
+    {
+        var model = new Model { Items = [new Item { Name = "way too long", Age = 9999 }] };
+
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+
+        Assert.False(isValid);
+        Assert.NotEmpty(results);
+    }
+
+    [Fact]
+    public void ReportsItemsViolatingRequiredAttributes()
+    {
+        var model = new Model { Items = [new Item { Name = null, Age = 1 }] };
+
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+
+        Assert.False(isValid);
+    }
+
+    [Fact]
+    public void AcceptsValidItems()
+    {
+        var model = new Model { Items = [new Item { Name = "ok", Age = 5 }] };
+
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+
+        Assert.True(isValid);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void AcceptsNullCollection()
+    {
+        var model = new Model { Items = null };
+
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+
+        Assert.True(isValid);
+    }
+
+    private sealed class Model
+    {
+        [ValidateCollectionItems]
+        public List<Item>? Items { get; set; }
+    }
+
+    private sealed class Item
+    {
+        [Required]
+        [StringLength(3)]
+        public string? Name { get; set; }
+
+        [Range(1, 10)]
+        public int Age { get; set; }
+    }
+}


### PR DESCRIPTION
## The bug

`ValidateCollectionItemsAttribute` calls the three-argument
`Validator.TryValidateObject(item, itemValidationContext, results)` overload
(`DataAnnotations/ValidateCollectionItemsAttribute.cs:28`). That overload is defined as
`validateAllProperties: false`, which evaluates only `[Required]` on properties plus type-level
attributes. Every other property-level rule on the items was silently ignored.

Measured before this change, with an item carrying `[StringLength(3)]` and `[Range(1, 10)]`, given a
12-character name and age 9999:

```
-> validation passed = True, errors = 0
-> same child with validateAllProperties: true => 2 error(s)
```

The attribute's stated purpose is "Validates each item in a collection by running validation on each
item", and it ran almost none of it. Callers who added it believe their collection contents are
validated, so invalid data flows through to whatever trusts the validated model. An input-validation
control that reports success is worse than no control at all.

## The change

Pass `validateAllProperties: true`.

## Not in this PR

Two related weaknesses are left alone to keep this diff to the actual defect:

- only the first failing item's first error is returned (line 30), and
- the `ValidationResult` carries no member name identifying *which* item failed.

Both are worth fixing, but they change the shape of the reported results rather than whether
validation runs at all. Happy to follow up if you want them.

## Verification

Four tests added in a new `ValidateCollectionItemsAttributeTests`. Confirmed
`ReportsItemsViolatingNonRequiredAttributes` fails without the change (1/4 failed) and that all four
pass with it — the other three cover `[Required]`, valid items, and a null collection, and pass
either way.
