### PR TITLE
Make DelayedCancellationTokenSource disposal idempotent

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/DelayedCancellationTokenSource.cs
+++ b/src/Meziantou.Framework.Threading/Threading/DelayedCancellationTokenSource.cs
@@ -17,6 +17,7 @@ public sealed class DelayedCancellationTokenSource : IDisposable, IAsyncDisposab
     private readonly CancellationTokenSource _cts;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly CancellationTokenRegistration _cancelRegistration;
+    private int _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="DelayedCancellationTokenSource"/> class that will be cancelled after the specified delay when the source token is cancelled.</summary>
     /// <param name="cancellationToken">The source cancellation token to monitor.</param>
@@ -53,6 +54,9 @@ public sealed class DelayedCancellationTokenSource : IDisposable, IAsyncDisposab
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
         _cancelRegistration.Dispose();
         _disposeCts.Cancel();
         _disposeCts.Dispose();
@@ -61,6 +65,9 @@ public sealed class DelayedCancellationTokenSource : IDisposable, IAsyncDisposab
 
     public async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
         await _cancelRegistration.DisposeAsync().ConfigureAwait(false);
         await _disposeCts.CancelAsync().ConfigureAwait(false);
         _disposeCts.Dispose();

--- a/tests/Meziantou.Framework.Threading.Tests/DelayedCancellationTokenSourceTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/DelayedCancellationTokenSourceTests.cs
@@ -1,0 +1,88 @@
+namespace Meziantou.Framework.Threading.Tests;
+
+public sealed class DelayedCancellationTokenSourceTests
+{
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var cts = new DelayedCancellationTokenSource(CancellationToken.None, TimeSpan.FromSeconds(1));
+        cts.Dispose();
+        cts.Dispose();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var cts = new DelayedCancellationTokenSource(CancellationToken.None, TimeSpan.FromSeconds(1));
+        await cts.DisposeAsync();
+        await cts.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ThenDispose_IsIdempotent()
+    {
+        var cts = new DelayedCancellationTokenSource(CancellationToken.None, TimeSpan.FromSeconds(1));
+        await cts.DisposeAsync();
+        cts.Dispose();
+    }
+
+    [Fact]
+    public async Task Dispose_ThenDisposeAsync_IsIdempotent()
+    {
+        var cts = new DelayedCancellationTokenSource(CancellationToken.None, TimeSpan.FromSeconds(1));
+        cts.Dispose();
+        await cts.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ConcurrentDispose_DisposesOnlyOnce()
+    {
+        using var cts = new DelayedCancellationTokenSource(CancellationToken.None, TimeSpan.FromSeconds(1));
+        using var start = new Barrier(4);
+
+        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            start.SignalAndWait();
+            cts.Dispose();
+        })).ToArray();
+
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void Token_IsNotCancelled_WhenTheSourceTokenIsNotCancelled()
+    {
+        using var source = new CancellationTokenSource();
+        using var cts = new DelayedCancellationTokenSource(source.Token, TimeSpan.FromMilliseconds(10));
+
+        Assert.False(cts.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Token_IsCancelled_AfterTheDelayElapses()
+    {
+        using var source = new CancellationTokenSource();
+        using var cts = new DelayedCancellationTokenSource(source.Token, TimeSpan.FromMilliseconds(10));
+        using var cancelled = new ManualResetEventSlim(initialState: false);
+        using var registration = cts.Token.Register(cancelled.Set);
+
+        await source.CancelAsync();
+
+        Assert.True(cancelled.Wait(TimeSpan.FromSeconds(30)));
+    }
+
+    [Fact]
+    public async Task Token_IsNotCancelled_WhenDisposedBeforeTheDelayElapses()
+    {
+        using var source = new CancellationTokenSource();
+        var cts = new DelayedCancellationTokenSource(source.Token, TimeSpan.FromSeconds(10));
+        var token = cts.Token;
+
+        await source.CancelAsync();
+        cts.Dispose();
+
+        // Disposal cancels the pending Task.Delay, so the delayed cancellation never fires.
+        await Task.Delay(200);
+        Assert.False(token.IsCancellationRequested);
+    }
+}


### PR DESCRIPTION
`DelayedCancellationTokenSource.Dispose()` throws `ObjectDisposedException` when called more than once.

### What happens

`Dispose()` calls `_disposeCts.Cancel()` before disposing it (`DelayedCancellationTokenSource.cs:56-58`), and `CancellationTokenSource.Cancel()` calls `ThrowIfDisposed()` first. There is no `_disposed` guard, so the second call throws. All three orderings were reproduced before the fix:

| Sequence | Before |
|---|---|
| `Dispose(); Dispose();` | `ObjectDisposedException` |
| `await DisposeAsync(); await DisposeAsync();` | `ObjectDisposedException` |
| `await DisposeAsync(); Dispose();` | `ObjectDisposedException` |

The third is the one most likely to be hit in practice: this type implements both `IDisposable` and `IAsyncDisposable`, and DI container teardown and `IAsyncDisposable` fallback paths will call one after the other. The `IDisposable` contract requires `Dispose()` to be safely callable more than once; because the throw usually happens in a `finally` or during shutdown, it masks whatever exception was actually propagating.

### What changed

An `Interlocked.Exchange(ref _disposed, 1) != 0` early-return at the top of both `Dispose()` and `DisposeAsync()`, sharing one flag so the two paths are idempotent with respect to each other. This matches the pattern already used in `MonoThreadedTaskScheduler.cs:69-70`.

### Verification

New `DelayedCancellationTokenSourceTests.cs` — 8 tests: the four disposal orderings above, concurrent disposal from four threads, and three behavioural tests that this type had no coverage for at all (token not cancelled while the source is live, token cancelled after the delay elapses, and — exercising the `_disposeCts` machinery at `:37` for the first time — the token *not* being cancelled when the instance is disposed before the delay elapses).

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full `Meziantou.Framework.Threading.Tests` suite green at 278 tests across net10.0 and net11.0 (262 before). No public API change, so `ref/` is unaffected.

<sub>Found during a review of `Meziantou.Framework.Threading` (finding M1, plus L2 for this type).</sub>
