### PR TITLE
Match Source Link document keys without a regex

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
@@ -467,36 +467,48 @@ internal sealed partial class SymbolsValidationRule : NuGetPackageValidationRule
     {
     }
 
-    private sealed class SourceLinkJson
+    internal sealed class SourceLinkJson
     {
         [JsonPropertyName("documents")]
         public Dictionary<string, string>? Documents { get; set; }
 
+        /// <summary>Maps a document path to its URL. A key may contain a single '*' standing for any sequence of characters,
+        /// and the matched text replaces the first '*' of the URL.</summary>
         public string? GetUrl(string file)
         {
             if (Documents is null)
                 return null;
 
-            foreach (var key in Documents.Keys)
+            foreach (var (key, url) in Documents)
             {
-                if (key.Contains('*', StringComparison.Ordinal))
+                var wildcardIndex = key.IndexOf('*', StringComparison.Ordinal);
+                if (wildcardIndex < 0)
                 {
-                    var pattern = Regex.Escape(key).Replace(@"\*", "(.+)", StringComparison.Ordinal);
-                    var m = Regex.Match(file, pattern, RegexOptions.None, Timeout.InfiniteTimeSpan);
-                    if (!m.Success)
-                        continue;
+                    if (string.Equals(key, file, StringComparison.Ordinal))
+                        return url;
 
-                    var url = Documents[key];
-                    var path = m.Groups[1].Value.Replace('\\', '/');
-                    return url.Replace("*", path, StringComparison.Ordinal);
+                    continue;
                 }
-                else
-                {
-                    if (!key.Equals(file, StringComparison.Ordinal))
-                        continue;
 
-                    return Documents[key];
-                }
+                // The Source Link specification allows a single wildcard per key
+                if (key.AsSpan(wildcardIndex + 1).Contains('*'))
+                    continue;
+
+                var prefix = key.AsSpan(0, wildcardIndex);
+                var suffix = key.AsSpan(wildcardIndex + 1);
+                if (file.Length < prefix.Length + suffix.Length)
+                    continue;
+
+                var fileSpan = file.AsSpan();
+                if (!fileSpan.StartsWith(prefix, StringComparison.Ordinal) || !fileSpan.EndsWith(suffix, StringComparison.Ordinal))
+                    continue;
+
+                var matchedValue = file[prefix.Length..(file.Length - suffix.Length)].Replace('\\', '/');
+                var urlWildcardIndex = url.IndexOf('*', StringComparison.Ordinal);
+                if (urlWildcardIndex < 0)
+                    return url;
+
+                return string.Concat(url.AsSpan(0, urlWildcardIndex), matchedValue, url.AsSpan(urlWildcardIndex + 1));
             }
 
             return null;

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -257,6 +257,64 @@ public sealed class NuGetPackageValidatorTests
         AssertNoErrors(result);
     }
 
+    [Theory]
+    // Exact match
+    [InlineData("/_/src/Foo.cs", "https://example.com/raw/src/Foo.cs")]
+    // No match
+    [InlineData("/_/src/Bar.cs", null)]
+    public void SourceLink_ExactMatch(string file, string? expected)
+    {
+        var json = new SymbolsValidationRule.SourceLinkJson
+        {
+            Documents = new(StringComparer.Ordinal) { ["/_/src/Foo.cs"] = "https://example.com/raw/src/Foo.cs" },
+        };
+
+        Assert.Equal(expected, json.GetUrl(file));
+    }
+
+    [Theory]
+    [InlineData("/_/src/Foo.cs", "https://example.com/raw/src/Foo.cs")]
+    [InlineData("/_/src/sub/Foo.cs", "https://example.com/raw/src/sub/Foo.cs")]
+    // Backslashes of the matched value are normalized
+    [InlineData("/_/src/sub\\Foo.cs", "https://example.com/raw/src/sub/Foo.cs")]
+    // The key is anchored: it must match the whole path, not a suffix of it
+    [InlineData("/other/_/src/Foo.cs", null)]
+    // The matched value cannot be empty of the prefix
+    [InlineData("/_/", null)]
+    public void SourceLink_Wildcard(string file, string? expected)
+    {
+        var json = new SymbolsValidationRule.SourceLinkJson
+        {
+            Documents = new(StringComparer.Ordinal) { ["/_/src/*"] = "https://example.com/raw/src/*" },
+        };
+
+        Assert.Equal(expected, json.GetUrl(file));
+    }
+
+    [Fact]
+    public void SourceLink_OnlyTheFirstWildcardOfTheUrlIsReplaced()
+    {
+        var json = new SymbolsValidationRule.SourceLinkJson
+        {
+            Documents = new(StringComparer.Ordinal) { ["/_/*"] = "https://example.com/*?ref=*" },
+        };
+
+        Assert.Equal("https://example.com/Foo.cs?ref=*", json.GetUrl("/_/Foo.cs"));
+    }
+
+    [Fact]
+    public void SourceLink_KeyWithSeveralWildcardsIsIgnored()
+    {
+        // The Source Link specification allows a single wildcard. Matching such a key with a regex built from
+        // the key made the lookup vulnerable to catastrophic backtracking, and it ran without a timeout.
+        var json = new SymbolsValidationRule.SourceLinkJson
+        {
+            Documents = new(StringComparer.Ordinal) { [new string('*', 8) + "Z"] = "https://example.com/*" },
+        };
+
+        Assert.Null(json.GetUrl(new string('a', 40)));
+    }
+
     [Fact]
     public async Task Validate_WithSymbolsServer()
     {


### PR DESCRIPTION
A crafted Source Link document map could hang the validator indefinitely, and the matching was wrong in two smaller ways besides.

## The defect

`SourceLinkJson.GetUrl` built a regex from each `documents` key by escaping it and replacing every `\*` with `(.+)`, then matched with `Timeout.InfiniteTimeSpan`. The key comes from the Source Link JSON blob inside the PDB of the package being validated, so it is fully controlled by whoever produced the package.

A key of eight adjacent `*` yields `(.+)(.+)(.+)(.+)(.+)(.+)(.+)(.+)Z`. Matched against a 40-character path that does not match, that is textbook exponential backtracking — measured here as **still running after 15 seconds**, with no timeout to stop it. The CLI is built to run unattended in CI, so this hangs the job with no diagnostic.

Two correctness bugs in the same method:

- The pattern was **not anchored**, so key `/_/src/*` matched document `/other/_/src/Foo.cs` and produced a URL for a path the map never covered.
- `url.Replace("*", path)` substituted **every** `*` in the URL template, not just the placeholder.

## The change

Drop the regex. The Source Link specification allows a single `*` per key, so the match is a prefix/suffix comparison:

- Split the key at its `*`; require `StartsWith(prefix)` **and** `EndsWith(suffix)` ordinally. That is inherently anchored, and linear.
- A key carrying more than one `*` is malformed under the spec and is now skipped, so the document falls through to the existing `SourceFileNotAccessible` report instead of being matched by an ambiguous pattern.
- Only the **first** `*` of the URL template is replaced.

Backslash normalisation of the matched value is unchanged, as is exact-match behaviour for keys without a wildcard. The remaining `[GeneratedRegex]` patterns in this file keep `matchTimeoutMilliseconds: -1`; their patterns are compile-time constants, so they are not exposed to this.

`SourceLinkJson` changes from `private` to `internal` so the matching can be tested directly. It stays nested in an `internal` type, so the public API surface is unchanged.

## Tests

- `SourceLink_ExactMatch` — exact key, and a non-matching path.
- `SourceLink_Wildcard` — wildcard substitution, nested paths, backslash normalisation, and the anchoring case `/other/_/src/Foo.cs` which must **not** match `/_/src/*`.
- `SourceLink_OnlyTheFirstWildcardOfTheUrlIsReplaced` — a URL template with two `*`.
- `SourceLink_KeyWithSeveralWildcardsIsIgnored` — the 8-wildcard key against a 40-character path. Against the old implementation this test does not fail, it *hangs*, which is the regression it guards.

Verified against the old implementation: the anchoring case fails 2/10, the URL-template case fails 2/2, and the multi-wildcard case never returns. With the change, the full suite passes (78/78).
