### PR TITLE
Avoid a closure allocation per await on SynchronizationContext

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/SynchronizationContextExtensions.cs
+++ b/src/Meziantou.Framework.Threading/Threading/SynchronizationContextExtensions.cs
@@ -9,6 +9,11 @@ public static class SynchronizationContextExtensions
     /// </summary>
     /// <param name="synchronizationContext">The synchronization context to post the continuation to.</param>
     /// <returns>A <see cref="SynchronizationContextAwaiter"/> instance.</returns>
+    /// <remarks>
+    /// The continuation is posted to the synchronization context. When <see cref="SynchronizationContext.Post"/>
+    /// throws — posting to a dispatcher that has already shut down, for instance — the exception surfaces on the
+    /// thread that completed the awaited operation and the awaiting method never resumes.
+    /// </remarks>
     public static SynchronizationContextAwaiter GetAwaiter(this SynchronizationContext synchronizationContext)
     {
         ArgumentNullException.ThrowIfNull(synchronizationContext);
@@ -25,7 +30,9 @@ public static class SynchronizationContextExtensions
 
         public void OnCompleted(Action continuation)
         {
-            synchronizationContext.Post(_ => continuation(), null);
+            // The continuation travels as the callback state so the lambda stays closure-free and can be cached
+            // by the compiler, instead of allocating a display class on every await.
+            synchronizationContext.Post(static state => ((Action)state!)(), continuation);
         }
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/SynchronizationContextExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/SynchronizationContextExtensionsTests.cs
@@ -64,6 +64,18 @@ public sealed class SynchronizationContextExtensionsTests
         Assert.Equal(0, result.PostCount);
     }
 
+    [Fact]
+    public async Task GetAwaiter_PassesTheContinuationAsTheCallbackState()
+    {
+        // The continuation is passed as state rather than captured, so the posted callback allocates no closure.
+        using var synchronizationContext = new DedicatedThreadSynchronizationContext();
+
+        await Task.Run(async () => await synchronizationContext).WaitAsync(Timeout);
+
+        Assert.Equal(1, synchronizationContext.PostCount);
+        Assert.IsType<Action>(synchronizationContext.LastPostedState);
+    }
+
     private readonly record struct AwaitResult(int BeforeAwaitThreadId, int AfterAwaitThreadId, SynchronizationContext? CurrentSynchronizationContext, int PostCount);
 
     private sealed class DedicatedThreadSynchronizationContext : SynchronizationContext, IDisposable
@@ -72,6 +84,7 @@ public sealed class SynchronizationContextExtensionsTests
         private readonly Thread _thread;
         private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _postCount;
+        private object? _lastPostedState;
 
         public DedicatedThreadSynchronizationContext()
         {
@@ -89,11 +102,14 @@ public sealed class SynchronizationContextExtensionsTests
 
         public int PostCount => Volatile.Read(ref _postCount);
 
+        public object? LastPostedState => Volatile.Read(ref _lastPostedState);
+
         public override void Post(SendOrPostCallback d, object? state)
         {
             ArgumentNullException.ThrowIfNull(d);
 
             Interlocked.Increment(ref _postCount);
+            Volatile.Write(ref _lastPostedState, state);
             _workItems.Add(new WorkItem(d, state));
         }
 


### PR DESCRIPTION
`SynchronizationContextAwaiter.OnCompleted` captured the continuation in a closure:

```csharp
synchronizationContext.Post(_ => continuation(), null);
```

That allocates a display class on **every** `await syncContext`, which is the one thing this awaiter exists to make cheap. Passing the continuation as the callback state instead lets the compiler cache the lambda as a static delegate, so the only remaining allocation is the one `SynchronizationContext.Post` makes itself:

```csharp
synchronizationContext.Post(static state => ((Action)state!)(), continuation);
```

Also documented a behaviour that was previously implicit: if `Post` throws — posting to a dispatcher that has already shut down, for instance — the exception surfaces on the thread that completed the awaited operation, and the awaiting method never resumes. There is no sensible place for the awaiter to resume the continuation in that situation, so this is a documentation fix rather than a code one.

### Verification

New `GetAwaiter_PassesTheContinuationAsTheCallbackState`, which asserts the posted state is the `Action` rather than `null`. **Confirmed to fail on the unfixed source.** The test synchronization context now records the last posted state to make that observable.

The three existing tests — posting to another context, completing synchronously when already on the target context, and the null-argument guard — are unchanged and still pass, confirming no behavioural difference.

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite green at 264 tests across net10.0 and net11.0 (262 before). No public API change, so `ref/` is unaffected.

<sub>Found during a review of `Meziantou.Framework.Threading` (finding L6).</sub>
