### PR TITLE
Make ResettableCancellationTokenSource thread-safe and Dispose idempotent

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/ResettableCancellationTokenSource.cs
+++ b/src/Meziantou.Framework.Threading/Threading/ResettableCancellationTokenSource.cs
@@ -1,6 +1,15 @@
 namespace Meziantou.Framework.Threading;
 
 /// <summary>Represents a cancellation token source that can be reset to its initial state.</summary>
+/// <remarks>
+/// All members are safe to call concurrently. Note that the callbacks registered on <see cref="Token"/> run while the
+/// internal lock is held, so a callback must not block waiting on another thread that uses the same instance.
+/// <para>
+/// <see cref="Reset"/> replaces the underlying <see cref="CancellationTokenSource"/>, so a <see cref="CancellationToken"/>
+/// obtained before the reset belongs to the previous generation: it never reacts to a later <see cref="Cancel"/>. Read
+/// <see cref="Token"/> again after resetting.
+/// </para>
+/// </remarks>
 /// <example>
 /// <code><![CDATA[
 /// var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
@@ -16,7 +25,9 @@ namespace Meziantou.Framework.Threading;
 public sealed class ResettableCancellationTokenSource : IDisposable
 {
     private readonly ResettableCancellationTokenSourceOptions _options;
+    private readonly Lock _lock = new();
     private CancellationTokenSource _cts = new();
+    private bool _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="ResettableCancellationTokenSource"/> class with the specified options.</summary>
     /// <param name="options">Options that control the behavior when resetting or disposing.</param>
@@ -36,40 +47,85 @@ public sealed class ResettableCancellationTokenSource : IDisposable
     }
 
     /// <summary>Gets the cancellation token associated with this <see cref="ResettableCancellationTokenSource"/>.</summary>
-    public CancellationToken Token => _cts.Token;
+    public CancellationToken Token
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _cts.Token;
+            }
+        }
+    }
 
     /// <summary>Gets whether cancellation has been requested for this token source.</summary>
-    public bool IsCancellationRequested => _cts.IsCancellationRequested;
+    public bool IsCancellationRequested
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _cts.IsCancellationRequested;
+            }
+        }
+    }
 
     /// <summary>Communicates a request for cancellation.</summary>
-    public void Cancel() => _cts.Cancel();
+    public void Cancel()
+    {
+        lock (_lock)
+        {
+            _cts.Cancel();
+        }
+    }
 
     /// <summary>Schedules a cancel operation on this <see cref="ResettableCancellationTokenSource"/> after the specified time span.</summary>
     /// <param name="delay">The time span to wait before canceling this <see cref="ResettableCancellationTokenSource"/>.</param>
-    public void CancelAfter(TimeSpan delay) => _cts.CancelAfter(delay);
+    public void CancelAfter(TimeSpan delay)
+    {
+        lock (_lock)
+        {
+            _cts.CancelAfter(delay);
+        }
+    }
 
     /// <summary>Resets the cancellation token source to its initial state.</summary>
     public void Reset()
     {
-        if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnReset))
+        lock (_lock)
         {
-            _cts.Cancel();
-        }
+            ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (!_cts.TryReset())
-        {
-            _cts.Dispose();
-            _cts = new CancellationTokenSource();
+            if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnReset))
+            {
+                _cts.Cancel();
+            }
+
+            // Replacing the source is only safe while the lock is held: every other member reads _cts under the same
+            // lock, so no caller can be using the instance that is about to be disposed.
+            if (!_cts.TryReset())
+            {
+                _cts.Dispose();
+                _cts = new CancellationTokenSource();
+            }
         }
     }
 
     public void Dispose()
     {
-        if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnDispose))
+        lock (_lock)
         {
-            _cts.Cancel();
-        }
+            if (_disposed)
+                return;
 
-        _cts.Dispose();
+            _disposed = true;
+
+            if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnDispose))
+            {
+                _cts.Cancel();
+            }
+
+            _cts.Dispose();
+        }
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/ResettableCancellationTokenSourceTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ResettableCancellationTokenSourceTests.cs
@@ -1,0 +1,122 @@
+namespace Meziantou.Framework.Threading.Tests;
+
+public sealed class ResettableCancellationTokenSourceTests
+{
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+        cts.Dispose();
+        cts.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent_WithoutCancelOnDispose()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);
+        cts.Dispose();
+        cts.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_CancelsTheToken_WhenCancelOnDisposeIsSet()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        var token = cts.Token;
+        cts.Dispose();
+
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotCancelTheToken_WhenCancelOnDisposeIsNotSet()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);
+        var token = cts.Token;
+        cts.Dispose();
+
+        Assert.False(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Reset_CancelsTheCurrentToken_WhenCancelOnResetIsSet()
+    {
+        using var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnReset);
+        var token = cts.Token;
+        cts.Reset();
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.False(cts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Reset_ProducesAFreshTokenAfterCancellation()
+    {
+        using var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);
+        cts.Cancel();
+        Assert.True(cts.IsCancellationRequested);
+
+        cts.Reset();
+
+        Assert.False(cts.IsCancellationRequested);
+        Assert.False(cts.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Reset_AfterDispose_Throws()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);
+        cts.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(cts.Reset);
+    }
+
+    [Fact]
+    public async Task ConcurrentResetAndCancel_DoesNotThrow()
+    {
+        // Reset replaces (and disposes) the underlying source. Without synchronization a concurrent reader observes
+        // the disposed instance and throws ObjectDisposedException.
+        for (var round = 0; round < 50; round++)
+        {
+            using var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+            using var start = new Barrier(2);
+
+            var resets = Task.Run(() =>
+            {
+                start.SignalAndWait();
+                for (var i = 0; i < 200; i++)
+                {
+                    cts.Reset();
+                }
+            });
+
+            var readers = Task.Run(() =>
+            {
+                start.SignalAndWait();
+                for (var i = 0; i < 200; i++)
+                {
+                    _ = cts.Token;
+                    _ = cts.IsCancellationRequested;
+                    cts.Cancel();
+                }
+            });
+
+            await Task.WhenAll(resets, readers).WaitAsync(TimeSpan.FromSeconds(30));
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentDispose_DisposesOnlyOnce()
+    {
+        using var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+        using var start = new Barrier(4);
+
+        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            start.SignalAndWait();
+            cts.Dispose();
+        })).ToArray();
+
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(30));
+    }
+}


### PR DESCRIPTION
`ResettableCancellationTokenSource` has no synchronization at all: `_cts` is a plain mutable field that `Reset()` disposes and replaces, while `Token`, `IsCancellationRequested`, `Cancel()` and `CancelAfter()` all read it unguarded.

### What happens

**Concurrent `Reset()` throws in unrelated callers.** A thread that reads `_cts` just before the swap then touches a disposed source:

```csharp
// thread 1                    // thread 2
for (...) cts.Reset();         for (...) { _ = cts.Token; cts.Cancel(); }
```

Reproduced before the fix — thread 2 throws `ObjectDisposedException` within the first few rounds. `ResettableCancellationTokenSource.cs:61-62` disposes the source; `:39-49` read it with no lock.

**`Dispose()` throws on the second call.** With `CancelOnDispose` set, `Dispose()` calls `_cts.Cancel()` before disposing, and `CancellationTokenSource.Cancel()` calls `ThrowIfDisposed()` first — so `Dispose(); Dispose();` throws `ObjectDisposedException`. That violates the `IDisposable` contract, and the throw typically lands in a `finally` or a container teardown where it masks the exception actually being propagated.

### What changed

- A `Lock` guards every access to `_cts`. Replacing the source in `Reset()` is now safe because no other member can be mid-call on the instance being disposed.
- `Dispose()` early-returns on a `_disposed` flag, so it is idempotent. `Reset()` after disposal throws `ObjectDisposedException` explicitly rather than incidentally.
- Documented two things that were previously implicit: token-registered callbacks run while the lock is held (so a callback must not block on another thread using the same instance), and a `CancellationToken` read before a `Reset()` belongs to the previous generation and will never observe a later `Cancel()`.

### Verification

New `ResettableCancellationTokenSourceTests.cs` — 9 tests covering idempotent disposal with and without `CancelOnDispose`, the cancel-on-reset and cancel-on-dispose behaviours, reset-after-cancel, reset-after-dispose, and the two concurrency repros above (`ConcurrentResetAndCancel_DoesNotThrow`, `ConcurrentDispose_DisposesOnlyOnce`). This type previously had no test file at all.

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full `Meziantou.Framework.Threading.Tests` suite green at 280 tests across net10.0 and net11.0 (262 before). `dotnet run ./eng/update-all.cs` reports no changes. No public API change, so `ref/` is unaffected.

<sub>Found during a review of `Meziantou.Framework.Threading` (finding H2, plus M1 and L2 for this type).</sub>
