### PR TITLE
Make the XUnitLogger formatting overridable by derived types

### DIFF
--- a/ref/Meziantou.Extensions.Logging.Xunit.v3.cs
+++ b/ref/Meziantou.Extensions.Logging.Xunit.v3.cs
@@ -6,6 +6,9 @@ namespace Meziantou.Extensions.Logging.Xunit.v3
 {
     public class XUnitLogger : Microsoft.Extensions.Logging.ILogger
     {
+        protected Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions Options { get => throw null; }
+        protected string? CategoryName { get => throw null; }
+        protected Xunit.ITestOutputHelper? TestOutputHelper { get => throw null; }
         public static Microsoft.Extensions.Logging.ILogger CreateLogger() => throw null;
         public static Microsoft.Extensions.Logging.ILogger CreateLogger(Xunit.ITestOutputHelper? testOutputHelper) => throw null;
         public static Microsoft.Extensions.Logging.ILogger CreateLogger(Xunit.ITestOutputHelper? testOutputHelper, Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) => throw null;
@@ -17,7 +20,8 @@ namespace Meziantou.Extensions.Logging.Xunit.v3
         public XUnitLogger(Xunit.ITestOutputHelper? testOutputHelper, Microsoft.Extensions.Logging.LoggerExternalScopeProvider scopeProvider, string? categoryName, Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => throw null;
         public System.IDisposable? BeginScope<TState>(TState state) => throw null;
-        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+        public virtual void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+        protected static string GetLogLevelString(Microsoft.Extensions.Logging.LogLevel logLevel) => throw null;
     }
 
     public static class XUnitLoggerBuilderExtensions

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
@@ -26,6 +26,16 @@ public class XUnitLogger : ILogger
     private readonly XUnitLoggerOptions _options;
     private readonly LoggerExternalScopeProvider _scopeProvider;
 
+    /// <summary>Gets the options used to format the messages.</summary>
+    protected XUnitLoggerOptions Options => _options;
+
+    /// <summary>Gets the category name for the messages produced by this logger.</summary>
+    protected string? CategoryName => _categoryName;
+
+    /// <summary>Gets the test output helper the messages are written to, or <see langword="null"/> when no test is running.</summary>
+    /// <remarks>When no helper was supplied to the constructor, this resolves the one of the test that is currently running.</remarks>
+    protected ITestOutputHelper? TestOutputHelper => _testOutputHelper ?? TestContext.Current.TestOutputHelper;
+
     /// <summary>Creates a new logger instance without a test output helper.</summary>
     /// <returns>A new <see cref="ILogger"/> instance.</returns>
     public static ILogger CreateLogger() => CreateLogger(testOutputHelper: null);
@@ -100,12 +110,12 @@ public class XUnitLogger : ILogger
     /// <inheritdoc/>
     [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs")]
     [SuppressMessage("Usage", "MA0011:IFormatProvider is missing")]
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         if (!IsEnabled(logLevel))
             return;
 
-        var testOutputHelper = _testOutputHelper ?? TestContext.Current.TestOutputHelper;
+        var testOutputHelper = TestOutputHelper;
         if (testOutputHelper is null)
             return;
 
@@ -155,7 +165,10 @@ public class XUnitLogger : ILogger
         }
     }
 
-    private static string GetLogLevelString(LogLevel logLevel)
+    /// <summary>Gets the four-character string written for a log level.</summary>
+    /// <param name="logLevel">The log level to format.</param>
+    /// <returns>The string written before the message when <see cref="XUnitLoggerOptions.IncludeLogLevel"/> is set.</returns>
+    protected static string GetLogLevelString(LogLevel logLevel)
     {
         return logLevel switch
         {

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
@@ -65,4 +65,55 @@ public sealed class XunitLoggerTests
 
         Assert.Empty(output.Logs);
     }
+
+    [Fact]
+    public void ADerivedLoggerCanReplaceTheFormatting()
+    {
+        var output = new InMemoryTestOutputHelper();
+        var logger = new PrefixingLogger(output, new XUnitLoggerOptions { IncludeLogLevel = true });
+        logger.LogWarning("the message");
+
+        Assert.Equal(["warn [TheCategory] the message (IncludeLogLevel=True)" + Environment.NewLine], output.Logs, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void ADerivedLoggerCanDelegateToTheDefaultFormatting()
+    {
+        var output = new InMemoryTestOutputHelper();
+        var logger = new DelegatingLogger(output);
+        logger.LogInformation("kept");
+        logger.LogInformation("dropped");
+
+        Assert.Equal(["kept" + Environment.NewLine], output.Logs, StringComparer.Ordinal);
+    }
+
+    private sealed class PrefixingLogger : XUnitLogger
+    {
+        public PrefixingLogger(ITestOutputHelper testOutputHelper, XUnitLoggerOptions options)
+            : base(testOutputHelper, new LoggerExternalScopeProvider(), "TheCategory", options)
+        {
+        }
+
+        public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var message = $"{GetLogLevelString(logLevel)} [{CategoryName}] {formatter(state, exception)} (IncludeLogLevel={Options.IncludeLogLevel})";
+            TestOutputHelper?.WriteLine(message);
+        }
+    }
+
+    private sealed class DelegatingLogger : XUnitLogger
+    {
+        public DelegatingLogger(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper, new LoggerExternalScopeProvider(), "TheCategory", options: null)
+        {
+        }
+
+        public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (formatter(state, exception) is "dropped")
+                return;
+
+            base.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
 }


### PR DESCRIPTION
`XUnitLogger` is public and unsealed, but nothing on it could actually be overridden.

### The problem

`Log` was non-virtual (`XUnitLogger.cs:103`), `GetLogLevelString` was `private static` (`:155`), and all four fields were private (`:24-27`). A consumer deriving from `XUnitLogger` to adjust formatting could override nothing and could not read the test output helper, the category or the options — so a subclass could not write anything at all. The only real subclass was the library's own internal ``XUnitLogger`1``.

No failure, just a public surface wider than what it supports, which invites consumers down a path that dead-ends.

### What changed

Committed to extensibility rather than sealing:

- `Log` is now `public virtual`
- `GetLogLevelString` is now `protected static`
- three `protected` accessors expose the state a subclass needs: `Options`, `CategoryName`, and `TestOutputHelper` (which resolves the ambient `TestContext.Current` helper when none was supplied, so subclasses inherit that behaviour for free)

Sealing was the alternative. It would have been the honest description of the old contract, but the class has shipped public and unsealed for years, so sealing risks breaking someone for no functional gain. The additive direction costs nothing to existing callers.

**The scope provider is deliberately not exposed.** `_scopeProvider`'s type is being widened to `IExternalScopeProvider` in #2857, and exposing it here would bake the current concrete type into the public API just before that change. It can follow later if there is demand for subclasses that enumerate scopes.

### One thing to weigh

Adding `virtual` to a shipped method is source-compatible for callers, but it is not a completely free change: an existing subclass in another assembly that happens to declare a `Log` with the same signature and no `new` keyword would start producing a hiding warning. That is unlikely here given nothing could usefully subclass this type before, but it is worth a conscious decision rather than my assumption — and once `virtual` ships it cannot be taken back.

### Verification

Two tests exercising the surface as a real consumer would:

- `ADerivedLoggerCanReplaceTheFormatting` — a subclass overrides `Log` and builds its own record from `GetLogLevelString`, `CategoryName`, `Options` and `TestOutputHelper`. It does not compile against `main`.
- `ADerivedLoggerCanDelegateToTheDefaultFormatting` — a subclass filters one message and forwards the rest to `base.Log`, confirming the default path is still reachable.

`dotnet test` — 12/12 across `net10.0` and `net11.0`. `ref/` regenerated with a Release `IsOfficialBuild` build; the diff is the three `protected` properties, `protected static GetLogLevelString`, and `virtual` on `Log`. `dotnet run ./eng/update-all.cs` produces no further changes.

---

**Stack 2 of 2** · merges into `fix/xunit-loglevel-none` · #2874 must merge first.
