### PR TITLE
Make Range<T> equality symmetric and consistent with GetHashCode

### DIFF
--- a/src/Meziantou.Framework/Range.cs
+++ b/src/Meziantou.Framework/Range.cs
@@ -110,25 +110,10 @@ public readonly struct Range<T> : IEquatable<Range<T>>
 
     public bool Equals(Range<T> other)
     {
-        if (From is not null)
-        {
-            if (From.CompareTo(other.From) != 0)
-                return false;
-
-            if (other.From is not null && other.From.CompareTo(From) != 0)
-                return false;
-        }
-
-        if (To is not null)
-        {
-            if (To.CompareTo(other.To) != 0)
-                return false;
-
-            if (other.To is not null && other.To.CompareTo(To) != 0)
-                return false;
-        }
-
-        return true;
+        // Both bounds are always compared: skipping the comparison when a bound is null made a null
+        // bound match anything, which is neither symmetric nor consistent with GetHashCode.
+        var comparer = EqualityComparer<T>.Default;
+        return comparer.Equals(From, other.From) && comparer.Equals(To, other.To);
     }
 
     public override int GetHashCode() => HashCode.Combine(From, To);

--- a/tests/Meziantou.Framework.Tests/RangeTests.cs
+++ b/tests/Meziantou.Framework.Tests/RangeTests.cs
@@ -113,4 +113,56 @@ public class RangeTests
         var result = range1.IsInRangeUpperInclusive(range2);
         Assert.Equal(expectedValue, result);
     }
+
+    [Fact]
+    public void Equals_IsSymmetricWhenABoundIsNull()
+    {
+        var withNullFrom = new Range<string>(from: null!, to: "b");
+        var withFrom = new Range<string>("a", "b");
+
+        Assert.Equal(withNullFrom.Equals(withFrom), withFrom.Equals(withNullFrom));
+        Assert.False(withNullFrom.Equals(withFrom));
+        Assert.False(withFrom.Equals(withNullFrom));
+    }
+
+    [Fact]
+    public void Equals_TwoRangesWithTheSameNullBoundAreEqual()
+    {
+        var first = new Range<string>(from: null!, to: "b");
+        var second = new Range<string>(from: null!, to: "b");
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_EqualRangesShareAHashCode()
+    {
+        var first = new Range<int>(1, 10);
+        var second = new Range<int>(1, 10);
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_DifferentRangesAreNotEqual()
+    {
+        Assert.NotEqual(new Range<int>(1, 10), new Range<int>(1, 11));
+        Assert.NotEqual(new Range<int>(1, 10), new Range<int>(2, 10));
+    }
+
+    [Fact]
+    public void CanBeUsedAsADictionaryKey()
+    {
+        var dictionary = new Dictionary<Range<string>, int>
+        {
+            [new Range<string>(from: null!, to: "b")] = 1,
+            [new Range<string>("a", "b")] = 2,
+        };
+
+        Assert.Equal(2, dictionary.Count);
+        Assert.Equal(1, dictionary[new Range<string>(from: null!, to: "b")]);
+        Assert.Equal(2, dictionary[new Range<string>("a", "b")]);
+    }
 }

--- a/tests/Meziantou.Framework.Tests/RangeTests.cs
+++ b/tests/Meziantou.Framework.Tests/RangeTests.cs
@@ -121,8 +121,8 @@ public class RangeTests
         var withFrom = new Range<string>("a", "b");
 
         Assert.Equal(withNullFrom.Equals(withFrom), withFrom.Equals(withNullFrom));
-        Assert.False(withNullFrom.Equals(withFrom));
-        Assert.False(withFrom.Equals(withNullFrom));
+        Assert.NotEqual(withFrom, withNullFrom);
+        Assert.NotEqual(withNullFrom, withFrom);
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class RangeTests
             [new Range<string>("a", "b")] = 2,
         };
 
-        Assert.Equal(2, dictionary.Count);
+        Assert.HasCount(2, dictionary);
         Assert.Equal(1, dictionary[new Range<string>(from: null!, to: "b")]);
         Assert.Equal(2, dictionary[new Range<string>("a", "b")]);
     }


### PR DESCRIPTION
## The bug

Each half of `Range<T>.Equals` was guarded by `if (From is not null)` / `if (To is not null)`
(`Range.cs:111-132`), so a null bound on `this` skipped the comparison entirely and matched anything:

```
a = Range(null, "b"), b = Range("a", "b")
a.Equals(b) = True, b.Equals(a) = False
hash a = -1166701843, b = 647726968
```

`Equals` must be symmetric, and equal values must hash equally — both were violated. `Range<T>` is a
`readonly struct` with `==`/`!=` and `IEquatable<T>`, exactly the sort of type that ends up as a
dictionary key, where an asymmetric `Equals` plus disagreeing hash codes produces lookups that
succeed or fail depending on argument order and on which instance was inserted first.

## The change

Compare both bounds unconditionally with `EqualityComparer<T>.Default`.

The previous code compared with `IComparable<T>.CompareTo`, which is worth calling out because it is
a behaviour change for a second reason: `HashCode.Combine` hashes with the *equality* comparer, so
any type where `CompareTo` returns 0 for values that are not `Equals` was already inconsistent.
`string` is such a type — `string.CompareTo` is culture-sensitive, so
`Range<string>("encyclopædia", …)` and `Range<string>("encyclopaedia", …)` compared equal while
hashing differently. Using the equality comparer makes `Equals` and `GetHashCode` agree by
construction and drops an accidental culture dependency.

The range-membership methods (`IsInRangeInclusive` and friends) still use `CompareTo` — ordering is
genuinely a comparison operation there, and they are untouched.

## Verification

Five tests added to `RangeTests` covering symmetry with a null bound, hash-code agreement, and use as
a dictionary key. `Equals_IsSymmetricWhenABoundIsNull` is the one that fails on `main` (1 of 49); the
other four pass either way and are there to pin the contract down. All 49 pass with the fix.
