### PR TITLE
Apply the CI and strategy gates to ForceUpdateSnapshots

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
@@ -144,7 +144,13 @@ public static class InlineSnapshot
         else if (settings.ForceUpdateSnapshots)
         {
             var context = GetCallerContext();
-            FileEditor.UpdateFile(context, settings, expected, actual);
+
+            // Reformatting a matching snapshot writes to the source file just like updating a failing one, so it
+            // must go through the same gate: continuous integration and LLM detection, and the update strategy.
+            if (settings.SnapshotUpdateStrategy.CanUpdateSnapshotInternal(settings, context.FilePath, expected, actual))
+            {
+                FileEditor.UpdateFile(context, settings, expected, actual);
+            }
         }
     }
 }

--- a/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategies/DisallowStrategy.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategies/DisallowStrategy.cs
@@ -6,5 +6,6 @@ internal sealed class DisallowStrategy : SnapshotUpdateStrategy
 
     public override bool MustReportError(InlineSnapshotSettings settings, string path) => true;
 
-    public override void UpdateFile(InlineSnapshotSettings settings, string currentFilePath, string newFilePath) => throw new InvalidOperationException();
+    public override void UpdateFile(InlineSnapshotSettings settings, string currentFilePath, string newFilePath)
+        => throw new InvalidOperationException($"'{nameof(SnapshotUpdateStrategy)}.{nameof(SnapshotUpdateStrategy.Disallow)}' never writes to source files. Set '{nameof(InlineSnapshotSettings)}.{nameof(InlineSnapshotSettings.SnapshotUpdateStrategy)}' to '{nameof(SnapshotUpdateStrategy.Overwrite)}' or '{nameof(SnapshotUpdateStrategy.OverwriteWithoutFailure)}' to update snapshots.");
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -62,6 +62,21 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
+    public void ForceUpdateSnapshots_WithDisallowStrategy_DoesNotThrow()
+    {
+        // The force-update path used to call FileEditor.UpdateFile without asking the strategy first, so
+        // Disallow reported a bare InvalidOperationException for a snapshot that actually matched.
+        var settings = InlineSnapshotSettings.Default with
+        {
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow,
+            AutoDetectContinuousEnvironment = false,
+            ForceUpdateSnapshots = true,
+        };
+
+        InlineSnapshot.Validate(new object(), settings, "{}");
+    }
+
+    [Fact]
     public void Validate_DoesNotComputeCallerContextWhenSnapshotMatches()
     {
         var exception = Record.Exception(() => InlineSnapshot.Validate(new object(), InlineSnapshotSettings.Default, "{}", "invalid\0path", 1));
@@ -617,6 +632,21 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
             expected: """
             InlineSnapshot.Validate(new object(), "{}");
             """);
+    }
+
+    [Fact]
+    public async Task DoNotForceUpdateSnapshotOnCI()
+    {
+        // Reformatting a matching snapshot is still a write to the source file, so continuous integration
+        // detection must stop it just like it stops updating a failing one.
+        await AssertSnapshot(forceUpdateSnapshots: true,
+            autoDetectCI: true,
+            environmentVariables: new[] { new KeyValuePair<string, string>("CI", "true") },
+            source: """"
+            InlineSnapshot.Validate(new object(), """
+                {}
+                """);
+            """");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`ShouldMatchInlineSnapshot` has two paths that write to the source file, and only one of them is gated.

The mismatch path goes through `CanUpdateSnapshotInternal`, which is where `AutoDetectContinuousEnvironment` consults `BuildServerDetector` / `ContinuousTestingDetector` / `LLMEnvironmentDetector`. The `ForceUpdateSnapshots` path calls `FileEditor.UpdateFile` directly and consults none of them:

```csharp
else if (settings.ForceUpdateSnapshots)
{
    var context = GetCallerContext();
    FileEditor.UpdateFile(context, settings, expected, actual);
}
```

Two consequences, both reproduced on `main`:

1. **The CI guarantee does not hold.** With `GITHUB_ACTIONS=true` / `CI=true` and `AutoDetectContinuousEnvironment = true` (the default), `ForceUpdateSnapshots = true` still rewrote the source file. The readme states "When running in a CI environment, the snapshot is never updated", and the "Recreate the snapshots" section tells users to set exactly this flag — so a reformatting config left in a committed `[ModuleInitializer]` silently rewrites checked-out sources on CI, and bypasses the LLM-environment guard that motivated the v4 default change.

2. **The default strategy throws a bare exception.** With `ForceUpdateSnapshots = true` and the default `SnapshotUpdateStrategy.Disallow`, a snapshot that *matches* throws `System.InvalidOperationException: Operation is not valid due to the current state of the object.` — `DisallowStrategy.UpdateFile` was `throw new InvalidOperationException()` with no message, so nothing tells the user they also need to change the strategy.

## Change

- Route the force-update path through `CanUpdateSnapshotInternal`, and treat `false` as "do nothing" — the snapshot already matches, so there is nothing to report.
- Give `DisallowStrategy.UpdateFile` a message that names the setting and the strategies that do write.

## Verification

Two regression tests, both confirmed to fail on `main`:

| Test | Failure without the fix |
|---|---|
| `ForceUpdateSnapshots_WithDisallowStrategy_DoesNotThrow` | `InvalidOperationException: Operation is not valid due to the current state of the object.` |
| `DoNotForceUpdateSnapshotOnCI` | source file rewritten despite `CI=true` |

Full test project: 133/133 passing with `/p:TreatWarningsAsErrors=true`.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
