### PR TITLE
Restrict stale-if-error to the 5xx statuses defined by RFC 5861

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -242,7 +242,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                     }
 
                     // RFC 5861: Handle error responses with stale-if-error
-                    if (!conditionalResponse.IsSuccessStatusCode && CanServeStaleOnError(cacheResult, currentAge, freshnessLifetime))
+                    if (IsStaleIfErrorStatus(conditionalResponse.StatusCode) && CanServeStaleOnError(cacheResult, currentAge, freshnessLifetime))
                     {
                         conditionalResponse.Dispose();
 
@@ -495,6 +495,15 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
         var staleness = currentAge - freshnessLifetime;
         return staleness <= entry.StaleIfError.Value;
+    }
+
+    private static bool IsStaleIfErrorStatus(HttpStatusCode statusCode)
+    {
+        // RFC 5861 Section 4: an error is a situation that would result in a 500, 502, 503 or 504 response.
+        // Any other status is the origin answering the request, and must reach the caller: a 404 or a 410
+        // means the representation is gone, a 401 or a 403 means it is no longer accessible, and a 3xx is a
+        // redirection. Serving the stored body for those would hide the answer the origin just gave.
+        return (int)statusCode is 500 or 502 or 503 or 504;
     }
 
     private static bool IsOriginUnreachable(Exception exception, CancellationToken cancellationToken)

--- a/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
@@ -302,6 +302,58 @@ public class StaleResponseTests
         Assert.Equal("from-origin", await response.Content.ReadAsStringAsync(CancellationToken.None));
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task WhenRevalidationReturnsAServerErrorAndStaleIfErrorAllowsItThenStaleResponseServed(HttpStatusCode statusCode)
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60"), ("ETag", "\"v1\"")));
+        innerHandler.AddResponse(() => CreateResponse(statusCode, "error"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal("cached", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+        Assert.Equal("110 - \"Response is Stale\", 111 - \"Revalidation Failed\"", string.Join(", ", secondResponse.Headers.GetValues("Warning")));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.MovedPermanently)]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Gone)]
+    [InlineData(HttpStatusCode.NotImplemented)]
+    public async Task WhenRevalidationReturnsANonErrorStatusThenStaleIfErrorDoesNotApply(HttpStatusCode statusCode)
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60"), ("ETag", "\"v1\"")));
+        innerHandler.AddResponse(() => CreateResponse(statusCode, "from-origin"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        // RFC 5861 Section 4: only 500, 502, 503 and 504 are errors. The origin answered, so the caller
+        // must see that answer instead of the stored representation.
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(statusCode, secondResponse.StatusCode);
+        Assert.Equal("from-origin", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
     private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode, string? content = null, params (string Name, string Value)[] headers)
     {


### PR DESCRIPTION
`stale-if-error` was applied to every response outside the 200–299 range, so a stale entry was served whenever the origin answered with anything that was not a success — including `301`, `401`, `403`, `404` and `410`.

RFC 5861 Section 4 defines the error set narrowly: *"a situation that would result in a 500, 502, 503, or 504 HTTP response status code being returned"*. Everything else is the origin answering the request, and that answer has to reach the caller.

## The failure

`HttpCachingDelegateHandler.cs:245` tested `!conditionalResponse.IsSuccessStatusCode`.

Given a resource cached with `Cache-Control: max-age=60, stale-if-error=86400` and an `ETag`, once the entry goes stale and the origin replies `404 Not Found`, the caller received `200 OK` with the old body — for the whole 24-hour window. The same held for `403` (access revoked) and `410` (gone). A `301` was swallowed too: the redirect never reached the caller, the stale body did.

A resource that has been deleted, or whose access has been revoked, kept being served from cache. It is a caching bug, but it reads as an authorization bug from the outside.

## The change

The condition is now `IsStaleIfErrorStatus(...)`, which matches only `500`, `502`, `503` and `504`.

The transport-failure path at `HttpCachingDelegateHandler.cs:222` is untouched — `IsOriginUnreachable` was already correct, and "the origin could not be reached at all" is squarely within RFC 5861.

## Verification

Two theories added to `StaleResponseTests`:

- `WhenRevalidationReturnsAServerErrorAndStaleIfErrorAllowsItThenStaleResponseServed` — 500/502/503/504 still serve the stale entry with the `110`/`111` warnings.
- `WhenRevalidationReturnsANonErrorStatusThenStaleIfErrorDoesNotApply` — 301/400/401/403/404/410/501 reach the caller unchanged.

The second theory fails on `main` (5 of its 7 cases assert the stale body was returned instead of the origin's answer) and passes with this change.

Full suite: 203 passed, 0 failed, 3 skipped (the skips are the container-backed Redis tests, which need a container runtime).
