### PR TITLE
Rewind the copy, not the source, in CopyToMemoryStream

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs
@@ -48,7 +48,10 @@ internal static class FileEditor
             try
             {
                 stream.CopyTo(ms);
-                stream.Seek(0, SeekOrigin.Begin);
+
+                // The copy, not the source: this branch only runs for a source that cannot seek, and SourceText.From
+                // reads the returned stream from its current position, which CopyTo leaves at the end.
+                ms.Seek(0, SeekOrigin.Begin);
                 return ms;
             }
             catch


### PR DESCRIPTION
## Problem

`FileEditor.GetSourceText` falls back to buffering when the file stream cannot seek:

```csharp
using var stream = fs.CanSeek ? fs : CopyToMemoryStream(fs);
return SourceText.From(stream, settings.FileEncoding);

static Stream CopyToMemoryStream(Stream stream)
{
    var ms = new MemoryStream();
    try
    {
        stream.CopyTo(ms);
        stream.Seek(0, SeekOrigin.Begin);   // <- the source, which by definition cannot seek here
        return ms;                          // <- positioned at the end, so SourceText.From reads nothing
    }
```

Two bugs in one line: it seeks the *source* — the stream this branch exists precisely because it cannot seek, so `Seek` would throw `NotSupportedException` — and it returns `ms` still positioned at the end of the copy, so `SourceText.From` would read an empty document and the snapshot update would fail to find its syntax node.

Unreachable today, because `File.OpenRead` always returns a seekable `FileStream`, so `fs.CanSeek` is never false. The branch is dead code that does not work if it ever stops being dead.

## Change

Rewind `ms` instead of `stream`.

## Verification

Full test project: 131/131 passing with `/p:TreatWarningsAsErrors=true`. No test is added — the branch is unreachable through the public API, so a test would have to fake the stream source, and there is no seam for that.

Found by an audit of `src/Meziantou.Framework.InlineSnapshotTesting`.
