### PR TITLE
Skip the trailing empty line when detecting indentation

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs
@@ -359,6 +359,10 @@ internal static class FileEditor
     {
         foreach (var line in sourceText.Lines)
         {
+            // A text ending with a line break has a trailing empty line whose Start is past the last character.
+            if (line.Start == line.End)
+                continue;
+
             if (sourceText[line.Start] is (' ' or '\t') and var space)
             {
                 for (var i = line.Start + 1; i < line.End; i++)

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/FileEditorTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/FileEditorTests.cs
@@ -17,4 +17,12 @@ public sealed class FileEditorTests
 
     [Fact]
     public void DetectIndentation_SecondLineIndented() => Assert.Equal("  ", FileEditor.DetectIndentation(SourceText.From("dummy\n  dummy")));
+
+    // A text ending with a line break has a trailing empty line. Indexing it used to throw IndexOutOfRangeException
+    // whenever no earlier line was indented, which is the shape of a top-level-statements file.
+    [Fact]
+    public void DetectIndentation_NoLineIndented_TrailingLineBreak() => Assert.Equal("    ", FileEditor.DetectIndentation(SourceText.From("dummy\ndummy\n")));
+
+    [Fact]
+    public void DetectIndentation_Empty() => Assert.Equal("    ", FileEditor.DetectIndentation(SourceText.From("")));
 }


### PR DESCRIPTION
## Problem

`FileEditor.DetectIndentation` indexes the first character of every line:

```csharp
foreach (var line in sourceText.Lines)
{
    if (sourceText[line.Start] is (' ' or '\t') and var space)
```

When the text ends with a line break, Roslyn's `SourceText.Lines` includes a trailing empty line whose `Start == Length`, and indexing there throws. The loop only reaches that line if no earlier line began with a space or a tab — i.e. a file with no indentation anywhere.

Reproduced end-to-end on `main` with a two-line top-level-statements `Program.cs` (every line at column 0, trailing newline) and `SnapshotUpdateStrategy.Overwrite`:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
```

`DetectIndentation` is called unconditionally on every snapshot update whenever `InlineSnapshotSettings.Indentation` is null, which is the default. The empty-text case throws for the same reason.

It is a narrow shape, but it hits exactly the situation where it is hardest to debug — a minimal single-file repro or a top-level-statements sample — and nothing in the exception mentions indentation. The existing tests covered `"  dummy"` and `"dummy\n  dummy"` only, so neither case was exercised.

## Change

Skip empty lines before indexing. The fallback of four spaces then applies, as it already did for a file with no trailing line break.

## Verification

Two regression tests, both confirmed to throw `IndexOutOfRangeException` on `main`:

- `DetectIndentation_NoLineIndented_TrailingLineBreak`
- `DetectIndentation_Empty`

Full test project: 133/133 passing with `/p:TreatWarningsAsErrors=true`.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
