### PR TITLE
Query the registration index to check package id availability on nuget.org

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/PackageIdAvailableOnNuGetOrgValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/PackageIdAvailableOnNuGetOrgValidationRule.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Meziantou.Framework.NuGetPackageValidation.Rules;
 
 internal sealed class PackageIdAvailableOnNuGetOrgValidationRule : NuGetPackageValidationRule
@@ -7,22 +9,27 @@ internal sealed class PackageIdAvailableOnNuGetOrgValidationRule : NuGetPackageV
         var packageIdentity = await context.Package.GetIdentityAsync(context.CancellationToken).ConfigureAwait(false);
         var packageId = packageIdentity.Id;
 
-        for (var i = 0; i < 5; i++)
+        // The registration index is the documented way to check if a package id is registered.
+        // The package page (https://www.nuget.org/packages/<id>) answers 404 to HEAD requests whether or not the package exists.
+        // https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource?WT.mc_id=DT-MVP-5003978
+        var url = "https://api.nuget.org/v3/registration5-semver1/" + Uri.EscapeDataString(packageId.ToLowerInvariant()) + "/index.json";
+
+        try
         {
-            using var request = new HttpRequestMessage(HttpMethod.Head, "https://www.nuget.org/packages/" + Uri.EscapeDataString(packageId));
+            using var request = new HttpRequestMessage(HttpMethod.Head, url);
             using var response = await context.SendHttpRequestAsync(request, context.CancellationToken).ConfigureAwait(false);
-            if ((int)response.StatusCode is >= 200 and <= 400)
+            if (response.IsSuccessStatusCode)
             {
-                // The package exists
                 context.ReportError(ErrorCodes.PackageIdExistsOnNuGetOrg, $"The package '{packageId}' already exists on nuget.org");
-                return;
             }
-
-            if ((int)response.StatusCode >= 500)
-                continue;
-
-            context.ReportError(ErrorCodes.CannotCheckPackageIdExistsOnNuGetOrg, $"Cannot check if the package '{packageId}' exists on nuget.org");
-            return;
+            else if (response.StatusCode is not HttpStatusCode.NotFound)
+            {
+                context.ReportError(ErrorCodes.CannotCheckPackageIdExistsOnNuGetOrg, $"Cannot check if the package '{packageId}' exists on nuget.org (HTTP status code = {(int)response.StatusCode})");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            context.ReportError(ErrorCodes.CannotCheckPackageIdExistsOnNuGetOrg, $"Cannot check if the package '{packageId}' exists on nuget.org: {ex.Message}");
         }
     }
 }

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -258,6 +258,20 @@ public sealed class NuGetPackageValidatorTests
     }
 
     [Fact]
+    public async Task Validate_PackageIdAvailableOnNuGetOrg_PackageExists()
+    {
+        var result = await ValidateAsync("meziantou.framework.2.6.0.nupkg", NuGetPackageValidationRules.PackageIdAvailableOnNuGetOrg);
+        AssertHasError(result, ErrorCodes.PackageIdExistsOnNuGetOrg);
+    }
+
+    [Fact]
+    public async Task Validate_PackageIdAvailableOnNuGetOrg_PackageDoesNotExist()
+    {
+        var result = await ValidateAsync("Release_Author.1.0.0.nupkg", NuGetPackageValidationRules.PackageIdAvailableOnNuGetOrg);
+        AssertNoErrors(result);
+    }
+
+    [Fact]
     public async Task Validate_WithSymbolsServer()
     {
         // Downloading symbols can be flaky on CI


### PR DESCRIPTION
`PackageIdAvailableOnNuGetOrg` could never give the answer it exists to give: it always reported `CannotCheckPackageIdExistsOnNuGetOrg` (91) and had never once reported `PackageIdExistsOnNuGetOrg` (92).

## The defect

The rule sent `HEAD https://www.nuget.org/packages/<id>`. That page does not implement `HEAD` — it answers `404` whether or not the package exists:

```
HEAD /packages/Newtonsoft.Json                        404      GET  200
HEAD /packages/ThisPackageDoesNotExist12345Meziantou  404      GET  404
```

(Reproduced with `curl` and with `HttpClient` on the rule's exact code path.)

`404` fails the `>= 200 and <= 400` branch and fails the `>= 500` branch, so every invocation fell through to the "cannot check" error.

Three smaller defects in the same method:

- `<= 400` classified `400 Bad Request` as "the package exists".
- The `continue` on `5xx` retried with **no delay**, on top of the five backed-off retries `SharedHttpClient` already performs — 25 requests, no pause between the outer five.
- If all five iterations saw `5xx`, the loop exited reporting **nothing at all** — a silent pass from a rule whose only job is to report.

## The change

Query the registration index instead, which is the documented programmatic surface for this and does support `HEAD`:

```
HEAD /v3/registration5-semver1/newtonsoft.json/index.json                        200
HEAD /v3/registration5-semver1/thispackagedoesnotexist12345meziantou/index.json  404
```

Classification is now: 2xx → the id is taken (error 92); `404` → available, no error; anything else → error 91 with the status code included. Redirects are followed by `HttpClient`, so 3xx never surfaces here.

The outer retry loop is gone — `SharedHttpClient` already retries `5xx` five times with backoff and honours `Retry-After`. A `HttpRequestException` surviving those retries is now reported as error 91 rather than thrown out of the rule.

## Tests

The rule had no test at all, which is why this shipped. Two added, using fixtures already in the corpus:

- `Validate_PackageIdAvailableOnNuGetOrg_PackageExists` — `meziantou.framework.2.6.0.nupkg` reports error 92.
- `Validate_PackageIdAvailableOnNuGetOrg_PackageDoesNotExist` — `Release_Author.1.0.0.nupkg` (id not registered) reports nothing.

Both hit nuget.org, consistent with the existing network tests in this file. Verified in both directions: with the fix the full suite passes (64/64); with the rule reverted, both new tests fail — the "exists" case never reports 92, and the "available" case wrongly reports 91.
