### PR TITLE
Reuse the JSON formatter buffers between log entries

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/JsonFileFormatter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/JsonFileFormatter.cs
@@ -9,6 +9,15 @@ namespace Meziantou.Extensions.Logging;
 /// <summary>A <see cref="FileFormatter"/> that writes one JSON object per log entry.</summary>
 public sealed class JsonFileFormatter : FileFormatter
 {
+    // Keep the cached buffer small, so a single big entry doesn't retain a big buffer for the lifetime of the thread
+    private const int MaxCachedCapacity = 4 * 1024;
+
+    [ThreadStatic]
+    private static ArrayBufferWriter<byte>? s_buffer;
+
+    [ThreadStatic]
+    private static Utf8JsonWriter? s_jsonWriter;
+
     /// <summary>Gets a shared instance of the <see cref="JsonFileFormatter"/> class.</summary>
     public static JsonFileFormatter Instance { get; } = new();
 
@@ -28,8 +37,23 @@ public sealed class JsonFileFormatter : FileFormatter
         if (string.IsNullOrEmpty(message) && logEntry.Exception is null)
             return;
 
-        var buffer = new ArrayBufferWriter<byte>(256);
-        using (var writer = new Utf8JsonWriter(buffer))
+        // The buffers are cached per thread. Detach them in case a formatter callback logs a message
+        var buffer = s_buffer;
+        var writer = s_jsonWriter;
+        if (buffer is null || writer is null)
+        {
+            buffer = new ArrayBufferWriter<byte>(256);
+            writer = new Utf8JsonWriter(buffer);
+        }
+        else
+        {
+            s_buffer = null;
+            s_jsonWriter = null;
+            buffer.ResetWrittenCount();
+            writer.Reset(buffer);
+        }
+
+        try
         {
             writer.WriteStartObject();
 
@@ -113,9 +137,37 @@ public sealed class JsonFileFormatter : FileFormatter
             }
 
             writer.WriteEndObject();
-        }
+            writer.Flush();
 
-        textWriter.Write(Encoding.UTF8.GetString(buffer.WrittenSpan));
+            WriteUtf8(textWriter, buffer.WrittenSpan);
+        }
+        finally
+        {
+            if (buffer.Capacity <= MaxCachedCapacity)
+            {
+                s_buffer = buffer;
+                s_jsonWriter = writer;
+            }
+            else
+            {
+                writer.Dispose();
+            }
+        }
+    }
+
+    private static void WriteUtf8(TextWriter textWriter, ReadOnlySpan<byte> utf8)
+    {
+        // Transcode into a pooled buffer instead of allocating a string for every entry
+        var chars = ArrayPool<char>.Shared.Rent(Encoding.UTF8.GetMaxCharCount(utf8.Length));
+        try
+        {
+            var charCount = Encoding.UTF8.GetChars(utf8, chars);
+            textWriter.Write(chars.AsSpan(0, charCount));
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(chars);
+        }
     }
 
     private static void WriteProperty(Utf8JsonWriter writer, string name, object? value)

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -200,6 +200,37 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task JsonFormatterWritesIndependentEntries()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            FormatterName = FileFormatterNames.Json,
+        });
+
+        var logger = provider.CreateLogger("Test");
+
+        // The first entry is too big to be cached and the next ones are short, so a buffer that is
+        // not reset between the entries would leak the previous content
+        string[] messages = [new('a', 5000), "short", new('b', 100), "x"];
+        foreach (var message in messages)
+        {
+            logger.LogInformation("{Message}", message);
+        }
+
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var lines = (await ReadLogFileAsync(provider.LogFilePath)).Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.HasCount(messages.Length, lines);
+        for (var i = 0; i < messages.Length; i++)
+        {
+            using var document = JsonDocument.Parse(lines[i]);
+            Assert.Equal(messages[i], document.RootElement.GetProperty("Message").GetString());
+        }
+    }
+
+    [Fact]
     public async Task CustomFormatter()
     {
         using var tempDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
> **Stack 2 of 2** · targets `fix/filelogger-json-timestamp-null` (#2871) · merge #2871 first

`JsonFileFormatter.Write` allocates a fresh `ArrayBufferWriter<byte>(256)` and a `Utf8JsonWriter` for **every** log entry (`JsonFileFormatter.cs:31-32`), then materializes the whole payload again as a `string` via `Encoding.UTF8.GetString` (`JsonFileFormatter.cs:113`).

That is on the hot path, on the caller's thread, in a class that otherwise goes to some length to avoid allocation — `FileLogger` caches a `StringWriter` per thread for exactly this reason (`FileLogger.cs:9-13`).

### What changed

The same pattern `FileLogger` already established:

- The `ArrayBufferWriter` and `Utf8JsonWriter` are cached in `[ThreadStatic]` fields and reset per entry, with the same 4 KB capacity cap so one big entry does not retain a big buffer for the life of the thread.
- The cached buffers are detached while in use, so a formatter callback that logs re-entrantly gets its own — mirroring the detach in `FileLogger.Log`.
- The final transcode writes through a pooled `char[]` and `TextWriter.Write(ReadOnlySpan<char>)` instead of allocating a string. Transcoding itself is unavoidable while the `FileFormatter` contract is `TextWriter`-based, but the string is not.

### Measured effect

100,000 entries of a typical message (category, level, message, two state properties), reusing one `TextWriter` as `FileLogger` does, so the numbers reflect the formatter only:

| | bytes allocated per entry |
| --- | --- |
| before | 992 |
| after | **184** |

An 81% reduction. No correctness impact — this is GC pressure only, which is why the finding was rated Low.

### Verification

New test `JsonFormatterWritesIndependentEntries` logs a 5,000-character entry (deliberately over the cache cap, so it exercises the discard path) followed by short ones, then parses every line and asserts each `Message` is exactly what was logged. Content leaking between entries from a buffer that was not reset is the real risk of this change, and that is what the test pins down.

Full suite 59/59 green on net10.0 and net11.0. `dotnet run ./eng/update-all.cs` reports no changes.
