### PR TITLE
Ignore s-maxage and proxy-revalidate in a private cache

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -311,7 +311,7 @@ internal sealed class CacheEntry
     }
 
     /// <summary>Calculates the freshness lifetime per RFC 7234 Section 4.2.1.</summary>
-    public TimeSpan FreshnessLifetime => CacheFreshness.GetFreshnessLifetime(SharedMaxAge, MaxAge, Expires, ResponseDate, LastModified);
+    public TimeSpan FreshnessLifetime => CacheFreshness.GetFreshnessLifetime(MaxAge, Expires, ResponseDate, LastModified);
 
     /// <summary>Gets whether heuristic expiration was used to calculate the freshness lifetime.</summary>
     public bool UsesHeuristicExpiration

--- a/src/Meziantou.Framework.Http.Caching/CacheFreshness.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheFreshness.cs
@@ -4,12 +4,14 @@ namespace Meziantou.Framework.Http.Caching;
 internal static class CacheFreshness
 {
     /// <summary>Computes the freshness lifetime per RFC 7234 Section 4.2.1.</summary>
-    public static TimeSpan GetFreshnessLifetime(TimeSpan? sharedMaxAge, TimeSpan? maxAge, DateTimeOffset? expires, DateTimeOffset responseDate, DateTimeOffset? lastModified)
+    /// <remarks>
+    /// RFC 9111 Section 5.2.2.10: <c>s-maxage</c> is only applicable to shared caches. This is a private
+    /// cache, so the directive is ignored and <c>max-age</c> decides, per the private-cache branch of
+    /// Section 4.2.1.
+    /// </remarks>
+    public static TimeSpan GetFreshnessLifetime(TimeSpan? maxAge, DateTimeOffset? expires, DateTimeOffset responseDate, DateTimeOffset? lastModified)
     {
-        // 1. Use s-maxage if present (takes precedence for shared caches), otherwise max-age
-        if (sharedMaxAge.HasValue)
-            return sharedMaxAge.Value;
-
+        // 1. Use max-age if present
         if (maxAge.HasValue)
             return maxAge.Value;
 

--- a/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
@@ -138,7 +138,7 @@ public sealed class HttpCachePersistenceEntry
     /// <summary>Computes the freshness lifetime of the entry, as defined by RFC 7234 Section 4.2.1.</summary>
     public TimeSpan GetFreshnessLifetime()
     {
-        return CacheFreshness.GetFreshnessLifetime(SharedMaxAge, MaxAge, Expires, ResponseDate, LastModified);
+        return CacheFreshness.GetFreshnessLifetime(MaxAge, Expires, ResponseDate, LastModified);
     }
 
     /// <summary>Computes the age of the entry at the specified time, as defined by RFC 7234 Section 4.2.3.</summary>

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -136,7 +136,9 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
             // RFC 7234 Section 5.2.2.1: must-revalidate response directive
             // RFC 8246: must-revalidate takes precedence over immutable when stale
-            if ((cacheResult.MustRevalidate || cacheResult.ProxyRevalidate) && !isFresh)
+            // RFC 9111 Section 5.2.2.8: proxy-revalidate applies to shared caches only, so it is not
+            // considered here.
+            if (cacheResult.MustRevalidate && !isFresh)
             {
                 requiresValidation = true;
             }
@@ -150,7 +152,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
             // RFC 7234 Section 5.2.1.2: max-stale request directive allows stale responses
             var allowStale = false;
-            if ((requestCacheControl?.MaxStale) is true && !cacheResult.MustRevalidate && !cacheResult.ProxyRevalidate)
+            if ((requestCacheControl?.MaxStale) is true && !cacheResult.MustRevalidate)
             {
                 if (requestCacheControl.MaxStaleLimit is not null)
                 {

--- a/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
@@ -629,7 +629,7 @@ public sealed class ComprehensiveRFC7234Tests
     }
 
     [Fact]
-    public async Task WhenResponseHasSMaxAgeThenItTakesPrecedenceOverMaxAge()
+    public async Task WhenResponseHasSMaxAgeThenMaxAgeDecidesInAPrivateCache()
     {
         await using var context = new HttpTestContext();
         context.AddResponse(HttpStatusCode.OK, "content",
@@ -646,32 +646,19 @@ public sealed class ComprehensiveRFC7234Tests
               Value: content
             """);
 
-        // Within s-maxage
-        context.TimeProvider.Advance(TimeSpan.FromSeconds(1));
+        // RFC 9111 Section 5.2.2.10: s-maxage is only applicable to shared caches. This is a private cache,
+        // so the entry stays fresh for max-age even once s-maxage has elapsed.
+        context.TimeProvider.Advance(TimeSpan.FromSeconds(30));
         await context.SnapshotResponse("http://example.com/resource", """
             StatusCode: 200 (OK)
             Headers:
-              Age: 1
+              Age: 30
               Cache-Control: max-age=3600, s-maxage=2
             Content:
               Headers:
                 Content-Length: 7
                 Content-Type: text/plain; charset=utf-8
               Value: content
-            """);
-
-        // After s-maxage but within max-age: still stale (s-maxage wins)
-        context.AddResponse(HttpStatusCode.OK, "new", ("Cache-Control", "max-age=3600, s-maxage=2"));
-        context.TimeProvider.Advance(TimeSpan.FromSeconds(2));
-        await context.SnapshotResponse("http://example.com/resource", """
-            StatusCode: 200 (OK)
-            Headers:
-              Cache-Control: max-age=3600, s-maxage=2
-            Content:
-              Headers:
-                Content-Length: 3
-                Content-Type: text/plain; charset=utf-8
-              Value: new
             """);
     }
 
@@ -868,6 +855,43 @@ public sealed class ComprehensiveRFC7234Tests
               Age: 3
               Cache-Control: proxy-revalidate, max-age=2
               ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 11
+                Content-Type: text/plain; charset=utf-8
+              Value: proxy-reval
+            """);
+    }
+
+    [Fact]
+    public async Task WhenResponseHasProxyRevalidateThenMaxStaleIsHonoredInAPrivateCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "proxy-reval", ("Cache-Control", "max-age=2, proxy-revalidate"));
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: proxy-revalidate, max-age=2
+            Content:
+              Headers:
+                Content-Length: 11
+                Content-Type: text/plain; charset=utf-8
+              Value: proxy-reval
+            """);
+
+        context.TimeProvider.Advance(TimeSpan.FromSeconds(10));
+
+        // RFC 9111 Section 5.2.2.8: proxy-revalidate applies to shared caches only, so it does not stop a
+        // private cache from honoring max-stale the way must-revalidate does.
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue { MaxStale = true };
+        await context.SnapshotResponse(request, """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 10
+              Cache-Control: proxy-revalidate, max-age=2
+              Warning: 110 - "Response is Stale"
             Content:
               Headers:
                 Content-Length: 11


### PR DESCRIPTION
The readme describes this as a **private** cache — *"it is attached to a single `HttpClient` and its entries are not shared between users"*. Two shared-cache-only directives were being honored anyway.

## `s-maxage` overrode `max-age`

`CacheFreshness.cs:14` returned `sharedMaxAge` before it even looked at `maxAge`. RFC 9111 Section 5.2.2.10 is explicit that `s-maxage` *"is only applicable to shared caches"*, and the private-cache branch of Section 4.2.1 uses `max-age`.

Given `Cache-Control: max-age=60, s-maxage=3600` — a very common CDN-oriented pairing — the entry was treated as fresh for an hour instead of a minute. Advancing the clock 10 minutes past a 60-second `max-age` still produced a cache hit with no revalidation. Users got data up to a day stale when the origin asked for a minute.

## `proxy-revalidate` forced revalidation and blocked `max-stale`

RFC 9111 Section 5.2.2.8 scopes `proxy-revalidate` to shared caches too. It was consulted in two places (`HttpCachingDelegateHandler.cs:139` and `:153`). The first is harmless — the entry is stale and carries a validator, so it revalidates regardless — but the second suppressed a client's `max-stale` request directive, which is a real behavior difference.

## The change

- `CacheFreshness.GetFreshnessLifetime` no longer takes `sharedMaxAge`; `max-age` decides.
- `proxy-revalidate` is no longer consulted when deciding to revalidate or to honor `max-stale`.

`HttpCachePersistenceEntry.SharedMaxAge` and `ProxyRevalidate` are unchanged — they are still parsed, still persisted, and still echoed back on the rebuilt `Cache-Control` header, so nothing is lost from the response the caller sees. Only the freshness and revalidation decisions stop consulting them. No public API signature changes.

## An existing test asserted the old behavior

`WhenResponseHasSMaxAgeThenItTakesPrecedenceOverMaxAge` encoded the shared-cache rule in its name and its assertions. It is replaced by `WhenResponseHasSMaxAgeThenMaxAgeDecidesInAPrivateCache`, which asserts the opposite: 30 seconds into a `max-age=3600, s-maxage=2` response, the entry is still served from cache. **This is the change worth scrutinizing in review** — the two tests are logically contradictory, so it is the flip in expectations, not a new case.

`WhenResponseHasProxyRevalidateThenRevalidatesWhenStale` is untouched and still passes: that entry carries an `ETag`, so it revalidates because it is stale, not because of the directive.

## Verification

New: `WhenResponseHasProxyRevalidateThenMaxStaleIsHonoredInAPrivateCache` — a `max-age=2, proxy-revalidate` entry with no validator is now served stale under `max-stale` with the `110` warning.

Both new tests fail on `main` and pass here. Full suite: 193 passed, 0 failed, 3 skipped (the skips are the container-backed Redis tests).

## Related

The companion PR "Stop applying shared-cache storage rules in a private cache" covers the `Authorization` gate and `s-maxage`-as-freshness in `HttpCache.cs`. The two touch no common file and can land in either order.
