### PR TITLE
Support cancellation in AsyncReaderWriterLock

### DIFF
--- a/ref/Meziantou.Framework.Threading.cs
+++ b/ref/Meziantou.Framework.Threading.cs
@@ -128,7 +128,9 @@ namespace Meziantou.Framework.Threading
     public sealed class AsyncReaderWriterLock
     {
         public System.Threading.Tasks.Task<Releaser> ReaderLockAsync() => throw null;
+        public System.Threading.Tasks.Task<Releaser> ReaderLockAsync(System.Threading.CancellationToken cancellationToken) => throw null;
         public System.Threading.Tasks.Task<Releaser> WriterLockAsync() => throw null;
+        public System.Threading.Tasks.Task<Releaser> WriterLockAsync(System.Threading.CancellationToken cancellationToken) => throw null;
         public readonly struct Releaser : System.IDisposable
         {
             public void Dispose() { }

--- a/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
@@ -3,6 +3,11 @@ using System.Runtime.InteropServices;
 namespace Meziantou.Framework.Threading;
 
 /// <summary>Provides an asynchronous reader-writer lock that allows multiple readers or a single writer.</summary>
+/// <remarks>
+/// The returned task must be awaited and the resulting <see cref="Releaser"/> disposed, otherwise the lock stays
+/// held forever. To give up on an acquisition, pass a <see cref="CancellationToken"/> rather than abandoning the
+/// task: a waiter that is never awaited is still granted ownership when its turn comes, and nothing will release it.
+/// </remarks>
 /// <example>
 /// <code><![CDATA[
 /// var rwLock = new AsyncReaderWriterLock();
@@ -30,10 +35,13 @@ public sealed class AsyncReaderWriterLock
 {
     private readonly Task<Releaser> _readerReleaser;
     private readonly Task<Releaser> _writerReleaser;
+    private readonly Action<object?> _onCancellationRequestHandler;
+    private readonly Lock _lock = new();
 
-    private readonly Queue<TaskCompletionSource<Releaser>> _waitingWriters = new();
-    private TaskCompletionSource<Releaser> _waitingReader = new();
-    private int _readersWaiting;
+    private readonly Queue<Waiter> _waitingWriters = new();
+    private readonly Queue<Waiter> _waitingReaders = new();
+
+    // 0 when the lock is free, the number of readers holding it when positive, -1 when a writer holds it.
     private int _status;
 
     /// <summary>Initializes a new instance of the <see cref="AsyncReaderWriterLock"/> class.</summary>
@@ -41,90 +49,212 @@ public sealed class AsyncReaderWriterLock
     {
         _readerReleaser = Task.FromResult(new Releaser(this, writer: false));
         _writerReleaser = Task.FromResult(new Releaser(this, writer: true));
+        _onCancellationRequestHandler = OnCancellationRequest;
     }
 
     /// <summary>Asynchronously acquires the reader lock. Multiple readers can hold the lock simultaneously.</summary>
     /// <returns>A task that returns a disposable releaser. Disposing the releaser releases the reader lock.</returns>
     public Task<Releaser> ReaderLockAsync()
     {
-        lock (_waitingWriters)
+        return ReaderLockAsync(CancellationToken.None);
+    }
+
+    /// <summary>Asynchronously acquires the reader lock. Multiple readers can hold the lock simultaneously.</summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the lock.</param>
+    /// <returns>A task that returns a disposable releaser. Disposing the releaser releases the reader lock.</returns>
+    public Task<Releaser> ReaderLockAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<Releaser>(cancellationToken);
+
+        Waiter waiter;
+        bool canceled;
+        lock (_lock)
         {
+            // Queued writers block new readers, otherwise a steady stream of readers would starve them.
             if (_status >= 0 && _waitingWriters.Count == 0)
             {
                 _status += 1;
                 return _readerReleaser;
             }
-            else
+
+            waiter = new Waiter(this, writer: false, cancellationToken);
+            canceled = cancellationToken.IsCancellationRequested;
+            if (!canceled)
             {
-                _readersWaiting += 1;
-                return _waitingReader.Task;
+                _waitingReaders.Enqueue(waiter);
             }
         }
+
+        return CompleteIfCanceled(waiter, canceled, cancellationToken);
     }
 
     /// <summary>Asynchronously acquires the writer lock. Only one writer can hold the lock at a time.</summary>
     /// <returns>A task that returns a disposable releaser. Disposing the releaser releases the writer lock.</returns>
     public Task<Releaser> WriterLockAsync()
     {
-        lock (_waitingWriters)
+        return WriterLockAsync(CancellationToken.None);
+    }
+
+    /// <summary>Asynchronously acquires the writer lock. Only one writer can hold the lock at a time.</summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the lock.</param>
+    /// <returns>A task that returns a disposable releaser. Disposing the releaser releases the writer lock.</returns>
+    public Task<Releaser> WriterLockAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<Releaser>(cancellationToken);
+
+        Waiter waiter;
+        bool canceled;
+        lock (_lock)
         {
             if (_status == 0)
             {
                 _status = -1;
                 return _writerReleaser;
             }
-            else
+
+            waiter = new Waiter(this, writer: true, cancellationToken);
+            canceled = cancellationToken.IsCancellationRequested;
+            if (!canceled)
             {
-                var waiter = new TaskCompletionSource<Releaser>(TaskCreationOptions.RunContinuationsAsynchronously);
                 _waitingWriters.Enqueue(waiter);
-                return waiter.Task;
             }
         }
+
+        return CompleteIfCanceled(waiter, canceled, cancellationToken);
+    }
+
+    private static Task<Releaser> CompleteIfCanceled(Waiter waiter, bool canceled, CancellationToken cancellationToken)
+    {
+        // The token was canceled between the registration and this check, so the waiter was never queued and must
+        // be completed here. This has to happen outside the lock: TrySetCanceled can inline continuations, and
+        // Registration.Dispose blocks until a callback running on another thread completes. That callback is
+        // OnCancellationRequest, which takes the same lock.
+        if (canceled)
+        {
+            waiter.TrySetCanceled(cancellationToken);
+            waiter.Registration.Dispose();
+        }
+
+        return waiter.Task;
     }
 
     private void ReaderRelease()
     {
-        TaskCompletionSource<Releaser>? toWake = null;
-
-        lock (_waitingWriters)
+        List<Waiter>? toWake;
+        lock (_lock)
         {
             _status -= 1;
-            if (_status == 0 && _waitingWriters.Count > 0)
-            {
-                _status = -1;
-                toWake = _waitingWriters.Dequeue();
-            }
+            toWake = GrantOwnership();
         }
 
-        toWake?.SetResult(new Releaser(this, writer: true));
+        CompleteWaiters(toWake);
     }
 
     private void WriterRelease()
     {
-        TaskCompletionSource<Releaser>? toWake = null;
-        var toWakeIsWriter = false;
-
-        lock (_waitingWriters)
+        List<Waiter>? toWake;
+        lock (_lock)
         {
-            if (_waitingWriters.Count > 0)
+            _status = 0;
+            toWake = GrantOwnership();
+        }
+
+        CompleteWaiters(toWake);
+    }
+
+    /// <summary>Hands the free lock to the next waiters. Must be called while holding <see cref="_lock"/>; the
+    /// returned waiters are completed outside it.</summary>
+    private List<Waiter>? GrantOwnership()
+    {
+        if (_status != 0)
+            return null;
+
+        if (_waitingWriters.Count > 0)
+        {
+            _status = -1;
+            return [_waitingWriters.Dequeue()];
+        }
+
+        if (_waitingReaders.Count > 0)
+        {
+            // Every queued reader is admitted at once. This also covers the case where the writers that were
+            // blocking them have all been canceled, which would otherwise leave the readers queued forever.
+            var readers = new List<Waiter>(_waitingReaders.Count);
+            while (_waitingReaders.Count > 0)
             {
-                toWake = _waitingWriters.Dequeue();
-                toWakeIsWriter = true;
+                readers.Add(_waitingReaders.Dequeue());
             }
-            else if (_readersWaiting > 0)
-            {
-                toWake = _waitingReader;
-                _status = _readersWaiting;
-                _readersWaiting = 0;
-                _waitingReader = new TaskCompletionSource<Releaser>();
+
+            _status = readers.Count;
+            return readers;
+        }
+
+        return null;
+    }
+
+    private void CompleteWaiters(List<Waiter>? waiters)
+    {
+        if (waiters is null)
+            return;
+
+        foreach (var waiter in waiters)
+        {
+            // A waiter that was dequeued here can no longer be canceled: OnCancellationRequest only completes a
+            // waiter it removed from the queue itself, so exactly one of the two paths owns it.
+            waiter.Registration.Dispose();
+            waiter.TrySetResult(new Releaser(this, waiter.IsWriter));
+        }
+    }
+
+    private void OnCancellationRequest(object? state)
+    {
+        var waiter = (Waiter)state!;
+        bool removed;
+        List<Waiter>? toWake;
+        lock (_lock)
+        {
+            removed = RemoveMidQueue(waiter.IsWriter ? _waitingWriters : _waitingReaders, waiter);
+
+            // Removing a waiter can leave the lock free with others still queued behind it. GrantOwnership is a
+            // no-op unless _status is 0, so this only does something when that actually happened.
+            toWake = removed ? GrantOwnership() : null;
+        }
+
+        // Both of these must run outside the lock: Registration.Dispose blocks until a callback running on
+        // another thread completes, and that callback is this method, which takes the same lock.
+        CompleteWaiters(toWake);
+
+        // We only cancel the task if we removed it from the queue. If it wasn't in the queue, either it has
+        // already been granted the lock or it hasn't even been added to the queue yet.
+        if (removed)
+        {
+            waiter.TrySetCanceled(waiter.CancellationToken);
+            waiter.Registration.Dispose();
+        }
+    }
+
+    private static bool RemoveMidQueue(Queue<Waiter> queue, Waiter valueToRemove)
+    {
+        var originalCount = queue.Count;
+        var dequeueCounter = 0;
+        var found = false;
+        while (dequeueCounter < originalCount)
+        {
+            dequeueCounter++;
+            var dequeued = queue.Dequeue();
+            if (!found && dequeued == valueToRemove)
+            { // only find 1 match
+                found = true;
             }
             else
             {
-                _status = 0;
+                queue.Enqueue(dequeued);
             }
         }
 
-        toWake?.SetResult(new Releaser(this, toWakeIsWriter));
+        return found;
     }
 
     /// <summary>Represents a disposable releaser for an <see cref="AsyncReaderWriterLock"/>. Disposing the releaser releases either the reader or writer lock.</summary>
@@ -155,5 +285,20 @@ public sealed class AsyncReaderWriterLock
                 }
             }
         }
+    }
+
+    private sealed class Waiter : TaskCompletionSource<Releaser>
+    {
+        internal Waiter(AsyncReaderWriterLock owner, bool writer, CancellationToken cancellationToken)
+            : base(TaskCreationOptions.RunContinuationsAsynchronously)
+        {
+            IsWriter = writer;
+            CancellationToken = cancellationToken;
+            Registration = cancellationToken.Register(owner._onCancellationRequestHandler, this);
+        }
+
+        internal bool IsWriter { get; }
+        internal CancellationToken CancellationToken { get; }
+        internal CancellationTokenRegistration Registration { get; }
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -99,4 +99,189 @@ public class AsyncReaderWriterLockTests
     {
         default(AsyncReaderWriterLock.Releaser).Dispose();
     }
+
+    [Fact]
+    public async Task WriterLockAsync_AlreadyCanceledToken_ReturnsCanceledTask()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => rwLock.WriterLockAsync(new CancellationToken(canceled: true)));
+    }
+
+    [Fact]
+    public async Task ReaderLockAsync_AlreadyCanceledToken_ReturnsCanceledTask()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => rwLock.ReaderLockAsync(new CancellationToken(canceled: true)));
+    }
+
+    [Fact]
+    public async Task WriterLockAsync_CanceledWhileWaiting_DoesNotHoldTheLock()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        using var cts = new CancellationTokenSource();
+
+        var releaser = await rwLock.WriterLockAsync();
+        var pending = rwLock.WriterLockAsync(cts.Token);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => pending);
+
+        // The canceled waiter must not be granted ownership when the current writer releases.
+        releaser.Dispose();
+
+        var next = rwLock.WriterLockAsync();
+        (await next.WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+    }
+
+    [Fact]
+    public async Task ReaderLockAsync_CanceledWhileWaiting_DoesNotHoldTheLock()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        using var cts = new CancellationTokenSource();
+
+        var releaser = await rwLock.WriterLockAsync();
+        var pending = rwLock.ReaderLockAsync(cts.Token);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => pending);
+
+        releaser.Dispose();
+
+        var next = rwLock.WriterLockAsync();
+        (await next.WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+    }
+
+    [Fact]
+    public async Task CancelingOneWaiter_LeavesTheOthersQueued()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        using var cts = new CancellationTokenSource();
+
+        var releaser = await rwLock.WriterLockAsync();
+        var canceled = rwLock.WriterLockAsync(cts.Token);
+        var survivor = rwLock.WriterLockAsync();
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => canceled);
+        Assert.False(survivor.IsCompleted);
+
+        releaser.Dispose();
+
+        (await survivor.WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+    }
+
+    [Fact]
+    public async Task CancelingTheQueuedWriters_ReleasesTheReadersBlockedBehindThem()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        using var cts = new CancellationTokenSource();
+
+        var writer = await rwLock.WriterLockAsync();
+        var queuedWriter = rwLock.WriterLockAsync(cts.Token);
+        var queuedReader = rwLock.ReaderLockAsync();
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => queuedWriter);
+
+        writer.Dispose();
+
+        (await queuedReader.WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+    }
+
+    [Fact]
+    public async Task ReaderContinuationsAreNotInlinedOnTheReleasingThread()
+    {
+        // The waiting readers used to share a TaskCompletionSource created without
+        // RunContinuationsAsynchronously, so releasing a writer ran every reader's continuation synchronously on
+        // the releasing thread.
+        var rwLock = new AsyncReaderWriterLock();
+        var writer = await rwLock.WriterLockAsync();
+
+        var readerThreadId = 0;
+        var readerRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reader = rwLock.ReaderLockAsync();
+        _ = reader.ContinueWith(
+            t =>
+            {
+                readerThreadId = Environment.CurrentManagedThreadId;
+                t.Result.Dispose();
+                readerRan.SetResult();
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        // Release from a dedicated thread rather than a pool thread: the thread pool is free to run the
+        // continuation on the releasing thread once it goes idle, which would make a plain "different thread"
+        // assertion flaky. A non-pool thread can only run the continuation if it was inlined.
+        var releasingThreadId = 0;
+        var releasingThread = new Thread(() =>
+        {
+            releasingThreadId = Environment.CurrentManagedThreadId;
+            writer.Dispose();
+        });
+
+        releasingThread.Start();
+        Assert.True(releasingThread.Join(TimeSpan.FromSeconds(30)));
+
+        await readerRan.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.NotEqual(releasingThreadId, readerThreadId);
+    }
+
+    [Fact]
+    public async Task ConcurrentReadersAndWritersKeepTheStateConsistent()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        var readers = 0;
+        var writers = 0;
+        var failures = 0;
+
+        async Task ReadAsync()
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                using (await rwLock.ReaderLockAsync())
+                {
+                    Interlocked.Increment(ref readers);
+                    if (Volatile.Read(ref writers) != 0)
+                    {
+                        Interlocked.Increment(ref failures);
+                    }
+
+                    Interlocked.Decrement(ref readers);
+                }
+            }
+        }
+
+        async Task WriteAsync()
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                using (await rwLock.WriterLockAsync())
+                {
+                    Interlocked.Increment(ref writers);
+                    if (Volatile.Read(ref readers) != 0 || Volatile.Read(ref writers) != 1)
+                    {
+                        Interlocked.Increment(ref failures);
+                    }
+
+                    Interlocked.Decrement(ref writers);
+                }
+            }
+        }
+
+        var tasks = new List<Task>();
+        for (var i = 0; i < 4; i++)
+        {
+            tasks.Add(Task.Run(ReadAsync));
+            tasks.Add(Task.Run(WriteAsync));
+        }
+
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(60));
+
+        Assert.Equal(0, failures);
+    }
 }


### PR DESCRIPTION
`AsyncReaderWriterLock` had no cancellation support, so the only way to bound an acquisition was to abandon the task — and abandoning it permanently wedges the lock.

### What happens

```csharp
var acquire = rwLock.WriterLockAsync();
if (await Task.WhenAny(acquire, Task.Delay(timeout)) != acquire)
    return false;   // give up — but the waiter is still queued
```

When the holder releases, that abandoned waiter is dequeued and completed, `_status` stays at `-1`, and nobody will ever dispose the `Releaser`. **Every subsequent reader and writer blocks forever.** Reproduced before this change: acquire a writer lock, start a second `WriterLockAsync()` and drop it, release the first — a third `WriterLockAsync()` never completes.

Separately, the waiting readers shared one `TaskCompletionSource` created without `RunContinuationsAsynchronously` (the writer queue at the old `:78` did pass it, so this was an oversight rather than a choice). Releasing a writer therefore ran **every** waiting reader's continuation synchronously, in sequence, on the releasing thread — `Releaser.Dispose()` did not return until all of them had finished.

### What changed

- **`ReaderLockAsync(CancellationToken)` and `WriterLockAsync(CancellationToken)`**, modelled on `AsyncLock.LockAsync`: the cancellation callback removes the waiter from its queue under the lock and only completes the task if the removal succeeded, so a waiter is owned by exactly one of the cancel path and the grant path. Waiters are completed outside the lock, because `TrySetCanceled` can inline continuations and `CancellationTokenRegistration.Dispose` blocks on a callback that takes the same lock.
- **Per-waiter completion sources for readers**, all with `RunContinuationsAsynchronously`. This is what makes individual readers cancellable, and it fixes the inlining above.
- **Release paths unified** into `GrantOwnership()`, which hands the free lock to the next writer or admits every queued reader at once. This also closes an edge case that cancellation introduces: if the queued writers that were blocking a set of readers are all canceled, those readers would otherwise stay queued forever.

### An honest correction to the finding

The review suggested also using `TrySetResult` on the grant paths and re-granting if it fails. That does not help: an abandoned task is still *pending*, so `TrySetResult` succeeds and the lock is still never released. **Abandoning the returned task without cancelling still wedges the lock, and that is not fixable** — no lock can detect a dropped `Task`. What this PR does is remove the reason to abandon it, and document the constraint in `<remarks>` on the type. If you'd rather not carry that footgun at all, marking the type `[Obsolete]` in favour of `AsyncLock` remains on the table and I'm happy to switch.

### Verification

Eight new tests: already-cancelled tokens for both acquire paths, cancellation while queued for both (asserting the lock is still usable afterwards), cancelling one of two waiters leaving the other queued, cancelling the queued writers releasing the readers behind them, the continuation-inlining check, and a 8-way concurrent reader/writer stress test asserting the reader/writer exclusion invariant never breaks.

The inlining test releases from a **dedicated** thread rather than a pool thread on purpose — the pool is free to run the continuation on the releasing thread once it goes idle, which makes a plain "different thread" assertion flaky; a non-pool thread can only run the continuation if it was inlined. Verified stable across three full-suite runs.

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite green at 278 tests across net10.0 and net11.0 (262 before). `ref/Meziantou.Framework.Threading.cs` regenerated with a Release `IsOfficialBuild` build — two added overloads, no removals, so this is source- and binary-compatible.

<sub>Found during a review of `Meziantou.Framework.Threading` (findings H1 and M3).</sub>
