### PR TITLE
Do not hold a dictionary ref across a user-supplied value factory

### DIFF
--- a/src/Meziantou.Framework/DictionaryExtensions.cs
+++ b/src/Meziantou.Framework/DictionaryExtensions.cs
@@ -21,15 +21,19 @@ public static class DictionaryExtensions
     }
 
     /// <summary>Gets the value associated with the specified key or adds it using the factory function if it doesn't exist.</summary>
+    /// <remarks>The key is only added once <paramref name="valueFactory"/> has returned, so a factory that throws leaves the dictionary unchanged.</remarks>
     public static TValue GetOrAdd<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key, Func<TKey, TValue> valueFactory)
         where TKey : notnull
     {
-        ref var dictionaryValue = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out var exists);
-        if (exists)
-            return dictionaryValue!;
+        if (dict.TryGetValue(key, out var existingValue))
+            return existingValue;
 
-        dictionaryValue = valueFactory(key);
-        return dictionaryValue;
+        // The value is computed before touching the dictionary: GetValueRefOrAddDefault would insert
+        // the key before the factory runs, and the ref it returns is invalidated if the factory
+        // mutates the same dictionary.
+        var value = valueFactory(key);
+        dict[key] = value;
+        return value;
     }
 
     /// <summary>Attempts to update the value associated with the specified key.</summary>
@@ -50,13 +54,12 @@ public static class DictionaryExtensions
     public static bool TryUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key, Func<TKey, TValue, TValue> valueFactory)
         where TKey : notnull
     {
-        ref var dictionaryValue = ref CollectionsMarshal.GetValueRefOrNullRef(dict, key);
-        if (!Unsafe.IsNullRef(ref dictionaryValue))
-        {
-            dictionaryValue = valueFactory(key, dictionaryValue);
-            return true;
-        }
+        if (!dict.TryGetValue(key, out var currentValue))
+            return false;
 
-        return false;
+        // The new value is stored through the indexer instead of the ref returned by
+        // GetValueRefOrNullRef, which the factory could invalidate by mutating the dictionary.
+        dict[key] = valueFactory(key, currentValue);
+        return true;
     }
 }

--- a/tests/Meziantou.Framework.Tests/DictionaryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/DictionaryExtensionsTests.cs
@@ -61,7 +61,7 @@ public sealed class DictionaryExtensionsTests
         var dict = new Dictionary<string, string>(StringComparer.Ordinal);
 
         Assert.Throws<InvalidOperationException>(() => dict.GetOrAdd("key", _ => throw new InvalidOperationException()));
-        Assert.False(dict.ContainsKey("key"));
+        Assert.DoesNotContain("key", dict);
 
         Assert.Equal("recovered", dict.GetOrAdd("key", _ => "recovered"));
         Assert.Equal("recovered", dict["key"]);

--- a/tests/Meziantou.Framework.Tests/DictionaryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/DictionaryExtensionsTests.cs
@@ -54,4 +54,57 @@ public sealed class DictionaryExtensionsTests
         Assert.False(dict.TryGetValue("key2", out _));
         Assert.Equal(43, dict["key"]);
     }
+
+    [Fact]
+    public void GetOrAddFactory_ThrowingFactoryDoesNotAddTheKey()
+    {
+        var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        Assert.Throws<InvalidOperationException>(() => dict.GetOrAdd("key", _ => throw new InvalidOperationException()));
+        Assert.False(dict.ContainsKey("key"));
+
+        Assert.Equal("recovered", dict.GetOrAdd("key", _ => "recovered"));
+        Assert.Equal("recovered", dict["key"]);
+    }
+
+    [Fact]
+    public void GetOrAddFactory_StoresTheValueWhenTheFactoryMutatesTheDictionary()
+    {
+        var dict = new Dictionary<int, string>();
+
+        var result = dict.GetOrAdd(0, _ =>
+        {
+            for (var i = 1; i <= 64; i++)
+            {
+                dict[i] = "filler";
+            }
+
+            return "computed";
+        });
+
+        Assert.Equal("computed", result);
+        Assert.Equal("computed", dict[0]);
+    }
+
+    [Fact]
+    public void TryUpdateFactory_StoresTheValueWhenTheFactoryMutatesTheDictionary()
+    {
+        var dict = new Dictionary<int, string>
+        {
+            [0] = "initial",
+        };
+
+        var result = dict.TryUpdate(0, (_, _) =>
+        {
+            for (var i = 1; i <= 64; i++)
+            {
+                dict[i] = "filler";
+            }
+
+            return "updated";
+        });
+
+        Assert.True(result);
+        Assert.Equal("updated", dict[0]);
+    }
 }


### PR DESCRIPTION
## The bug

`GetOrAdd(dict, key, valueFactory)` and `TryUpdate(dict, key, valueFactory)` invoke the caller's
factory while holding a `ref` into the dictionary's bucket array. `CollectionsMarshal`'s docs are
explicit that such a ref is invalidated by any subsequent mutation — and for
`GetValueRefOrAddDefault`, the key is inserted with `default(TValue)` *before* the factory runs.

Two failures, both measured before this change:

```
[factory throws]    ContainsKey("k") = True, value = <null>
                    retry returned = <null>   <- the poisoned entry is returned forever
[reentrant factory] returned = "computed", stored = <null>
                    <- the write through the ref went to the pre-resize array
```

`GetOrAdd` is a memoization primitive and both failure modes are the ones memoization actually hits:

- A factory that throws once (transient IO, a parse failure) permanently caches `null`. The retry
  silently succeeds with the wrong answer instead of recomputing.
- A factory that recursively populates the same dictionary — the standard shape for memoized graph
  traversal — returns the right value to its caller while storing `null`, so the next lookup
  disagrees with the last.

Neither throws. `ConcurrentDictionary.GetOrAdd` has neither behaviour, which is what callers expect.

`TryUpdate`'s factory overload has the same stale-ref hazard (it does not insert, so it cannot
poison, but a reentrant factory still loses the write).

## The change

Both factory overloads now compute the value first and store it through the indexer, so no ref is
held across the callback. This costs a second lookup on the miss path in exchange for removing both
hazards.

The non-factory `GetOrAdd`/`TryUpdate` overloads are left on `CollectionsMarshal` — with no user
callback there is nothing that can invalidate the ref.

## Verification

Three regression tests added to `DictionaryExtensionsTests`. Confirmed all three fail on `main`
(3/7 failed) and pass with the fix (7/7), with the four pre-existing tests unaffected.
