### PR TITLE
Ignore LogLevel.None instead of throwing

### DIFF
--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
@@ -102,6 +102,9 @@ public class XUnitLogger : ILogger
     [SuppressMessage("Usage", "MA0011:IFormatProvider is missing")]
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
+        if (!IsEnabled(logLevel))
+            return;
+
         var testOutputHelper = _testOutputHelper ?? TestContext.Current.TestOutputHelper;
         if (testOutputHelper is null)
             return;

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
@@ -45,4 +45,24 @@ public sealed class XunitLoggerTests
 
         // Nothing to assert, it will throw an exception if something goes wrong
     }
+
+    [Fact]
+    public void LogLevelNoneIsIgnoredInsteadOfThrowing()
+    {
+        var output = new InMemoryTestOutputHelper();
+        var logger = XUnitLogger.CreateLogger(output, new XUnitLoggerOptions { IncludeLogLevel = true });
+        logger.Log(LogLevel.None, "message");
+
+        Assert.Empty(output.Logs);
+    }
+
+    [Fact]
+    public void LogLevelNoneIsIgnoredWhenTheLevelIsNotWritten()
+    {
+        var output = new InMemoryTestOutputHelper();
+        var logger = XUnitLogger.CreateLogger(output);
+        logger.Log(LogLevel.None, "message");
+
+        Assert.Empty(output.Logs);
+    }
 }


### PR DESCRIPTION
`XUnitLogger.Log` threw `ArgumentOutOfRangeException` for `LogLevel.None`, and the class contradicted itself about whether that level was loggable.

### The problem

`IsEnabled` already returns `false` for `LogLevel.None` (`XUnitLogger.cs:95`), but `Log` never consulted it. It went straight to `GetLogLevelString` (`:155-167`), whose switch has no `None` arm and falls through to `throw`:

```csharp
var logger = XUnitLogger.CreateLogger(helper, new XUnitLoggerOptions { IncludeLogLevel = true });
logger.Log(LogLevel.None, new EventId(0), "state", exception: null, (s, e) => s);
// → System.ArgumentOutOfRangeException
```

This is reachable from ordinary code, not just the raw five-argument call: `LoggerExtensions.Log(this ILogger, LogLevel, string, params object[])` forwards straight to `ILogger.Log` **without** checking `IsEnabled`. Routing through a `LoggerFactory` masked it, because the composite `Logger` does check — so the crash only appeared on the loggers returned by the static `CreateLogger` factories, which are this package's headline API.

A logging call throwing fails the user's test with an exception that has nothing to do with what they were testing.

### What changed

`Log` now starts with `if (!IsEnabled(logLevel)) return;`.

This fixes the whole class of problem rather than just the string lookup, makes `Log` agree with `IsEnabled`, and skips the `StringBuilder` work for records that would be discarded. The `throw` in `GetLogLevelString` is kept as an assertion of what is now an unreachable state.

Note that without `IncludeLogLevel` the old code did not throw — it wrote the record anyway, even though `IsEnabled` said the level was disabled. Both behaviours are corrected.

### Verification

Two tests, both of which fail on `main`:

- `LogLevelNoneIsIgnoredInsteadOfThrowing` — fails with the exact `ArgumentOutOfRangeException` above
- `LogLevelNoneIsIgnoredWhenTheLevelIsNotWritten` — fails because the record is written despite the level being disabled

`dotnet test` — 8/8 across `net10.0` and `net11.0`. `dotnet run ./eng/update-all.cs` produces no further changes. No public API change, so `ref/` is unaffected.

---

**Stack 1 of 2** · merges into `main` · must merge before #2875.
