### PR TITLE
Validate the arguments of ConcurrentHashSet.CopyTo

### DIFF
--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentHashSet.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentHashSet.cs
@@ -260,15 +260,29 @@ public sealed class ConcurrentHashSet<T> : ISet<T>, IReadOnlySet<T>
     /// <summary>Copies the elements of the <see cref="ConcurrentHashSet{T}"/> to an array, starting at the specified array index.</summary>
     /// <param name="array">The destination array.</param>
     /// <param name="arrayIndex">The zero-based index in the array at which copying begins.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is negative.</exception>
+    /// <exception cref="ArgumentException">The number of elements in the set is greater than the available space from <paramref name="arrayIndex"/> to the end of <paramref name="array"/>.</exception>
     public void CopyTo(T[] array, int arrayIndex)
     {
-        // PERF: Do not use dictionary.Keys here because that creates a snapshot
-        // of the collection resulting in a List<T> allocation.
-        // Instead, enumerate the set and copy over the elements.
-        foreach (var element in this)
+        ArgumentNullException.ThrowIfNull(array);
+        ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+
+        // The set can grow while it is being copied, so the size cannot be validated against a live Count and
+        // then trusted. Snapshotting first is also what keeps the destination untouched when it turns out to be
+        // too small, instead of leaving it partially written.
+        // Enumerate the dictionary directly: new List<T>(this) would detect ICollection<T> and call back into
+        // this method, recursing until the stack overflows.
+        var items = new List<T>(_dictionary.Count);
+        foreach (var kvp in _dictionary)
         {
-            array[arrayIndex++] = element;
+            items.Add(kvp.Key);
         }
+
+        if (items.Count > array.Length - arrayIndex)
+            throw new ArgumentException("The destination array is too small to contain all the elements of the collection.", nameof(array));
+
+        items.CopyTo(array, arrayIndex);
     }
 
     private HashSet<T> CreateSet(IEnumerable<T> values) => new(values, _dictionary.Comparer);

--- a/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
@@ -108,4 +108,51 @@ public class ConcurrentHashSetTests
         set.ExceptWith(["C"]);
         Assert.Equal(["d"], set);
     }
+
+    [Fact]
+    public void CopyTo_NullArray_Throws()
+    {
+        var set = new ConcurrentHashSet<int> { 1 };
+
+        Assert.Throws<ArgumentNullException>(() => set.CopyTo(array: null!, 0));
+    }
+
+    [Fact]
+    public void CopyTo_NegativeIndex_Throws()
+    {
+        var set = new ConcurrentHashSet<int> { 1 };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => set.CopyTo(new int[4], -1));
+    }
+
+    [Fact]
+    public void CopyTo_DestinationTooSmall_ThrowsArgumentExceptionAndLeavesTheArrayUntouched()
+    {
+        var set = new ConcurrentHashSet<int> { 1, 2, 3 };
+        var destination = new int[2];
+
+        Assert.Throws<ArgumentException>(() => set.CopyTo(destination, 0));
+        Assert.Equal([0, 0], destination);
+    }
+
+    [Fact]
+    public void CopyTo_IndexPastTheEnd_ThrowsArgumentException()
+    {
+        var set = new ConcurrentHashSet<int> { 1 };
+
+        Assert.Throws<ArgumentException>(() => set.CopyTo(new int[2], 4));
+    }
+
+    [Fact]
+    public void CopyTo_CopiesTheElementsAtTheGivenOffset()
+    {
+        var set = new ConcurrentHashSet<int> { 1, 2, 3 };
+        var destination = new int[5];
+
+        set.CopyTo(destination, 1);
+
+        Assert.Equal(0, destination[0]);
+        Assert.Equal(0, destination[4]);
+        Assert.Equal([1, 2, 3], destination[1..4].Order());
+    }
 }


### PR DESCRIPTION
`ConcurrentHashSet<T>.CopyTo` performed no argument validation at all.

### What happens

```csharp
public void CopyTo(T[] array, int arrayIndex)
{
    foreach (var element in this)
        array[arrayIndex++] = element;
}
```

No null check, no range check, no capacity check. `ICollection<T>.CopyTo` is specified to throw `ArgumentNullException`, `ArgumentOutOfRangeException` and `ArgumentException`; this threw `NullReferenceException` or `IndexOutOfRangeException` from the middle of the loop instead — **after** having already written some elements into the caller's array.

The capacity case is not a caller error here, it is routine: sizing an array from `Count` and then copying is inherently racy on a concurrent set, so a concurrent `Add` in between turns a correct-looking call into an `IndexOutOfRangeException`.

This code came in from Roslyn's internal `ConcurrentSet` (noted at the top of the file), where the callers were trusted. As public API the contract applies.

### What changed

Validate `array` and `arrayIndex` up front, snapshot the contents, check the destination has room, and only then copy. Snapshotting is what makes the failure clean: the destination array is left untouched when it turns out to be too small, rather than partially written.

**Tradeoff worth flagging:** this allocates a `List<T>` per call, and there is an existing `// PERF: Do not use dictionary.Keys here ... resulting in a List<T> allocation` comment in this file. That comment is about the enumeration path (`GetEnumerator`), which is unchanged. For `CopyTo` the copy is already O(n) and the allocation is the only way to avoid both the race and the partial write — but if you'd rather keep it allocation-free and accept partial writes, say so and I'll switch to bounds-checking inside the loop.

One trap encountered while writing this, called out in a comment so it doesn't get "simplified" back: the snapshot must enumerate `_dictionary` directly. `new List<T>(this)` detects `ICollection<T>` and calls back into `CopyTo`, recursing until the stack overflows — it crashed the test host before being caught.

### Verification

Five new tests: null array, negative index, destination too small (including asserting the array is untouched), index past the end, and a happy-path copy at a non-zero offset. **Four of the five are confirmed to fail on the unfixed source**; the fifth is the happy path, which worked before and still does.

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite green at 272 tests across net10.0 and net11.0 (262 before). No public API change — a Release `IsOfficialBuild` build confirms `ref/` is unchanged.

<sub>Found during a review of `Meziantou.Framework.Threading` (finding L4).</sub>
