### PR TITLE
Run the file logger writer loop on a dedicated thread

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
@@ -30,7 +30,8 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
     // kept out of the channel, so they cannot be discarded by FileLoggerOptions.QueueFullMode
     private readonly Channel<LogMessage>? _channel;
     private readonly ConcurrentQueue<TaskCompletionSource> _pendingFlushes = new();
-    private readonly Task? _writerTask;
+    private readonly Thread? _writerThread;
+    private readonly TaskCompletionSource? _writerCompletion;
 
     private FileLoggerOptions _options;
     private IExternalScopeProvider _scopeProvider = new LoggerExternalScopeProvider();
@@ -128,8 +129,17 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
                 SingleWriter = false,
             });
 
-        // The messages are written synchronously, so use a dedicated thread instead of a thread pool thread
-        _writerTask = Task.Factory.StartNew(ProcessLogQueueAsync, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap();
+        // The messages are written synchronously and the loop blocks while the queue is empty, so it
+        // needs a thread of its own. TaskCreationOptions.LongRunning would not be enough: it only
+        // covers the synchronous prefix of an async method, and every continuation after the first
+        // await runs on the thread pool, where the loggers blocking in QueueFullMode.Wait can starve it
+        _writerCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _writerThread = new Thread(ProcessLogQueue)
+        {
+            IsBackground = true,
+            Name = "Meziantou.Extensions.Logging.FileLogger",
+        };
+        _writerThread.Start();
     }
 
     private static FileLoggerOptions GetCurrentValue(IOptionsMonitor<FileLoggerOptions> options)
@@ -190,7 +200,7 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
     }
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The application must keep running when the log file cannot be written")]
-    private async Task ProcessLogQueueAsync()
+    private void ProcessLogQueue()
     {
         var channel = _channel!;
         var fileWriter = _fileWriter!;
@@ -200,7 +210,8 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
 
         try
         {
-            while (await channel.Reader.WaitToReadAsync().ConfigureAwait(false))
+            // Blocking is the point: this is a dedicated thread, and it must not depend on the thread pool
+            while (channel.Reader.WaitToReadAsync().AsTask().GetAwaiter().GetResult())
             {
                 // Take the requests registered so far: every message logged before them is already in the
                 // queue drained below. A request registered while the queue is drained refers to a message
@@ -278,6 +289,7 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
         {
             // Release the pending FlushAsync calls, the queue is not drained anymore
             CompletePendingFlushes();
+            _writerCompletion!.TrySetResult();
         }
 
         void Flush()
@@ -361,15 +373,8 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
         // Any message already in the channel will be drained by the writer task
         _channel?.Writer.TryComplete();
 
-        try
-        {
-            // Wait for the writer task to finish processing ALL remaining messages
-            _writerTask?.GetAwaiter().GetResult();
-        }
-        catch (Exception)
-        {
-            // The error is already reported by the writer task
-        }
+        // Wait for the writer thread to finish processing ALL remaining messages
+        _writerThread?.Join();
 
         _fileWriter?.Dispose();
     }
@@ -384,16 +389,10 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
         _optionsReloadToken?.Dispose();
         _channel?.Writer.TryComplete();
 
-        if (_writerTask is not null)
+        if (_writerCompletion is not null)
         {
-            try
-            {
-                await _writerTask.ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                // The error is already reported by the writer task
-            }
+            // Wait for the writer thread to finish processing ALL remaining messages, without blocking
+            await _writerCompletion.Task.ConfigureAwait(false);
         }
 
         _fileWriter?.Dispose();

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
@@ -796,6 +797,28 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task TheWriterDoesNotRunOnTheThreadPool()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new ThreadPoolTrackingTimeProvider();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath }, timeProvider);
+        var logger = provider.CreateLogger("Test");
+
+        // The first flush leaves the writer waiting on an empty queue, so the next message resumes it.
+        // That resumption is what used to move the loop onto the thread pool
+        logger.LogInformation("First");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        timeProvider.RanOnThreadPoolThread.Clear();
+
+        logger.LogInformation("Second");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(timeProvider.RanOnThreadPoolThread);
+        Assert.DoesNotContain(true, timeProvider.RanOnThreadPoolThread);
+    }
+
+    [Fact]
     public void MissingDirectoryThrows()
     {
         Assert.Throws<InvalidOperationException>(() => new FileLoggerProvider(new FileLoggerOptions()));
@@ -976,6 +999,18 @@ public sealed class FileLoggerProviderTests
         await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         using var reader = new StreamReader(stream);
         return await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+    }
+
+    private sealed class ThreadPoolTrackingTimeProvider : TimeProvider
+    {
+        // Only the writer loop reads the timestamps, so this records the kind of thread it runs on
+        public ConcurrentQueue<bool> RanOnThreadPoolThread { get; } = new();
+
+        public override long GetTimestamp()
+        {
+            RanOnThreadPoolThread.Enqueue(Thread.CurrentThread.IsThreadPoolThread);
+            return base.GetTimestamp();
+        }
     }
 
     private sealed class UppercaseFileFormatter() : FileFormatter("uppercase")


### PR DESCRIPTION
> **Stack 4 of 4** · targets `fix/filelogger-writer-resilience` (#2859) · merge #2821 → #2838 → #2859 → this

The comment at `FileLoggerProvider.cs:126` says the writer uses *"a dedicated thread instead of a thread pool thread"*, and `TaskCreationOptions.LongRunning` does give the **synchronous prefix** of `ProcessLogQueueAsync` a dedicated thread. But the method is `async`: the first time the queue drains, `await WaitToReadAsync()` yields, and every continuation after that is scheduled on `TaskScheduler.Default` — the thread pool.

Verified directly: `Thread.CurrentThread.IsThreadPoolThread` is `False` before the first yielding await and `True` after it.

### Failure scenario

After warming the provider so the writer is parked on `WaitToReadAsync`, blocking 60 thread-pool threads made a subsequent log message take **27.3 seconds** to reach disk, released only by the pool's ~500 ms-per-thread injection.

This is self-reinforcing under the default `QueueFullMode.Wait`, because `WriteLog` blocks its caller with `GetAwaiter().GetResult()`: pool threads producing log messages block pool threads, starving the consumer that would unblock them. With producers on pool threads and a 1-slot queue, the same run took 9.6 s and lost 10,231 messages.

The class's headline promise is that logging never blocks the application. Under pool starvation — which logging bursts can themselves trigger — it blocks hard, and starvation is usually being diagnosed *from the logs* that are now delayed by half a minute.

### What changed

The consumer runs on a real `Thread` instead of a task, and the loop is synchronous:

- `ProcessLogQueueAsync` becomes `ProcessLogQueue`, blocking on `WaitToReadAsync().AsTask().GetAwaiter().GetResult()`. Blocking is the intent here — the thread belongs to the provider and nothing else is queued behind it. The `AsTask` allocation only happens when the queue is empty, never on the hot path.
- The thread is named and `IsBackground = true`, matching the previous behavior on process exit.
- `Dispose` joins the thread. `DisposeAsync` awaits a `TaskCompletionSource` completed in the writer's `finally`, so it still does not block.
- The `try`/`catch` around the disposal wait is gone: the loop already handles its own exceptions, so there is no faulted task to observe.

### Verification

New test `TheWriterDoesNotRunOnTheThreadPool` uses a `TimeProvider` whose `GetTimestamp` records `Thread.CurrentThread.IsThreadPoolThread`. Only the writer loop reads timestamps, so the recording identifies the thread the loop runs on. The test first flushes to leave the writer parked on an empty queue — the exact resumption that used to move it onto the pool — then clears the recording and logs again.

- Without the source change: fails 3/3 runs, both target frameworks.
- With it: passes.

Full suite 67/67 green on net10.0 and net11.0, run three times. `dotnet run ./eng/update-all.cs` reports no changes.
