### PR TITLE
Keep the single-threaded guarantee when disposing MonoThreadedTaskScheduler

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/MonoThreadedTaskScheduler.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MonoThreadedTaskScheduler.cs
@@ -69,29 +69,23 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        // Signal the worker thread to stop, then wait for it to exit before disposing the wait
-        // handles it relies on. Disposing a wait handle while another thread is blocked on it (in
-        // ThreadExecute's WaitAny) is a race condition that can throw or corrupt the wait, so the
-        // join must happen first.
+        // Signal the worker thread to stop. It drains the remaining tasks itself (see ThreadExecute), so
+        // the single-threaded execution guarantee holds even when the join below times out.
         _stop.Set();
 
         var thread = Thread;
-        if (thread is not null && thread.IsAlive)
-        {
-            thread.Join(DisposeThreadJoinTimeout);
-        }
+        var exited = thread is null || !thread.IsAlive || thread.Join(DisposeThreadJoinTimeout);
 
         Thread = null;
 
-        // The worker thread has stopped, so draining the remaining tasks on the current thread no
-        // longer races with the worker and preserves the single-threaded execution guarantee.
-        if (DequeueOnDispose)
+        // Disposing a wait handle while the worker is still blocked on it (in ThreadExecute's WaitAny) is a
+        // race condition that can throw or corrupt the wait. When the join times out the worker is still
+        // running, so the handles are left to be reclaimed by the GC instead of being pulled out from under it.
+        if (exited)
         {
-            Dequeue();
+            _stop.Dispose();
+            _dequeue.Dispose();
         }
-
-        _stop.Dispose();
-        _dequeue.Dispose();
     }
 
     private bool ExecuteTask(Task task)
@@ -134,6 +128,13 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
             Dequeue();
         }
         while (true);
+
+        // The final drain runs on the worker thread rather than on the thread calling Dispose, so queued
+        // tasks never execute on two threads at once.
+        if (DequeueOnDispose)
+        {
+            Dequeue();
+        }
     }
 
     protected override IEnumerable<Task> GetScheduledTasks() => _tasks;
@@ -141,6 +142,7 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
     protected override void QueueTask(Task task)
     {
         ArgumentNullException.ThrowIfNull(task);
+        ObjectDisposedException.ThrowIf(_disposed != 0, this);
 
         _tasks.Enqueue(task);
         _dequeue.Set();

--- a/tests/Meziantou.Framework.Threading.Tests/MonoThreadedTaskSchedulerTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/MonoThreadedTaskSchedulerTests.cs
@@ -121,6 +121,70 @@ public sealed class MonoThreadedTaskSchedulerTests : IDisposable
         Assert.Equal(5, executed);
     }
 
+    [Fact]
+    public async Task Dispose_DoesNotRunTasksOnTheDisposingThread()
+    {
+        // The join below times out while the first task is still running. Draining on the disposing thread
+        // would then execute the queued tasks concurrently with the still-live worker.
+        using var started = new ManualResetEventSlim(initialState: false);
+        var threadIds = new System.Collections.Concurrent.ConcurrentBag<int>();
+
+        var scheduler = new MonoThreadedTaskScheduler("shutdown")
+        {
+            DequeueOnDispose = true,
+            DisposeThreadJoinTimeout = TimeSpan.FromMilliseconds(50),
+        };
+
+        _ = Task.Factory.StartNew(
+            () =>
+            {
+                started.Set();
+                Thread.Sleep(500);
+                threadIds.Add(Environment.CurrentManagedThreadId);
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        started.Wait();
+
+        var queued = new Task[5];
+        for (var i = 0; i < queued.Length; i++)
+        {
+            queued[i] = Task.Factory.StartNew(
+                () => threadIds.Add(Environment.CurrentManagedThreadId),
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                scheduler);
+        }
+
+        scheduler.Dispose();
+
+        await Task.WhenAll(queued).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.HasCount(6, threadIds);
+        Assert.Single(threadIds.Distinct());
+        Assert.DoesNotContain(Environment.CurrentManagedThreadId, threadIds);
+    }
+
+    [Fact]
+    public void QueueTask_AfterDispose_Throws()
+    {
+        var scheduler = new MonoThreadedTaskScheduler("disposed");
+        scheduler.Dispose();
+
+        var exception = Assert.Throws<TaskSchedulerException>(() =>
+        {
+            _ = Task.Factory.StartNew(
+                () => { },
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                scheduler);
+        });
+
+        Assert.IsType<ObjectDisposedException>(exception.InnerException);
+    }
+
     private Task EnqueueTask()
     {
         return Task.Factory.StartNew(() =>


### PR DESCRIPTION
`MonoThreadedTaskScheduler.Dispose()` can run queued tasks on two threads at once — which is precisely the guarantee the type exists to provide.

### What happens

`Dispose()` signals `_stop` and then calls `thread.Join(DisposeThreadJoinTimeout)` — a *timed* join, defaulting to 1s. If a task is still running when the timeout expires, `Join` returns anyway and `Dispose` proceeds as though the worker had exited:

1. With `DequeueOnDispose` set, `Dequeue()` then runs on the **disposing** thread while the worker is still alive and draining the same queue. The comment at `:86-87` asserted the opposite ("The worker thread has stopped, so draining the remaining tasks on the current thread no longer races with the worker") — an invariant a timed join does not establish. Reproduced with a long-running task, a 50 ms join timeout and 5 queued tasks: work landed on 2 distinct threads.
2. `_stop.Dispose(); _dequeue.Dispose();` then destroy the handles the live worker is about to re-enter `WaitHandle.WaitAny` on (`:129`). The resulting `ObjectDisposedException` is swallowed by the empty `catch` in `SafeThreadExecute`, so the worker dies silently and any remaining queued tasks never complete — their awaiters hang.

Separately, `QueueTask` had no disposal check. A task enqueued after the worker exited but before the handles were disposed was accepted without error, sat in `_tasks` forever, and its awaiter never completed.

### What changed

- **The worker owns the final drain.** `ThreadExecute` now drains after it observes `_stop`, so `Dispose` never executes tasks itself. `Dispose` still blocks until the drain finishes (the join waits for the worker to exit), so the observable behaviour of `DequeueOnDispose` is unchanged — it just can no longer happen on two threads.
- **The wait handles are only disposed when the join actually succeeded.** If it timed out, they are left for the GC rather than pulled out from under a live thread.
- **`QueueTask` throws `ObjectDisposedException`** once disposed, per the `ObjectDisposedException.ThrowIf` guidance in `AGENTS.md`. The TPL wraps it in `TaskSchedulerException`, which is its documented behaviour; the value is that the failure is immediate and named instead of a silent hang.

### Verification

Two new tests in `MonoThreadedTaskSchedulerTests`:

- `Dispose_DoesNotRunTasksOnTheDisposingThread` — the repro above. **Confirmed to fail on the unfixed source** (`Assert.HasCount` sees fewer tasks completed, and the thread set is not a singleton) and to pass with the fix.
- `QueueTask_AfterDispose_Throws` — asserts `TaskSchedulerException` wrapping `ObjectDisposedException`.

The existing `DequeueOnDispose_RunsPendingTasks` still passes, confirming the drain semantics are preserved. `dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite green at 266 tests across net10.0 and net11.0 (262 before). No public API change, so `ref/` is unaffected.

### Not addressed here

The blanket `catch {}` in `SafeThreadExecute` (`:116-122`) still swallows worker-thread failures. This change removes the shutdown race that was its most common trigger, but there is no logging seam in this type to route a genuine failure to, so leaving it is a separate decision rather than a drive-by fix.

<sub>Found during a review of `Meziantou.Framework.Threading` (findings M2 and M4).</sub>
