### PR TITLE
Throw YamlException instead of overflowing the stack on deeply nested documents

### DIFF
--- a/src/Meziantou.Framework.Yaml/Parser.cs
+++ b/src/Meziantou.Framework.Yaml/Parser.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Meziantou.Framework.Yaml.Tokens;
 using AnchorAlias = Meziantou.Framework.Yaml.Tokens.AnchorAlias;
 using DocumentEnd = Meziantou.Framework.Yaml.Tokens.DocumentEnd;
@@ -130,6 +131,19 @@ public class Parser<TBuffer> : IParser where TBuffer : ILookAheadBuffer
             if (_currentDepth >= _maxDepth)
             {
                 throw YamlDepthHelper.CreateMaxDepthExceededException(_maxDepth, current.Start, current.End, _sourceName);
+            }
+
+            // Consumers such as converters and the document object model recurse once per nesting level, so a
+            // large MaxDepth can exhaust the stack before the depth limit is reached. Every nested read passes
+            // through here at its deepest point, so probing the stack now turns an uncatchable process crash
+            // into a regular YamlException.
+            try
+            {
+                RuntimeHelpers.EnsureSufficientExecutionStack();
+            }
+            catch (InsufficientExecutionStackException exception)
+            {
+                throw YamlDepthHelper.CreateInsufficientStackException(_currentDepth, current.Start, current.End, _sourceName, exception);
             }
 
             _currentDepth++;

--- a/src/Meziantou.Framework.Yaml/YamlDepthHelper.cs
+++ b/src/Meziantou.Framework.Yaml/YamlDepthHelper.cs
@@ -32,4 +32,9 @@ internal static class YamlDepthHelper
     {
         return new YamlException(sourceName, start, end, $"The maximum nesting depth of {maxDepth} has been exceeded.");
     }
+
+    public static YamlException CreateInsufficientStackException(int depth, Mark start, Mark end, string? sourceName, Exception innerException)
+    {
+        return new YamlException(sourceName, start, end, $"The document is nested too deeply to be processed on the current thread. Nesting depth {depth} exhausted the available stack space. Reduce MaxDepth, or process the document on a thread with a larger stack.", innerException);
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/MaxDepthTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/MaxDepthTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Meziantou.Framework.Yaml.Model;
 using Meziantou.Framework.Yaml.Serialization;
 
@@ -114,6 +115,69 @@ public sealed class MaxDepthTests
         var node = YamlNode.FromObject(value, options);
 
         Assert.IsType<YamlSequence>(node);
+    }
+
+    [Fact]
+    public void DeeplyNestedDocument_WithLargeMaxDepth_ThrowsInsteadOfOverflowingTheStack()
+    {
+        // A MaxDepth far above what the stack can support used to kill the process with an
+        // uncatchable StackOverflowException, because converters recurse once per nesting level.
+        var yaml = CreateDeepFlowSequenceYaml(100_000);
+        var options = new YamlSerializerOptions { MaxDepth = int.MaxValue };
+
+        var exception = RunOnSmallStack(() => Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<object>(yaml, options)));
+
+        Assert.Contains("nested too deeply", exception.Message);
+        Assert.IsType<InsufficientExecutionStackException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void DeeplyNestedDocument_WithLargeMaxDepth_TryDeserializeReturnsFalse()
+    {
+        var yaml = CreateDeepFlowSequenceYaml(100_000);
+        var options = new YamlSerializerOptions { MaxDepth = int.MaxValue };
+
+        var result = RunOnSmallStack(() => YamlSerializer.TryDeserialize<object>(yaml, out _, options));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ModeratelyNestedDocument_StillSucceeds()
+    {
+        // The stack guard must not reject documents that comfortably fit, otherwise it would be
+        // a stricter limit than MaxDepth rather than a backstop for it.
+        var depth = 200;
+        var yaml = CreateDeepFlowSequenceYaml(depth);
+        var options = new YamlSerializerOptions { MaxDepth = depth };
+
+        var result = YamlSerializer.Deserialize<object>(yaml, options);
+
+        Assert.NotNull(result);
+    }
+
+    private static T RunOnSmallStack<T>(Func<T> func)
+    {
+        T result = default!;
+        ExceptionDispatchInfo? failure = null;
+
+        // 512 KB keeps the test fast and deterministic regardless of the runner's default stack size.
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                result = func();
+            }
+            catch (Exception exception)
+            {
+                failure = ExceptionDispatchInfo.Capture(exception);
+            }
+        }, 512 * 1024);
+
+        thread.Start();
+        thread.Join();
+        failure?.Throw();
+        return result;
     }
 
     private static List<Events.ParsingEvent> Drain(IParser parser)


### PR DESCRIPTION
Deeply nested documents could kill the process with an uncatchable `StackOverflowException` instead of reporting a parse failure.

## The defect

Converters and the document object model recurse once per nesting level — `YamlUntypedObjectConverter.Read` calls itself for each nested sequence/mapping, and `YamlNode.ReadElement` does the same. `MaxDepth` is the only thing bounding that recursion.

The default of 64 is safe. The trap is a caller who legitimately has deep documents, raises `MaxDepth`, and converts a clean `YamlException` into an unrecoverable crash. Before this change:

```csharp
var options = new YamlSerializerOptions { MaxDepth = int.MaxValue };
YamlSerializer.Deserialize<object>(deeplyNestedYaml, options);
// Stack overflow.
//    at …YamlUntypedObjectConverter.Read(YamlReader, Type)
//    at …YamlUntypedObjectConverter.Read(YamlReader, Type)
//    …
```

A .NET stack overflow cannot be caught. The process dies immediately, taking any unrelated in-flight work with it — so in a server this is one bad config value away from dropping every concurrent request. `TryDeserialize` did not help either; there is nothing to catch.

The XML docs on `MaxDepth` state only that `0` means the default, so nothing warned that large values are unsafe.

## Why not just cap MaxDepth

That was the first idea, but the measurements rule it out. Cost is roughly **340 bytes of stack per nesting level**, so the safe depth is a function of the thread's stack size:

| Thread stack | Highest depth that survived | First depth that crashed |
| --- | --- | --- |
| 256 KB | 500 | 750 |
| 1 MB | 2 500 | 3 000 |
| 16 MB | 30 000+ | — |

Any single constant is either unsafe on a 256 KB thread or needlessly restrictive on a 16 MB one, and the library cannot know which it is running on. So this probes the actual stack instead.

## The change

`RuntimeHelpers.EnsureSufficientExecutionStack()` in `Parser<TBuffer>.EnforceMaxDepth`, with `InsufficientExecutionStackException` translated to `YamlException`.

`EnforceMaxDepth` is the right single place: consumers recurse and then call `reader.Read()` → `parser.MoveNext()`, so **every nested read passes through here at its deepest stack point**. One call site therefore covers the untyped converter, the generated and reflection-based converters, the DOM, and any external consumer driving `IParser` directly — without touching each recursive converter.

Reporting it as `YamlException` keeps the documented contract that every parse failure derives from `YamlException`, so `TryDeserialize` now returns `false` rather than crashing.

## Verified

Same matrix, after the change — every previously fatal case is now a catchable exception, and the case that legitimately fits still succeeds:

| Thread stack | Depth | Before | After |
| --- | --- | --- | --- |
| 256 KB | 750 | process killed | `YamlException` |
| 256 KB | 100 000 | process killed | `YamlException` |
| 1 MB | 750 | OK | **OK** (not over-restrictive) |
| 1 MB | 3 000 | process killed | `YamlException` |
| 1 MB | 100 000 | process killed | `YamlException` |

Three tests added to `MaxDepthTests`, run on a 512 KB thread so they are deterministic regardless of the runner's default stack size:

- `DeeplyNestedDocument_WithLargeMaxDepth_ThrowsInsteadOfOverflowingTheStack` — asserts `YamlException` wrapping `InsufficientExecutionStackException`.
- `DeeplyNestedDocument_WithLargeMaxDepth_TryDeserializeReturnsFalse` — the contract that was previously impossible to honour.
- `ModeratelyNestedDocument_StillSucceeds` — guards against the fix becoming a stricter limit than `MaxDepth` itself.

`dotnet test` on `Meziantou.Framework.Yaml.Tests`: **883 passed, 0 failed** (Release, net10.0). No public API change, so `ref/` is unchanged.

Found during a project review of `Meziantou.Framework.Yaml`.
