### PR TITLE
Fix the range arithmetic of NextUInt64 and NextDecimal

### DIFF
--- a/src/Meziantou.Framework/RandomExtensions.cs
+++ b/src/Meziantou.Framework/RandomExtensions.cs
@@ -191,22 +191,38 @@ public static class RandomExtensions
         return (uint)random.NextInt64(min, max);
     }
 
-    /// <summary>Returns a random 64-bit unsigned integer within the specified range.</summary>
+    /// <summary>Returns a random 64-bit unsigned integer greater than or equal to <paramref name="min"/> and less than <paramref name="max"/>.</summary>
     public static ulong NextUInt64(this Random random, ulong min = 0ul, ulong max = ulong.MaxValue)
     {
         ArgumentNullException.ThrowIfNull(random);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(min, max);
 
-        var buffer = new byte[sizeof(long)];
+        if (min == max)
+            return min;
+
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         random.NextBytes(buffer);
-        return (BitConverter.ToUInt64(buffer, 0) * (max - min) / ulong.MaxValue) + min;
+        var value = BitConverter.ToUInt64(buffer);
+
+        // Scale with a 128-bit intermediate. Multiplying in 64 bits overflows for any non-tiny
+        // range, and the wrapped product divided by ulong.MaxValue collapses to min.
+        return min + (ulong)(((UInt128)value * (max - min)) >> 64);
     }
 
-    /// <summary>Returns a random decimal value within the specified range.</summary>
+    /// <summary>Returns a random decimal value greater than or equal to <paramref name="min"/> and less than <paramref name="max"/>.</summary>
+    /// <remarks>The value is derived from <see cref="Random.NextDouble"/>, so it carries the granularity of a double rather than that of a decimal.</remarks>
     public static decimal NextDecimal(this Random random, decimal min = decimal.MinValue, decimal max = decimal.MaxValue)
     {
         ArgumentNullException.ThrowIfNull(random);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(min, max);
 
-        return (((decimal)random.NextDouble()) * (max - min)) + min;
+        if (min == max)
+            return min;
+
+        // Interpolate instead of scaling (max - min): the default range is twice decimal.MaxValue,
+        // so computing the difference overflows. Both terms below stay within the decimal range.
+        var ratio = (decimal)random.NextDouble();
+        return (min * (1m - ratio)) + (max * ratio);
     }
 
     /// <summary>Returns a random string of the specified length using characters from the provided character set.</summary>

--- a/tests/Meziantou.Framework.Tests/RandomExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/RandomExtensionsTests.cs
@@ -13,7 +13,7 @@ public sealed class RandomExtensionsTests
         }
 
         // The previous implementation overflowed and returned 0 for every draw
-        Assert.True(values.Count > 900, $"Expected a spread over [0, 1000), got {values.Count} distinct values");
+        Assert.HasCountGreaterThan(900, values);
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public sealed class RandomExtensionsTests
             values.Add(random.NextUInt64());
         }
 
-        Assert.True(values.Count > 90, $"Expected distinct values over the full range, got {values.Count}");
+        Assert.HasCountGreaterThan(90, values);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/RandomExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/RandomExtensionsTests.cs
@@ -1,0 +1,88 @@
+namespace Meziantou.Framework.Tests;
+
+public sealed class RandomExtensionsTests
+{
+    [Fact]
+    public void NextUInt64_SpreadsOverASmallRange()
+    {
+        var random = new Random(42);
+        var values = new HashSet<ulong>();
+        for (var i = 0; i < 20_000; i++)
+        {
+            values.Add(random.NextUInt64(0, 1000));
+        }
+
+        // The previous implementation overflowed and returned 0 for every draw
+        Assert.True(values.Count > 900, $"Expected a spread over [0, 1000), got {values.Count} distinct values");
+    }
+
+    [Fact]
+    public void NextUInt64_StaysWithinTheRange()
+    {
+        var random = new Random(42);
+        for (var i = 0; i < 20_000; i++)
+        {
+            var value = random.NextUInt64(100, 200);
+            Assert.InRange(value, 100ul, 199ul);
+        }
+    }
+
+    [Fact]
+    public void NextUInt64_FullRangeIsNotConstant()
+    {
+        var random = new Random(42);
+        var values = new HashSet<ulong>();
+        for (var i = 0; i < 100; i++)
+        {
+            values.Add(random.NextUInt64());
+        }
+
+        Assert.True(values.Count > 90, $"Expected distinct values over the full range, got {values.Count}");
+    }
+
+    [Fact]
+    public void NextUInt64_EmptyRangeReturnsMin()
+    {
+        Assert.Equal(7ul, new Random(42).NextUInt64(7, 7));
+    }
+
+    [Fact]
+    public void NextUInt64_InvertedRangeThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Random(42).NextUInt64(10, 5));
+    }
+
+    [Fact]
+    public void NextDecimal_DefaultRangeDoesNotOverflow()
+    {
+        var random = new Random(42);
+        for (var i = 0; i < 1000; i++)
+        {
+            var value = random.NextDecimal();
+            Assert.InRange(value, decimal.MinValue, decimal.MaxValue);
+        }
+    }
+
+    [Fact]
+    public void NextDecimal_StaysWithinTheRange()
+    {
+        var random = new Random(42);
+        for (var i = 0; i < 10_000; i++)
+        {
+            var value = random.NextDecimal(-10m, 10m);
+            Assert.InRange(value, -10m, 10m);
+        }
+    }
+
+    [Fact]
+    public void NextDecimal_EmptyRangeReturnsMin()
+    {
+        Assert.Equal(7m, new Random(42).NextDecimal(7m, 7m));
+    }
+
+    [Fact]
+    public void NextDecimal_InvertedRangeThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Random(42).NextDecimal(10m, 5m));
+    }
+}


### PR DESCRIPTION
## The bug

Two range calculations in `RandomExtensions` overflow.

**`NextUInt64`** computed `(random * (max - min) / ulong.MaxValue) + min`. The multiplication wraps
for any non-tiny range, and the wrapped value divided by `ulong.MaxValue` is 0 in essentially every
draw — so the method returned `min`, not a random number:

```
NextUInt64(0, 1000): 20k draws produced only 1 distinct value: 0
```

Any caller sampling, jittering a backoff, or picking a shard silently got a constant.

**`NextDecimal`** computed `(decimal)NextDouble() * (max - min) + min`. Its own default arguments make
`max - min` equal `decimal.MaxValue - decimal.MinValue`, which is not representable:

```
NextDecimal(): OverflowException on the documented default arguments
```

So the defaults advertised in the signature could not be used at all.

Neither method had a test.

## The change

- `NextUInt64` scales through a `UInt128` intermediate (multiply-shift), which cannot overflow.
- `NextDecimal` interpolates — `min * (1 - t) + max * t` — instead of scaling `(max - min)`, so both
  terms stay inside the decimal range.
- Both now validate `min <= max` and return `min` for an empty range.

Both are documented as `[min, max)`, matching `Random.NextInt64` and the rest of this class.
`NextDecimal` carries a remark that it inherits `NextDouble`'s granularity — it is driven from a
double, so it cannot address every decimal in a wide range. That was already true; it is now written
down.

## Not in this PR

`NextByte`/`NextSByte`/`NextInt16`/`NextUInt16` never return their own default `max` (they forward to
the max-exclusive `Random.Next`), and `NextInt64` routes through `double`. Those are contract
questions rather than arithmetic bugs, so they are left alone.

## Verification

Nine tests added in a new `RandomExtensionsTests`, covering spread, range bounds, empty ranges and
inverted ranges. Confirmed 5 of the 9 fail on `main` and all 9 pass with the fix.
