### PR TITLE
Stop DiffEngine_Tool from resolving the environment merge tool itself

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/MergeToolFromEnvironment.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/MergeToolFromEnvironment.cs
@@ -8,6 +8,11 @@ internal sealed class MergeToolFromEnvironment : MergeTool
         if (string.IsNullOrEmpty(variable))
             return null;
 
+        // This instance is itself exposed as MergeTool.DiffToolFromEnvironmentVariable, so resolving that name
+        // would hand back this very object and recurse until the process died with a StackOverflowException.
+        if (string.Equals(variable, nameof(MergeTool.DiffToolFromEnvironmentVariable), StringComparison.Ordinal))
+            return null;
+
         var property = typeof(MergeTool).GetProperty(variable, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
         if (property is null)
             return null;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -99,6 +99,15 @@ public sealed class InlineSnapshotSettingsTests
         Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
     }
 
+    [Fact]
+    public void DiffToolFromEnvironmentVariable_NamingItself_DoesNotRecurse()
+    {
+        // The reflection lookup used to resolve this very instance and call Start on it again.
+        using var _ = new EnvironmentVariableScope("DiffEngine_Tool", nameof(MergeTool.DiffToolFromEnvironmentVariable));
+
+        Assert.Null(MergeTool.DiffToolFromEnvironmentVariable.Start("current.cs", "new.cs"));
+    }
+
     private static SnapshotUpdateStrategy GetSnapshotUpdateStrategy(string name)
     {
         return name switch


### PR DESCRIPTION
## Problem

`MergeToolFromEnvironment` resolves `DiffEngine_Tool` by looking up a static property on `MergeTool`:

```csharp
var property = typeof(MergeTool).GetProperty(variable, BindingFlags.Public | BindingFlags.Static);
...
var tool = (MergeTool?)property.GetValue(null);
return tool.Start(currentFilePath, newFilePath);
```

This instance *is* one of those properties — `MergeTool.DiffToolFromEnvironmentVariable`. Setting `DiffEngine_Tool=DiffToolFromEnvironmentVariable` resolves it back to itself and calls `Start` again, recursing until the process dies.

Confirmed by running the regression test against unpatched source:

```
Stack overflow.
Test host crashed and no test results could be recovered from the TRX streaming sidecar; the TRX is empty.
```

This is the same shape as the `INTERNALSNAPSHOTTESTING_STRATEGY=Default` recursion in #2816, in a second reflection lookup. Far less likely to be typed by a human, but the failure mode is identical and uncatchable.

## Change

Return `null` when the variable names this tool, so resolution falls through to the next merge tool in `InlineSnapshotSettings.MergeTools`. The comparison is `Ordinal` to match `GetProperty`, which is case-sensitive.

## Verification

- `DiffToolFromEnvironmentVariable_NamingItself_DoesNotRecurse` — confirmed to crash the test host on `main`.
- Full test project: 132/132 passing with `/p:TreatWarningsAsErrors=true`.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
