### PR TITLE
Yield the replacement character instead of truncating on invalid UTF-8

### DIFF
--- a/src/Meziantou.Framework/Text/Utf8Extensions.cs
+++ b/src/Meziantou.Framework/Text/Utf8Extensions.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Text;
@@ -29,9 +28,18 @@ public static class Utf8Extensions
 
         public bool MoveNext()
         {
-            var operationStatus = Rune.DecodeFromUtf8(_remaining, out _current, out var bytesConsumed);
+            if (_remaining.IsEmpty)
+            {
+                _current = default;
+                return false;
+            }
+
+            // Invalid and incomplete sequences decode to Rune.ReplacementChar with the number of bytes
+            // to skip, so enumeration continues instead of silently truncating the rest of the input.
+            // This matches MemoryExtensions.EnumerateRunes.
+            Rune.DecodeFromUtf8(_remaining, out _current, out var bytesConsumed);
             _remaining = _remaining[bytesConsumed..];
-            return operationStatus is OperationStatus.Done;
+            return true;
         }
     }
 }

--- a/tests/Meziantou.Framework.Tests/Text/Utf8ExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/Text/Utf8ExtensionsTests.cs
@@ -20,4 +20,69 @@ public sealed class Utf8ExtensionsTests
         };
         Assert.Equal(expected, runes);
     }
+
+    [Fact]
+    public void InvalidByteYieldsTheReplacementCharacterAndEnumerationContinues()
+    {
+        ReadOnlySpan<byte> bytes = [0x41, 0xFF, 0x42];
+
+        var runes = new List<Rune>();
+        foreach (var rune in bytes.EnumerateRunesFromUtf8())
+        {
+            runes.Add(rune);
+        }
+
+        Assert.Equal([new Rune('A'), Rune.ReplacementChar, new Rune('B')], runes);
+    }
+
+    [Fact]
+    public void IncompleteTrailingSequenceYieldsTheReplacementCharacter()
+    {
+        // The leading byte of a 3-byte sequence with its continuation bytes missing
+        ReadOnlySpan<byte> bytes = [0x41, 0xE2, 0x88];
+
+        var runes = new List<Rune>();
+        foreach (var rune in bytes.EnumerateRunesFromUtf8())
+        {
+            runes.Add(rune);
+        }
+
+        Assert.Equal([new Rune('A'), Rune.ReplacementChar], runes);
+    }
+
+    [Fact]
+    public void EmptyInputYieldsNothing()
+    {
+        ReadOnlySpan<byte> bytes = [];
+
+        var runes = new List<Rune>();
+        foreach (var rune in bytes.EnumerateRunesFromUtf8())
+        {
+            runes.Add(rune);
+        }
+
+        Assert.Empty(runes);
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0x41, 0xFF, 0x42 })]
+    [InlineData(new byte[] { 0x41, 0xE2, 0x88 })]
+    [InlineData(new byte[] { 0xF0, 0x9F, 0x98, 0x8A, 0x3C })]
+    [InlineData(new byte[] { 0x80 })]
+    public void MatchesMemoryExtensionsEnumerateRunes(byte[] bytes)
+    {
+        var actual = new List<Rune>();
+        foreach (var rune in new ReadOnlySpan<byte>(bytes).EnumerateRunesFromUtf8())
+        {
+            actual.Add(rune);
+        }
+
+        var expected = new List<Rune>();
+        foreach (var rune in Encoding.UTF8.GetString(bytes).EnumerateRunes())
+        {
+            expected.Add(rune);
+        }
+
+        Assert.Equal(expected, actual);
+    }
 }


### PR DESCRIPTION
## The bug

`SpanUtf8BytesRuneEnumerator.MoveNext` returned `false` for any status other than
`OperationStatus.Done` (`Text/Utf8Extensions.cs:30-35`). `Rune.DecodeFromUtf8` returns `InvalidData`
with `Rune.ReplacementChar` and a consumed count for malformed bytes, and `NeedMoreData` for a
truncated tail — so both silently ended the enumeration:

```
bytes [41 FF 42] yielded [A]   -- the trailing 'B' was silently dropped
```

The BCL's `MemoryExtensions.EnumerateRunes` yields U+FFFD and continues, so this enumerator looks
like a drop-in replacement and was not one. Decoding a byte range with one bad byte returned a
silently shortened result rather than an error or a replacement character — the kind of difference
that shows up as truncated data far from the call site.

The one existing test used only well-formed input.

## The change

Terminate on an empty span, and otherwise always advance: `DecodeFromUtf8` sets `_current` to
`Rune.ReplacementChar` and reports how many bytes to skip for both invalid and incomplete sequences,
so enumeration continues. `bytesConsumed` is at least 1 for a non-empty input, so this cannot loop.

This makes the enumerator agree with `MemoryExtensions.EnumerateRunes`. The now-unused
`System.Buffers` using is removed.

## Verification

Seven tests added to `Utf8ExtensionsTests`, including a theory asserting the output matches
`MemoryExtensions.EnumerateRunes` for four malformed inputs. Confirmed they fail on `main` and pass
with the fix.
