### PR TITLE
Bound SortedList indexing and copying by Count instead of capacity

### DIFF
--- a/src/Meziantou.Framework/Collections/SortedList.cs
+++ b/src/Meziantou.Framework/Collections/SortedList.cs
@@ -48,7 +48,19 @@ public sealed class SortedList<T> : ICollection<T>, ICollection, IReadOnlyList<T
 
     public int Count { get; private set; }
 
-    public T this[int index] => _items[index];
+    public T this[int index]
+    {
+        get
+        {
+            // Bounds are checked against Count: _items is the backing array and its tail is uninitialized
+            if ((uint)index >= (uint)Count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
+            }
+
+            return _items[index];
+        }
+    }
 
     public int Capacity
     {
@@ -152,8 +164,8 @@ public sealed class SortedList<T> : ICollection<T>, ICollection, IReadOnlyList<T
     }
 
     public void CopyTo(T[] array) => CopyTo(array, 0);
-    public void CopyTo(Span<T> array) => _items.CopyTo(array);
-    public void CopyTo(Memory<T> array) => _items.CopyTo(array);
+    public void CopyTo(Span<T> array) => _items.AsSpan(0, Count).CopyTo(array);
+    public void CopyTo(Memory<T> array) => _items.AsMemory(0, Count).CopyTo(array);
 
     void ICollection.CopyTo(Array array, int arrayIndex)
     {
@@ -183,12 +195,21 @@ public sealed class SortedList<T> : ICollection<T>, ICollection, IReadOnlyList<T
 
     public void CopyTo(int index, Span<T> array, int count)
     {
+        ValidateRange(index, count);
         _items.AsSpan(index, count).CopyTo(array);
     }
 
     public void CopyTo(int index, Memory<T> array, int count)
     {
+        ValidateRange(index, count);
         _items.AsMemory(index, count).CopyTo(array);
+    }
+
+    private void ValidateRange(int index, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(count, Count - index);
     }
 
     public void CopyTo(T[] array, int arrayIndex)

--- a/tests/Meziantou.Framework.Tests/Collections/SortedListTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/SortedListTests.cs
@@ -372,7 +372,8 @@ public sealed class SortedListTests
     {
         var list = new SortedList<int> { 1, 2 };
 
-        Assert.True(list.Capacity > list.Count, "This test needs spare capacity to be meaningful");
+        // The test only means something while the backing array is larger than the item count
+        Assert.HasCountLessThan(list.Capacity, list);
         Assert.Throws<ArgumentOutOfRangeException>(() => list[list.Count]);
         Assert.Throws<ArgumentOutOfRangeException>(() => list[-1]);
     }

--- a/tests/Meziantou.Framework.Tests/Collections/SortedListTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/SortedListTests.cs
@@ -366,4 +366,54 @@ public sealed class SortedListTests
 
         Assert.Equal([42], result);
     }
+
+    [Fact]
+    public void Indexer_ThrowsBeyondCountEvenWhenTheBackingArrayIsLarger()
+    {
+        var list = new SortedList<int> { 1, 2 };
+
+        Assert.True(list.Capacity > list.Count, "This test needs spare capacity to be meaningful");
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[list.Count]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[-1]);
+    }
+
+    [Fact]
+    public void CopyToSpan_CopiesOnlyTheItems()
+    {
+        var list = new SortedList<int> { 1, 2 };
+
+        var destination = new int[list.Count];
+        list.CopyTo(destination.AsSpan());
+
+        Assert.Equal([1, 2], destination);
+    }
+
+    [Fact]
+    public void CopyToMemory_CopiesOnlyTheItems()
+    {
+        var list = new SortedList<int> { 1, 2 };
+
+        var destination = new int[list.Count];
+        list.CopyTo(destination.AsMemory());
+
+        Assert.Equal([1, 2], destination);
+    }
+
+    [Fact]
+    public void CopyToSpanRange_ValidatesAgainstCount()
+    {
+        var list = new SortedList<int> { 1, 2 };
+
+        var destination = new int[4];
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.CopyTo(0, destination.AsSpan(), list.Count + 1));
+    }
+
+    [Fact]
+    public void CopyToMemoryRange_ValidatesAgainstCount()
+    {
+        var list = new SortedList<int> { 1, 2 };
+
+        var destination = new int[4];
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.CopyTo(0, destination.AsMemory(), list.Count + 1));
+    }
 }


### PR DESCRIPTION
## The bug

Three members of `SortedList<T>` bounded themselves by the backing array's length instead of `Count`,
so they reached into the uninitialised tail:

- `this[int index]` was `_items[index]` (`Collections/SortedList.cs:51`) — no check against `Count`.
- `CopyTo(Span<T>)` / `CopyTo(Memory<T>)` copied the whole backing array (`:155-156`).
- `CopyTo(int, Span<T>, int)` / `CopyTo(int, Memory<T>, int)` sliced against capacity (`:184-192`).

Measured before this change:

```
Count=2 Capacity=4; list[3] returned 0 instead of throwing
CopyTo(stackalloc int[2]) -> ArgumentException (it tries to copy Capacity=4 items)
```

Two opposite failures from one root cause. The indexer silently handed back slots the list does not
contain — `default(T)`, or a stale reference the list already removed, which also defeats the
clearing `RemoveAt` does at line 130. It breaks the `IReadOnlyList<T>` contract the class declares.
The span overloads meanwhile rejected destinations correctly sized for `Count`, and when they did
succeed they wrote trailing garbage.

## The change

- The indexer checks `(uint)index >= (uint)Count` and throws through the existing `ThrowHelper`,
  matching `RemoveAt`.
- The whole-collection span/memory copies use `AsSpan(0, Count)` / `AsMemory(0, Count)`.
- The ranged copies validate `index` and `count` against `Count` before slicing.

## Verification

Five tests added to `SortedListTests`. Confirmed they fail on `main` and pass with the fix.
