### PR TITLE
Remove the matched length, not the argument length, in RemoveSuffix and RemovePrefix

### DIFF
--- a/src/Meziantou.Framework/StringExtensions.cs
+++ b/src/Meziantou.Framework/StringExtensions.cs
@@ -917,12 +917,20 @@ static partial class StringExtensions
     /// <summary>Removes the trailing occurrence of a specified string from the current string.</summary>
     public static string RemoveSuffix(this string str, string suffix, StringComparison stringComparison)
     {
-        if (str.EndsWith(suffix, stringComparison))
-        {
-            return str[..^suffix.Length];
-        }
+        // Ordinal comparisons always match exactly suffix.Length characters
+        if (stringComparison is StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase)
+            return str.EndsWith(suffix, stringComparison) ? str[..^suffix.Length] : str;
 
-        return str;
+        // A linguistic comparison can match a number of characters that differs from suffix.Length,
+        // so the length of the match is what must be removed.
+        var (compareInfo, options) = GetCompareInfo(stringComparison);
+
+        // A suffix made only of ignorable characters matches everywhere and stands for nothing,
+        // so there is nothing to remove. IsSuffix would report the whole string as the match.
+        if (compareInfo.Compare(suffix, "", options) is 0)
+            return str;
+
+        return compareInfo.IsSuffix(str, suffix, options, out var matchLength) ? str[..^matchLength] : str;
     }
 
     /// <summary>Removes the leading occurrence of a specified string from the current string.</summary>
@@ -934,11 +942,33 @@ static partial class StringExtensions
     /// <summary>Removes the leading occurrence of a specified string from the current string.</summary>
     public static string RemovePrefix(this string str, string prefix, StringComparison stringComparison)
     {
-        if (str.StartsWith(prefix, stringComparison))
-        {
-            return str[prefix.Length..];
-        }
+        // Ordinal comparisons always match exactly prefix.Length characters
+        if (stringComparison is StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase)
+            return str.StartsWith(prefix, stringComparison) ? str[prefix.Length..] : str;
 
-        return str;
+        // A linguistic comparison can match a number of characters that differs from prefix.Length,
+        // so the length of the match is what must be removed.
+        var (compareInfo, options) = GetCompareInfo(stringComparison);
+
+        // A prefix made only of ignorable characters matches everywhere and stands for nothing,
+        // so there is nothing to remove. IsPrefix would report the whole string as the match.
+        if (compareInfo.Compare(prefix, "", options) is 0)
+            return str;
+
+        return compareInfo.IsPrefix(str, prefix, options, out var matchLength) ? str[matchLength..] : str;
+    }
+
+    private static (CompareInfo CompareInfo, CompareOptions Options) GetCompareInfo(StringComparison stringComparison)
+    {
+        return stringComparison switch
+        {
+            StringComparison.CurrentCulture => (CultureInfo.CurrentCulture.CompareInfo, CompareOptions.None),
+            StringComparison.CurrentCultureIgnoreCase => (CultureInfo.CurrentCulture.CompareInfo, CompareOptions.IgnoreCase),
+#pragma warning disable RS0030 // The banned invariant comparisons are mapped here, not chosen: the caller decides which comparison to use
+            StringComparison.InvariantCulture => (CultureInfo.InvariantCulture.CompareInfo, CompareOptions.None),
+            StringComparison.InvariantCultureIgnoreCase => (CultureInfo.InvariantCulture.CompareInfo, CompareOptions.IgnoreCase),
+#pragma warning restore RS0030
+            _ => throw new ArgumentException($"The string comparison type '{stringComparison}' is not supported.", nameof(stringComparison)),
+        };
     }
 }

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -163,4 +163,41 @@ public class StringExtensionsTests
     {
         Assert.Equal(expected, str.RemovePrefix(suffx, comparison));
     }
+
+    [Theory]
+    // A wholly ignorable affix stands for nothing, so it removes nothing
+    [InlineData("abc", "\u200D", "abc")]
+    [InlineData("abc", "", "abc")]
+    // "e" followed by a combining acute accent is the decomposed form of "\u00E9": the match is 2 chars long
+    [InlineData("cafe\u0301", "\u00E9", "caf")]
+    [InlineData("cafe\u0301", "e\u0301", "caf")]
+    [InlineData("abc", "c", "ab")]
+    [InlineData("abc", "d", "abc")]
+    public void RemoveSuffix_CultureSensitive(string str, string suffix, string expected)
+    {
+        Assert.Equal(expected, CultureInfoUtilities.UseCulture(CultureInfo.InvariantCulture, () => str.RemoveSuffix(suffix, StringComparison.CurrentCulture)));
+    }
+
+    [Theory]
+    [InlineData("abc", "\u200D", "abc")]
+    [InlineData("abc", "", "abc")]
+    [InlineData("e\u0301cole", "\u00E9", "cole")]
+    [InlineData("abc", "a", "bc")]
+    [InlineData("abc", "d", "abc")]
+    public void RemovePrefix_CultureSensitive(string str, string prefix, string expected)
+    {
+        Assert.Equal(expected, CultureInfoUtilities.UseCulture(CultureInfo.InvariantCulture, () => str.RemovePrefix(prefix, StringComparison.CurrentCulture)));
+    }
+
+    [Fact]
+    public void RemoveSuffix_UnsupportedComparisonThrows()
+    {
+        Assert.Throws<ArgumentException>(() => "abc".RemoveSuffix("c", (StringComparison)42));
+    }
+
+    [Fact]
+    public void RemovePrefix_UnsupportedComparisonThrows()
+    {
+        Assert.Throws<ArgumentException>(() => "abc".RemovePrefix("a", (StringComparison)42));
+    }
 }

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Tests;
 
@@ -168,26 +169,48 @@ public class StringExtensionsTests
     // A wholly ignorable affix stands for nothing, so it removes nothing
     [InlineData("abc", "\u200D", "abc")]
     [InlineData("abc", "", "abc")]
-    // "e" followed by a combining acute accent is the decomposed form of "\u00E9": the match is 2 chars long
-    [InlineData("cafe\u0301", "\u00E9", "caf")]
+    // The suffix is ordinally identical to the end of the string, so the match is 2 chars long
     [InlineData("cafe\u0301", "e\u0301", "caf")]
     [InlineData("abc", "c", "ab")]
     [InlineData("abc", "d", "abc")]
     public void RemoveSuffix_CultureSensitive(string str, string suffix, string expected)
     {
-        Assert.Equal(expected, CultureInfoUtilities.UseCulture(CultureInfo.InvariantCulture, () => str.RemoveSuffix(suffix, StringComparison.CurrentCulture)));
+        Assert.Equal(expected, RemoveSuffixInInvariantCulture(str, suffix));
     }
 
     [Theory]
     [InlineData("abc", "\u200D", "abc")]
     [InlineData("abc", "", "abc")]
-    [InlineData("e\u0301cole", "\u00E9", "cole")]
     [InlineData("abc", "a", "bc")]
     [InlineData("abc", "d", "abc")]
     public void RemovePrefix_CultureSensitive(string str, string prefix, string expected)
     {
-        Assert.Equal(expected, CultureInfoUtilities.UseCulture(CultureInfo.InvariantCulture, () => str.RemovePrefix(prefix, StringComparison.CurrentCulture)));
+        Assert.Equal(expected, RemovePrefixInInvariantCulture(str, prefix));
     }
+
+    // "e" followed by a combining acute accent is canonically equivalent to the precomposed "\u00E9",
+    // but recognising that needs ICU. These two tests pin both supported configurations.
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void RemoveAffix_CanonicalEquivalence()
+    {
+        Assert.Equal("caf", RemoveSuffixInInvariantCulture("cafe\u0301", "\u00E9"));
+        Assert.Equal("cole", RemovePrefixInInvariantCulture("e\u0301cole", "\u00E9"));
+    }
+
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Invariant)]
+    public void RemoveAffix_CanonicalEquivalence_InvariantGlobalization()
+    {
+        // Without ICU a linguistic comparison degrades to ordinal, so the decomposed form does not
+        // match the precomposed one and nothing is removed
+        Assert.Equal("cafe\u0301", RemoveSuffixInInvariantCulture("cafe\u0301", "\u00E9"));
+        Assert.Equal("e\u0301cole", RemovePrefixInInvariantCulture("e\u0301cole", "\u00E9"));
+    }
+
+    private static string RemoveSuffixInInvariantCulture(string str, string suffix)
+        => CultureInfoUtilities.UseCulture(CultureInfo.InvariantCulture, () => str.RemoveSuffix(suffix, StringComparison.CurrentCulture));
+
+    private static string RemovePrefixInInvariantCulture(string str, string prefix)
+        => CultureInfoUtilities.UseCulture(CultureInfo.InvariantCulture, () => str.RemovePrefix(prefix, StringComparison.CurrentCulture));
 
     [Fact]
     public void RemoveSuffix_UnsupportedComparisonThrows()


### PR DESCRIPTION
## The bug

`RemoveSuffix`/`RemovePrefix` accept any `StringComparison`, test the match with
`EndsWith`/`StartsWith`, then slice off a fixed `suffix.Length`/`prefix.Length` characters
(`StringExtensions.cs:918-943`). Under a linguistic comparison the matched region's length is not the
argument's length, so the wrong characters are removed.

Measured before this change:

```
"abc".RemoveSuffix("‍", InvariantCulture)        => "ab"    (expected "abc")
"abc".RemovePrefix("‍", InvariantCulture)        => "bc"    (expected "abc")
"café".RemoveSuffix("é", InvariantCulture) => "cafe"  (expected "caf")
```

The `‍` (ZERO WIDTH JOINER) pair is the sharp one: it is linguistically ignorable, so *every*
string "ends with" it, and the call deleted a real character with nothing to do with the argument.

This is silent, content-dependent string corruption in a helper whose whole contract is "remove
exactly this". It only bites on culture-sensitive comparisons and on text with combining marks,
ignorable characters or ligatures — non-ASCII user data, which is where nobody is looking. The
existing tests covered only `Ordinal` and `OrdinalIgnoreCase`, the two modes where the code happens
to be right.

## The change

Ordinal comparisons keep the existing fast path — they always match exactly `suffix.Length`
characters. Linguistic comparisons now go through `CompareInfo.IsSuffix`/`IsPrefix` with the
`out int matchLength` overload and remove the length that actually matched.

One extra guard is needed. For an affix made only of ignorable characters, ICU reports the *whole*
string as the match:

```
IsSuffix("abc", "‍") = True, matchLength = 3   // removing 3 would return ""
IsSuffix("café", "é") = True, matchLength = 2
```

So an affix that collates equal to the empty string is treated as standing for nothing and removes
nothing, which is the only sensible reading. Without that guard the fix would turn `"ab"` into `""` —
a worse result than the original bug.

`GetCompareInfo` carries a scoped `#pragma warning disable RS0030`: the banned invariant comparisons
are being *mapped* there, not chosen — the caller decides which comparison to use — and an unsupported
`StringComparison` now throws `ArgumentException`.

## Verification

13 theory cases and 2 exception tests added to `StringExtensionsTests`, run under a pinned invariant
culture. All 72 tests in the class pass.
