### PR TITLE
Document that Append needs a stable log file name

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
@@ -46,6 +46,14 @@ public sealed class FileLoggerOptions
     /// Gets or sets a value indicating whether an existing log file is reused instead of creating a new one. Defaults to <see langword="false" />.
     /// When a matching file is already in use by another process, a new file is created.
     /// </summary>
+    /// <remarks>
+    /// A file is reused only when its name matches the name the provider computes when it starts, so this option has no effect unless the name is stable:
+    /// <list type="bullet">
+    /// <item><description><see cref="RollInterval" /> must be set. <see cref="RollInterval.None" /> includes the seconds in the name, so the name changes on every start.</description></item>
+    /// <item><description><see cref="IncludeProcessIdInFileName" /> must be <see langword="false" /> to reuse a file across restarts, as the identifier of the process changes.</description></item>
+    /// </list>
+    /// With the default values of these two options, a new file is created on every start even when this option is <see langword="true" />.
+    /// </remarks>
     public bool Append { get; set; }
 
     /// <summary>Gets or sets how often a new log file is created based on time. Defaults to <see cref="RollInterval.None" />.</summary>

--- a/src/Meziantou.Extensions.Logging.FileLogger/readme.md
+++ b/src/Meziantou.Extensions.Logging.FileLogger/readme.md
@@ -64,9 +64,22 @@ Note that the options related to the log file itself (`Directory`, file name, `A
 | `MaxFileSizeInBytes` | Creates a new file when the current one reaches the size limit |
 | `MaxRetainedFiles` | Deletes the oldest files when a new file is created |
 | `Compression` | Compresses the log files using gzip, Brotli, or Zstandard (.NET 11+) |
-| `Append` | Reuses an existing file instead of creating a new one at startup |
+| `Append` | Reuses an existing file instead of creating a new one at startup. See the note below |
 
 The log files are named `{FileNamePrefix}{timestamp}-{processId}{FileNameExtension}`, so they are ordered chronologically by name. When the name is already used, a suffix is added (`_001`, `_002`, …).
+
+`Append` reuses a file only when its name matches the name computed at startup, so it needs a stable file name:
+
+- `RollInterval` must be set. `RollInterval.None` includes the seconds in the name, so the name changes on every start.
+- `IncludeProcessIdInFileName` must be `false` to reuse a file across restarts, as the identifier of the process changes.
+
+With the default values of these two options, a new file is created on every start even when `Append` is `true`.
+
+```c#
+options.Append = true;
+options.RollInterval = RollInterval.Daily;
+options.IncludeProcessIdInFileName = false; // Required to reuse the file after a restart
+```
 
 ## Compression
 

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -452,6 +452,56 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task AppendReusesTheFileAcrossRestartsWhenTheNameIsStable()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+
+        // The process id is what changes between two runs, so the name is only stable without it
+        var options = new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            Append = true,
+            RollInterval = RollInterval.Daily,
+            IncludeProcessIdInFileName = false,
+        };
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var provider = new FileLoggerProvider(options, timeProvider);
+            provider.CreateLogger("Test").LogInformation("Run {Index}", i);
+        }
+
+        Assert.Equal(["2024-01-02.log"], GetFileNames(tempDirectory));
+        var content = await File.ReadAllTextAsync(Path.Combine(tempDirectory.FullPath, "2024-01-02.log"), TestContext.Current.CancellationToken);
+        Assert.Contains("Run 0", content);
+        Assert.Contains("Run 2", content);
+    }
+
+    [Fact]
+    public async Task AppendCreatesANewFileOnEveryStartWithTheDefaultFileName()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+
+        // RollInterval.None puts the seconds in the name and the process id is included by default,
+        // so Append cannot find a file to reuse. This pins the behavior documented on the option
+        var options = new FileLoggerOptions { Directory = tempDirectory.FullPath, Append = true };
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var provider = new FileLoggerProvider(options, timeProvider);
+            provider.CreateLogger("Test").LogInformation("Run {Index}", i);
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal(
+            [$"2024-01-02-03-04-05-{pid}.log", $"2024-01-02-03-04-06-{pid}.log", $"2024-01-02-03-04-07-{pid}.log"],
+            GetFileNames(tempDirectory));
+    }
+
+    [Fact]
     public async Task AppendDoesNotReuseAFullFile()
     {
         using var tempDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
`Append` is documented as *"Reuses an existing file instead of creating a new one at startup"* (`readme.md:67`), but in the default configuration it silently does nothing.

Appending requires the freshly computed file name to match an existing file (`LogFileWriter.cs:99-104`). With defaults it never can:

- `RollInterval.None` selects the `yyyy-MM-dd-HH-mm-ss` name format (`LogFileWriter.cs:180`), so the name changes every second.
- `IncludeProcessIdInFileName` defaults to `true`, so the name also changes on every restart.

Reproduced: three provider lifetimes with `Append = true` and otherwise default options produce three separate files. Users who set the option get unbounded file proliferation instead of reuse — and with `MaxRetainedFiles` unset, nothing cleans up.

Both existing `Append` tests set a `RollInterval` and run inside a single process, which is why the gap went unnoticed.

### What changed

Documentation only — the prerequisites are now stated on the option itself and in the readme, with a working example:

```c#
options.Append = true;
options.RollInterval = RollInterval.Daily;
options.IncludeProcessIdInFileName = false; // Required to reuse the file after a restart
```

### Why documentation rather than making it work by default

I considered changing `Append` to search the directory for the most recent matching file instead of requiring an exact name match. I don't think that is right, at least not as a drive-by fix:

Making it work across restarts by default would mean appending to a file whose name carries **another process's id**. That directly contradicts the reason the process id is in the name — one file per process — and would produce files whose name no longer identifies their writer. The two options are genuinely in tension, and `Append` + `IncludeProcessIdInFileName` is a contradictory request rather than something the library can silently resolve.

Throwing on the contradictory combination was the other candidate, but that turns a silent no-op into a breaking change for anyone who already sets `Append` with defaults on a published v3 package.

So this PR fixes the expectation rather than the selection semantics. If you'd prefer the behavioral change, or a validation error on the contradictory combination, that's a small follow-up and I'm happy to do it — it just seemed like your call rather than mine.

### Verification

Two new tests pin both sides of the documented contract:

- `AppendReusesTheFileAcrossRestartsWhenTheNameIsStable` — with `RollInterval.Daily` and `IncludeProcessIdInFileName = false`, three provider lifetimes share one file containing every run's messages.
- `AppendCreatesANewFileOnEveryStartWithTheDefaultFileName` — with defaults, three lifetimes produce three files. This is the behavior the documentation now describes, so a future change to the naming would have to update the docs with it.

Full suite 59/59 green on net10.0 and net11.0; `dotnet run ./eng/update-all.cs` reports no changes to generated files.
