### PR TITLE
Report a maximum concurrency level of 1 for MonoThreadedTaskScheduler

### DIFF
--- a/ref/Meziantou.Framework.Threading.cs
+++ b/ref/Meziantou.Framework.Threading.cs
@@ -176,6 +176,7 @@ namespace Meziantou.Framework.Threading
         public System.TimeSpan WaitTimeout { get => throw null; set { } }
         public System.TimeSpan DequeueTimeout { get => throw null; set { } }
         public int QueueCount { get => throw null; }
+        public override int MaximumConcurrencyLevel { get => throw null; }
         public MonoThreadedTaskScheduler(string? threadName) { }
         public void Dispose() { }
         protected override System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task> GetScheduledTasks() => throw null;

--- a/src/Meziantou.Framework.Threading/Threading/MonoThreadedTaskScheduler.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MonoThreadedTaskScheduler.cs
@@ -136,6 +136,9 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
         while (true);
     }
 
+    /// <summary>Gets the maximum concurrency level supported by this scheduler, which is always 1.</summary>
+    public override int MaximumConcurrencyLevel => 1;
+
     protected override IEnumerable<Task> GetScheduledTasks() => _tasks;
 
     protected override void QueueTask(Task task)

--- a/tests/Meziantou.Framework.Threading.Tests/MonoThreadedTaskSchedulerTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/MonoThreadedTaskSchedulerTests.cs
@@ -18,6 +18,14 @@ public sealed class MonoThreadedTaskSchedulerTests : IDisposable
     }
 
     [Fact]
+    public void MaximumConcurrencyLevel_IsOne()
+    {
+        // The TPL reads this to size partitions; the base TaskScheduler value is int.MaxValue, which is the
+        // wrong answer for a scheduler that runs everything on a single thread.
+        Assert.Equal(1, _taskScheduler.MaximumConcurrencyLevel);
+    }
+
+    [Fact]
     public async Task SequentialEnqueue()
     {
         const int Count = 1000;


### PR DESCRIPTION
`MonoThreadedTaskScheduler` did not override `MaximumConcurrencyLevel`, so it inherited `TaskScheduler`'s default and reported **2147483647** — for a scheduler whose defining property is that it runs everything on one thread.

### What happens

`MaximumConcurrencyLevel` is the one question the TPL asks a custom scheduler about its capacity. Consumers that read it get the wrong answer:

- `Parallel.For` / `Parallel.ForEach` with `ParallelOptions.TaskScheduler` set to this instance size their partitions for unlimited concurrency and then execute them serially.
- `TaskScheduler`-aware partitioners and diagnostic tooling read the same property.

`MixedConsumerProducer.Process` in this same package is itself a consumer of `ParallelOptions.TaskScheduler`, so the two types interact through exactly this property.

No crash — just degraded and confusing behaviour for anything that composes this scheduler with the TPL's parallel APIs.

### What changed

```csharp
public override int MaximumConcurrencyLevel => 1;
```

(The base member is `public virtual`, not protected, so the override is public. `ref/Meziantou.Framework.Threading.cs` is regenerated accordingly — one added line.)

### Verification

New `MaximumConcurrencyLevel_IsOne` test. `dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite green at 264 tests across net10.0 and net11.0 (262 before). The API baseline was regenerated with a Release `IsOfficialBuild` build and the single-line change is included.

<sub>Found during a review of `Meziantou.Framework.Threading` (finding M5).</sub>
