### PR TITLE
Correct the InlineSnapshotTesting readme samples that do not compile

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
@@ -89,7 +89,7 @@ InlineSnapshot.Validate(data, settings, "");
 If you prefer, you can use the builder syntax:
 
 ````c#
-InlineSnapshot.CreateBuilder()
+InlineSnapshot
     .WithSettings(settings)
     .Validate(data, "");
 ````
@@ -97,7 +97,7 @@ InlineSnapshot.CreateBuilder()
 Or configure settings inline:
 
 ````c#
-InlineSnapshot.CreateBuilder()
+InlineSnapshot
     .WithSettings(settings => settings.SnapshotUpdateStrategy = SnapshotUpdateStrategy.Overwrite)
     .Validate(data, "");
 ````
@@ -115,14 +115,14 @@ By default, `InlineSnapshot` uses the [`HumanReadableSerializer`](https://www.nu
 
 ````c#
 // Configure the HumanReadableSerializer
-InlineSnapshot.CreateBuilder()
+InlineSnapshot
     .WithSerializer(options => options.PropertyOrder = StringComparer.Ordinal)
     .Validate(data);
 ````
 
 ````c#
 // Use System.Text.Json
-InlineSnapshot.CreateBuilder()
+InlineSnapshot
     .WithSerializer(new JsonSnapshotSerializer())
     .Validate(data);
 ````
@@ -142,7 +142,7 @@ public sealed class MySnapshotSerializer : SnapshotSerializer
     }
 }
 
-InlineSnapshot.CreateBuilder()
+InlineSnapshot
     .WithSerializer(new MySnapshotSerializer())
     .Validate(data);
 ````
@@ -233,7 +233,7 @@ When a snapshot is updated, a diff tool is used to compare the expected value an
 - The diff tool configured by the `DiffEngine_Tool` environment variable
 - The merge tool from the local git configuration
 - The diff tool from the local git configuration
-- The diff tool from the current IDE (support VS Code, VS, Rider)
+- The diff tool from the current IDE (support VS Code, VS, Rider). This relies on inspecting the ancestor processes, which is only supported on Windows.
 - The first available diff tool (rely on [Meziantou.Framework.DiffEngine](../Meziantou.Framework.DiffEngine/readme.md))
 
 You can disable the diff tool by setting the `DiffEngine_Disabled` environment variable.
@@ -376,11 +376,11 @@ InlineSnapshot
 
 ## String formats
 
-By default, the snapshot can use string, verbatim string, or raw string. It uses the information from the PDB file to determine which C# features are available. You can override the default behavior by setting the `CSharpStringFormat` property.
+By default, the snapshot can use string, verbatim string, or raw string. It uses the information from the PDB file to determine which C# features are available. You can override the default behavior by setting the `AllowedStringFormats` property.
 
 ````c#
 InlineSnapshot
-    .WithSerializer(options => options.AllowedStringFormats = CSharpStringFormats.Quoted | CSharpStringFormats.Verbatim | CSharpStringFormats.Raw)
+    .WithSettings(settings => settings.AllowedStringFormats = CSharpStringFormats.Quoted | CSharpStringFormats.Verbatim | CSharpStringFormats.Raw)
     .Validate(...);
 ````
 
@@ -390,7 +390,7 @@ You can also change the indentation of raw strings:
 
 ````c#
 InlineSnapshot
-    .WithSerializer(options => options.AllowedStringFormats = CSharpStringFormats.Raw)
+    .WithSettings(settings => settings.AllowedStringFormats = CSharpStringFormats.Raw)
     .Validate(new object(), """
         {}
         """);
@@ -398,7 +398,7 @@ InlineSnapshot
 
 ````c#
 InlineSnapshot
-    .WithSerializer(options => options.AllowedStringFormats = CSharpStringFormats.LeftAlignedRaw)
+    .WithSettings(settings => settings.AllowedStringFormats = CSharpStringFormats.LeftAlignedRaw)
     .Validate(new object(), """
 {}
 """);
@@ -408,11 +408,11 @@ You can also change the indentation, end of line, and the encoding of the file i
 
 ````c#
 InlineSnapshot
-    .WithSerializer(options => options.CSharpStringFormat = new CSharpStringFormat
+    .WithSettings(settings =>
     {
-        Indentation = "    ",
-        EndOfLine = "\r\n",
-        FileEncoding = Encoding.UTF8,
+        settings.Indentation = "    ";
+        settings.EndOfLine = "\r\n";
+        settings.FileEncoding = Encoding.UTF8;
     })
     .Validate(...);
 ````


### PR DESCRIPTION
## Problem

Nine code samples in the package readme do not compile. This file is the NuGet package description page and the main onboarding path, and the first broken sample is three lines into the Configuration section.

| Sample uses | Reality |
|---|---|
| `InlineSnapshot.CreateBuilder()` (5×, incl. the "builder syntax" intro and every Serializer sample) | No such member. The builder comes from `InlineSnapshot.WithSettings(...)` / `InlineSnapshot.WithSerializer(...)`. |
| `WithSerializer(options => options.AllowedStringFormats = ...)` (3×, "String formats") | `AllowedStringFormats` is on `InlineSnapshotSettings`, not `HumanReadableSerializerOptions`. Needs `WithSettings`. |
| `options.CSharpStringFormat = new CSharpStringFormat { Indentation, EndOfLine, FileEncoding }` (1×) | The type `CSharpStringFormat` does not exist — only the `CSharpStringFormats` **enum** — and those three are `InlineSnapshotSettings` properties. |

Confirmed against the current API:

```
error CS0117: 'InlineSnapshot' does not contain a definition for 'CreateBuilder'
error CS1061: 'HumanReadableSerializerOptions' does not contain a definition for 'AllowedStringFormats'
```

## Change

- `InlineSnapshot.CreateBuilder()` → `InlineSnapshot`, which is what the working samples elsewhere in the same file already do.
- The three `AllowedStringFormats` samples move from `WithSerializer` to `WithSettings`, and the prose now names `AllowedStringFormats` instead of the non-existent `CSharpStringFormat` property.
- The indentation / end-of-line / encoding sample is rewritten against the real `InlineSnapshotSettings` properties.
- Also noted in the "Diff tool" list that IDE detection inspects ancestor processes and is therefore Windows-only — `MergeToolIfCurrentProcess.GetContextProcessName` returns `null` off Windows, so `RiderIfCurrentProcess`, `VisualStudioCodeIfCurrentProcess` and `VisualStudioMergeIfCurrentProcess` silently never match on macOS and Linux.

Doc-only; no source changes.

## Verification

Every corrected sample was compiled against this branch's `Meziantou.Framework.InlineSnapshotTesting` in a scratch project (`dotnet build /p:TreatWarningsAsErrors=true` → succeeded), and the originals were confirmed to produce the errors quoted above.

The rest of the readme was spot-checked and is accurate: `ShowInvisibleCharactersInValues`, `IgnoreMembersWithType`, `IgnoreMembersThatThrow`, `AddUrlEncodedFormFormatter`, `RedactContentSecurityPolicyNonce`, `PropertyOrder`, `DictionaryKeyOrder` and `FormatAsStandardObject` all exist as documented.

`dotnet run ./eng/update-all.cs` → no changes.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
