### PR TITLE
Throw instead of dividing by zero or wrapping in TimeSpan.Average

### DIFF
--- a/src/Meziantou.Framework/EnumerableExtensions.cs
+++ b/src/Meziantou.Framework/EnumerableExtensions.cs
@@ -277,13 +277,16 @@ public static partial class EnumerableExtensions
         var count = 0;
         foreach (var item in enumerable)
         {
-            result += item.Ticks;
-
             checked
             {
+                // The sum is what can realistically overflow, so it is the part that must be checked
+                result += item.Ticks;
                 count++;
             }
         }
+
+        if (count is 0)
+            throw new InvalidOperationException("Sequence contains no elements");
 
         return TimeSpan.FromTicks(result / count);
     }

--- a/tests/Meziantou.Framework.Tests/EnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/EnumerableTests.cs
@@ -529,4 +529,26 @@ public class EnumerableTests
         A = 2,
         C = 3,
     }
+
+    [Fact]
+    public void TimeSpanAverage_EmptySequenceThrowsInvalidOperationException()
+    {
+        Assert.Throws<InvalidOperationException>(() => Array.Empty<TimeSpan>().Average());
+    }
+
+    [Fact]
+    public void TimeSpanAverage_OverflowingSumThrows()
+    {
+        var values = new[] { TimeSpan.MaxValue, TimeSpan.MaxValue };
+
+        Assert.Throws<OverflowException>(() => values.Average());
+    }
+
+    [Fact]
+    public void TimeSpanAverage_ComputesTheAverage()
+    {
+        var values = new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3) };
+
+        Assert.Equal(TimeSpan.FromSeconds(2), values.Average());
+    }
 }


### PR DESCRIPTION
## The bug

`Average(IEnumerable<TimeSpan>)` (`EnumerableExtensions.cs:272-289`) had the `checked` block on the
wrong statement:

```csharp
result += item.Ticks;      // unchecked: silently wraps

checked
{
    count++;               // checked: cannot realistically overflow
}

return TimeSpan.FromTicks(result / count);   // DivideByZeroException when count is 0
```

Two problems:

- An **empty sequence** divides by zero. LINQ's `Average` throws
  `InvalidOperationException("Sequence contains no elements")`, so callers catching that will not
  catch `DivideByZeroException`.
- The **tick sum is unchecked**, so a sum exceeding `long` wraps silently and returns a
  plausible-looking wrong average — a wrong duration reported as fact, with no exception. Meanwhile
  the counter, which cannot realistically overflow, was the guarded one.

## The change

Move the accumulation inside `checked` alongside the counter, and throw
`InvalidOperationException` for an empty sequence to match LINQ.

## Verification

Three tests added to `EnumerableTests` covering the empty sequence, an overflowing sum, and the happy
path. Confirmed the first two fail on `main` and all three pass with the fix.
