### PR TITLE
Stop yielding a trailing default item from the non-thread-safe async cached enumerable

### DIFF
--- a/src/Meziantou.Framework/CachedAsyncEnumerable.cs
+++ b/src/Meziantou.Framework/CachedAsyncEnumerable.cs
@@ -64,7 +64,7 @@ internal sealed class CachedAsyncEnumerable<T> : ICachedAsyncEnumerable<T>
             await _enumerator.DisposeAsync().ConfigureAwait(false);
             _enumerator = null;
             _enumerated = true;
-            return new(default!);
+            return new();
         }
     }
 

--- a/tests/Meziantou.Framework.Tests/CachedEnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/CachedEnumerableTests.cs
@@ -193,6 +193,37 @@ public sealed class CachedEnumerableTests
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AsyncEnumerable_DoesNotYieldATrailingDefaultItem(bool threadSafe)
+    {
+        await using var cachedEnumerable = CachedEnumerable.Create(new SingleAsyncEnumerable<int>(RangeAsync(1, 2)), threadSafe);
+
+        await Assert.Equal([1, 2], cachedEnumerable);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AsyncEnumerable_EmptySourceYieldsNothing(bool threadSafe)
+    {
+        await using var cachedEnumerable = CachedEnumerable.Create(new SingleAsyncEnumerable<int>(RangeAsync(0, 0)), threadSafe);
+
+        await Assert.Equal([], cachedEnumerable);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Enumerable_MultipleEnumerations_ShouldEnumerateOnce(bool threadSafe)
+    {
+        using var cachedEnumerable = CachedEnumerable.Create(new SingleEnumerable<int>([1, 2, 3]), threadSafe);
+
+        Assert.Equal([1, 2, 3], cachedEnumerable);
+        Assert.Equal([1, 2, 3], cachedEnumerable);
+    }
+
     private static async IAsyncEnumerable<int> RangeAsync(int start, int count)
     {
         for (var i = 0; i < count; i++)

--- a/tests/Meziantou.Framework.Tests/CachedEnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/CachedEnumerableTests.cs
@@ -216,7 +216,7 @@ public sealed class CachedEnumerableTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task Enumerable_MultipleEnumerations_ShouldEnumerateOnce(bool threadSafe)
+    public void Enumerable_MultipleEnumerations_ShouldEnumerateOnce_ExplicitThreadSafety(bool threadSafe)
     {
         using var cachedEnumerable = CachedEnumerable.Create(new SingleEnumerable<int>([1, 2, 3]), threadSafe);
 


### PR DESCRIPTION
## The bug

When the source is exhausted, `CachedAsyncEnumerable.TryGetItem` returned
`new Optional<T>(default!)` (`CachedAsyncEnumerable.cs:67`). That invokes the *value* constructor,
which sets `HasValue = true`, so `GetAsyncEnumerator` yielded one extra `default(T)` before the next
call correctly returned `new Optional<T>()`:

```
source [1,2] enumerated as [1,2,0]
```

Only the first enumeration is affected — the cache is correct afterwards, so a second pass returns
`[1,2]`. That makes it a spurious `null`/`0`/`default` element at the end of a sequence, exactly
once, which disappears when you re-run it to investigate. For reference types the caller gets a
`null` in a non-nullable sequence.

Reached via `CachedEnumerable.Create(asyncEnumerable, threadSafe: false)`.

The thread-safe twin returns `new()` on the same path
(`CachedAsyncEnumerableThreadSafe.cs:82`), which is what makes this a typo rather than a design
choice.

## Why the existing tests missed it

`CachedEnumerableTests` never passed `threadSafe: false`, so both non-thread-safe implementations
(`CachedEnumerable<T>` and `CachedAsyncEnumerable<T>`) were entirely unexercised — the parameter is
part of the public API and had no coverage at all.

## The change

`return new(default!);` → `return new();`

## Verification

Three theories added to `CachedEnumerableTests`, each run for both `threadSafe: true` and
`threadSafe: false`, covering the trailing-item case, an empty source, and repeated enumeration of
the synchronous variant. Confirmed the async cases fail on `main` for `threadSafe: false` and all
pass with the fix.
