### PR TITLE
Let stores reclaim stale entries that carry no validator

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
@@ -179,17 +179,26 @@ public sealed class HttpCachePersistenceEntry
 
     /// <summary>Gets a value indicating whether the entry becomes unusable as soon as it is stale.</summary>
     /// <remarks>
-    /// An entry that may be served stale, or that carries a validator allowing it to be revalidated, remains
-    /// usable after it expires and must be kept.
+    /// <para>
+    /// Two things keep an entry useful past its freshness lifetime: a validator, which lets it be
+    /// revalidated with a conditional request, and <c>stale-if-error</c> (RFC 5861), which lets it be served
+    /// as-is while the origin is failing. An entry with neither can only ever be discarded once it is stale,
+    /// so a store is free to reclaim it.
+    /// </para>
+    /// <para>
+    /// <c>must-revalidate</c>, <c>proxy-revalidate</c> and <c>no-cache</c> are deliberately not consulted.
+    /// They say when a stored response must be revalidated before reuse, not whether it can be reused at
+    /// all, so requiring one of them here left an ordinary <c>max-age</c> entry unreclaimable forever.
+    /// </para>
     /// </remarks>
     public bool IsUnusableWhenStale
     {
         get
         {
-            if (!MustRevalidate && !ProxyRevalidate && !ResponseNoCache)
+            if (!string.IsNullOrEmpty(ETag) || LastModified is not null)
                 return false;
 
-            return string.IsNullOrEmpty(ETag) && LastModified is null;
+            return StaleIfError is null;
         }
     }
 

--- a/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
@@ -396,6 +396,67 @@ public class PersistenceProvidersTests
     }
 
     [Fact]
+    public async Task InMemoryProviderPruneRemovesExpiredEntriesWithoutAnyRevalidateDirective()
+    {
+        var provider = new InMemoryHttpCacheStore();
+        var primaryKey = "http://example.com/cleanup";
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        // A plain max-age entry with no validator can only be discarded once it is stale, so a store must be
+        // able to reclaim it even though it carries no must-revalidate directive.
+        await provider.SetEntryAsync(primaryKey, CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(1), mustRevalidate: false), CancellationToken.None);
+
+        await provider.PruneObsoleteEntriesAsync(now, CancellationToken.None);
+
+        Assert.Empty(await provider.GetEntriesAsync(primaryKey, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InMemoryProviderPruneKeepsExpiredEntriesWithinTheirStaleIfErrorWindow()
+    {
+        var provider = new InMemoryHttpCacheStore();
+        var primaryKey = "http://example.com/cleanup";
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        // RFC 5861: the entry can still be served while the origin is failing, so it must be kept.
+        await provider.SetEntryAsync(primaryKey, CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(1), mustRevalidate: false, staleIfError: TimeSpan.FromHours(1)), CancellationToken.None);
+
+        await provider.PruneObsoleteEntriesAsync(now, CancellationToken.None);
+
+        Assert.Single(await provider.GetEntriesAsync(primaryKey, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InMemoryProviderPruneKeepsExpiredEntriesWithALastModifiedValidator()
+    {
+        var provider = new InMemoryHttpCacheStore();
+        var primaryKey = "http://example.com/cleanup";
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        var entry = CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(1), mustRevalidate: false);
+        entry.LastModified = now - TimeSpan.FromDays(1);
+        await provider.SetEntryAsync(primaryKey, entry, CancellationToken.None);
+
+        await provider.PruneObsoleteEntriesAsync(now, CancellationToken.None);
+
+        Assert.Single(await provider.GetEntriesAsync(primaryKey, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InMemoryProviderPruneKeepsFreshEntries()
+    {
+        var provider = new InMemoryHttpCacheStore();
+        var primaryKey = "http://example.com/cleanup";
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        await provider.SetEntryAsync(primaryKey, CreatePersistenceEntry(now, maxAge: TimeSpan.FromHours(1), mustRevalidate: false), CancellationToken.None);
+
+        await provider.PruneObsoleteEntriesAsync(now, CancellationToken.None);
+
+        Assert.Single(await provider.GetEntriesAsync(primaryKey, CancellationToken.None));
+    }
+
+    [Fact]
     public async Task SqliteProviderPruneRemovesExpiredUnusableEntries()
     {
         var tempDirectory = Path.Combine(Path.GetTempPath(), "meziantou-http-cache", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
@@ -424,6 +485,24 @@ public class PersistenceProvidersTests
                 Directory.Delete(tempDirectory, recursive: true);
             }
         }
+    }
+
+    [Fact]
+    public async Task SqliteProviderPruneRemovesExpiredEntriesWithoutAnyRevalidateDirective()
+    {
+        var connectionString = CreateInMemorySqliteConnectionString();
+        using var keepAliveConnection = CreateSqliteAnchorConnection(connectionString);
+        using var provider = new SqliteHttpCacheStore(connectionString);
+        var primaryKey = "http://example.com/cleanup";
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        // The store persists IsUnusableWhenStale as DeleteWhenExpired and reclaims the row through the
+        // indexed fast path, so the new rule has to reach that column too.
+        await provider.SetEntryAsync(primaryKey, CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(1), mustRevalidate: false), CancellationToken.None);
+
+        await provider.PruneObsoleteEntriesAsync(now, CancellationToken.None);
+
+        Assert.Empty(await provider.GetEntriesAsync(primaryKey, CancellationToken.None));
     }
 
     [Fact]
@@ -527,7 +606,8 @@ public class PersistenceProvidersTests
         DateTimeOffset now,
         TimeSpan maxAge,
         bool mustRevalidate,
-        string? eTag = null)
+        string? eTag = null,
+        TimeSpan? staleIfError = null)
     {
         var requestTime = now - TimeSpan.FromMinutes(3);
         var responseTime = now - TimeSpan.FromMinutes(2);
@@ -541,6 +621,7 @@ public class PersistenceProvidersTests
             MaxAge = maxAge,
             MustRevalidate = mustRevalidate,
             ETag = eTag,
+            StaleIfError = staleIfError,
             SerializedResponse = new byte[] { 1, 2, 3 },
         };
     }


### PR DESCRIPTION
`PruneObsoleteEntriesAsync` reclaimed almost nothing, on every store.

## The failure

`HttpCachePersistenceEntry.cs:185-194`. `IsObsolete` gates on `IsUnusableWhenStale`, which required the entry to carry `must-revalidate`, `proxy-revalidate` or `no-cache` **and** to have no `ETag`/`Last-Modified`. An ordinary `Cache-Control: max-age=60` response satisfies neither half, so it was never obsolete — at any point in the future.

Measured directly: an entry with `max-age=60`, evaluated ten years past its `ResponseTime`, reports `IsObsolete = false`. End to end, 500 URLs cached with `max-age=1` and then pruned with `now = UtcNow + 10 years` left **500 of 500** entries in the store.

Since there is no size cap or eviction policy anywhere either, prune was the only reclamation mechanism, and it was a no-op for the overwhelming majority of entries. `InMemoryHttpCacheStore` grows its heap until the process dies; Redis and SQLite grow their storage indefinitely.

## The change

`IsUnusableWhenStale` now asks the question its name implies: *is there any way to use this entry once it is stale?* There are exactly two:

- a validator (`ETag` or `Last-Modified`) — it can be revalidated with a conditional request;
- `stale-if-error` (RFC 5861) — it can be served as-is while the origin is failing.

An entry with neither can only ever be discarded, so a store may reclaim it.

`must-revalidate`, `proxy-revalidate` and `no-cache` are no longer consulted. They say when a stored response must be revalidated *before reuse* — not whether it can be reused at all — so requiring one of them was the bug.

`IsObsolete` is unchanged: `IsUnusableWhenStale && GetCurrentAge(now) >= GetFreshnessLifetime()`. No public API signature changes; the two properties are already public and only their result changes.

## What this does not fix

This is one half of the eviction problem. It makes prune reclaim the large class of entries that are simply dead. It does **not** bound the cache: entries carrying a validator are still kept indefinitely, which is correct — they are revalidatable cache assets — but it means an application over a high-cardinality URL space still needs a size cap and an eviction policy. That needs a new option and probably a last-accessed field on this type, so it is deliberately left out of this PR.

Entries with `stale-if-error` are also kept past their window rather than reclaimed once it lapses; that is conservative, and no worse than today.

## Verification

Five tests added to `PersistenceProvidersTests`:

- `InMemoryProviderPruneRemovesExpiredEntriesWithoutAnyRevalidateDirective` — a plain stale `max-age` entry is reclaimed. **Fails on `main`.**
- `SqliteProviderPruneRemovesExpiredEntriesWithoutAnyRevalidateDirective` — same, through the SQLite store, which persists this property as its `DeleteWhenExpired` column and reclaims through the indexed fast path. **Fails on `main`.**
- `InMemoryProviderPruneKeepsExpiredEntriesWithinTheirStaleIfErrorWindow`
- `InMemoryProviderPruneKeepsExpiredEntriesWithALastModifiedValidator`
- `InMemoryProviderPruneKeepsFreshEntries`

The existing prune tests are untouched and still pass: they use `mustRevalidate: true` with no validator, which the new rule still classifies as reclaimable, and their `eTag` counterparts are still kept.

Full suite on both target frameworks: 394 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
