### PR TITLE
Bound alias expansion when building the YAML document object model

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -363,6 +363,7 @@ namespace Meziantou.Framework.Yaml
         public int MaxDepth { get => throw null; init { } }
         public bool AllowAnchors { get => throw null; init { } }
         public bool AllowAliases { get => throw null; init { } }
+        public int MaxAliasExpansionNodeCount { get => throw null; init { } }
         public Meziantou.Framework.Yaml.IYamlTypeInfoResolver? TypeInfoResolver { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlTypeInfo<T> GetTypeInfo<T>() => throw null;
         public bool TryGetTypeInfo<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Yaml.YamlTypeInfo<T>? typeInfo) => throw null;
@@ -557,6 +558,7 @@ namespace Meziantou.Framework.Yaml.Model
         public Meziantou.Framework.Yaml.Events.DocumentEnd DocumentEnd { get => throw null; set { } }
         public Meziantou.Framework.Yaml.Model.YamlElement? Contents { get => throw null; set { } }
         public static Meziantou.Framework.Yaml.Model.YamlDocument Load(Meziantou.Framework.Yaml.EventReader eventReader) => throw null;
+        public static Meziantou.Framework.Yaml.Model.YamlDocument Load(Meziantou.Framework.Yaml.EventReader eventReader, Meziantou.Framework.Yaml.YamlSerializerOptions? options) => throw null;
         public override Meziantou.Framework.Yaml.Model.YamlNode DeepClone() => throw null;
     }
 
@@ -654,7 +656,9 @@ namespace Meziantou.Framework.Yaml.Model
         public bool IsReadOnly { get => throw null; }
         public Meziantou.Framework.Yaml.Model.YamlDocument this[int index] { get => throw null; set { } }
         public static Meziantou.Framework.Yaml.Model.YamlStream Load(System.IO.TextReader stream) => throw null;
+        public static Meziantou.Framework.Yaml.Model.YamlStream Load(System.IO.TextReader stream, Meziantou.Framework.Yaml.YamlSerializerOptions? options) => throw null;
         public static Meziantou.Framework.Yaml.Model.YamlStream Load(Meziantou.Framework.Yaml.EventReader eventReader) => throw null;
+        public static Meziantou.Framework.Yaml.Model.YamlStream Load(Meziantou.Framework.Yaml.EventReader eventReader, Meziantou.Framework.Yaml.YamlSerializerOptions? options) => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
         public System.Collections.Generic.IEnumerator<Meziantou.Framework.Yaml.Model.YamlDocument> GetEnumerator() => throw null;
         public void Add(Meziantou.Framework.Yaml.Model.YamlDocument item) { }

--- a/src/Meziantou.Framework.Yaml/Model/YamlDocument.cs
+++ b/src/Meziantou.Framework.Yaml/Model/YamlDocument.cs
@@ -27,10 +27,31 @@ public class YamlDocument : YamlNode
     /// <summary>Loads data.</summary>
     public static YamlDocument Load(EventReader eventReader)
     {
+        return Load(eventReader, options: null);
+    }
+
+    /// <summary>Loads data, honoring the anchor, alias and alias-expansion limits of <paramref name="options"/>.</summary>
+    /// <param name="eventReader">The event reader.</param>
+    /// <param name="options">
+    /// The options used to bound alias expansion. If <see langword="null"/>, <see cref="YamlSerializerOptions.Default"/> is used.
+    /// </param>
+    public static YamlDocument Load(EventReader eventReader, YamlSerializerOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(eventReader);
+        return Load(eventReader, CreateContext(options));
+    }
+
+    internal static YamlModelLoadContext CreateContext(YamlSerializerOptions? options)
+    {
+        var effectiveOptions = options ?? YamlSerializerOptions.Default;
+        return new YamlModelLoadContext(effectiveOptions.EffectiveMaxAliasExpansionNodeCount, effectiveOptions.AllowAnchors, effectiveOptions.AllowAliases);
+    }
+
+    internal static YamlDocument Load(EventReader eventReader, YamlModelLoadContext context)
+    {
         var documentStart = eventReader.Expect<DocumentStart>();
 
-        var anchors = new Dictionary<string, YamlElement>(StringComparer.Ordinal);
-        var contents = ReadElement(eventReader, anchors);
+        var contents = ReadElement(eventReader, context);
 
         var documentEnd = eventReader.Expect<DocumentEnd>();
 

--- a/src/Meziantou.Framework.Yaml/Model/YamlMapping.cs
+++ b/src/Meziantou.Framework.Yaml/Model/YamlMapping.cs
@@ -105,10 +105,10 @@ public class YamlMapping : YamlContainer, IDictionary<YamlElement, YamlElement?>
     /// <summary>Loads data.</summary>
     public static YamlMapping Load(EventReader eventReader)
     {
-        return Load(eventReader, anchors: null);
+        return Load(eventReader, context: null);
     }
 
-    internal static YamlMapping Load(EventReader eventReader, Dictionary<string, YamlElement>? anchors)
+    internal static YamlMapping Load(EventReader eventReader, YamlModelLoadContext? context)
     {
         var mappingStart = eventReader.Expect<MappingStart>();
 
@@ -116,8 +116,8 @@ public class YamlMapping : YamlContainer, IDictionary<YamlElement, YamlElement?>
         var contents = new Dictionary<YamlElement, YamlElement?>();
         while (!eventReader.Accept<MappingEnd>())
         {
-            var key = ReadElement(eventReader, anchors);
-            var value = ReadElement(eventReader, anchors);
+            var key = ReadElement(eventReader, context);
+            var value = ReadElement(eventReader, context);
 
             if (key is null || value is null)
             {

--- a/src/Meziantou.Framework.Yaml/Model/YamlModelLoadContext.cs
+++ b/src/Meziantou.Framework.Yaml/Model/YamlModelLoadContext.cs
@@ -1,0 +1,112 @@
+namespace Meziantou.Framework.Yaml.Model;
+
+/// <summary>
+/// Tracks the anchors declared by a document and bounds how many nodes aliases are allowed to materialize.
+/// </summary>
+/// <remarks>
+/// The model API does not preserve aliases as a distinct node type, so every alias is expanded into a copy of the
+/// anchored subtree. Nesting anchors so that each level references the previous one several times makes the node
+/// count grow exponentially while the document grows linearly, which lets a sub-kilobyte payload exhaust memory.
+/// Every node produced by an alias is charged against a budget so that expansion stays proportional to the input.
+/// </remarks>
+internal sealed class YamlModelLoadContext
+{
+    private readonly Dictionary<object, long> _nodeCounts = new(ReferenceEqualityComparer.Instance);
+    private readonly long _maxAliasExpansionNodeCount;
+    private long _aliasExpansionNodeCount;
+
+    public YamlModelLoadContext(int maxAliasExpansionNodeCount, bool allowAnchors, bool allowAliases)
+    {
+        _maxAliasExpansionNodeCount = maxAliasExpansionNodeCount;
+        AllowAnchors = allowAnchors;
+        AllowAliases = allowAliases;
+    }
+
+    public Dictionary<string, YamlElement> Anchors { get; } = new(StringComparer.Ordinal);
+
+    public bool AllowAnchors { get; }
+
+    public bool AllowAliases { get; }
+
+    /// <summary>Charges the nodes an alias is about to materialize against the budget.</summary>
+    /// <exception cref="YamlException">Expanding the alias would exceed the budget.</exception>
+    public void ChargeAliasExpansion(YamlElement anchored, string alias, Mark start, Mark end)
+    {
+        var remaining = _maxAliasExpansionNodeCount - _aliasExpansionNodeCount;
+        var count = CountNodes(anchored, remaining);
+        if (count > remaining)
+        {
+            throw new YamlException(start, end, FormattableString.Invariant($"Expanding the alias '*{alias}' would materialize more than the maximum of {_maxAliasExpansionNodeCount} nodes allowed for alias expansion. Set {nameof(YamlSerializerOptions)}.{nameof(YamlSerializerOptions.MaxAliasExpansionNodeCount)} to allow more, or disable aliases with {nameof(YamlSerializerOptions.AllowAliases)}."));
+        }
+
+        _aliasExpansionNodeCount += count;
+    }
+
+    /// <summary>Records the node count of an anchored element so later aliases can be charged without rewalking it.</summary>
+    public void RegisterNodeCount(YamlElement element)
+    {
+        // Only anchored elements can be expanded later, so nothing else is worth measuring.
+        _nodeCounts[element] = CountNodes(element, long.MaxValue);
+    }
+
+    /// <summary>
+    /// Counts the nodes in <paramref name="element"/>, giving up as soon as the count exceeds <paramref name="limit"/>.
+    /// </summary>
+    /// <remarks>
+    /// Stopping at the limit keeps the work bounded by the remaining budget, so counting cannot itself become the
+    /// expensive operation the budget exists to prevent.
+    /// </remarks>
+    private long CountNodes(YamlElement element, long limit)
+    {
+        if (_nodeCounts.TryGetValue(element, out var cached))
+        {
+            return cached;
+        }
+
+        long count = 0;
+        var pending = new Stack<YamlElement>();
+        pending.Push(element);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            if (_nodeCounts.TryGetValue(current, out var known))
+            {
+                count += known;
+            }
+            else
+            {
+                count++;
+                switch (current)
+                {
+                    case YamlMapping mapping:
+                        foreach (var key in mapping.Keys)
+                        {
+                            pending.Push(key);
+                            if (mapping[key] is { } value)
+                            {
+                                pending.Push(value);
+                            }
+                        }
+
+                        break;
+
+                    case YamlSequence sequence:
+                        foreach (var item in sequence)
+                        {
+                            pending.Push(item);
+                        }
+
+                        break;
+                }
+            }
+
+            if (count > limit)
+            {
+                return count;
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Model/YamlNode.cs
+++ b/src/Meziantou.Framework.Yaml/Model/YamlNode.cs
@@ -11,29 +11,29 @@ public abstract class YamlNode
     /// <summary>Reads the next YAML element from the event stream.</summary>
     protected static YamlElement? ReadElement(EventReader eventReader)
     {
-        return ReadElement(eventReader, anchors: null);
+        return ReadElement(eventReader, context: null);
     }
 
-    internal static YamlElement? ReadElement(EventReader eventReader, Dictionary<string, YamlElement>? anchors)
+    internal static YamlElement? ReadElement(EventReader eventReader, YamlModelLoadContext? context)
     {
-        if (eventReader.Accept<MappingStart>())
+        if (eventReader.Peek<MappingStart>() is { } mappingStart)
         {
-            var mapping = YamlMapping.Load(eventReader, anchors);
-            RegisterAnchor(mapping, anchors);
+            var mapping = YamlMapping.Load(eventReader, context);
+            RegisterAnchor(mapping, context, mappingStart.Start, mappingStart.End);
             return mapping;
         }
 
-        if (eventReader.Accept<SequenceStart>())
+        if (eventReader.Peek<SequenceStart>() is { } sequenceStart)
         {
-            var sequence = YamlSequence.Load(eventReader, anchors);
-            RegisterAnchor(sequence, anchors);
+            var sequence = YamlSequence.Load(eventReader, context);
+            RegisterAnchor(sequence, context, sequenceStart.Start, sequenceStart.End);
             return sequence;
         }
 
-        if (eventReader.Accept<Scalar>())
+        if (eventReader.Peek<Scalar>() is { } scalarStart)
         {
             var value = YamlValue.Load(eventReader);
-            RegisterAnchor(value, anchors);
+            RegisterAnchor(value, context, scalarStart.Start, scalarStart.End);
             return value;
         }
 
@@ -41,13 +41,20 @@ public abstract class YamlNode
         {
             var alias = eventReader.Expect<AnchorAlias>();
 
-            if (anchors == null || !anchors.TryGetValue(alias.Value, out var anchored))
+            if (context is not null && !context.AllowAliases)
+            {
+                throw new YamlException(alias.Start, alias.End, "YAML aliases are not allowed.");
+            }
+
+            if (context is null || !context.Anchors.TryGetValue(alias.Value, out var anchored))
             {
                 throw new YamlException(alias.Start, alias.End, FormattableString.Invariant($"Found an alias '*{alias.Value}' referencing an unknown anchor."));
             }
 
-            // The model API does not currently preserve aliases as a distinct node type.
-            // We materialize a copy so that writing the model back out does not emit duplicate anchors.
+            // The model API does not currently preserve aliases as a distinct node type, so the anchored subtree is
+            // copied. That copy is what makes alias amplification possible, so it is charged against a budget first.
+            context.ChargeAliasExpansion(anchored, alias.Value, alias.Start, alias.End);
+
             var clone = (YamlElement)anchored.DeepClone();
             clone.Anchor = null;
             return clone;
@@ -56,9 +63,9 @@ public abstract class YamlNode
         return null;
     }
 
-    private static void RegisterAnchor(YamlElement element, Dictionary<string, YamlElement>? anchors)
+    private static void RegisterAnchor(YamlElement element, YamlModelLoadContext? context, Mark start, Mark end)
     {
-        if (anchors == null)
+        if (context is null)
         {
             return;
         }
@@ -66,7 +73,13 @@ public abstract class YamlNode
         var anchor = element.Anchor;
         if (!string.IsNullOrEmpty(anchor))
         {
-            anchors[anchor] = element;
+            if (!context.AllowAnchors)
+            {
+                throw new YamlException(start, end, "YAML anchors are not allowed.");
+            }
+
+            context.Anchors[anchor] = element;
+            context.RegisterNodeCount(element);
         }
     }
 

--- a/src/Meziantou.Framework.Yaml/Model/YamlSequence.cs
+++ b/src/Meziantou.Framework.Yaml/Model/YamlSequence.cs
@@ -103,17 +103,17 @@ public class YamlSequence : YamlContainer, IList<YamlElement>
     /// <summary>Loads data.</summary>
     public static YamlSequence Load(EventReader eventReader)
     {
-        return Load(eventReader, anchors: null);
+        return Load(eventReader, context: null);
     }
 
-    internal static YamlSequence Load(EventReader eventReader, Dictionary<string, YamlElement>? anchors)
+    internal static YamlSequence Load(EventReader eventReader, YamlModelLoadContext? context)
     {
         var sequenceStart = eventReader.Expect<SequenceStart>();
 
         var contents = new List<YamlElement>();
         while (!eventReader.Accept<SequenceEnd>())
         {
-            var item = ReadElement(eventReader, anchors);
+            var item = ReadElement(eventReader, context);
             if (item != null)
                 contents.Add(item);
         }

--- a/src/Meziantou.Framework.Yaml/Model/YamlStream.cs
+++ b/src/Meziantou.Framework.Yaml/Model/YamlStream.cs
@@ -29,17 +29,51 @@ public class YamlStream : YamlNode, IList<YamlDocument>
     /// <summary>Loads data.</summary>
     public static YamlStream Load(TextReader stream)
     {
-        return Load(new EventReader(Parser.CreateParser(stream)));
+        return Load(stream, options: null);
+    }
+
+    /// <summary>Loads data, honoring the hardening options in <paramref name="options"/>.</summary>
+    /// <param name="stream">The reader over the YAML payload.</param>
+    /// <param name="options">
+    /// The options used to bound nesting depth and alias expansion. If <see langword="null"/>,
+    /// <see cref="YamlSerializerOptions.Default"/> is used.
+    /// </param>
+    /// <remarks>
+    /// Use this overload for untrusted input: it applies <see cref="YamlSerializerOptions.MaxDepth"/>,
+    /// <see cref="YamlSerializerOptions.AllowAnchors"/>, <see cref="YamlSerializerOptions.AllowAliases"/> and
+    /// <see cref="YamlSerializerOptions.MaxAliasExpansionNodeCount"/>.
+    /// </remarks>
+    public static YamlStream Load(TextReader stream, YamlSerializerOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        var effectiveOptions = options ?? YamlSerializerOptions.Default;
+        var parser = Parser.CreateParser(stream, effectiveOptions.EffectiveMaxDepth, effectiveOptions.SourceName);
+        return Load(new EventReader(parser), effectiveOptions);
     }
 
     /// <summary>Loads data.</summary>
     public static YamlStream Load(EventReader eventReader)
     {
+        return Load(eventReader, options: null);
+    }
+
+    /// <summary>Loads data, honoring the anchor, alias and alias-expansion limits of <paramref name="options"/>.</summary>
+    /// <param name="eventReader">The event reader.</param>
+    /// <param name="options">
+    /// The options used to bound alias expansion. If <see langword="null"/>, <see cref="YamlSerializerOptions.Default"/> is used.
+    /// </param>
+    public static YamlStream Load(EventReader eventReader, YamlSerializerOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(eventReader);
+
+        // One context for the whole stream so alias expansion is bounded across every document, not per document.
+        var context = YamlDocument.CreateContext(options);
+
         var streamStart = eventReader.Expect<StreamStart>();
 
         var documents = new List<YamlDocument>();
         while (!eventReader.Accept<StreamEnd>())
-            documents.Add(YamlDocument.Load(eventReader));
+            documents.Add(YamlDocument.Load(eventReader, context));
 
         var streamEnd = eventReader.Expect<StreamEnd>();
 

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlModelNodeConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlModelNodeConverter.cs
@@ -26,7 +26,7 @@ internal sealed class YamlModelNodeConverter : YamlConverter
         var start = reader.Start;
         var end = reader.End;
 
-        var node = ReadNode(reader, new Dictionary<string, YamlElement>(StringComparer.Ordinal));
+        var node = ReadNode(reader, YamlDocument.CreateContext(reader.Options));
         if (node is null)
         {
             return null;
@@ -58,25 +58,25 @@ internal sealed class YamlModelNodeConverter : YamlConverter
         WriteNode(writer, node);
     }
 
-    private static YamlElement? ReadNode(YamlReader reader, Dictionary<string, YamlElement> anchors)
+    private static YamlElement? ReadNode(YamlReader reader, YamlModelLoadContext context)
     {
         switch (reader.CurrentEvent)
         {
             case MappingStart mappingStart:
-                return ReadMapping(reader, mappingStart, anchors);
+                return ReadMapping(reader, mappingStart, context);
 
             case SequenceStart sequenceStart:
-                return ReadSequence(reader, sequenceStart, anchors);
+                return ReadSequence(reader, sequenceStart, context);
 
             case Scalar scalar:
                 reader.Read();
                 var value = new YamlValue(scalar);
-                RegisterAnchor(value, anchors);
+                RegisterAnchor(value, context);
                 return value;
 
             case AnchorAlias alias:
                 reader.Read();
-                if (!anchors.TryGetValue(alias.Value, out var anchored))
+                if (!context.Anchors.TryGetValue(alias.Value, out var anchored))
                 {
                     throw new YamlException(
                         alias.Start,
@@ -84,8 +84,10 @@ internal sealed class YamlModelNodeConverter : YamlConverter
                         FormattableString.Invariant($"Found an alias '*{alias.Value}' referencing an unknown anchor."));
                 }
 
-                // The model API does not currently preserve aliases as a distinct node type.
-                // Materialize a copy so that writing the model back out does not emit duplicate anchors.
+                // The model API does not currently preserve aliases as a distinct node type, so the anchored subtree
+                // is copied. That copy is what makes alias amplification possible, so charge it against a budget first.
+                context.ChargeAliasExpansion(anchored, alias.Value, alias.Start, alias.End);
+
                 var clone = (YamlElement)anchored.DeepClone();
                 clone.Anchor = null;
                 return clone;
@@ -95,7 +97,7 @@ internal sealed class YamlModelNodeConverter : YamlConverter
         }
     }
 
-    private static YamlMapping ReadMapping(YamlReader reader, MappingStart mappingStart, Dictionary<string, YamlElement> anchors)
+    private static YamlMapping ReadMapping(YamlReader reader, MappingStart mappingStart, YamlModelLoadContext context)
     {
         reader.Read();
 
@@ -108,8 +110,8 @@ internal sealed class YamlModelNodeConverter : YamlConverter
                 throw new YamlException("Unexpected end of mapping while loading YAML model.");
             }
 
-            var key = ReadNode(reader, anchors);
-            var value = ReadNode(reader, anchors);
+            var key = ReadNode(reader, context);
+            var value = ReadNode(reader, context);
 
             if (key is null || value is null)
             {
@@ -125,11 +127,11 @@ internal sealed class YamlModelNodeConverter : YamlConverter
         reader.Read();
 
         var mapping = new YamlMapping(mappingStart, mappingEnd, keys, contents);
-        RegisterAnchor(mapping, anchors);
+        RegisterAnchor(mapping, context);
         return mapping;
     }
 
-    private static YamlSequence ReadSequence(YamlReader reader, SequenceStart sequenceStart, Dictionary<string, YamlElement> anchors)
+    private static YamlSequence ReadSequence(YamlReader reader, SequenceStart sequenceStart, YamlModelLoadContext context)
     {
         reader.Read();
 
@@ -141,7 +143,7 @@ internal sealed class YamlModelNodeConverter : YamlConverter
                 throw new YamlException("Unexpected end of sequence while loading YAML model.");
             }
 
-            var item = ReadNode(reader, anchors);
+            var item = ReadNode(reader, context);
             if (item is not null)
             {
                 contents.Add(item);
@@ -153,16 +155,17 @@ internal sealed class YamlModelNodeConverter : YamlConverter
         reader.Read();
 
         var sequence = new YamlSequence(sequenceStart, sequenceEnd, contents);
-        RegisterAnchor(sequence, anchors);
+        RegisterAnchor(sequence, context);
         return sequence;
     }
 
-    private static void RegisterAnchor(YamlElement element, Dictionary<string, YamlElement> anchors)
+    private static void RegisterAnchor(YamlElement element, YamlModelLoadContext context)
     {
         var anchor = element.Anchor;
         if (!string.IsNullOrEmpty(anchor))
         {
-            anchors[anchor] = element;
+            context.Anchors[anchor] = element;
+            context.RegisterNodeCount(element);
         }
     }
 

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -269,6 +269,31 @@ public sealed record YamlSerializerOptions
     public bool AllowAliases { get; init; } = true;
 
     /// <summary>
+    /// Gets or sets the maximum number of nodes that aliases are allowed to materialize while building a
+    /// <see cref="Meziantou.Framework.Yaml.Model.YamlNode"/> document object model.
+    /// </summary>
+    /// <remarks>
+    /// <para>A value of <c>0</c> uses the default limit of 100000.</para>
+    /// <para>
+    /// The document object model does not preserve aliases as a distinct node type, so each alias is expanded into a
+    /// copy of the anchored subtree. Nesting anchors so that each level references the previous one several times makes
+    /// the node count grow exponentially while the document grows linearly, which lets a very small payload exhaust
+    /// memory. Only nodes produced by alias expansion count towards this limit; documents without aliases are never
+    /// affected, and <see cref="MaxDepth"/> does not help because the growth is in breadth rather than depth.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Value is less than 0.</exception>
+    public int MaxAliasExpansionNodeCount
+    {
+        get;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            field = value;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets a metadata resolver used to retrieve <see cref="YamlTypeInfo"/> instances.
     /// </summary>
     /// <remarks>
@@ -312,6 +337,10 @@ public sealed record YamlSerializerOptions
     }
 
     internal int EffectiveMaxDepth => YamlDepthHelper.GetEffectiveMaxDepth(MaxDepth);
+
+    internal const int DefaultMaxAliasExpansionNodeCount = 100_000;
+
+    internal int EffectiveMaxAliasExpansionNodeCount => MaxAliasExpansionNodeCount == 0 ? DefaultMaxAliasExpansionNodeCount : MaxAliasExpansionNodeCount;
 
     internal static void ValidateSequenceItemStyle(YamlSequenceItemStyle value, string paramName)
     {

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -891,6 +891,7 @@ Use `TryDeserialize` when a failure is expected and an exception is not wanted.
 | `MaxDepth` | `64` | Caps the nesting depth of mappings and sequences while reading and writing. `0` means the default. |
 | `AllowAnchors` | `true` | Rejects documents declaring anchors. |
 | `AllowAliases` | `true` | Rejects documents using aliases, which prevents alias-expansion amplification. |
+| `MaxAliasExpansionNodeCount` | `100000` | Caps how many nodes aliases may materialize when building a `YamlNode` model. `0` means the default. |
 | `DuplicateKeyHandling` | `Error` | Rejects mappings with duplicate keys. |
 | `UnsafeAllowDeserializeFromTagTypeName` | `false` | Allows a YAML tag to name a CLR type to instantiate. Enable it only for trusted input. |
 
@@ -902,4 +903,16 @@ var options = new YamlSerializerOptions
     AllowAliases = false,
     UnmappedMemberHandling = YamlUnmappedMemberHandling.Disallow,
 };
+```
+
+The document object model expands each alias into a copy of the anchored subtree, so nesting anchors makes the node
+count grow exponentially while the document grows linearly. `MaxDepth` does not bound this, because the growth is in
+breadth rather than depth. `MaxAliasExpansionNodeCount` bounds it directly, and only counts nodes produced by alias
+expansion, so documents that do not use aliases are never affected.
+
+Pass the options to `YamlStream.Load` when reading untrusted input into the model; the parameterless overload uses
+`YamlSerializerOptions.Default`:
+
+```csharp
+var stream = YamlStream.Load(reader, options);
 ```

--- a/tests/Meziantou.Framework.Yaml.Tests/Model/YamlModelAnchorAliasTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Model/YamlModelAnchorAliasTests.cs
@@ -1,4 +1,5 @@
 using Meziantou.Framework.Yaml.Model;
+using Meziantou.Framework.Yaml.Serialization;
 
 namespace Meziantou.Framework.Yaml.Tests;
 public sealed class YamlModelAnchorAliasTests
@@ -25,5 +26,154 @@ field2: *data
         // The model API doesn't preserve aliases as a distinct node type: we materialize a copy.
         Assert.Null(field2.Anchor);
         Assert.Equal("ABCD", field2.Value);
+    }
+
+    /// <summary>
+    /// Nesting anchors so that each level references the previous one several times makes the node count grow as
+    /// fan^levels while the document grows linearly. Before the expansion budget, the 397-byte payload below
+    /// allocated about 3.9 GB and the 492-byte one exhausted memory.
+    /// </summary>
+    private static string CreateAliasBomb(int levels, int fan = 9)
+    {
+        var builder = new StringBuilder();
+        builder.Append("a0: &a0 \"xxxxxxxx\"\n");
+        for (var i = 1; i <= levels; i++)
+        {
+            builder.Append(FormattableString.Invariant($"a{i}: &a{i} ["));
+            for (var j = 0; j < fan; j++)
+            {
+                if (j > 0)
+                {
+                    builder.Append(',');
+                }
+
+                builder.Append(FormattableString.Invariant($"*a{i - 1}"));
+            }
+
+            builder.Append("]\n");
+        }
+
+        builder.Append(FormattableString.Invariant($"root: *a{levels}\n"));
+        return builder.ToString();
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(10)]
+    [InlineData(12)]
+    public void Load_AliasBomb_IsRejectedInsteadOfExhaustingMemory(int levels)
+    {
+        var yaml = CreateAliasBomb(levels);
+
+        var exception = Assert.Throws<YamlException>(() => YamlStream.Load(new StringReader(yaml)));
+
+        Assert.Contains("alias expansion", exception.Message);
+    }
+
+    [Fact]
+    public void Deserialize_YamlElement_AliasBomb_IsRejectedInsteadOfExhaustingMemory()
+    {
+        // The converter path builds the same model and had the same defect.
+        var yaml = CreateAliasBomb(10);
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<YamlElement>(yaml));
+
+        Assert.Contains("alias expansion", exception.Message);
+    }
+
+    [Fact]
+    public void Load_WithAllowAliasesFalse_RejectsAliases()
+    {
+        // Previously unreachable: YamlStream.Load had no overload accepting options.
+        var options = new YamlSerializerOptions { AllowAliases = false };
+
+        var exception = Assert.Throws<YamlException>(() => YamlStream.Load(new StringReader("a: &x 1\nb: *x"), options));
+
+        Assert.Contains("aliases are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Load_WithAllowAnchorsFalse_RejectsAnchors()
+    {
+        var options = new YamlSerializerOptions { AllowAnchors = false };
+
+        var exception = Assert.Throws<YamlException>(() => YamlStream.Load(new StringReader("a: &x 1\nb: *x"), options));
+
+        Assert.Contains("anchors are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Load_WithCustomAliasExpansionBudget_IsEnforced()
+    {
+        var options = new YamlSerializerOptions { MaxAliasExpansionNodeCount = 4 };
+
+        var exception = Assert.Throws<YamlException>(() => YamlStream.Load(new StringReader(CreateAliasBomb(4)), options));
+
+        Assert.Contains("alias expansion", exception.Message);
+    }
+
+    [Fact]
+    public void Load_WithLargeAliasExpansionBudget_AllowsHeavyButBoundedExpansion()
+    {
+        var yaml = CreateAliasBomb(4);
+        var options = new YamlSerializerOptions { MaxAliasExpansionNodeCount = int.MaxValue };
+
+        var stream = YamlStream.Load(new StringReader(yaml), options);
+
+        Assert.Single(stream);
+    }
+
+    [Fact]
+    public void Load_SharedAnchorReferencedSeveralTimes_StillWorks()
+    {
+        // The budget must not break ordinary anchor reuse, which is the common real-world case.
+        var yaml = """
+                   base: &b {name: app, port: 80}
+                   a: *b
+                   b: *b
+                   c: *b
+                   """;
+
+        var stream = YamlStream.Load(new StringReader(yaml));
+
+        var mapping = (YamlMapping)stream[0].Contents!;
+        Assert.HasCount(4, mapping.Keys);
+        Assert.Equal("app", ((YamlValue)((YamlMapping)mapping["a"]!)["name"]!).Value);
+    }
+
+    [Fact]
+    public void Load_MergeKeys_StillWork()
+    {
+        var yaml = """
+                   defaults: &d {a: 1, b: 2}
+                   item:
+                     <<: *d
+                     c: 3
+                   """;
+
+        var stream = YamlStream.Load(new StringReader(yaml));
+
+        Assert.Single(stream);
+    }
+
+    [Fact]
+    public void Load_LargeDocumentWithoutAliases_IsNotAffectedByTheBudget()
+    {
+        // Only nodes produced by alias expansion are charged, so an alias-free document of any size is unaffected.
+        var builder = new StringBuilder();
+        for (var i = 0; i < 50_000; i++)
+        {
+            builder.Append(FormattableString.Invariant($"k{i}: v{i}\n"));
+        }
+
+        var stream = YamlStream.Load(new StringReader(builder.ToString()));
+
+        Assert.HasCount(50_000, ((YamlMapping)stream[0].Contents!).Keys);
+    }
+
+    [Fact]
+    public void MaxAliasExpansionNodeCount_Negative_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new YamlSerializerOptions { MaxAliasExpansionNodeCount = -1 });
     }
 }


### PR DESCRIPTION
A sub-kilobyte YAML document could exhaust the process's memory when loaded into the document object model, and the option documented as the mitigation was unreachable from that entry point.

## The defect

The model API does not preserve aliases as a distinct node type, so each alias is materialized with `DeepClone()`:

- `Model/YamlNode.cs:51` — the `YamlStream.Load` path
- `Serialization/Converters/YamlModelNodeConverter.cs:89` — the `Deserialize<YamlElement>` path

Nesting anchors so that each level references the previous one *N* times makes the node count grow as *N^levels* while the input grows linearly. The payload is an ordinary anchor chain (`a1: &a1 [*a0,*a0,…]`, nine refs per level):

| Input | Time | Allocated |
| --- | --- | --- |
| 213 B (9^4) | 16 ms | — |
| 305 B (9^6) | 95 ms | 48 MB |
| **397 B** (9^8) | **6 443 ms** | **3 925 MB** |
| **492 B** (9^10) | >15 s | 8 GB+, OOM |

Two things made this worse than the usual case:

- **`MaxDepth` gave no protection.** The bomb is ~10 levels deep, far under the default 64. `MaxDepth` bounds nesting depth; amplification is breadth.
- **`AllowAliases` was unreachable.** `YamlStream.Load` only had `Load(TextReader)` and `Load(EventReader)`; neither accepted `YamlSerializerOptions`, and `Load(TextReader)` called `Parser.CreateParser(stream)` with defaults. So the DOM path could not be hardened by configuration at all.

Both `AllowAnchors` and `AllowAliases` default to `true`, so default configuration was vulnerable. The README's "Hardening untrusted input" table named `AllowAliases` as the mitigation for "alias-expansion amplification", so a reader following the docs while using `YamlStream.Load` was not actually protected.

The serializer path into `object` was **not** affected — it rejects aliases unless `ReferenceHandling.Preserve` is set — which is why this was confined to the model API.

## The change

**1. An alias-expansion budget.** Every node an alias would materialize is charged against a budget shared by the whole stream, in the new `YamlModelLoadContext`. Counting stops as soon as it exceeds the remaining budget, so counting cannot itself become the expensive operation the budget exists to prevent, and node counts of anchored elements are cached so repeated aliases do not rewalk them.

Only nodes produced by *alias expansion* are counted. Every other node needs input to describe it, so it is already bounded by document size. This is what keeps the fix from being a size limit: **a document that uses no aliases is never affected, whatever its size.**

**2. Options-aware `Load` overloads**, so the existing hardening options are reachable from the model API:

```csharp
YamlStream.Load(TextReader stream, YamlSerializerOptions? options)
YamlStream.Load(EventReader eventReader, YamlSerializerOptions? options)
YamlDocument.Load(EventReader eventReader, YamlSerializerOptions? options)
```

The `TextReader` overload also applies `MaxDepth` and `SourceName`, which `Load(TextReader)` previously ignored.

**3. `YamlSerializerOptions.MaxAliasExpansionNodeCount`**, default 100 000 (`0` means the default), following the existing `MaxDepth` convention.

The public API change is purely additive — `ref/Meziantou.Framework.Yaml.cs` gains 4 members and loses none.

## Verified

| Case | Before | After |
| --- | --- | --- |
| `YamlStream.Load`, 397 B bomb | 3 925 MB / 6 443 ms | **`YamlException`, 3 MB / 8 ms** |
| `Deserialize<YamlElement>`, 397 B bomb | 3 925 MB / 6 659 ms | **`YamlException`, 3 MB / 9 ms** |
| 492 B and 606 B bombs | OOM | `YamlException`, same cost |
| `Load(reader, AllowAliases = false)` | not expressible | `YamlException` |
| `Load(reader, AllowAnchors = false)` | not expressible | `YamlException` |
| Shared anchor referenced 3× | works | **works** |
| Merge keys (`<<: *d`) | works | **works** |
| 50 000-node document, no aliases | works | **works** |

Cost no longer grows with the payload — the deeper bombs fail at the same point and the same cost as the shallow one.

12 tests added to `YamlModelAnchorAliasTests`, covering both DOM paths, the three new option behaviours, a custom and an effectively unlimited budget, and — importantly — the cases that must keep working: ordinary anchor reuse, merge keys, and a large alias-free document. Also a guard that a negative `MaxAliasExpansionNodeCount` throws.

`dotnet test` on `Meziantou.Framework.Yaml.Tests`: **892 passed, 0 failed** (Release, net10.0; 880 before, plus the 12 new). `ref/` regenerated with `IsOfficialBuild=true`; `dotnet run ./eng/update-all.cs` run and clean. README hardening section updated to document the new option and to say plainly that `MaxDepth` does not bound alias expansion.

## Note on the default

100 000 expanded nodes is far above ordinary anchor use (a shared config block referenced a few dozen times is in the hundreds) and far below what is needed to hurt. Callers who legitimately expand more can raise it; callers hardening against untrusted input can lower it or set `AllowAliases = false`. If you would prefer a different default, that is a one-line change in `YamlSerializerOptions.DefaultMaxAliasExpansionNodeCount`.

Found during a project review of `Meziantou.Framework.Yaml`.
