### PR TITLE
Report a delete failure that never clears instead of swallowing it

### DIFF
--- a/src/Meziantou.Framework/IOUtilities.Delete.cs
+++ b/src/Meziantou.Framework/IOUtilities.Delete.cs
@@ -7,6 +7,8 @@ internal
 #endif
 static partial class IOUtilities
 {
+    private const int MaxDeleteAttempts = 10;
+
     /// <summary>Determines whether the specified exception is a sharing violation exception.</summary>
     /// <param name="exception">The exception. May not be null.</param>
     /// <returns>
@@ -82,22 +84,22 @@ static partial class IOUtilities
 
     private static void Retry(Action action)
     {
-        var attempt = 0;
-        while (attempt < 10)
+        // The exception filters stop matching on the last attempt, so a failure that never clears is
+        // reported to the caller instead of being swallowed by the loop.
+        for (var attempt = 1; ; attempt++)
         {
             try
             {
                 action();
                 return;
             }
-            catch (IOException ex) when (IsSharingViolation(ex))
+            catch (IOException ex) when (attempt < MaxDeleteAttempts && IsSharingViolation(ex))
             {
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException) when (attempt < MaxDeleteAttempts)
             {
             }
 
-            attempt++;
             Thread.Sleep(50);
         }
     }
@@ -182,22 +184,22 @@ static partial class IOUtilities
 
     private static async ValueTask RetryOnSharingViolationAsync(Action action, CancellationToken cancellationToken)
     {
-        var attempt = 0;
-        while (attempt < 10)
+        // The exception filters stop matching on the last attempt, so a failure that never clears is
+        // reported to the caller instead of being swallowed by the loop.
+        for (var attempt = 1; ; attempt++)
         {
             try
             {
                 action();
                 return;
             }
-            catch (IOException ex) when (IsSharingViolation(ex))
+            catch (IOException ex) when (attempt < MaxDeleteAttempts && IsSharingViolation(ex))
             {
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException) when (attempt < MaxDeleteAttempts)
             {
             }
 
-            attempt++;
             await Task.Delay(50, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
@@ -83,4 +83,41 @@ public class IOUtilitiesTests
 
         return directoryInfo;
     }
+
+    [Fact]
+    public void DeleteThrowsWhenTheFailureNeverClears()
+    {
+        // Producing this on Windows needs mandatory locking; on Unix an unwritable parent directory does it
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Directory.CreateTempSubdirectory();
+        var locked = root.CreateSubdirectory("locked");
+        var probe = Path.Combine(locked.FullName, "probe.txt");
+        var target = Path.Combine(locked.FullName, "target.txt");
+        File.WriteAllText(probe, "probe");
+        File.WriteAllText(target, "target");
+
+        try
+        {
+            File.SetUnixFileMode(locked.FullName, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            // Skip when the permission is not enforced for the current user, e.g. root
+            try
+            {
+                File.Delete(probe);
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            Assert.Throws<UnauthorizedAccessException>(() => IOUtilities.Delete(target));
+        }
+        finally
+        {
+            File.SetUnixFileMode(locked.FullName, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            root.Delete(recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
## The bug

`Retry` and `RetryOnSharingViolationAsync` looped ten times swallowing
`IOException`/`UnauthorizedAccessException`, then fell out of the loop and returned normally
(`IOUtilities.Delete.cs:82-102` and `:180-200`). The last failure was never rethrown and nothing
recorded that the operation did not happen, so `Delete` returned `void` and looked successful whether
the tree was deleted or is entirely still there.

Callers use this to guarantee a clean slate — wipe a temp directory, remove a build output tree — and
then write into it. Silent failure means the next step runs against stale content: tests that pass on
a dirty directory, a package built from leftovers, a "cleaned" cache that was never cleaned.

## The change

The retry loops now put `attempt < MaxDeleteAttempts` into the exception *filters*, so on the final
attempt the filters stop matching and the original exception propagates with its stack intact — no
rethrow, no wrapping. Successful retries behave exactly as before.

## Behaviour change — worth a look

This is deliberately observable: `IOUtilities.Delete` / `DeleteAsync` now throw where they previously
returned silently after ~500 ms of retries. That is the point of the fix, but it can surface failures
in callers that were quietly relying on the old behaviour. Say the word if you would rather have this
as a `bool` return or an opt-in flag instead.

Note this only bites where the retry applies at all: `IsSharingViolation` matches a Windows-specific
HRESULT, so on other platforms only `UnauthorizedAccessException` is retried.

The surrounding `catch (FileNotFoundException)` / `catch (DirectoryNotFoundException)` handlers are
untouched — a file that is already gone still counts as deleted.

## Verification

One test added to `IOUtilitiesTests` asserting `Delete` throws when the failure never clears, using an
unwritable parent directory. It is skipped on Windows (mandatory locking would be needed) and
self-skips when the permission is not enforced for the current user, so it cannot fail as root.
Confirmed it fails on `main` and passes with the fix; the seven existing tests are unaffected.
