### PR TITLE
Publish throttled arguments under the lock and reset the throttle in a finally

### DIFF
--- a/src/Meziantou.Framework/ThrottleExtensions.cs
+++ b/src/Meziantou.Framework/ThrottleExtensions.cs
@@ -51,19 +51,27 @@ public static class ThrottleExtensions
         var l = new object();
         return () =>
         {
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action();
-                    t.Dispose();
-                    task = null;
+                    try
+                    {
+                        action();
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -105,20 +113,38 @@ public static class ThrottleExtensions
         T0 args = default!;
         return (T0 arg0) =>
         {
-            args = arg0;
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = arg0;
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args);
-                    t.Dispose();
-                    task = null;
+                    T0 pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -162,20 +188,38 @@ public static class ThrottleExtensions
         (T0, T1) args = default;
         return (T0 arg0, T1 arg1) =>
         {
-            args = (arg0, arg1);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -221,20 +265,38 @@ public static class ThrottleExtensions
         (T0, T1, T2) args = default;
         return (T0 arg0, T1 arg1, T2 arg2) =>
         {
-            args = (arg0, arg1, arg2);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -282,20 +344,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3) =>
         {
-            args = (arg0, arg1, arg2, arg3);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -345,20 +425,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3, T4) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) =>
         {
-            args = (arg0, arg1, arg2, arg3, arg4);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3, arg4);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4, args.Item5);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3, T4) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -410,20 +508,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3, T4, T5) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) =>
         {
-            args = (arg0, arg1, arg2, arg3, arg4, arg5);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3, arg4, arg5);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4, args.Item5, args.Item6);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3, T4, T5) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -477,20 +593,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3, T4, T5, T6) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) =>
         {
-            args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4, args.Item5, args.Item6, args.Item7);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3, T4, T5, T6) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -546,20 +680,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3, T4, T5, T6, T7) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) =>
         {
-            args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4, args.Item5, args.Item6, args.Item7, args.Item8);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3, T4, T5, T6, T7) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7, pendingArgs.Item8);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -617,20 +769,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3, T4, T5, T6, T7, T8) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) =>
         {
-            args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4, args.Item5, args.Item6, args.Item7, args.Item8, args.Item9);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3, T4, T5, T6, T7, T8) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7, pendingArgs.Item8, pendingArgs.Item9);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };
@@ -690,20 +860,38 @@ public static class ThrottleExtensions
         (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) args = default;
         return (T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) =>
         {
-            args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
-            if (task is not null)
-                return;
-
             lock (l)
             {
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(args.Item1, args.Item2, args.Item3, args.Item4, args.Item5, args.Item6, args.Item7, args.Item8, args.Item9, args.Item10);
-                    t.Dispose();
-                    task = null;
+                    (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+                    try
+                    {
+                        action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7, pendingArgs.Item8, pendingArgs.Item9, pendingArgs.Item10);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };

--- a/src/Meziantou.Framework/ThrottleExtensions.tt
+++ b/src/Meziantou.Framework/ThrottleExtensions.tt
@@ -58,22 +58,42 @@ public static class ThrottleExtensions
 <# } #>
         return (<#= GetTypedArgsString(i, "arg") #>) =>
         {
-<# if (i > 0) { #>
-            args = <#= GetTupleCreationExpression(i) #>;
-<# } #>
-            if (task is not null)
-                return;
-
             lock (l)
             {
+<# if (i > 0) { #>
+                // Published under the lock: writing a multi-field tuple is not atomic, so an
+                // unsynchronized write let the scheduled invocation observe a torn combination of
+                // arguments coming from different calls.
+                args = <#= GetTupleCreationExpression(i) #>;
+
+<# } #>
+                // task is only ever read and written under the lock, so the scheduling decision
+                // cannot be made against a stale value.
                 if (task is not null)
                     return;
 
-                task = Task.Delay(interval, timeProvider).ContinueWith(t =>
+                task = Task.Delay(interval, timeProvider).ContinueWith(_ =>
                 {
-                    action(<#= GetTupleItemsString(i, "args") #>);
-                    t.Dispose();
-                    task = null;
+<# if (i > 0) { #>
+                    <#= GetTupleTypeString(i) #> pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
+
+<# } #>
+                    try
+                    {
+                        action(<#= GetTupleItemsString(i, "pendingArgs") #>);
+                    }
+                    finally
+                    {
+                        // Reset in a finally so an action that throws does not stall the throttle forever
+                        lock (l)
+                        {
+                            task = null;
+                        }
+                    }
                 }, TaskScheduler.Default);
             }
         };

--- a/tests/Meziantou.Framework.Tests/ThrottleExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/ThrottleExtensionsTests.cs
@@ -27,4 +27,48 @@ public class ThrottleExtensionsTests
         Assert.Equal(1, count);
         Assert.Equal(2, lastArg);
     }
+
+    [Fact]
+    public void Throttle_UsesAConsistentSetOfArguments()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var observed = new List<(int First, int Second)>();
+        var throttled = ((Action<int, int>)((first, second) => observed.Add((first, second))))
+            .Throttle(TimeSpan.FromSeconds(1), timeProvider);
+
+        // Every call passes a matching pair, so the invocation must observe a matching pair
+        for (var i = 0; i < 100; i++)
+        {
+            throttled(i, i);
+        }
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => observed.Count > 0, TimeSpan.FromSeconds(5));
+
+        Assert.Single(observed);
+        Assert.Equal(observed[0].First, observed[0].Second);
+    }
+
+    [Fact]
+    public void Throttle_KeepsWorkingAfterTheActionThrows()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var callCount = 0;
+        var throttled = ((Action)(() =>
+        {
+            callCount++;
+            throw new InvalidOperationException("boom");
+        })).Throttle(TimeSpan.FromSeconds(1), timeProvider);
+
+        throttled();
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => callCount >= 1, TimeSpan.FromSeconds(5));
+        Assert.Equal(1, callCount);
+
+        // The first invocation threw; the throttle must not be stuck
+        throttled();
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => callCount >= 2, TimeSpan.FromSeconds(5));
+        Assert.Equal(2, callCount);
+    }
 }


### PR DESCRIPTION
## The bug

Three problems in the closure generated by `ThrottleExtensions.tt` (and so in all eleven overloads of
`ThrottleExtensions.cs`):

1. **Torn arguments.** `args = (arg0, arg1, ...)` was assigned *outside* the `lock` on every call.
   Writing a multi-field tuple is not atomic, so the continuation — running on a thread-pool thread
   with no synchronisation — could read a mix of `arg0` from one call and `arg1` from another,
   producing an argument combination no caller ever passed. The XML doc promises "the most recent
   arguments".

2. **Unsynchronised `task`.** It was read outside the lock and written back to `null` inside the
   continuation with no lock and no volatile semantics, so the double-checked locking had a barrier on
   neither side. On a weakly-ordered architecture (arm64 — Apple Silicon, Graviton) a caller can
   observe a stale non-`null` `task` and drop invocations that should have been scheduled.

3. **A throwing action stalls the throttle forever.** `task = null` ran after `action(...)`, so if
   the action threw, `task` was never reset and the throttled delegate never scheduled again. The
   exception was also swallowed into the continuation's task.

## The change

In `ThrottleExtensions.tt`, and regenerated into `ThrottleExtensions.cs` via
`dotnet run ./eng/update-all.cs -- --step templates`:

- the argument publication and every read/write of `task` now happen under the lock;
- the continuation snapshots the arguments under the lock before invoking the action, so the action
  itself does not run while holding it;
- the reset is in a `finally`, so a throwing action no longer stalls the throttle;
- the no-op `t.Dispose()` on the completed antecedent task is dropped.

The lock-free fast path on `task` is gone — every call now takes an uncontended lock. That is the
price of publishing the arguments safely, and it is cheap relative to scheduling a timer.

## Verification

Two tests added to `ThrottleExtensionsTests` using `FakeTimeProvider`. The throwing-action test is
the one that fails deterministically on `main`.

Being straight about the limits: the argument-tearing test asserts the invariant (both arguments come
from the same call) but is a race, so it passes on `main` too — I could not make it fail on demand.
The `task` visibility issue is likewise not reachable by a test. Those two rest on reading the
generated code rather than on a red-to-green demonstration.
