### PR TITLE
Skip the machine and user name scrubbers when the name is empty

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettingsScrubberExtensions.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettingsScrubberExtensions.cs
@@ -41,8 +41,26 @@ public static class InlineSnapshotSettingsScrubberExtensions
     public static void ScrubLinesWithReplace(this InlineSnapshotSettings settings, Func<string, string?> replaceLine) => settings.Scrubbers.Add(new LineReplaceScrubber(replaceLine));
 
     /// <summary>Adds a scrubber that replaces the machine name with a consistent value.</summary>
-    public static void ScrubMachineName(this InlineSnapshotSettings settings) => settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(Environment.MachineName, "TheMachineName", StringComparison.OrdinalIgnoreCase)));
+    /// <remarks>Does nothing when <see cref="Environment.MachineName"/> is empty.</remarks>
+    public static void ScrubMachineName(this InlineSnapshotSettings settings)
+    {
+        // string.Replace throws on an empty search value, and the machine name can be empty in a container.
+        var machineName = Environment.MachineName;
+        if (string.IsNullOrEmpty(machineName))
+            return;
+
+        settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(machineName, "TheMachineName", StringComparison.OrdinalIgnoreCase)));
+    }
 
     /// <summary>Adds a scrubber that replaces the user name with a consistent value.</summary>
-    public static void ScrubUserName(this InlineSnapshotSettings settings) => settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(Environment.UserName, "TheUserName", StringComparison.OrdinalIgnoreCase)));
+    /// <remarks>Does nothing when <see cref="Environment.UserName"/> is empty.</remarks>
+    public static void ScrubUserName(this InlineSnapshotSettings settings)
+    {
+        // string.Replace throws on an empty search value, and the user name can be empty in a container.
+        var userName = Environment.UserName;
+        if (string.IsNullOrEmpty(userName))
+            return;
+
+        settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(userName, "TheUserName", StringComparison.OrdinalIgnoreCase)));
+    }
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -48,6 +48,26 @@ public sealed class InlineSnapshotSettingsTests
     }
 
     [Fact]
+    public void ScrubMachineName_ReplacesTheMachineName()
+    {
+        var settings = new InlineSnapshotSettings();
+        settings.ScrubMachineName();
+
+        var scrubber = Assert.Single(settings.Scrubbers);
+        Assert.Equal("host TheMachineName end", scrubber.Scrub($"host {Environment.MachineName} end"));
+    }
+
+    [Fact]
+    public void ScrubUserName_ReplacesTheUserName()
+    {
+        var settings = new InlineSnapshotSettings();
+        settings.ScrubUserName();
+
+        var scrubber = Assert.Single(settings.Scrubbers);
+        Assert.Equal("user TheUserName end", scrubber.Scrub($"user {Environment.UserName} end"));
+    }
+
+    [Fact]
     public void AssertSnapshot_ShouldContainResolutionGuidance()
     {
         var settings = new InlineSnapshotSettings();


### PR DESCRIPTION
## Problem

```csharp
public static void ScrubMachineName(this InlineSnapshotSettings settings)
    => settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(Environment.MachineName, "TheMachineName", StringComparison.OrdinalIgnoreCase)));
```

`string.Replace` throws `ArgumentException: String cannot be of zero length` when the search value is empty, and both `Environment.MachineName` and `Environment.UserName` can come back empty — a container with no hostname set, or a process with no resolvable passwd entry. The throw happens on every scrubbed line during serialization, not at configuration time, so it surfaces as an unrelated failure inside an assertion.

The environment value was also read inside the per-line lambda, so every line of every snapshot re-read it.

## Change

Read the name once, skip registering the scrubber when it is empty, and document that on the methods. A snapshot then keeps the (empty) name unscrubbed instead of failing the test, which is the better of the two outcomes when there is nothing to scrub.

## Verification

- `ScrubMachineName_ReplacesTheMachineName` and `ScrubUserName_ReplacesTheUserName` cover the normal path, which had no test.
- Full test project: 133/133 passing with `/p:TreatWarningsAsErrors=true`.

The empty-name path is not directly testable: `Environment.MachineName` and `Environment.UserName` are not settable from the test process.

## Not addressed here

A short name (`ci`, `app`, `root`) still rewrites unrelated substrings — `line.Replace("ci", "TheUserName")` mangles any word containing "ci". Making the match word-bounded would change existing snapshots, so it belongs in its own change.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
