### PR TITLE
Reuse a single timer per debounced delegate instead of one per call

### DIFF
--- a/src/Meziantou.Framework/DebounceExtensions.cs
+++ b/src/Meziantou.Framework/DebounceExtensions.cs
@@ -9,7 +9,6 @@
 #nullable enable
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Meziantou.Framework;
 
@@ -48,19 +47,23 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
         return () =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
                     action();
-                }
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -95,19 +98,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        T0 args = default!;
         return (arg0) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = arg0;
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0);
-                }
+                    T0 pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -144,19 +159,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1) args = default;
         return (arg0, arg1) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1);
-                }
+                    (T0, T1) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -195,19 +222,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2) args = default;
         return (arg0, arg1, arg2) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2);
-                }
+                    (T0, T1, T2) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -248,19 +287,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2, T3) args = default;
         return (arg0, arg1, arg2, arg3) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2, arg3);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2, arg3);
-                }
+                    (T0, T1, T2, T3) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -303,19 +354,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2, T3, T4) args = default;
         return (arg0, arg1, arg2, arg3, arg4) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2, arg3, arg4);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2, arg3, arg4);
-                }
+                    (T0, T1, T2, T3, T4) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -360,19 +423,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2, T3, T4, T5) args = default;
         return (arg0, arg1, arg2, arg3, arg4, arg5) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2, arg3, arg4, arg5);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2, arg3, arg4, arg5);
-                }
+                    (T0, T1, T2, T3, T4, T5) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -419,19 +494,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2, T3, T4, T5, T6) args = default;
         return (arg0, arg1, arg2, arg3, arg4, arg5, arg6) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
-                }
+                    (T0, T1, T2, T3, T4, T5, T6) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -480,19 +567,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2, T3, T4, T5, T6, T7) args = default;
         return (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-                }
+                    (T0, T1, T2, T3, T4, T5, T6, T7) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7, pendingArgs.Item8);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -543,19 +642,31 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+        (T0, T1, T2, T3, T4, T5, T6, T7, T8) args = default;
         return (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+                args = (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-                }
+                    (T0, T1, T2, T3, T4, T5, T6, T7, T8) pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+                    action(pendingArgs.Item1, pendingArgs.Item2, pendingArgs.Item3, pendingArgs.Item4, pendingArgs.Item5, pendingArgs.Item6, pendingArgs.Item7, pendingArgs.Item8, pendingArgs.Item9);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 

--- a/src/Meziantou.Framework/DebounceExtensions.tt
+++ b/src/Meziantou.Framework/DebounceExtensions.tt
@@ -11,7 +11,6 @@
 #nullable enable
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Meziantou.Framework;
 
@@ -51,19 +50,37 @@ public static class DebounceExtensions
         ArgumentNullException.ThrowIfNull(action);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        var last = 0;
+        var l = new object();
+        ITimer? timer = null;
+<# if (i > 0) { #>
+        <#= GetTupleTypeString(i) #> args = <#= GetTupleDefaultValue(i) #>;
+<# } #>
         return (<#= GetArgsString(i) #>) =>
         {
-            var current = Interlocked.Increment(ref last);
-            Task.Delay(interval, timeProvider).ContinueWith(task =>
+            lock (l)
             {
-                if (current == last)
+<# if (i > 0) { #>
+                args = <#= GetTupleCreationExpression(i) #>;
+<# } #>
+                // A single timer is reused and restarted on every call. Scheduling one Task.Delay per
+                // call kept every pending delay alive for the whole interval, which is the opposite of
+                // what a debounce is reached for on a high-frequency event.
+                timer ??= timeProvider.CreateTimer(_ =>
                 {
-                    action(<#= GetArgsString(i) #>);
-                }
+<# if (i > 0) { #>
+                    <#= GetTupleTypeString(i) #> pendingArgs;
+                    lock (l)
+                    {
+                        pendingArgs = args;
+                    }
 
-                task.Dispose();
-            }, TaskScheduler.Default);
+<# } #>
+                    action(<#= GetTupleItemsString(i, "pendingArgs") #>);
+                }, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                // Restart the countdown so only the last call of a burst fires
+                timer.Change(interval, Timeout.InfiniteTimeSpan);
+            }
         };
     }
 
@@ -95,6 +112,54 @@ public static class DebounceExtensions
         {
             str += "    /// <typeparam name=\"T" + i + "\">The type of the parameter " + i + " of the action.</typeparam>\r\n";
         }
+        return str;
+    }
+
+    static string GetTupleTypeString(int count)
+    {
+        return count switch
+        {
+            1 => "T0",
+            _ => "(" + GetTemplateString(count).Substring(1, GetTemplateString(count).Length - 2) + ")",
+        };
+    }
+
+    static string GetTupleCreationExpression(int count)
+    {
+        if (count == 1)
+            return "arg0";
+
+        return "(" + GetArgsString(count) + ")";
+    }
+
+    static string GetTupleDefaultValue(int count)
+    {
+        return count switch
+        {
+            1 => "default!",
+            _ => "default",
+        };
+    }
+
+    static string GetTupleItemsString(int count, string tupleName)
+    {
+        if (count == 0)
+            return "";
+
+        if (count == 1)
+            return tupleName;
+
+        var str = "";
+        for (var i = 1; i <= count; i++)
+        {
+            if (i > 1)
+            {
+                str += ", ";
+            }
+
+            str += tupleName + ".Item" + i;
+        }
+
         return str;
     }
 

--- a/tests/Meziantou.Framework.Tests/DebounceExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/DebounceExtensionsTests.cs
@@ -31,4 +31,79 @@ public sealed class DebounceExtensionsTests
         Assert.Equal(1, count);
         Assert.Equal(2, lastArg);
     }
+
+    [Fact]
+    public void Debounce_ReusesASingleTimerAcrossCalls()
+    {
+        var fakeTimeProvider = new FakeTimeProvider();
+        var timeProvider = new CountingTimeProvider(fakeTimeProvider);
+        var callCount = 0;
+        var debounced = ((Action)(() => Interlocked.Increment(ref callCount))).Debounce(TimeSpan.FromSeconds(1), timeProvider);
+
+        for (var i = 0; i < 10_000; i++)
+        {
+            debounced();
+        }
+
+        // One reused timer, not one pending delay per call
+        Assert.Equal(1, timeProvider.TimersCreated);
+
+        fakeTimeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => Volatile.Read(ref callCount) > 0, TimeSpan.FromSeconds(5));
+        Assert.Equal(1, Volatile.Read(ref callCount));
+    }
+
+    [Fact]
+    public void Debounce_InvokesWithTheArgumentsOfTheLastCall()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var observed = new List<(int First, int Second)>();
+        var debounced = ((Action<int, int>)((first, second) => observed.Add((first, second))))
+            .Debounce(TimeSpan.FromSeconds(1), timeProvider);
+
+        debounced(1, 1);
+        debounced(2, 2);
+        debounced(3, 3);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => observed.Count > 0, TimeSpan.FromSeconds(5));
+
+        Assert.Equal([(3, 3)], observed);
+    }
+
+    [Fact]
+    public void Debounce_CanFireAgainAfterAnInvocation()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var callCount = 0;
+        var debounced = ((Action)(() => Interlocked.Increment(ref callCount))).Debounce(TimeSpan.FromSeconds(1), timeProvider);
+
+        debounced();
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => Volatile.Read(ref callCount) >= 1, TimeSpan.FromSeconds(5));
+
+        debounced();
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        SpinWait.SpinUntil(() => Volatile.Read(ref callCount) >= 2, TimeSpan.FromSeconds(5));
+
+        Assert.Equal(2, Volatile.Read(ref callCount));
+    }
+
+    private sealed class CountingTimeProvider(TimeProvider inner) : TimeProvider
+    {
+        private int _timersCreated;
+
+        public int TimersCreated => Volatile.Read(ref _timersCreated);
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            Interlocked.Increment(ref _timersCreated);
+            return inner.CreateTimer(callback, state, dueTime, period);
+        }
+
+        public override DateTimeOffset GetUtcNow() => inner.GetUtcNow();
+        public override long GetTimestamp() => inner.GetTimestamp();
+        public override TimeZoneInfo LocalTimeZone => inner.LocalTimeZone;
+        public override long TimestampFrequency => inner.TimestampFrequency;
+    }
 }


### PR DESCRIPTION
## The bug

Every invocation of a debounced delegate created a fresh `Task.Delay(interval)` plus a continuation
(`DebounceExtensions.cs:98-112`, generated from the `.tt`). The stale ones were not cancelled — they
ran to completion and then discarded themselves via a `current == last` check — so all of them stayed
alive for the full interval.

Debouncing is applied precisely to high-frequency events: keystrokes, file-system notifications,
mouse moves, log lines. With a 30-second interval and a few thousand events per second, tens of
thousands of timers accumulate in the timer queue simultaneously, along with their closures and
captured arguments. The functional result was correct; the cost profile was the opposite of what a
caller reaches for a debouncer to achieve.

A related nit in the same code: `current == last` read `last` non-atomically while the writes went
through `Interlocked.Increment`.

## The change

In `DebounceExtensions.tt`, regenerated via `dotnet run ./eng/update-all.cs -- --step templates`: hold
a single `ITimer` from the injected `TimeProvider` and restart it with `Change(interval, infinite)` on
each call. The trailing-edge semantics are unchanged — only the last call of a burst fires — and the
counter-and-compare scheme goes away with it.

Because one timer now serves every call, the arguments become shared state, so they are published and
snapshotted under a lock rather than captured per call.

`System.Threading.Tasks` is no longer needed and is dropped from the template header.

## Verification

Four tests in `DebounceExtensionsTests`, including a counting `TimeProvider` that records how many
timers get created. 10,000 calls create **1** timer with this change and **10,000** on `main` (the old
code reaches `CreateTimer` through `Task.Delay`), so that test fails on `main` and passes here. The
others cover last-call-wins arguments and firing again after an invocation.
