### PR TITLE
Return null instead of a decoded hash for deterministically built assemblies

### DIFF
--- a/src/Meziantou.Framework/AssemblyUtilities.cs
+++ b/src/Meziantou.Framework/AssemblyUtilities.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Reflection.PortableExecutable;
 
 namespace Meziantou.Framework;
 
@@ -35,8 +36,9 @@ public static class AssemblyUtilities
                 return GetLinkerTimestampUtc(location);
             }
         }
-        catch
+        catch (NotSupportedException)
         {
+            // Dynamic assemblies have no location
         }
 
         return null;
@@ -44,7 +46,12 @@ public static class AssemblyUtilities
 
     /// <summary>Gets the linker timestamp of a specified assembly.</summary>
     /// <param name="filePath">The assembly file path.</param>
-    /// <returns>A valid date time or null if an error occurred.</returns>
+    /// <returns>A valid date time, or <see langword="null"/> if the file has no meaningful timestamp or could not be read.</returns>
+    /// <remarks>
+    /// Deterministic builds, which the .NET SDK produces by default, store a hash of the content in the
+    /// COFF <c>TimeDateStamp</c> field instead of a date. Those are reported as <see langword="null"/>
+    /// rather than as the arbitrary date the hash decodes to.
+    /// </remarks>
     public static DateTime? GetLinkerTimestampUtc(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);
@@ -54,20 +61,28 @@ public static class AssemblyUtilities
             if (!File.Exists(filePath))
                 return null;
 
-            const int PeHeaderOffset = 60;
-            const int LinkerTimestampOffset = 8;
-            var bytes = new byte[2048];
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var peReader = new PEReader(stream);
 
-            using (var file = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            // A deterministic build advertises itself with a Reproducible debug directory entry
+            foreach (var entry in peReader.ReadDebugDirectory())
             {
-                file.TryReadAll(bytes, 0, bytes.Length);
+                if (entry.Type == DebugDirectoryEntryType.Reproducible)
+                    return null;
             }
 
-            var headerPos = BitConverter.ToInt32(bytes, PeHeaderOffset);
-            var secondsSince1970 = BitConverter.ToInt32(bytes, headerPos + LinkerTimestampOffset);
-            return DateTime.UnixEpoch.AddSeconds(secondsSince1970);
+            var timestamp = unchecked((uint)peReader.PEHeaders.CoffHeader.TimeDateStamp);
+            return DateTime.UnixEpoch.AddSeconds(timestamp);
         }
-        catch
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
         {
             return null;
         }

--- a/tests/Meziantou.Framework.Tests/AssemblyUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/AssemblyUtilitiesTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class AssemblyUtilitiesTests
+{
+    [Fact]
+    public void GetLinkerTimestampUtc_ReturnsNullForADeterministicBuild()
+    {
+        var location = typeof(AssemblyUtilities).Assembly.Location;
+        Assert.NotEmpty(location);
+
+        // The SDK builds deterministically by default, so TimeDateStamp holds a hash and not a date
+        Assert.Null(AssemblyUtilities.GetLinkerTimestampUtc(location));
+    }
+
+    [Fact]
+    public void GetLinkerTimestampUtc_ReturnsNullForAMissingFile()
+    {
+        Assert.Null(AssemblyUtilities.GetLinkerTimestampUtc(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".dll")));
+    }
+
+    [Fact]
+    public void GetLinkerTimestampUtc_ReturnsNullForAFileThatIsNotAnAssembly()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "not a PE file");
+            Assert.Null(AssemblyUtilities.GetLinkerTimestampUtc(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void GetLinkerTimestampUtc_ThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => AssemblyUtilities.GetLinkerTimestampUtc(filePath: null!));
+    }
+
+    [Fact]
+    public void GetInformationalVersion_ReturnsTheAttributeValue()
+    {
+        var assembly = typeof(AssemblyUtilities).Assembly;
+        var expected = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        Assert.Equal(expected, assembly.GetInformationalVersion());
+    }
+}


### PR DESCRIPTION
## The bug

`GetLinkerTimestampUtc` read the PE COFF header's `TimeDateStamp` at a hardcoded byte offset and
converted it as seconds since the Unix epoch (`AssemblyUtilities.cs:48-74`). Deterministic builds —
the .NET SDK default, and what this repository produces — store a **content hash** in that field, not
a timestamp.

Measured against this repository's own `Meziantou.Framework.dll`:

```
debug entry: CodeView
debug entry: PdbChecksum
debug entry: Reproducible
CoffHeader.TimeDateStamp = -1252113796 -> 2066-06-04
```

The method is documented to return "a valid date time or null if an error occurred". It returned a
confidently wrong value instead of null, so callers displaying a build date or comparing versions by
it got nonsense with no indication anything went wrong.

Two supporting weaknesses in the same method: the `TryReadAll` result was discarded, so a file shorter
than 2048 bytes yielded a garbage header offset, and both `catch { }` blocks were unfiltered and
swallowed every exception type including the ones you want to see.

## The change

Parse with `PEReader` instead of hand-rolled offsets, and return `null` when the debug directory
carries a `Reproducible` entry — the marker a deterministic build advertises itself with. The
`catch` clauses are narrowed to `BadImageFormatException`, `IOException` and
`UnauthorizedAccessException`, and the `Assembly` overload now catches only `NotSupportedException`
(dynamic assemblies have no location).

`System.Reflection.PortableExecutable` is already used elsewhere in this package
(`ReflectionUtilities`), so this adds no new dependency.

## Behaviour note

Callers of this method against SDK-built assemblies will now get `null` where they previously got a
date. That date was meaningless, but it was non-null, so anything doing `.Value` on it will start
throwing. The XML doc now says so explicitly.

## Verification

Five tests added in a new `AssemblyUtilitiesTests`. The deterministic-build test is the one that
fails on `main` (it returns 2066-06-04 there); the others cover a missing file, a non-PE file, a null
argument, and the informational version.
