### PR TITLE
Store responses to authorized requests in a private cache

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -177,18 +177,10 @@ internal sealed class HttpCache
         if ((responseCacheControl?.NoStore) is true)
             return false;
 
-        // Authorization header without explicit cacheable directive
-        if (request.Headers.Authorization is not null)
-        {
-            // RFC 7234 Section 3.2: Must have must-revalidate, public, or s-maxage
-            if (responseCacheControl is null)
-                return false;
-
-            if (!responseCacheControl.MustRevalidate &&
-                !responseCacheControl.Public &&
-                responseCacheControl.SharedMaxAge is null)
-                return false;
-        }
+        // RFC 9111 Section 3.5: the restriction on responses to a request carrying an Authorization header
+        // applies to shared caches only. This is a private cache attached to a single HttpClient, so such a
+        // response is stored under the same rules as any other. It remains the caller's responsibility not
+        // to share one HttpClient, and therefore one cache, between users.
 
         // Check if response has explicit freshness information or is cacheable by default
         var hasExplicitFreshness = responseCacheControl?.MaxAge is not null ||

--- a/src/Meziantou.Framework.Http.Caching/readme.md
+++ b/src/Meziantou.Framework.Http.Caching/readme.md
@@ -3,6 +3,8 @@
 An HTTP caching implementation for `HttpClient` that follows [RFC 7234 (HTTP Caching)](https://www.rfc-editor.org/rfc/rfc7234.html), since obsoleted by [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html), together with [RFC 8246 (Immutable directive)](https://www.rfc-editor.org/rfc/rfc8246.html), [RFC 5861 (stale-if-error)](https://www.rfc-editor.org/rfc/rfc5861.html), and [No-Vary-Search](https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html).
 
 This is a **private** cache: it is attached to a single `HttpClient` and its entries are not shared between users.
+Responses to requests carrying an `Authorization` header are stored like any other, which is what RFC 9111 Section 3.5
+allows for a private cache. Do not share one `HttpClient`, and therefore one cache, between users.
 
 ## What is it?
 

--- a/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
@@ -676,6 +676,114 @@ public sealed class ComprehensiveRFC7234Tests
     }
 
     [Fact]
+    public async Task WhenRequestHasAuthorizationThenResponseIsStoredInAPrivateCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "authorized-content", ("Cache-Control", "max-age=3600"));
+
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request1.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token");
+        await context.SnapshotResponse(request1, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+            Content:
+              Headers:
+                Content-Length: 18
+                Content-Type: text/plain; charset=utf-8
+              Value: authorized-content
+            """);
+
+        // RFC 9111 Section 3.5: the Authorization restriction applies to shared caches only.
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token");
+        await context.SnapshotResponse(request2, """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+            Content:
+              Headers:
+                Content-Length: 18
+                Content-Type: text/plain; charset=utf-8
+              Value: authorized-content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenRequestHasAuthorizationAndResponseIsNoStoreThenNotCached()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first", ("Cache-Control", "no-store"));
+        context.AddResponse(HttpStatusCode.OK, "second", ("Cache-Control", "no-store"));
+
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request1.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token");
+        await context.SnapshotResponse(request1, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: no-store
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        // Dropping the shared-cache gate does not weaken the directives that actually forbid storage.
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token");
+        await context.SnapshotResponse(request2, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: no-store
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+
+    [Fact]
+    public async Task WhenRequestHasAuthorizationAndResponseVariesOnItThenVariantsAreSeparate()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "alice-content", ("Cache-Control", "max-age=3600"), ("Vary", "Authorization"));
+        context.AddResponse(HttpStatusCode.OK, "bob-content", ("Cache-Control", "max-age=3600"), ("Vary", "Authorization"));
+
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request1.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "alice");
+        await context.SnapshotResponse(request1, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary: Authorization
+            Content:
+              Headers:
+                Content-Length: 13
+                Content-Type: text/plain; charset=utf-8
+              Value: alice-content
+            """);
+
+        // A server that returns per-principal content declares Vary: Authorization, which keeps the
+        // variants apart.
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "bob");
+        await context.SnapshotResponse(request2, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary: Authorization
+            Content:
+              Headers:
+                Content-Length: 11
+                Content-Type: text/plain; charset=utf-8
+              Value: bob-content
+            """);
+    }
+
+    [Fact]
     public async Task WhenResponseHasNoStoreThenNotCached()
     {
         await using var context = new HttpTestContext();


### PR DESCRIPTION
`IsCacheable` refused to store any response to a request carrying an `Authorization` header unless the response also had `must-revalidate`, `public`, or `s-maxage`.

That rule is RFC 9111 Section 3.5, and it is scoped to **shared** caches: *"a shared cache MUST NOT use a cached response to a request with an Authorization header field"*. This library is documented as a private cache — *"attached to a single `HttpClient`"* — where the restriction does not apply.

## The failure

`HttpCache.cs:181-191`.

A request with `Authorization: Bearer …` whose response said plainly `Cache-Control: max-age=3600` was never stored. Every subsequent request went to the origin. Nothing warned; caching just silently did nothing.

That is the main use case for a per-`HttpClient` private cache — an authenticated API client — so this was arguably the most-used path through the library, and the one where it did the least.

## The change

The gate is removed. Authenticated responses are now stored under the same rules as everything else.

Nothing else is relaxed. `no-store` on either the request or the response still forbids storage, `Vary` still separates variants, and `ShouldCacheResponse` still gets the final say. Two of the three new tests assert exactly that.

## The tradeoff — worth a look before merging

This makes the cache store authenticated response bodies where it previously did not. That is correct for a private cache and wrong for a shared one, so it rests entirely on the contract in the readme: one `HttpClient` per user. A consumer who has a process-wide singleton `HttpClient` serving many principals, and an origin that returns per-principal content *without* `Vary: Authorization` or `Cache-Control: private`, would now get cross-user reuse where before they got none.

The readme already stated the private-cache contract; this PR makes the `Authorization` consequence explicit rather than leaving it implied.

If you would rather keep the conservative behavior, this is the PR to close — it is deliberately separated from "Ignore s-maxage and proxy-revalidate in a private cache" so the two decisions are independent, and the two touch no common file.

## Verification

Three tests added to `ComprehensiveRFC7234Tests`:

- `WhenRequestHasAuthorizationThenResponseIsStoredInAPrivateCache` — fails on `main`, passes here.
- `WhenRequestHasAuthorizationAndResponseIsNoStoreThenNotCached` — passes on `main` and here; guards against relaxing too much.
- `WhenRequestHasAuthorizationAndResponseVariesOnItThenVariantsAreSeparate` — passes on `main` and here; guards the per-principal case.

Full suite: 195 passed, 0 failed, 3 skipped (the skips are the container-backed Redis tests).
