### PR TITLE
Track visited objects by reference identity in ObjectGraphVisitor

### DIFF
--- a/src/Meziantou.Framework/ObjectGraphVisitor.cs
+++ b/src/Meziantou.Framework/ObjectGraphVisitor.cs
@@ -11,7 +11,9 @@ public abstract class ObjectGraphVisitor
         if (obj is null)
             return;
 
-        var hashSet = new HashSet<object>();
+        // Reference identity is what breaks cycles. The default comparer uses the objects' own
+        // Equals/GetHashCode, which makes distinct but equal instances look already visited.
+        var hashSet = new HashSet<object>(ReferenceEqualityComparer.Instance);
         Visit(hashSet, obj);
     }
 

--- a/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
+++ b/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
@@ -59,4 +59,61 @@ public sealed class ObjectGraphVisitorTests
             VisitedValues.Add(value);
         }
     }
+
+    [Fact]
+    public void VisitsDistinctInstancesThatAreEqualByValue()
+    {
+        var first = new EqualByName { Name = "same" };
+        var second = new EqualByName { Name = "same" };
+        var third = new EqualByName { Name = "other" };
+
+        Assert.False(ReferenceEquals(first, second));
+        Assert.Equal(first, second);
+
+        var visitor = new InstanceCollector();
+        visitor.Visit(new List<EqualByName> { first, second, third });
+
+        Assert.Equal(3, visitor.Instances.Count);
+        Assert.Contains(first, visitor.Instances);
+        Assert.Contains(second, visitor.Instances);
+        Assert.Contains(third, visitor.Instances);
+    }
+
+    [Fact]
+    public void StillBreaksReferenceCycles()
+    {
+        var node = new Node();
+        node.Self = node;
+
+        var visitor = new InstanceCollector();
+        visitor.Visit(node);
+
+        Assert.Single(visitor.Instances.Where(i => ReferenceEquals(i, node)));
+    }
+
+    private sealed class InstanceCollector : ObjectGraphVisitor
+    {
+        public HashSet<object> Instances { get; } = new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitValue(object value)
+        {
+            if (value is EqualByName or Node)
+            {
+                Instances.Add(value);
+            }
+        }
+    }
+
+    private sealed class EqualByName
+    {
+        public string? Name { get; set; }
+
+        public override bool Equals(object? obj) => obj is EqualByName other && other.Name == Name;
+        public override int GetHashCode() => Name?.GetHashCode(StringComparison.Ordinal) ?? 0;
+    }
+
+    private sealed class Node
+    {
+        public Node? Self { get; set; }
+    }
 }

--- a/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
+++ b/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
@@ -67,13 +67,13 @@ public sealed class ObjectGraphVisitorTests
         var second = new EqualByName { Name = "same" };
         var third = new EqualByName { Name = "other" };
 
-        Assert.False(ReferenceEquals(first, second));
+        Assert.NotSame(first, second);
         Assert.Equal(first, second);
 
         var visitor = new InstanceCollector();
         visitor.Visit(new List<EqualByName> { first, second, third });
 
-        Assert.Equal(3, visitor.Instances.Count);
+        Assert.HasCount(3, visitor.Instances);
         Assert.Contains(first, visitor.Instances);
         Assert.Contains(second, visitor.Instances);
         Assert.Contains(third, visitor.Instances);
@@ -88,7 +88,7 @@ public sealed class ObjectGraphVisitorTests
         var visitor = new InstanceCollector();
         visitor.Visit(node);
 
-        Assert.Single(visitor.Instances.Where(i => ReferenceEquals(i, node)));
+        Assert.Single(visitor.Instances, i => ReferenceEquals(i, node));
     }
 
     private sealed class InstanceCollector : ObjectGraphVisitor
@@ -108,7 +108,7 @@ public sealed class ObjectGraphVisitorTests
     {
         public string? Name { get; set; }
 
-        public override bool Equals(object? obj) => obj is EqualByName other && other.Name == Name;
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is EqualByName other && string.Equals(other.Name, Name, StringComparison.Ordinal);
         public override int GetHashCode() => Name?.GetHashCode(StringComparison.Ordinal) ?? 0;
     }
 


### PR DESCRIPTION
## The bug

The cycle-detection set was `new HashSet<object>()` (`ObjectGraphVisitor.cs:14`), which uses the
default comparer and therefore each object's own `Equals`/`GetHashCode`. Distinct instances that
compare equal were treated as the same node and skipped:

```
ReferenceEquals(a,b) = False, a.Equals(b) = True
VisitValue called for 2 Node(s); distinct instances reached = 2   (of 3)
```

Boxed value types collapse the same way — a list `[1, 2, 1, 3, 1]` visits `1` once.

The set exists to break reference cycles, and identity is the correct notion for that. Using value
equality makes the visitor skip real, distinct nodes, so a visitor written to audit, serialise or
collect every object in a graph quietly misses parts of it whenever the graph contains records, value
objects, or repeated primitives. Nothing indicates the traversal was incomplete.

## The change

`new HashSet<object>(ReferenceEqualityComparer.Instance)`.

## Not in this PR

Two further hazards in the same method, left alone to keep this diff to the reported defect:

- the recursion is unbounded, so a long linked list overflows the stack (not catchable), and
- `prop.GetValue(obj)` at line 38 propagates whatever a property getter throws, aborting the whole
  traversal.

## Verification

Two tests added to `ObjectGraphVisitorTests`: one asserting three distinct instances are all visited
when two of them are equal by value, and one asserting reference cycles are still broken. Confirmed
the first fails on `main` and both pass with the fix.
