### PR TITLE
Bound the response body read when the origin announces no Content-Length

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/BoundedContentReader.cs
+++ b/src/Meziantou.Framework.Http.Caching/BoundedContentReader.cs
@@ -1,0 +1,161 @@
+using System.Buffers;
+using System.Net;
+
+namespace Meziantou.Framework.Http.Caching;
+
+/// <summary>Reads a response body for storage without buffering an unbounded amount of it.</summary>
+/// <remarks>
+/// <see cref="HttpContent.ReadAsByteArrayAsync(CancellationToken)"/> materializes the whole body before its
+/// size can be compared to the limit, so an origin that announces no <c>Content-Length</c> can push
+/// arbitrarily many bytes into memory before the response is rejected. This reader stops once the limit is
+/// exceeded, and in every case leaves the response body fully readable by the caller: the caching handler
+/// must stay transparent even for the responses it declines to store.
+/// </remarks>
+internal static class BoundedContentReader
+{
+    private const int ChunkSize = 81920;
+
+    /// <summary>Reads the body, or returns <see langword="null"/> when it exceeds <paramref name="maximumSize"/>.</summary>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership of the content is transferred to the response message")]
+    public static async Task<byte[]?> ReadAsync(HttpResponseMessage response, long maximumSize, CancellationToken cancellationToken)
+    {
+        var originalContent = response.Content;
+        var stream = await originalContent.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        using var buffer = new MemoryStream();
+        var chunk = ArrayPool<byte>.Shared.Rent(ChunkSize);
+        try
+        {
+            while (buffer.Length <= maximumSize)
+            {
+                var read = await stream.ReadAsync(chunk.AsMemory(0, ChunkSize), cancellationToken).ConfigureAwait(false);
+                if (read is 0)
+                {
+                    // The whole body fits. It has been drained from the original content, so the response is
+                    // given an equivalent content holding the bytes that were just read.
+                    var bytes = buffer.ToArray();
+                    ReplaceContent(response, new BufferedContent(bytes), originalContent, disposeOriginal: true);
+                    return bytes;
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(chunk);
+        }
+
+        // Over the limit: nothing is stored, and the caller gets the bytes already read followed by the rest
+        // of the original stream. The original content owns the connection, so it is disposed with the
+        // stream that replaces it rather than here.
+        ReplaceContent(response, new StreamContent(new PrefixedStream(buffer.ToArray(), stream, originalContent)), originalContent, disposeOriginal: false);
+        return null;
+    }
+
+    private static void ReplaceContent(HttpResponseMessage response, HttpContent newContent, HttpContent originalContent, bool disposeOriginal)
+    {
+        foreach (var header in originalContent.Headers)
+        {
+            newContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        response.Content = newContent;
+        if (disposeOriginal)
+        {
+            originalContent.Dispose();
+        }
+    }
+
+    /// <summary>Holds an already-read body without announcing a length the original response did not.</summary>
+    /// <remarks>
+    /// <see cref="ByteArrayContent"/> computes its length, which would add a <c>Content-Length</c> header to
+    /// a response that carried none — a <c>204</c>, or any chunked response. The headers are copied from the
+    /// content this one replaces instead, so the caller sees exactly what the origin sent.
+    /// </remarks>
+    private sealed class BufferedContent(byte[] content) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            return stream.WriteAsync(content).AsTask();
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+        {
+            return Task.FromResult<Stream>(new MemoryStream(content, writable: false));
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+
+    /// <summary>A read-only stream that yields a buffered prefix before continuing with the stream it was read from.</summary>
+    private sealed class PrefixedStream(byte[] prefix, Stream inner, HttpContent owner) : Stream
+    {
+        private int _prefixPosition;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            var fromPrefix = ReadPrefix(buffer);
+            return fromPrefix > 0 ? fromPrefix : inner.Read(buffer);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var fromPrefix = ReadPrefix(buffer.Span);
+            return fromPrefix > 0 ? ValueTask.FromResult(fromPrefix) : inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        private int ReadPrefix(Span<byte> buffer)
+        {
+            var remaining = prefix.Length - _prefixPosition;
+            if (remaining is 0 || buffer.IsEmpty)
+                return 0;
+
+            var count = Math.Min(remaining, buffer.Length);
+            prefix.AsSpan(_prefixPosition, count).CopyTo(buffer);
+            _prefixPosition += count;
+            return count;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Disposing the content that produced the stream is what releases the connection.
+                owner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -111,7 +111,8 @@ internal sealed class HttpCache
             return;
 
         // Check the announced size before reading anything. Buffering a multi-gigabyte response only to
-        // discard it is a needless allocation, and serialization would grow it further.
+        // discard it is a needless allocation, and serialization would grow it further. A response that
+        // announces no Content-Length is bounded while it is read instead, by BoundedContentReader.
         var maximumResponseSize = _options.MaximumResponseSize;
         if (maximumResponseSize is not null && response.Content?.Headers.ContentLength > maximumResponseSize.GetValueOrDefault())
             return;

--- a/src/Meziantou.Framework.Http.Caching/ResponseSerializer.cs
+++ b/src/Meziantou.Framework.Http.Caching/ResponseSerializer.cs
@@ -13,15 +13,29 @@ internal static class ResponseSerializer
 
     /// <summary>Serializes the response, or returns <see langword="null"/> when it exceeds <paramref name="maximumSize"/>.</summary>
     /// <remarks>
-    /// The body is checked before it is serialized. JSON encoding only grows the payload, since the body is
+    /// The body is read through <see cref="BoundedContentReader"/> so that a response which announces no
+    /// <c>Content-Length</c> cannot push an unbounded number of bytes into memory before being rejected. It
+    /// is checked before it is serialized: JSON encoding only grows the payload, since the body is
     /// Base64-encoded and the headers are added, so a body already over the limit can never fit and the
     /// serialization is skipped entirely.
     /// </remarks>
     public static async Task<byte[]?> SerializeAsync(HttpResponseMessage response, long? maximumSize, CancellationToken cancellationToken)
     {
-        var content = response.Content is null ? null : await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-        if (maximumSize is not null && content is not null && content.Length > maximumSize.GetValueOrDefault())
-            return null;
+        byte[]? content;
+        if (response.Content is null)
+        {
+            content = null;
+        }
+        else if (maximumSize is null)
+        {
+            content = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            content = await BoundedContentReader.ReadAsync(response, maximumSize.GetValueOrDefault(), cancellationToken).ConfigureAwait(false);
+            if (content is null)
+                return null;
+        }
 
         var serialized = new SerializedResponseMessage
         {

--- a/tests/Meziantou.Framework.Http.Caching.Tests/BoundedResponseSizeTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/BoundedResponseSizeTests.cs
@@ -1,0 +1,240 @@
+using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
+
+namespace Meziantou.Framework.Http.Caching.Tests;
+
+/// <summary>Tests for <see cref="HttpCachingOptions.MaximumResponseSize"/> and the bounded body read.</summary>
+public sealed class BoundedResponseSizeTests
+{
+    [Fact]
+    public async Task WhenBodyHasNoContentLengthAndExceedsTheLimitThenOnlyTheLimitIsBuffered()
+    {
+        using var body = new UnknownLengthContent(32 * 1024 * 1024);
+        using var innerHandler = new StubHandler(() => body);
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { MaximumResponseSize = 1024 * 1024 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/big", HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+
+        // The origin is not drained just to discard the response: the read stops shortly past the limit.
+        Assert.InRange(body.BytesProduced, 1024 * 1024, 4 * 1024 * 1024);
+    }
+
+    [Fact]
+    public async Task WhenBodyHasNoContentLengthAndExceedsTheLimitThenTheCallerStillReadsTheWholeBody()
+    {
+        using var body = new UnknownLengthContent(3 * 1024 * 1024);
+        using var innerHandler = new StubHandler(() => body);
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { MaximumResponseSize = 1024 * 1024 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/big", HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+        var received = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+
+        // Declining to store a response must never truncate it.
+        Assert.HasCount(3 * 1024 * 1024, received);
+        Assert.All(received, static b => b is 0x42);
+        Assert.Equal("text/plain", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task WhenBodyHasNoContentLengthAndExceedsTheLimitThenItIsNotCached()
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var innerHandler = new StubHandler(() => new UnknownLengthContent(2 * 1024 * 1024));
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store, new HttpCachingOptions { MaximumResponseSize = 1024 * 1024 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/big", CancellationToken.None);
+        _ = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+
+        Assert.Empty(await store.GetEntriesAsync("GET http://example.com/big", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenBodyHasNoContentLengthAndFitsThenItIsCachedAndReadable()
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var innerHandler = new StubHandler(() => new UnknownLengthContent(1000));
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store, new HttpCachingOptions { MaximumResponseSize = 1024 * 1024 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/small", CancellationToken.None);
+        var received = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+
+        Assert.HasCount(1000, received);
+        Assert.All(received, static b => b is 0x42);
+        Assert.Single(await store.GetEntriesAsync("GET http://example.com/small", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenBodyIsReadTwiceThenTheSecondReadReturnsTheSameBytes()
+    {
+        using var innerHandler = new StubHandler(() => new UnknownLengthContent(1000));
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { MaximumResponseSize = 1024 * 1024 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/small", CancellationToken.None);
+
+        // The replacement content must be buffered, like the one it replaces.
+        Assert.HasCount(1000, await response.Content.ReadAsByteArrayAsync(CancellationToken.None));
+        Assert.HasCount(1000, await response.Content.ReadAsByteArrayAsync(CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(999)]
+    [InlineData(1000)]
+    public async Task WhenBodyIsAtOrUnderTheLimitThenItIsCached(int size)
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var innerHandler = new StubHandler(() => new UnknownLengthContent(size));
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store, new HttpCachingOptions { MaximumResponseSize = 1000 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/edge", CancellationToken.None);
+        _ = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+
+        // The serialized entry is larger than the body, so the entry itself may still be rejected; what
+        // matters here is that a body at the limit is not rejected by the reader.
+        Assert.Equal(size, ((UnknownLengthContent)innerHandler.LastContent!).BytesProduced);
+    }
+
+    [Fact]
+    public async Task WhenMaximumResponseSizeIsNullThenTheBodyIsStillReadable()
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var innerHandler = new StubHandler(() => new UnknownLengthContent(1000));
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store, new HttpCachingOptions { MaximumResponseSize = null });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/unbounded", CancellationToken.None);
+
+        Assert.HasCount(1000, await response.Content.ReadAsByteArrayAsync(CancellationToken.None));
+        Assert.Single(await store.GetEntriesAsync("GET http://example.com/unbounded", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenContentLengthAnnouncesMoreThanTheLimitThenTheBodyIsNeverRead()
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var body = new UnknownLengthContent(2 * 1024 * 1024, announceLength: true);
+        using var innerHandler = new StubHandler(() => body);
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store, new HttpCachingOptions { MaximumResponseSize = 1024 });
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/announced", HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+
+        Assert.Equal(0, body.BytesProduced);
+        Assert.Empty(await store.GetEntriesAsync("GET http://example.com/announced", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenTheBodyIsBufferedThenNoContentLengthIsInvented()
+    {
+        using var innerHandler = new StubHandler(() => new UnknownLengthContent(1000));
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { MaximumResponseSize = 1024 * 1024 });
+        using var client = new HttpClient(handler);
+
+        // ResponseContentRead would buffer the content and let HttpContent report the buffer length, which
+        // would hide the header the replacement content does or does not carry.
+        using var response = await client.GetAsync("http://example.com/chunked", HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+
+        // The origin announced no length, so neither does the response the caller sees.
+        Assert.Null(response.Content.Headers.ContentLength);
+        Assert.HasCount(1000, await response.Content.ReadAsByteArrayAsync(CancellationToken.None));
+    }
+
+    /// <summary>Models a streaming response body, the way <see cref="StreamContent"/> wraps a network stream.</summary>
+    private sealed class UnknownLengthContent(long size, bool announceLength = false) : HttpContent
+    {
+        private readonly GeneratorStream _stream = new(size);
+
+        public long BytesProduced => _stream.BytesProduced;
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) => _stream.CopyToAsync(stream);
+
+        protected override Task<Stream> CreateContentReadStreamAsync() => Task.FromResult<Stream>(_stream);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = size;
+            return announceLength;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _stream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>Produces <paramref name="size"/> bytes on demand, and counts how many were actually pulled.</summary>
+    private sealed class GeneratorStream(long size) : Stream
+    {
+        private const int MaximumChunk = 64 * 1024;
+
+        public long BytesProduced { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            var remaining = size - BytesProduced;
+            if (remaining <= 0 || buffer.IsEmpty)
+                return 0;
+
+            var count = (int)Math.Min(Math.Min(buffer.Length, remaining), MaximumChunk);
+            buffer[..count].Fill(0x42);
+            BytesProduced += count;
+            return count;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(Read(buffer.Span));
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class StubHandler(Func<HttpContent> contentFactory) : HttpMessageHandler
+    {
+        public HttpContent? LastContent { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var content = contentFactory();
+            LastContent = content;
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+            response.Headers.TryAddWithoutValidation("Cache-Control", "max-age=3600");
+            content.Headers.TryAddWithoutValidation("Content-Type", "text/plain");
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
`MaximumResponseSize` only ever consulted the *announced* `Content-Length`. When the origin sent none, the body went straight into `HttpContent.ReadAsByteArrayAsync` and was fully materialized in memory before its size was compared to the limit and it was thrown away.

## The failure

`HttpCache.cs:115-117` pre-checks `Content-Length`; `ResponseSerializer.cs:22` then buffers unconditionally.

With `MaximumResponseSize = 1 MB` and an origin returning a 32 MB body with no `Content-Length`, all 32 MB were pulled into memory to cache nothing. The request even used `HttpCompletionOption.ResponseHeadersRead`.

This is not an exotic case. `HttpClient` strips `Content-Length` after `AutomaticDecompression`, so every gzip/brotli response reaches this path with an unknown length — and chunked transfer encoding does the same. The practical ceiling is `HttpContent`'s 2 GB internal buffer limit, so a misbehaving or hostile origin can drive the client process to `OutOfMemoryException` no matter how `MaximumResponseSize` was configured.

The readme's *"✅ **Bounded**: Responses whose `Content-Length` exceeds `MaximumResponseSize` are never buffered"* is true as literally worded, which is what made this easy to miss.

## The change

New internal `BoundedContentReader` reads the body in chunks and stops once the limit is passed, so at most `MaximumResponseSize + 80 KB` is ever held.

The hard requirement is that **declining to store a response must never damage it**. A caching handler is supposed to be transparent, and reading the body consumes the underlying stream, so the reader always puts an equivalent content back on the response:

- **Body fits** — the stream is drained, so the response gets a content holding the bytes just read. The original content is disposed, which releases the connection.
- **Body is over the limit** — the response gets the prefix already read followed by the rest of the original stream (`PrefixedStream`). The caller reads the complete body; nothing is stored. The original content is disposed together with that stream, since it owns the connection.

`ReadAsByteArrayAsync` is still used unchanged when `MaximumResponseSize` is `null`, which is documented as "disable size checking".

## One subtlety worth reviewing

The first version of this used `ByteArrayContent` for the replacement, and it broke `When204NoContentThenCacheable`: `ByteArrayContent` computes its own length, so it added `Content-Length: 0` to a `204` that carried none.

The replacement is now `BufferedContent`, whose `TryComputeLength` returns `false`, so the only content headers on the response are the ones copied from the content it replaced. That is the property `WhenTheBodyIsBufferedThenNoContentLengthIsInvented` pins down — and it has to use `ResponseHeadersRead`, because `ResponseContentRead` buffers the content and makes `HttpContent` report the buffer length regardless.

## Verification

New `BoundedResponseSizeTests`, 10 tests:

- 32 MB body, 1 MB limit → between 1 MB and 4 MB is pulled from the origin. **Fails on `main`** (pulls all 32 MB).
- 3 MB body, 1 MB limit → the caller still reads all 3 MB, every byte intact, `Content-Type` preserved.
- Over the limit → nothing is stored; under the limit → stored and readable; body readable twice.
- 999 and 1000 bytes against a 1000-byte limit → the reader does not reject a body at the limit.
- `MaximumResponseSize = null` → still cached and readable.
- `Content-Length` announcing more than the limit → the body is never read at all (0 bytes pulled), so the cheap pre-check still short-circuits.

Full suite on **both** target frameworks: 404 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
