### PR TITLE
Apply the rules selected with --rules instead of running none

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
@@ -54,6 +54,13 @@ internal static partial class Program
                     options.Rules.Add(rule);
                 }
             }
+            else
+            {
+                foreach (var rule in includedRules)
+                {
+                    options.Rules.Add(rule);
+                }
+            }
 
             var excludedRules = parseResult.GetValue(excludedRulesOptions);
             if (excludedRules is not null && excludedRules.Length > 0)

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
@@ -73,7 +73,19 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
     [Fact]
     public async Task CustomRules()
     {
-        var result = await RunValidation("Packages/Release_Author.1.0.0.nupkg", "--rules", "AssembliesMustBeOptimized,AuthorMustBeSet");
+        var result = await RunValidation("Packages/Debug.1.0.0.nupkg", "--rules", "AssembliesMustBeOptimized");
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(result.ValidationResult!.IsValid);
+        Assert.Contains(result.ValidationResult.Errors, item => item.ErrorCode == 81);
+
+        // Only the requested rule must run
+        Assert.DoesNotContain(result.ValidationResult.Errors, item => item.ErrorCode != 81);
+    }
+
+    [Fact]
+    public async Task CustomRules_PackageSatisfiesTheRequestedRule()
+    {
+        var result = await RunValidation("Packages/Release_Author.1.0.0.nupkg", "--rules", "AuthorMustBeSet");
         Assert.Equal(0, result.ExitCode);
         Assert.True(result.ValidationResult!.IsValid);
         Assert.Empty(result.ValidationResult.Errors);
@@ -91,9 +103,23 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
     [Fact]
     public async Task CustomRules_Multiple()
     {
-        var result = await RunValidation("Packages/Release_Author.1.0.0.nupkg", "--rules", "AssembliesMustBeOptimized", "--rules", "AuthorMustBeSet");
-        Assert.Equal(0, result.ExitCode);
-        Assert.True(result.ValidationResult!.IsValid);
-        Assert.Empty(result.ValidationResult.Errors);
+        var result = await RunValidation("Packages/Debug.1.0.0.nupkg", "--rules", "AssembliesMustBeOptimized", "--rules", "XmlDocumentationMustBePresent");
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(result.ValidationResult!.IsValid);
+        Assert.Contains(result.ValidationResult.Errors, item => item.ErrorCode == 81);
+        Assert.Contains(result.ValidationResult.Errors, item => item.ErrorCode == 101);
+
+        // Only the requested rules must run
+        Assert.DoesNotContain(result.ValidationResult.Errors, item => item.ErrorCode is not (81 or 101));
+    }
+
+    [Fact]
+    public async Task CustomRules_Default()
+    {
+        var result = await RunValidation("Packages/Debug.1.0.0.nupkg", "--rules", "default");
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(result.ValidationResult!.IsValid);
+        Assert.Contains(result.ValidationResult.Errors, item => item.ErrorCode == 81);
+        Assert.Contains(result.ValidationResult.Errors, item => item.ErrorCode == 131);
     }
 }


### PR DESCRIPTION
Fixes the `--rules` option, which parsed its argument and then discarded it.

## The defect

`Program.cs:49-56` read `includedRules` and used it *only* as the condition for loading the default rule set. There was no `else` adding the parsed rules to `options.Rules`, so any invocation passing `--rules` ran with an **empty** rule collection — `NuGetPackageValidator.ValidateAsync` iterated nothing and reported every package as valid.

Before this change, on the same package:

```
$ meziantou.validate-nuget-package Debug.1.0.0.nupkg
IsValid: false, 12 errors, exit 1

$ meziantou.validate-nuget-package Debug.1.0.0.nupkg --rules AssembliesMustBeOptimized
IsValid: true, "Errors": [], exit 0
```

`--rules default` behaved identically. Any pipeline that narrowed the rule set — the documented use of the flag — was green regardless of package contents, and nothing in the output hinted that zero rules had run.

## The change

Add the `else` branch that copies `includedRules` into `options.Rules`. That is the only behaviour change; `--excluded-rules`, `--excluded-rule-ids` and the no-flag default path are untouched.

## Tests

The two existing tests covering this flag asserted `IsValid == true` on a package that *passes* the selected rules — indistinguishable from "no rules ran", which is why the defect shipped. They now use `Debug.1.0.0.nupkg`, which fails the selected rule, and assert both directions:

- `CustomRules` — `--rules AssembliesMustBeOptimized` reports error 81 and **no other** error code, so the selection is neither empty nor ignored.
- `CustomRules_Multiple` — two `--rules` occurrences report 81 and 101, and nothing else.
- `CustomRules_Default` — `--rules default` resolves to the full default set.
- `CustomRules_PackageSatisfiesTheRequestedRule` — the previous positive case, kept.

Verified in both directions: with the fix all 18 tool tests pass; with `Program.cs` reverted and these tests in place, 6 of 10 fail.
