### PR TITLE
Document the logger options, the builder extensions and the ambient test output helper

### DIFF
--- a/src/Meziantou.Extensions.Logging.Xunit.v3/readme.md
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/readme.md
@@ -7,12 +7,65 @@ ILogger logger = XUnitLogger.CreateLogger();
 ILogger<MyType> logger = XUnitLogger.CreateLogger<MyType>();
 ```
 
+These overloads do not take an `ITestOutputHelper`. The logger resolves `TestContext.Current.TestOutputHelper`
+each time it writes, so it always targets the test that is currently running. This is the recommended way to log
+from code whose lifetime is not tied to a single test, such as a host or a fixture shared by several tests.
+
 ## Statically create XUnitLogger or XUnitLogger\<T\> by passing an existing ITestOutputHelper
 
 ```c#
 ILogger logger = XUnitLogger.CreateLogger(testOutputHelper);
 ILogger<MyType> logger = XUnitLogger.CreateLogger<MyType>(testOutputHelper);
 ```
+
+A logger created this way writes to that specific helper. If the helper belongs to a test that has already
+finished, the log record is dropped instead of throwing.
+
+## Configure the output
+
+Every entry point accepts an optional `XUnitLoggerOptions`:
+
+```c#
+ILogger logger = XUnitLogger.CreateLogger(testOutputHelper, new XUnitLoggerOptions
+{
+    IncludeLogLevel = true,
+    IncludeCategory = true,
+    IncludeScopes = true,
+    TimestampFormat = "HH:mm:ss.fff",
+    UseUtcTimestamp = true,
+});
+
+// 12:20:41.812 warn [MyNamespace.MyType] Something happened
+//  => TheScope
+```
+
+| Property | Default | Effect |
+| --- | --- | --- |
+| `IncludeLogLevel` | `false` | Prefixes the record with `trce`, `dbug`, `info`, `warn`, `fail` or `crit`. |
+| `IncludeCategory` | `false` | Prefixes the record with `[CategoryName]`. |
+| `IncludeScopes` | `false` | Appends the active scopes, one per line, prefixed with ` => `. |
+| `TimestampFormat` | `null` | Date and time format string. No timestamp is written when `null`. |
+| `UseUtcTimestamp` | `false` | Formats the timestamp in UTC instead of local time. |
+
+## Register the logger with dependency injection
+
+```c#
+var host = new HostBuilder()
+    .ConfigureLogging(builder =>
+    {
+        builder.AddXunit();
+    })
+    .Build();
+```
+
+`AddXunit` has four overloads: no argument, an `ITestOutputHelper`, an `XUnitLoggerOptions`, or both. Use the
+parameterless one to write to whichever test is running, and pass an `ITestOutputHelper` only when you need to
+target a specific one.
+
+Because `ITestOutputHelper` and `XUnitLoggerOptions` are both optional reference types, `AddXunit(null)` is
+ambiguous and does not compile. Call `AddXunit()` to say "no test output helper", or name the argument
+(`AddXunit(testOutputHelper: null)`) if you are passing one through. The same applies to the
+`XUnitLoggerProvider` constructors.
 
 ## Using WebApplicationFactory
 
@@ -34,11 +87,14 @@ public class UnitTest1(ITestOutputHelper testOutputHelper)
                     //builder.AddFilter(_ => true);
 
                     // Register the xUnit logger provider
-                    builder.Services.AddSingleton<ILoggerProvider>(new XUnitLoggerProvider(testOutputHelper, appendScope: false));
+                    builder.AddXunit(testOutputHelper, new XUnitLoggerOptions { IncludeScopes = true });
                 });
             });
     }
 }
 ```
+
+If the factory outlives the test that created it, prefer `builder.AddXunit()` without the helper so each record
+goes to the test that is running when it is written.
 
 Blog post about this package: [How to write logs from ILogger to xUnit.net ITestOutputHelper](https://www.meziantou.net/how-to-view-logs-from-ilogger-in-xunitdotnet.htm)


### PR DESCRIPTION
The readme is the NuGet package description page, so it is the whole discoverability surface for this package. It documented the static factories and one `WebApplicationFactory` example, and nothing else.

### What was missing

- **`XUnitLoggerOptions` was never mentioned.** All five formatting knobs — the reason most people would reach past `CreateLogger()` — were undiscoverable from the docs.
- **The `AddXunit` builder extensions were never mentioned**, even though DI registration is the common path for host-based tests.
- **The ambient fallback was never mentioned.** Omitting the helper makes the logger resolve `TestContext.Current.TestOutputHelper` *at write time*, which is this package's answer to the "host outlives the test that created the helper" problem. Nothing told the reader it exists.
- The only DI example used the older `appendScope: false` boolean constructor rather than the options overload.

### What changed

Added sections for the options (with a table of every property and its default), for `AddXunit`, and for the ambient fallback, explaining when to prefer `AddXunit()` over `AddXunit(testOutputHelper)`. The `WebApplicationFactory` example now uses `AddXunit` with `XUnitLoggerOptions`.

Also documented the `AddXunit(null)` ambiguity. `ITestOutputHelper?` and `XUnitLoggerOptions?` are both optional reference types, so a bare `null` literal converts equally well to either overload and the call fails to compile with `CS0121`. That reads like the natural spelling for "no helper", so the readme now points at `AddXunit()` and at naming the argument. This is the documentation remedy for that finding — it is not worth a breaking signature change on its own.

### Verification

Every factual claim was checked against the code rather than written from memory:

- four `AddXunit` overloads — confirmed
- all `bool` options default to `false` and `TimestampFormat` to `null` — confirmed (auto-properties, no initializers)
- the segment order in the sample output (timestamp, level, category, message, scopes) matches `XUnitLogger.Log`
- the ` => ` scope prefix matches `XUnitLogger.cs:140`
- "dropped instead of throwing" matches the `catch` around `WriteLine`
- `AddXunit(testOutputHelper: null)` and `new XUnitLoggerProvider(testOutputHelper: null)` **do** compile — verified with a throwaway compilation, which produced no `CS0121`

Documentation only; no code changes. `dotnet run ./eng/update-all.cs` produces no further changes.
