### PR TITLE
Look up the snapshot parameter by parameter count, not by name length

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/CallerContext.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/CallerContext.cs
@@ -47,13 +47,20 @@ internal record struct CallerContext(FullPath FilePath, int LineNumber, int Colu
             if (parameterName is not null)
             {
                 var parameters = method.GetParameters();
-                for (var j = 0; j < parameterName.Length; j++)
+                for (var j = 0; j < parameters.Length; j++)
                 {
                     if (parameters[j].Name == parameterName)
                     {
                         parameterIndex = j;
                         break;
                     }
+                }
+
+                // Falling through with an unknown index would let FindArgumentExpression pick the first argument
+                // whose literal happens to equal the expected value, which can be an unrelated argument.
+                if (parameterIndex < 0)
+                {
+                    throw new InlineSnapshotException($"'{method.DeclaringType?.FullName}.{method.Name}' is decorated with '{nameof(InlineSnapshotAssertionAttribute)}' referencing the parameter '{parameterName}', but the method has no such parameter.");
                 }
             }
 

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -290,6 +290,46 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
+    public async Task SupportHelperMethods_SnapshotParameterIsNotTheFirstParameter()
+    {
+        // The parameter lookup used to bound its loop by the length of the parameter *name*, so a short name on a
+        // later parameter was never found and the value-matching fallback rewrote the first matching argument
+        // instead: "Helper(null, null)" became "Helper(\"<null>\", null)".
+        await AssertSnapshot(
+            """"
+            Helper(null, null);
+
+            [InlineSnapshotAssertion(nameof(v))]
+            static void Helper(object data, string v, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = -1)
+            {
+                InlineSnapshot.Validate(data, v, filePath, lineNumber);
+            }
+            """",
+            """"
+            Helper(null, "<null>");
+
+            [InlineSnapshotAssertion(nameof(v))]
+            static void Helper(object data, string v, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = -1)
+            {
+                InlineSnapshot.Validate(data, v, filePath, lineNumber);
+            }
+            """");
+    }
+
+    [Fact]
+    public void HelperMethod_WithUnknownParameterName_ReportsTheAttribute()
+    {
+        var exception = Assert.Throws<InlineSnapshotException>(() => HelperWithUnknownParameterName(new object(), "not the actual snapshot"));
+
+        Assert.Contains(nameof(InlineSnapshotAssertionAttribute), exception.Message);
+        Assert.Contains("thisParameterDoesNotExist", exception.Message);
+    }
+
+    [InlineSnapshotAssertion("thisParameterDoesNotExist")]
+    private static void HelperWithUnknownParameterName(object data, string expected, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
+        => InlineSnapshot.Validate(data, expected, filePath, lineNumber);
+
+    [Fact]
     public async Task SupportAsyncHelperMethods()
     {
         await AssertSnapshot(


### PR DESCRIPTION
## Problem

`CallerContext.Get` resolves the index of the `[InlineSnapshotAssertion]` parameter with a loop bounded by the number of *characters* in the parameter name:

```csharp
var parameters = method.GetParameters();
for (var j = 0; j < parameterName.Length; j++)   // <- string length, not parameters.Length
{
    if (parameters[j].Name == parameterName)
```

Two distinct failures, both reproduced on `main`:

**1. Crash.** `[InlineSnapshotAssertion("thisParameterDoesNotExist")]` on a 4-parameter method walks past the array at `j == 4`:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
```

Nothing in the message points at the attribute. This is what an attribute string literal left stale by a parameter rename produces.

**2. Silent source corruption.** When the parameter name is shorter than its own position, the loop never reaches it, `ParameterIndex` stays `-1`, and `FindArgumentExpression` falls through to `FindSingleArgumentMatchingValue` — which returns the **first** argument whose literal equals the expected value. For a helper `Helper(object data, string v, ...)` called as `Helper(null, null)`, that first match is the *subject*:

```diff
- Helper(null, null);
+ Helper("<null>", null);
```

The library rewrote a line of the caller's source that has nothing to do with the snapshot, and the resulting test failure points somewhere else entirely. `[InlineSnapshotAssertion]` on helper methods is a documented feature ("Using helper methods" in the readme).

Every existing helper test declares the snapshot as parameter **0**, which is why the bound was never exercised.

## Change

- Bound the loop by `parameters.Length`.
- When the named parameter genuinely does not exist, throw an `InlineSnapshotException` naming the method and the missing parameter, instead of falling through to the value-matching heuristic. Matching by value across arguments of unrelated meaning is what turns "couldn't find it" into "edited the wrong thing".

## Verification

Two regression tests, both confirmed to fail on `main`:

| Test | Failure without the fix |
|---|---|
| `SupportHelperMethods_SnapshotParameterIsNotTheFirstParameter` | rewrites `Helper(null, null)` to `Helper("<null>", null)` |
| `HelperMethod_WithUnknownParameterName_ReportsTheAttribute` | `IndexOutOfRangeException` instead of `InlineSnapshotException` |

Full test project: 133/133 passing with `/p:TreatWarningsAsErrors=true`.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
