### PR TITLE
Omit the JSON timestamp when TimestampFormat is null

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/JsonFileFormatter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/JsonFileFormatter.cs
@@ -32,7 +32,12 @@ public sealed class JsonFileFormatter : FileFormatter
         using (var writer = new Utf8JsonWriter(buffer))
         {
             writer.WriteStartObject();
-            writer.WriteString("Timestamp", timestamp.ToString(options.TimestampFormat ?? "o", CultureInfo.InvariantCulture));
+
+            // A null format means the timestamp must be omitted, like in SimpleFileFormatter
+            if (options.TimestampFormat is not null)
+            {
+                writer.WriteString("Timestamp", timestamp.ToString(options.TimestampFormat, CultureInfo.InvariantCulture));
+            }
 
             if (options.IncludeLogLevel)
             {

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -180,6 +180,26 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task JsonFormatterOmitsTheTimestampWhenTheFormatIsNull()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            FormatterName = FileFormatterNames.Json,
+            TimestampFormat = null,
+        });
+
+        provider.CreateLogger("Test").LogInformation("Hello");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        using var document = JsonDocument.Parse(content);
+        Assert.False(document.RootElement.TryGetProperty("Timestamp", out _));
+        Assert.Equal("Hello", document.RootElement.GetProperty("Message").GetString());
+    }
+
+    [Fact]
     public async Task CustomFormatter()
     {
         using var tempDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
`FileLoggerOptions.TimestampFormat` is documented as *"Set it to `null` to omit the timestamp"* (`FileLoggerOptions.cs:118-120`), and `SimpleFileFormatter` honors that (`SimpleFileFormatter.cs:29-32`). `JsonFileFormatter` instead substitutes the round-trip format:

```csharp
writer.WriteString("Timestamp", timestamp.ToString(options.TimestampFormat ?? "o", CultureInfo.InvariantCulture));
```

### Failure scenario

With `TimestampFormat = null` and the JSON formatter, the entry still carries a timestamp, in a format that appears nowhere else in the library's output:

```json
{"Timestamp":"2026-08-27T04:27:03.8407960+00:00","LogLevel":"INFO","Category":"T","Message":"hi",...}
```

The two built-in formatters disagree on the meaning of a documented option, so switching `FormatterName` silently changes behavior. A pipeline that omits the timestamp because its ingester stamps its own gets an unexpected field.

### What changed

The `Timestamp` property is skipped entirely when `TimestampFormat` is `null`, matching the documented contract and `SimpleFileFormatter`. When a format is set, the output is unchanged.

### Verification

New test `JsonFormatterOmitsTheTimestampWhenTheFormatIsNull` parses the written entry and asserts `TryGetProperty("Timestamp", ...)` returns false while the rest of the entry is intact.

Confirmed the test fails without the source change and passes with it, on both target frameworks. Full suite 57/57 green on net10.0 and net11.0; `dotnet run ./eng/update-all.cs` reports no changes.
