### PR TITLE
Stop reporting a missing project url when only the repository url is absent

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/ProjectUrlBeSetValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/ProjectUrlBeSetValidationRule.cs
@@ -6,32 +6,29 @@ internal sealed class ProjectUrlBeSetValidationRule : NuGetPackageValidationRule
     {
         var projectUrl = context.Package.NuspecReader.GetProjectUrl();
         var repositoryUrl = context.Package.NuspecReader.GetRepositoryMetadata()?.Url;
-        if (string.IsNullOrWhiteSpace(projectUrl) || string.IsNullOrWhiteSpace(repositoryUrl))
+
+        if (string.IsNullOrWhiteSpace(projectUrl))
         {
+            // A missing repository url is reported by RepositoryInfoMustBeSetValidationRule
             context.ReportError(ErrorCodes.ProjectUrlNotSet, "Project url is not set");
         }
-
-        if (!string.IsNullOrWhiteSpace(projectUrl))
+        else if (!Uri.TryCreate(projectUrl, UriKind.Absolute, out var projectUri) || !IsHttpUri(projectUri))
         {
-            if (!Uri.TryCreate(projectUrl, UriKind.Absolute, out var uri))
+            context.ReportError(ErrorCodes.ProjectUrlNotAccessible, $"Project url '{projectUrl}' is not valid");
+        }
+        else if (!await context.IsUrlAccessible(projectUri, context.CancellationToken).ConfigureAwait(false))
+        {
+            context.ReportError(ErrorCodes.ProjectUrlNotAccessible, $"Project url '{projectUrl}' is not accessible");
+        }
+
+        if (!string.IsNullOrWhiteSpace(repositoryUrl) && Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var repositoryUri) && IsHttpUri(repositoryUri))
+        {
+            if (!await context.IsUrlAccessible(repositoryUri, context.CancellationToken).ConfigureAwait(false))
             {
-                context.ReportError(ErrorCodes.ProjectUrlNotAccessible, $"Project url '{projectUrl}' is not valid");
-            }
-            else if (!await context.IsUrlAccessible(uri, context.CancellationToken).ConfigureAwait(false))
-            {
-                context.ReportError(ErrorCodes.ProjectUrlNotAccessible, $"Project url '{projectUrl}' is not accessible");
+                context.ReportError(ErrorCodes.ProjectUrlNotAccessible, $"Repository url '{repositoryUrl}' is not accessible");
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(repositoryUrl))
-        {
-            if (Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri) && (uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp))
-            {
-                if (!await context.IsUrlAccessible(uri, context.CancellationToken).ConfigureAwait(false))
-                {
-                    context.ReportError(ErrorCodes.ProjectUrlNotAccessible, $"Repository url '{projectUrl}' is not accessible");
-                }
-            }
-        }
+        static bool IsHttpUri(Uri uri) => uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp;
     }
 }

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Meziantou.Framework.NuGetPackageValidation.Rules;
 
 namespace Meziantou.Framework.NuGetPackageValidation.Tests;
@@ -42,6 +43,35 @@ public sealed class NuGetPackageValidatorTests
     private static Task<NuGetPackageValidationResult> ValidateAsync(string packageName, params NuGetPackageValidationRule[] rules)
     {
         return ValidateAsync(packageName, excludedRuleIds: null, rules);
+    }
+
+    /// <summary>Validates a package built on the fly from the provided nuspec metadata. Rules that only read the
+    /// nuspec can be exercised this way without adding a binary fixture to the Packages folder.</summary>
+    private static async Task<NuGetPackageValidationResult> ValidateMetadataAsync(string metadata, params NuGetPackageValidationRule[] rules)
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var packagePath = temporaryDirectory / "package.nupkg";
+
+        await using (var stream = File.Create(packagePath))
+        {
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+            await using var entry = archive.CreateEntry("Sample.nuspec").Open();
+            await using var writer = new StreamWriter(entry);
+            await writer.WriteAsync($"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+                  <metadata>
+                    <id>Sample</id>
+                    <version>1.0.0</version>
+                    <authors>Sample author</authors>
+                    <description>Sample description</description>
+                {metadata}
+                  </metadata>
+                </package>
+                """);
+        }
+
+        return await ValidateAsync(packagePath, excludedRuleIds: null, rules);
     }
 
     private static void AssertNoErrors(NuGetPackageValidationResult result)
@@ -122,6 +152,35 @@ public sealed class NuGetPackageValidatorTests
     {
         var result = await ValidateAsync("Release_Icon_IconUrl.1.0.0.nupkg", NuGetPackageValidationRules.IconMustBeSet);
         AssertNoErrors(result);
+    }
+
+    [Fact]
+    public async Task Validate_ProjectUrl_ProjectUrlSetWithoutRepository()
+    {
+        var result = await ValidateMetadataAsync("""    <projectUrl>https://www.example.com/</projectUrl>""", NuGetPackageValidationRules.ProjectUrlMustBeSet);
+        Assert.DoesNotContain(result.Errors, item => item.ErrorCode == ErrorCodes.ProjectUrlNotSet);
+    }
+
+    [Fact]
+    public async Task Validate_ProjectUrl_RepositorySetWithoutProjectUrl()
+    {
+        var result = await ValidateMetadataAsync("""    <repository type="git" url="https://www.example.com/" />""", NuGetPackageValidationRules.ProjectUrlMustBeSet);
+        AssertHasError(result, ErrorCodes.ProjectUrlNotSet);
+    }
+
+    [Fact]
+    public async Task Validate_ProjectUrl_NotSet()
+    {
+        var result = await ValidateMetadataAsync("", NuGetPackageValidationRules.ProjectUrlMustBeSet);
+        AssertHasError(result, ErrorCodes.ProjectUrlNotSet);
+    }
+
+    [Fact]
+    public async Task Validate_ProjectUrl_NotAnHttpUrl()
+    {
+        var result = await ValidateMetadataAsync("""    <projectUrl>ftp://www.example.com/</projectUrl>""", NuGetPackageValidationRules.ProjectUrlMustBeSet);
+        AssertHasError(result, ErrorCodes.ProjectUrlNotAccessible);
+        Assert.DoesNotContain(result.Errors, item => item.ErrorCode == ErrorCodes.ProjectUrlNotSet);
     }
 
     [Fact]


### PR DESCRIPTION
`ProjectUrlMustBeSet` reported "Project url is not set" for packages whose project URL *is* set.

## The defect

```csharp
if (string.IsNullOrWhiteSpace(projectUrl) || string.IsNullOrWhiteSpace(repositoryUrl))
{
    context.ReportError(ErrorCodes.ProjectUrlNotSet, "Project url is not set");
}
```

A missing **repository** URL produced error 51 about the **project** URL. Packed with `/p:PackageProjectUrl=https://www.example.com/` and no repository metadata:

```json
{ "ErrorCode": 51, "Message": "Project url is not set" }
```

— while the accessibility check on that same URL passed, so the rule fetched the project URL successfully and then claimed it was unset.

`ProjectUrlMustBeSet` is in the default rule set, so this hit every package without repository metadata — the normal case for packages built outside CI. It also duplicated `RepositoryInfoMustBeSetValidationRule`'s error 73, which is the rule that actually owns that check, and pointed the user at the wrong csproj property. The rule's own description in `readme.md` ("Verifies a project URL is specified and accessible") confirms the `||` was unintended.

Two more fixes in the same file:

- The "Repository url '…' is not accessible" message interpolated `projectUrl`, so it printed the wrong URL — or an empty one when no project URL was set.
- The project URL had no scheme check, unlike the repository URL branch immediately below it. `Uri.TryCreate` accepts `ftp://`, `file://` and anything else absolute, and the rule then handed it to `HttpClient`, which threw and was swallowed into a misleading "is not accessible". Non-`http`/`https` project URLs are now reported as "is not valid" without a request, matching how the repository URL is already treated.

## Tests

The rule had no test, which is why this shipped. Testing it needed a package with a project URL and no repository metadata, and no fixture in the corpus has that shape — the two real-world fixtures carry both.

Rather than add another binary, this adds `ValidateMetadataAsync`, which builds a `.nupkg` in a temporary directory from a nuspec fragment. Rules that only read nuspec metadata can now be tested inline, without a fixture:

- `Validate_ProjectUrl_ProjectUrlSetWithoutRepository` — the regression: no error 51.
- `Validate_ProjectUrl_RepositorySetWithoutProjectUrl` — error 51 is still reported when the project URL really is missing.
- `Validate_ProjectUrl_NotSet` — neither set, error 51.
- `Validate_ProjectUrl_NotAnHttpUrl` — `ftp://` reports 52 and not 51.

Verified in both directions: with the fix the full suite passes (68/68); with the rule reverted, 4 of the 8 new test cases fail.
