### PR TITLE
Release the KeyedLock reference count even when Exit throws

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/KeyedLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/KeyedLock.cs
@@ -2,6 +2,11 @@ namespace Meziantou.Framework.Threading;
 
 /// <summary>Provides a synchronous lock mechanism that locks based on a key, allowing concurrent operations on different keys.</summary>
 /// <typeparam name="TKey">The type of the key.</typeparam>
+/// <remarks>
+/// The lock is thread-affine: it is built on <see cref="System.Threading.Lock"/>, which requires the lease to be
+/// released on the thread that acquired it. The critical section must therefore stay on one thread and must not
+/// <see langword="await"/>. Use <see cref="KeyedAsyncLock{TKey}"/> for asynchronous code.
+/// </remarks>
 /// <example>
 /// <code><![CDATA[
 /// var keyedLock = new KeyedLock<string>();
@@ -41,6 +46,10 @@ public sealed class KeyedLock<TKey> where TKey : notnull
     /// <summary>Acquires the lock for the specified key.</summary>
     /// <param name="key">The key to lock on.</param>
     /// <returns>A disposable object. Disposing the object releases the lock.</returns>
+    /// <remarks>
+    /// The returned object must be disposed on the thread that called this method. Disposing it on another thread
+    /// throws <see cref="SynchronizationLockException"/> and leaves the underlying lock held.
+    /// </remarks>
     public IDisposable Lock(TKey key)
     {
         Entry entry;
@@ -63,12 +72,21 @@ public sealed class KeyedLock<TKey> where TKey : notnull
 
     private void Release(TKey key, Entry entry)
     {
-        entry.Lock.Exit();
-        lock (_locks)
+        try
         {
-            if (--entry.ReferenceCount == 0)
+            entry.Lock.Exit();
+        }
+        finally
+        {
+            // The reference count must be released even when Exit throws, which happens when the lease is
+            // disposed on a thread that does not own the lock. Skipping it would leave the entry in the
+            // dictionary forever and permanently deadlock every later acquisition of the same key.
+            lock (_locks)
             {
-                _locks.Remove(key);
+                if (--entry.ReferenceCount == 0)
+                {
+                    _locks.Remove(key);
+                }
             }
         }
     }

--- a/tests/Meziantou.Framework.Threading.Tests/KeyedLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/KeyedLockTests.cs
@@ -106,6 +106,41 @@ public sealed class KeyedLockTests
     }
 
     [Fact]
+    public void Lock_DisposedOnAnotherThread_ThrowsButStillEvictsTheEntry()
+    {
+        // System.Threading.Lock is thread-affine, so Exit throws here. The reference count must still be
+        // released, otherwise the entry stays in the dictionary and every later Lock(1) deadlocks.
+        var locks = new KeyedLock<int>();
+        var lease = locks.Lock(1);
+
+        // A dedicated thread, not the thread pool: xunit runs the test body on a pool thread, so Task.Run can
+        // schedule the disposal back onto that same thread and Exit would then legitimately succeed.
+        Exception? captured = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                lease.Dispose();
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        });
+
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
+
+        Assert.IsType<SynchronizationLockException>(captured);
+        Assert.Empty(GetEntries(locks));
+
+        // A fresh entry is created, so the key is usable again rather than permanently wedged.
+        using (locks.Lock(1))
+        {
+        }
+    }
+
+    [Fact]
     public void Dispose_IsIdempotent()
     {
         var locks = new KeyedLock<int>();


### PR DESCRIPTION
`KeyedLock<TKey>` is thread-affine, but nothing in its public documentation says so — and when the constraint is violated the key becomes permanently unusable.

### What happens

`Lock(key)` returns `IDisposable`, which invites the obvious usage:

```csharp
using var lease = keyedLock.Lock(userId);
await UpdateUserDataAsync(userId);   // may resume on a different thread
```

The entry is guarded by `System.Threading.Lock`, whose `Exit()` throws `SynchronizationLockException` when the calling thread is not the owner. `Release` called `entry.Lock.Exit()` **before** taking the bookkeeping lock, so the throw skipped the reference-count decrement entirely. The entry could then never be evicted from `_locks`, and because its underlying lock was still held by a thread that had moved on, **every subsequent `Lock(key)` for that key deadlocked**.

`KeyedAsyncLock<TKey>` sits in the same namespace with a near-identical API, so choosing the wrong one produced a deadlock rather than a compile error or an exception at the call site.

### What changed

- **`Release` decrements the reference count in a `finally`.** `Exit()` still throws — the misuse is still an error, and it should be loud — but the entry is now evicted. A later `Lock(key)` creates a fresh entry with a fresh lock, so a single mistake no longer wedges that key forever. The orphaned lock object is unreferenced and collected.
- **Documented the thread affinity** on the type (`<remarks>` pointing at `KeyedAsyncLock{TKey}` for asynchronous code) and on `Lock` (the lease must be disposed on the acquiring thread). The constraint was previously stated only in a comment inside `KeyedLockTests`.

This does not make the misuse safe — a *waiting* thread blocked on the orphaned lock is still stuck — but it converts "this key is dead for the lifetime of the process" into "one operation threw, and the key recovered".

### Verification

New `Lock_DisposedOnAnotherThread_ThrowsButStillEvictsTheEntry` — asserts the `SynchronizationLockException`, that the dictionary is empty afterwards, and that the key can be re-acquired. **Confirmed to fail on the unfixed source** (`Assert.Empty` sees the leaked entry).

The test uses a dedicated `Thread` rather than `Task.Run` on purpose: xunit runs the test body on a thread-pool thread, so `Task.Run` can schedule the disposal back onto that same thread, `Exit()` then legitimately succeeds, and the test fails intermittently depending on pool contention. Verified stable across three full-suite runs.

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite green at 264 tests across net10.0 and net11.0 (262 before). No public API change, so `ref/` is unaffected.

<sub>Found during a review of `Meziantou.Framework.Threading` (finding M7).</sub>
