### PR TITLE
Fall back to the default settings for default(InlineSnapshotBuilder)

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotBuilder.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotBuilder.cs
@@ -13,12 +13,16 @@ namespace Meziantou.Framework.InlineSnapshotTesting;
 /// </example>
 public readonly struct InlineSnapshotBuilder
 {
-    private readonly InlineSnapshotSettings _settings;
+    private readonly InlineSnapshotSettings? _settings;
 
     internal InlineSnapshotBuilder(InlineSnapshotSettings? settings)
     {
         _settings = settings ?? InlineSnapshotSettings.Default;
     }
+
+    /// <summary>The settings of this builder, falling back to the defaults for <c>default(InlineSnapshotBuilder)</c>,
+    /// which never runs the constructor and therefore has no settings of its own.</summary>
+    private InlineSnapshotSettings Settings => _settings ?? InlineSnapshotSettings.Default;
 
     /// <summary>Configures the settings for the snapshot validation.</summary>
     public InlineSnapshotBuilder WithSettings(Action<InlineSnapshotSettings>? configure)
@@ -26,7 +30,7 @@ public readonly struct InlineSnapshotBuilder
         if (configure is null)
             return this;
 
-        var settings = _settings with { };
+        var settings = Settings with { };
         configure(settings);
         return new InlineSnapshotBuilder(settings);
     }
@@ -34,7 +38,7 @@ public readonly struct InlineSnapshotBuilder
     /// <summary>Sets the snapshot serializer to use for serializing objects.</summary>
     public InlineSnapshotBuilder WithSerializer(SnapshotSerializer serializer)
     {
-        var settings = _settings with { };
+        var settings = Settings with { };
         settings.SnapshotSerializer = serializer;
         return new InlineSnapshotBuilder(settings);
     }
@@ -45,7 +49,7 @@ public readonly struct InlineSnapshotBuilder
         if (options is null)
             return this;
 
-        var settings = _settings with { };
+        var settings = Settings with { };
         settings.UseHumanReadableSerializer(options);
         return new InlineSnapshotBuilder(settings);
     }
@@ -56,7 +60,7 @@ public readonly struct InlineSnapshotBuilder
         if (configure is null)
             return this;
 
-        var settings = _settings with { };
+        var settings = Settings with { };
         settings.UseHumanReadableSerializer(configure);
         return new InlineSnapshotBuilder(settings);
     }
@@ -73,7 +77,7 @@ public readonly struct InlineSnapshotBuilder
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     public void Validate(object? subject, string? expected = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {
-        var settings = _settings;
+        var settings = Settings;
         InlineSnapshot.ShouldMatchInlineSnapshot(subject, settings, expected, filePath, lineNumber);
     }
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -56,6 +56,15 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
+    public void DefaultBuilder_UsesTheDefaultSettings()
+    {
+        // default(InlineSnapshotBuilder) does not run the constructor, so the settings field is null.
+        InlineSnapshotBuilder builder = default;
+
+        builder.Validate(new object(), "{}");
+    }
+
+    [Fact]
     public void Validate_WithSettings()
     {
         InlineSnapshot.Validate(new object(), InlineSnapshotSettings.Default, "{}");


### PR DESCRIPTION
## Problem

`InlineSnapshotBuilder` is a public `readonly struct` whose only constructor is `internal`:

```csharp
private readonly InlineSnapshotSettings _settings;

internal InlineSnapshotBuilder(InlineSnapshotSettings? settings)
{
    _settings = settings ?? InlineSnapshotSettings.Default;
}
```

`default(InlineSnapshotBuilder)` — or an uninitialised field or array element of that type, which callers can create without the constructor — leaves `_settings` null, and every member dereferences it:

```
System.NullReferenceException: Object reference not set to an instance of an object.
```

The field is declared non-nullable, so nothing warns about it.

## Change

Make the field nullable and route the members through a `Settings` property that falls back to `InlineSnapshotSettings.Default`. The constructor still captures `Default` eagerly, so behaviour for every builder obtained through `InlineSnapshot.WithSettings` / `WithSerializer` is unchanged.

## Verification

- `DefaultBuilder_UsesTheDefaultSettings` — confirmed to fail on `main` with `NullReferenceException`.
- Full test project: 132/132 passing with `/p:TreatWarningsAsErrors=true`.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
