### PR TITLE
Implement ISupportExternalScope on XUnitLoggerProvider

### DIFF
--- a/ref/Meziantou.Extensions.Logging.Xunit.v3.cs
+++ b/ref/Meziantou.Extensions.Logging.Xunit.v3.cs
@@ -38,13 +38,14 @@ namespace Meziantou.Extensions.Logging.Xunit.v3
         public bool UseUtcTimestamp { get => throw null; set { } }
     }
 
-    public sealed class XUnitLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable
+    public sealed class XUnitLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {
         public XUnitLoggerProvider(Xunit.ITestOutputHelper? testOutputHelper) { }
         public XUnitLoggerProvider(Xunit.ITestOutputHelper? testOutputHelper, bool appendScope) { }
         public XUnitLoggerProvider(Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
         public XUnitLoggerProvider(Xunit.ITestOutputHelper? testOutputHelper, Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => throw null;
+        public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public void Dispose() { }
     }
 }

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/MutableExternalScopeProvider.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/MutableExternalScopeProvider.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable IDE1006 // Naming Styles
+namespace Meziantou.Extensions.Logging.Xunit.v3;
+#pragma warning restore IDE1006 // Naming Styles
+
+// ILoggerFactory hands a provider its own scope provider through ISupportExternalScope, but only
+// once the provider is registered. Loggers therefore hold this indirection instead of a specific
+// IExternalScopeProvider, so a logger created before that hand-off still observes the factory's
+// scopes afterwards.
+internal sealed class MutableExternalScopeProvider : IExternalScopeProvider
+{
+    private IExternalScopeProvider _current;
+
+    public MutableExternalScopeProvider(IExternalScopeProvider current)
+    {
+        _current = current;
+    }
+
+    public IExternalScopeProvider Current
+    {
+        get => Volatile.Read(ref _current);
+        set => Volatile.Write(ref _current, value);
+    }
+
+    public void ForEachScope<TState>(Action<object?, TState> callback, TState state) => Current.ForEachScope(callback, state);
+
+    public IDisposable Push(object? state) => Current.Push(state);
+}

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
@@ -24,7 +24,7 @@ public class XUnitLogger : ILogger
     private readonly ITestOutputHelper? _testOutputHelper;
     private readonly string? _categoryName;
     private readonly XUnitLoggerOptions _options;
-    private readonly LoggerExternalScopeProvider _scopeProvider;
+    private readonly IExternalScopeProvider _scopeProvider;
 
     /// <summary>Creates a new logger instance without a test output helper.</summary>
     /// <returns>A new <see cref="ILogger"/> instance.</returns>
@@ -84,6 +84,11 @@ public class XUnitLogger : ILogger
     /// <param name="categoryName">The category name for messages produced by the logger.</param>
     /// <param name="options">The logger options.</param>
     public XUnitLogger(ITestOutputHelper? testOutputHelper, LoggerExternalScopeProvider scopeProvider, string? categoryName, XUnitLoggerOptions? options)
+        : this(testOutputHelper, (IExternalScopeProvider)scopeProvider, categoryName, options)
+    {
+    }
+
+    internal XUnitLogger(ITestOutputHelper? testOutputHelper, IExternalScopeProvider scopeProvider, string? categoryName, XUnitLoggerOptions? options)
     {
         _testOutputHelper = testOutputHelper;
         _scopeProvider = scopeProvider;

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLoggerProvider.cs
@@ -21,11 +21,11 @@ namespace Meziantou.Extensions.Logging.Xunit.v3;
 /// </code>
 /// </example>
 [ProviderAlias("XUnit")]
-public sealed class XUnitLoggerProvider : ILoggerProvider
+public sealed class XUnitLoggerProvider : ILoggerProvider, ISupportExternalScope
 {
     private readonly ITestOutputHelper? _testOutputHelper;
     private readonly XUnitLoggerOptions _options;
-    private readonly LoggerExternalScopeProvider _scopeProvider = new();
+    private readonly MutableExternalScopeProvider _scopeProvider = new(new LoggerExternalScopeProvider());
 
     /// <summary>Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.</summary>
     public XUnitLoggerProvider()
@@ -68,6 +68,18 @@ public sealed class XUnitLoggerProvider : ILoggerProvider
     public ILogger CreateLogger(string categoryName)
     {
         return new XUnitLogger(_testOutputHelper, _scopeProvider, categoryName, _options);
+    }
+
+    /// <summary>Sets the external scope provider supplied by the logger factory.</summary>
+    /// <param name="scopeProvider">The scope provider the factory uses to track scopes.</param>
+    /// <remarks>
+    /// Implementing <see cref="ISupportExternalScope"/> is what makes the factory route its scopes
+    /// through this provider, including the ones it synthesises from the current activity when
+    /// <c>LoggerFactoryOptions.ActivityTrackingOptions</c> is set.
+    /// </remarks>
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+    {
+        _scopeProvider.Current = scopeProvider;
     }
 
     /// <inheritdoc/>

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
@@ -67,4 +67,42 @@ public sealed class XunitLoggerTests
 
         Assert.Equal(["kept" + Environment.NewLine], output.Logs, StringComparer.Ordinal);
     }
+
+    [Fact]
+    public void ActivityTrackingScopesAreWrittenToTheOutput()
+    {
+        var output = new InMemoryTestOutputHelper();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.Configure(options => options.ActivityTrackingOptions = ActivityTrackingOptions.TraceId | ActivityTrackingOptions.SpanId);
+            builder.AddXunit(output, new XUnitLoggerOptions { IncludeScopes = true });
+        });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        using var activity = new System.Diagnostics.Activity("test");
+        activity.Start();
+        serviceProvider.GetRequiredService<ILogger<XunitLoggerTests>>().LogInformation("message");
+
+        var log = Assert.Single(output.Logs);
+        Assert.Contains(activity.TraceId.ToString(), log, StringComparison.Ordinal);
+        Assert.Contains(activity.SpanId.ToString(), log, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ScopesStartedByTheCallerAreStillWrittenToTheOutput()
+    {
+        var output = new InMemoryTestOutputHelper();
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddXunit(output, new XUnitLoggerOptions { IncludeScopes = true }));
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var logger = serviceProvider.GetRequiredService<ILogger<XunitLoggerTests>>();
+        using (logger.BeginScope("TheScope"))
+        {
+            logger.LogInformation("message");
+        }
+
+        Assert.Equal(["message\n => TheScope" + Environment.NewLine], output.Logs, StringComparer.Ordinal);
+    }
 }


### PR DESCRIPTION
Scopes the logger factory synthesises from the current `Activity` never reached the xUnit output.

### The problem

`XUnitLoggerProvider` implemented `ILoggerProvider` only, and each instance owned a private `LoggerExternalScopeProvider` (`XUnitLoggerProvider.cs:27`). `LoggerFactory` injects `TraceId`/`SpanId` scopes into its *own* scope provider and hands that out only to providers implementing `ISupportExternalScope`, so this provider never received it.

Measured with `ActivityTrackingOptions.SpanId | ActivityTrackingOptions.TraceId`, `AddXunit(output, new XUnitLoggerOptions { IncludeScopes = true })` and a started `Activity`, the emitted line was exactly:

```
act
```

No `TraceId`, no `SpanId`.

Scopes created explicitly through `ILogger.BeginScope` were unaffected and did appear — the composite `Logger` pushes those into each provider's logger directly — which is what made this easy to miss.

This matters in the scenario the package exists for: running an ASP.NET Core host under `WebApplicationFactory` and reading its logs in a test. That is exactly where correlation ids matter, and a `Console` provider running alongside *will* show them, so the discrepancy looks unexplainable.

### What changed

Mirrors #2642 (`Implement ISupportExternalScope on InMemoryLoggerProvider`), including the `MutableExternalScopeProvider` indirection: the factory hands over its scope provider only after the provider is registered, so loggers hold the indirection rather than a fixed `IExternalScopeProvider` and a logger created before the hand-off still observes the factory's scopes afterwards.

`XUnitLogger._scopeProvider` widens from `LoggerExternalScopeProvider` to `IExternalScopeProvider`, with a new `internal` constructor taking the interface. **All three public constructors keep their existing `LoggerExternalScopeProvider` parameter**, so there is no public API break — the `ref/` diff is limited to the added interface and `SetScopeProvider`.

### Verification

- `ActivityTrackingScopesAreWrittenToTheOutput` asserts the record contains the activity's `TraceId` and `SpanId`. It fails on `main` and passes here.
- `ScopesStartedByTheCallerAreStillWrittenToTheOutput` is a regression guard for ordinary `BeginScope` output; it passes both before and after, confirming the widening does not disturb the existing path.

`dotnet test` — 10/10 across `net10.0` and `net11.0`. `ref/` regenerated with a Release `IsOfficialBuild` build; `dotnet run ./eng/update-all.cs` produces no further changes.

---

**Stack 2 of 2** · merges into `fix/xunit-provider-alias` · #2856 must merge first.
