### PR TITLE
Report unreadable packages as a validation error instead of throwing

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidationContext.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidationContext.cs
@@ -15,11 +15,18 @@ public sealed class NuGetPackageValidationContext : IDisposable
         _options = options;
         CancellationToken = cancellationToken;
         Package = new PackageArchiveReader(file);
-
-        var symbolPackagePath = file.WithExtension(".snupkg");
-        if (File.Exists(symbolPackagePath))
+        try
         {
-            SymbolPackage = new PackageArchiveReader(symbolPackagePath);
+            var symbolPackagePath = file.WithExtension(".snupkg");
+            if (File.Exists(symbolPackagePath))
+            {
+                SymbolPackage = new PackageArchiveReader(symbolPackagePath);
+            }
+        }
+        catch
+        {
+            Package.Dispose();
+            throw;
         }
     }
 

--- a/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidator.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidator.cs
@@ -57,19 +57,38 @@ public static class NuGetPackageValidator
     public static async Task<NuGetPackageValidationResult> ValidateAsync(FullPath packagePath, NuGetPackageValidationOptions options, CancellationToken cancellationToken = default)
     {
         if (!File.Exists(packagePath))
-        {
-            return new NuGetPackageValidationResult(
-            [
-                new (ErrorCodes.FileNotFound, $"NuGet package '{packagePath}' not found", helpText: null),
-            ]);
-        }
+            return CreateResult(options, ErrorCodes.FileNotFound, $"NuGet package '{packagePath}' not found");
 
-        using var context = new NuGetPackageValidationContext(packagePath, options, cancellationToken);
-        foreach (var rule in options.Rules)
+        NuGetPackageValidationContext? context = null;
+        try
         {
-            await rule.ExecuteAsync(context).ConfigureAwait(false);
-        }
+            try
+            {
+                context = new NuGetPackageValidationContext(packagePath, options, cancellationToken);
+            }
+            catch (InvalidDataException ex)
+            {
+                return CreateResult(options, ErrorCodes.InvalidPackage, $"NuGet package '{packagePath}' cannot be read: {ex.Message}");
+            }
 
-        return new NuGetPackageValidationResult(context.Errors);
+            foreach (var rule in options.Rules)
+            {
+                await rule.ExecuteAsync(context).ConfigureAwait(false);
+            }
+
+            return new NuGetPackageValidationResult(context.Errors);
+        }
+        finally
+        {
+            context?.Dispose();
+        }
+    }
+
+    private static NuGetPackageValidationResult CreateResult(NuGetPackageValidationOptions options, int errorCode, string message)
+    {
+        if (options.ExcludedRuleIds.Contains(errorCode))
+            return new NuGetPackageValidationResult([]);
+
+        return new NuGetPackageValidationResult([new NuGetPackageValidationError(errorCode, message, helpText: null)]);
     }
 }

--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/ErrorCodes.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/ErrorCodes.cs
@@ -3,6 +3,7 @@ namespace Meziantou.Framework.NuGetPackageValidation.Rules;
 internal static class ErrorCodes
 {
     public const int FileNotFound = 1;
+    public const int InvalidPackage = 2;
 
     public const int AuthorNotSet = 11;
     public const int DefaultAuthorSet = 12;

--- a/src/Meziantou.Framework.NuGetPackageValidation/readme.md
+++ b/src/Meziantou.Framework.NuGetPackageValidation/readme.md
@@ -110,6 +110,7 @@ Each validation error has a specific error code for easy identification and filt
 
 ### General Errors (1-10)
 - `1` - FileNotFound: Package file not found
+- `2` - InvalidPackage: Package file cannot be read as a NuGet package
 
 ### Author Errors (11-20)
 - `11` - AuthorNotSet: Author metadata is missing

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -55,6 +55,40 @@ public sealed class NuGetPackageValidatorTests
     }
 
     [Fact]
+    public async Task Validate_PackageFileNotFound()
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var result = await ValidateAsync(temporaryDirectory / "missing.nupkg", excludedRuleIds: null, NuGetPackageValidationRules.Default.ToArray());
+        AssertHasError(result, ErrorCodes.FileNotFound);
+    }
+
+    [Fact]
+    public async Task Validate_PackageFileNotFound_ExcludedRuleId()
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var result = await ValidateAsync(temporaryDirectory / "missing.nupkg", [ErrorCodes.FileNotFound], NuGetPackageValidationRules.Default.ToArray());
+        AssertNoErrors(result);
+    }
+
+    [Fact]
+    public async Task Validate_PackageIsNotAValidArchive()
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var packagePath = await temporaryDirectory.CreateTextFileAsync("corrupted.nupkg", "This is not a zip archive");
+        var result = await ValidateAsync(packagePath, excludedRuleIds: null, NuGetPackageValidationRules.Default.ToArray());
+        AssertHasError(result, ErrorCodes.InvalidPackage);
+    }
+
+    [Fact]
+    public async Task Validate_PackageIsNotAValidArchive_ExcludedRuleId()
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var packagePath = await temporaryDirectory.CreateTextFileAsync("corrupted.nupkg", "This is not a zip archive");
+        var result = await ValidateAsync(packagePath, [ErrorCodes.InvalidPackage], NuGetPackageValidationRules.Default.ToArray());
+        AssertNoErrors(result);
+    }
+
+    [Fact]
     public async Task Validate_AssembliesMustBeOptimizedMustBeSet_Debug()
     {
         var result = await ValidateAsync("Debug.1.0.0.nupkg", NuGetPackageValidationRules.AssembliesMustBeOptimized);


### PR DESCRIPTION
A corrupt or truncated `.nupkg` threw out of `ValidateAsync` instead of being reported, and `ErrorCodes.FileNotFound` ignored `ExcludedRuleIds`.

## The defects

**Unreadable packages throw.** `new PackageArchiveReader(file)` throws `System.IO.InvalidDataException: The file is not a valid nupkg` on anything that is not a readable zip. It runs in the `NuGetPackageValidationContext` constructor, before `ValidateAsync` can take ownership, so the exception propagates to the caller. `ValidateAsync` already models "cannot open this" as a result — `ErrorCodes.FileNotFound` — but only for a missing file.

Consequences: the CLI prints an unhandled-exception stack trace instead of the JSON its callers parse, and in the multi-package loop one bad package aborts validation of every package after it. Truncated downloads and partially written artifacts are routine in CI, so this breaks the machine-readable contract exactly when it is most needed.

There was also a leak: if the sibling `.snupkg` was the unreadable one, the `PackageArchiveReader` already created for the main package was never disposed, because the constructor threw before anything could own it.

**`FileNotFound` bypassed `ExcludedRuleIds`.** Error 1 was constructed directly rather than going through `context.ReportError`, which is where the exclusion filter lives, so `--excluded-rule-ids 1` was silently ignored.

## The change

- New `ErrorCodes.InvalidPackage = 2`, in the existing 1-10 "general errors" range, documented in `readme.md`.
- `ValidateAsync` catches `InvalidDataException` from constructing the context and returns it as error 2, carrying the underlying message. The `catch` is scoped to the construction only, so an `InvalidDataException` raised later by a rule still surfaces as an exception rather than being relabelled.
- Both early-return paths now go through a `CreateResult` helper that applies `ExcludedRuleIds`, so codes 1 and 2 can be excluded like any other.
- The context constructor disposes the package reader if opening the symbol package throws.

## Tests

- `Validate_PackageFileNotFound` / `Validate_PackageFileNotFound_ExcludedRuleId` — error 1 is reported, and suppressed when excluded.
- `Validate_PackageIsNotAValidArchive` / `Validate_PackageIsNotAValidArchive_ExcludedRuleId` — a text file named `.nupkg` reports error 2 instead of throwing, and is suppressed when excluded.

Verified in both directions: with the fix the full suite passes (68/68); against the previous code 6 of the 8 new cases fail — the two archive tests throw `InvalidDataException` out of `ValidateAsync`, and the exclusion test for code 1 still reports the error.
