### PR TITLE
Enable Process.Exited so GitMergeTool deletes its temporary copy

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/GitMergeTool.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/GitMergeTool.cs
@@ -22,8 +22,28 @@ internal sealed class GitMergeTool : GitTool
                          .Replace("$MERGED", currentFilePath, StringComparison.Ordinal));
 
                 var process = Process.Start(filename, args);
-                process.Exited += (sender, args) =>
+
+                // Exited is only raised when EnableRaisingEvents is set. Without it the handler below never ran,
+                // so every merge left a full copy of the source file behind under the temp directory.
+                process.EnableRaisingEvents = true;
+
+                var cleanedUp = 0;
+                process.Exited += (sender, args) => DeleteOriginalCopy();
+
+                // The tool may already have exited before the handler was attached.
+                if (process.HasExited)
                 {
+                    DeleteOriginalCopy();
+                }
+
+                return new ProcessMergeToolResult(process);
+
+                void DeleteOriginalCopy()
+                {
+                    // Exited and the HasExited check above can both reach this.
+                    if (Interlocked.Exchange(ref cleanedUp, 1) is not 0)
+                        return;
+
                     try
                     {
                         var fi = new FileInfo(originalCopy);
@@ -33,10 +53,7 @@ internal sealed class GitMergeTool : GitTool
                     catch
                     {
                     }
-
-                    process.Dispose();
-                };
-                return new ProcessMergeToolResult(process);
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

`GitMergeTool` copies the source file aside for the merge tool's `$LOCAL` and relies on `Process.Exited` to delete that copy:

```csharp
var process = Process.Start(filename, args);
process.Exited += (sender, args) => { /* delete originalCopy */ };
```

`Process.Start` returns a process with `EnableRaisingEvents == false`, and `Exited` is only raised when that flag is `true`. The handler was never invoked, so every `merge.tool`-driven snapshot update left a full copy of the user's source file in a fresh GUID directory under the temp path, permanently. It is silent, so nobody notices until the temp directory is large.

Reproduced with a scratch git repo configured with `merge.tool` / `mergetool.<name>.cmd`:

```
temporary copy created at: /var/folders/.../1e975e325a3f40569c6c1d315d69ffda/Current.cs
RESULT: temporary copy LEAKED
```

The handler also raced: even with the flag set, a tool that exits before the subscription would never fire it.

## Change

- Set `EnableRaisingEvents = true` before subscribing.
- Check `HasExited` right after subscribing to cover the race, with an `Interlocked` guard so the copy is deleted exactly once.
- Stop disposing the `Process` from inside the handler. Now that the handler actually runs, disposing there would pull the process out from under `BlockingDiffToolStrategy`, which calls `WaitForExit()` on it afterwards. `ProcessMergeToolResult.Dispose()` already owns that lifetime.

Same repro on this branch:

```
RESULT: temporary copy cleaned up
```

## Scope

This fixes the paths where something in-process observes the exit: `SnapshotUpdateStrategy.MergeToolSync`, and any tool that exits quickly.

It does **not** fix `SnapshotUpdateStrategy.MergeTool` (non-blocking), which disposes the `MergeToolResult` immediately after launching — and `Process.Dispose()` stops the exit watcher, so `Exited` cannot fire there. Cleaning that path up properly means moving temp-file ownership into `MergeToolResult` rather than relying on an event, which is a design change and belongs in its own PR. The empty GUID directory is also left behind on every path, as it was before.

## Verification

- The scratch repro above, both directions.
- Full test project: 133/133 passing with `/p:TreatWarningsAsErrors=true`.

No automated test: asserting on an asynchronous `Exited` handler needs polling with a timeout, and the setup requires a real git repo plus a spawned process, which is a poor trade for CI stability. The repro program above is the honest verification.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
