### PR TITLE
Preserve DateTimeKind in StartOfMonth, EndOfMonth and StartOfYear

### DIFF
--- a/src/Meziantou.Framework/DateTimeExtensions.cs
+++ b/src/Meziantou.Framework/DateTimeExtensions.cs
@@ -37,13 +37,13 @@ public static class DateTimeExtensions
             return dt.AddDays(-dt.Day + 1);
         }
 
-        return new DateTime(dt.Year, dt.Month, 1);
+        return new DateTime(dt.Year, dt.Month, 1, 0, 0, 0, dt.Kind);
     }
 
     /// <summary>Returns the last day of the month for the specified date at midnight.</summary>
     public static DateTime EndOfMonth(this DateTime dt)
     {
-        return new DateTime(dt.Year, dt.Month, DateTime.DaysInMonth(dt.Year, dt.Month));
+        return new DateTime(dt.Year, dt.Month, DateTime.DaysInMonth(dt.Year, dt.Month), 0, 0, 0, dt.Kind);
     }
 
     /// <summary>Returns the first day of the year for the specified date at midnight.</summary>
@@ -61,7 +61,7 @@ public static class DateTimeExtensions
         }
         else
         {
-            return new DateTime(dt.Year, 1, 1);
+            return new DateTime(dt.Year, 1, 1, 0, 0, 0, dt.Kind);
         }
     }
 

--- a/tests/Meziantou.Framework.Tests/DateTimeUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/DateTimeUtilitiesTests.cs
@@ -43,4 +43,55 @@ public class DateTimeUtilitiesTests
         var expected = new DateTime(2018, 2, 3, 4, 5, 6, 0, DateTimeKind.Utc);
         Assert.Equal(expected, actual);
     }
+
+    [Theory]
+    [InlineData(DateTimeKind.Utc)]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void StartOfMonth_PreservesKind(DateTimeKind kind)
+    {
+        var value = new DateTime(2024, 5, 17, 13, 45, 30, kind);
+
+        Assert.Equal(kind, value.StartOfMonth().Kind);
+        Assert.Equal(kind, value.StartOfMonth(keepTime: true).Kind);
+    }
+
+    [Theory]
+    [InlineData(DateTimeKind.Utc)]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void EndOfMonth_PreservesKind(DateTimeKind kind)
+    {
+        var value = new DateTime(2024, 5, 17, 13, 45, 30, kind);
+
+        Assert.Equal(kind, value.EndOfMonth().Kind);
+    }
+
+    [Theory]
+    [InlineData(DateTimeKind.Utc)]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void StartOfYear_PreservesKind(DateTimeKind kind)
+    {
+        var value = new DateTime(2024, 5, 17, 13, 45, 30, kind);
+
+        Assert.Equal(kind, value.StartOfYear().Kind);
+        Assert.Equal(kind, value.StartOfYear(keepTime: true).Kind);
+    }
+
+    [Fact]
+    public void StartOfMonth_StillReturnsTheFirstDayAtMidnight()
+    {
+        var value = new DateTime(2024, 5, 17, 13, 45, 30, DateTimeKind.Utc);
+
+        Assert.Equal(new DateTime(2024, 5, 1, 0, 0, 0, DateTimeKind.Utc), value.StartOfMonth());
+    }
+
+    [Fact]
+    public void EndOfMonth_StillReturnsTheLastDayAtMidnight()
+    {
+        var value = new DateTime(2024, 2, 3, 13, 45, 30, DateTimeKind.Utc);
+
+        Assert.Equal(new DateTime(2024, 2, 29, 0, 0, 0, DateTimeKind.Utc), value.EndOfMonth());
+    }
 }


### PR DESCRIPTION
## The bug

`StartOfMonth`, `EndOfMonth` and `StartOfYear` built their results with
`new DateTime(year, month, day)` (`DateTimeExtensions.cs:40`, `:46`, `:64`), whose `Kind` is
`Unspecified`. A UTC input produced an `Unspecified` output.

Within the same file, `TruncateMilliseconds` threads `dt.Kind` through correctly (`:71`), and the
`keepTime: true` branches use `AddDays`, which also preserves it — so three methods kept `Kind` and
three dropped it.

An `Unspecified` `DateTime` is interpreted as *local* by `ToUniversalTime`, by `Kind`-sensitive
serialisers, and by most database drivers. Taking the start of a month from a UTC timestamp and
persisting it shifts the value by the local offset — a silent off-by-hours error in exactly the
date-bucketing code these helpers exist for, and one that only appears outside UTC machines.

None of the three methods had a test.

## The change

Pass `dt.Kind` to the `DateTime` constructor in all three, matching `TruncateMilliseconds`.

## Verification

Eleven tests added to `DateTimeUtilitiesTests`: `Kind` round-trips for all three
`DateTimeKind` values across the five affected entry points, plus two tests pinning the existing
date arithmetic (first day of the month, last day of a leap February) so the fix cannot change it.
Confirmed the `Kind` theories fail on `main` and all pass with the fix.
