### PR TITLE
Return only direct children from GetChildProcesses and dispose discarded handles

### DIFF
--- a/src/Meziantou.Framework/ProcessExtensions.cs
+++ b/src/Meziantou.Framework/ProcessExtensions.cs
@@ -92,7 +92,10 @@ public static partial class ProcessExtensions
                 {
                     p = entry.ToProcess();
                     if (p is null || p.StartTime > process.StartTime)
+                    {
+                        p?.Dispose();
                         continue;
+                    }
                 }
                 catch (ArgumentException)
                 {
@@ -245,10 +248,16 @@ public static partial class ProcessExtensions
                 {
                     var child = entry.ToProcess();
                     if (child is null || child.StartTime < process.StartTime)
+                    {
+                        child?.Dispose();
                         continue;
+                    }
 
                     children.Add(child);
-                    if (currentDepth < maxDepth)
+
+                    // currentDepth is the depth of the children being collected, so descending is only
+                    // allowed while the next level still fits within maxDepth
+                    if (currentDepth + 1 < maxDepth)
                     {
                         GetChildProcesses(entries, child, children, maxDepth, currentDepth + 1);
                     }

--- a/tests/Meziantou.Framework.Tests/ProcessExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/ProcessExtensionsTests.cs
@@ -199,4 +199,30 @@ public class ProcessExtensionsTests
         Assert.Contains(descendants, p => p.Id == current.Id);
         Assert.Contains(descendants, p => p.Id == parent.Id);
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetChildProcessesDoesNotReturnGrandChildren()
+    {
+        using var process = Process.Start("cmd.exe", "/C ping 127.0.0.1 -n 10");
+        try
+        {
+            // We need to wait for the process to be started by cmd
+            IReadOnlyCollection<Process> grandChildren;
+            while ((grandChildren = process.GetDescendantProcesses()).Count is 0)
+            {
+                Thread.Sleep(100);
+            }
+
+            using var current = Process.GetCurrentProcess();
+            var children = current.GetChildProcesses();
+
+            Assert.Contains(children, p => p.Id == process.Id);
+            Assert.DoesNotContain(children, p => grandChildren.Any(grandChild => grandChild.Id == p.Id));
+        }
+        finally
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+    }
 }


### PR DESCRIPTION
## The bugs

**Wrong depth.** `GetChildProcesses` calls the recursive helper with `maxDepth: 1, currentDepth: 0`
(`ProcessExtensions.cs:33`), and the guard is `if (currentDepth < maxDepth)` (`:251`). That is true at
depth 0, so the walk descends one more level and adds *grandchildren* before stopping. The method's
name — and its contrast with `GetDescendantProcesses` — promises one level.

Callers using it to enumerate or signal a process's immediate children reach one level further than
intended. If the result is used to terminate processes, that kills more than was asked for.

**Leaked handles.** `Process` instances that fail the `StartTime` check were abandoned with `continue`
without being disposed (`:247-248`, and the same in `GetAncestorProcesses` at `:94-95`), leaking a
native handle each time until the finalizer runs.

## The change

- The guard becomes `currentDepth + 1 < maxDepth`: `currentDepth` is the depth of the children being
  collected, so descending is only allowed while the next level still fits. `GetDescendantProcesses`
  passes `int.MaxValue` and is unaffected.
- The discarded `Process` objects are disposed on both `continue` paths.

## Verification

`GetChildProcessesDoesNotReturnGrandChildren` added to `ProcessExtensionsTests`: it starts
`cmd.exe /C ping`, waits for `cmd` to spawn `ping`, and asserts the test process's children contain
`cmd` but not `ping`.

To be clear about what I could check: this code is Windows-only and I am on macOS, so I verified it
compiles and reasoned through the depth arithmetic, but I could not run the new test locally. The CI
matrix includes `windows-2025-vs2026`, so that leg is what actually exercises it — worth a look at
those results before merging. On every other platform the test is skipped by `RunIf`.
