### PR TITLE
Fix the cleared range when a CircularBuffer has wrapped

### DIFF
--- a/src/Meziantou.Framework/Collections/CircularBuffer.cs
+++ b/src/Meziantou.Framework/Collections/CircularBuffer.cs
@@ -178,7 +178,7 @@ sealed class CircularBuffer<T> : ICollection<T>, IReadOnlyList<T>
         // Clear the elements so that the gc can reclaim the references.
         if (RuntimeHelpers.IsReferenceOrContainsReferences<T>() && Count > 0)
         {
-            Array.Clear(_items, _startIndex, Math.Min(Count - _startIndex, Capacity - _startIndex));
+            Array.Clear(_items, _startIndex, Math.Min(Count, Capacity - _startIndex));
             if (_startIndex + Count > Capacity)
             {
                 Array.Clear(_items, 0, (_startIndex + Count) % Capacity);

--- a/tests/Meziantou.Framework.Tests/Collections/CircularBufferTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/CircularBufferTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Meziantou.Framework.Collections;
 
 namespace Meziantou.Framework.Tests.Collections;
@@ -497,5 +498,53 @@ public class CircularBufferTests
 
         Assert.Equal([1, 2, 3], firstPass);
         Assert.Equal(firstPass, secondPass);
+    }
+
+    [Fact]
+    public void Clear_WrappedBufferOfReferenceType()
+    {
+        var list = new CircularBuffer<string>(3) { AllowOverwrite = true };
+        list.AddLast("a");
+        list.AddLast("b");
+        list.AddLast("c");
+        list.RemoveFirst();
+        list.RemoveFirst();
+
+        list.Clear();
+
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void Clear_ReleasesTheReferencesOfAWrappedBuffer()
+    {
+        var list = new CircularBuffer<string>(2) { AllowOverwrite = true };
+        list.AddLast("a");
+        list.AddLast("b");
+        list.RemoveFirst();
+
+        list.Clear();
+
+        // Clear exists to let the GC reclaim the items, so no slot may still reference one
+        var items = (string?[])typeof(CircularBuffer<string>)
+            .GetField("_items", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(list)!;
+        Assert.All(items, item => Assert.Null(item));
+    }
+
+    [Fact]
+    public void Clear_BufferThatWrapsAroundTheEndOfTheArray()
+    {
+        var list = new CircularBuffer<string>(3) { AllowOverwrite = true };
+        list.AddLast("a");
+        list.AddLast("b");
+        list.AddLast("c");
+        list.AddLast("d");
+
+        list.Clear();
+
+        Assert.Empty(list);
+        list.AddLast("e");
+        Assert.Equal(["e"], list);
     }
 }


### PR DESCRIPTION
## The bug

`CircularBuffer.Clear()` computes the clear length as
`Math.Min(Count - _startIndex, Capacity - _startIndex)` (`Collections/CircularBuffer.cs:181`).
`Count` is a length and `_startIndex` is an offset, so subtracting one from the other is meaningless.
It should be `Math.Min(Count, Capacity - _startIndex)`.

Two failure modes, both measured before this change:

```
capacity 3, add a/b/c, RemoveFirst x2, Clear()  -> IndexOutOfRangeException
capacity 2, add a/b,   RemoveFirst,    Clear()  -> slot[1] still holds a reference
```

When `_startIndex > Count` the expression goes negative and `Array.Clear` throws from a method
documented to just empty the buffer. When `_startIndex <= Count` it under-counts and leaves live
slots untouched — defeating the GC reclamation the block exists for, and keeping arbitrary object
graphs alive. A ring buffer typically holds recent log entries or messages, so the retained graph can
be large.

Only `CircularBuffer<T>` of a reference type reaches this branch at all
(`RuntimeHelpers.IsReferenceOrContainsReferences<T>()`), which is the common case.

`DoubleEndedQueue.Clear` (`Collections/DoubleEndedQueue.cs:122`) is the same algorithm written
correctly, which is what pins this down as a typo rather than a design difference.

## Why the existing test missed it

`CircularBufferTests.Clear` uses `CircularBuffer<int>`, so
`IsReferenceOrContainsReferences<int>()` is false and the whole buggy block is skipped.

## The change

Use `Math.Min(Count, Capacity - _startIndex)`, matching `DoubleEndedQueue`.

## Verification

Three tests added to `CircularBufferTests`, all over a reference type with a non-zero `_startIndex`.
Confirmed they fail on `main` and pass with the fix.
