### PR TITLE
Accept every JPEG variant and case-insensitive icon extensions

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/IconMustBeSetValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/IconMustBeSetValidationRule.cs
@@ -25,13 +25,15 @@ internal sealed class IconMustBeSetValidationRule : NuGetPackageValidationRule
         else
         {
             var extension = Path.GetExtension(icon);
-            if (extension is ".png")
+            if (string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase))
             {
                 await ValidateMagicNumber(context, realPath, [0x89, 0x50, 0x4E, 0x47], extension, "PNG").ConfigureAwait(false);
             }
-            else if (extension is ".jpg" or ".jpeg")
+            else if (string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase) || string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase))
             {
-                await ValidateMagicNumber(context, realPath, [0xFF, 0xD8, 0xFF, 0xE0], extension, "JPEG").ConfigureAwait(false);
+                // Start of Image marker followed by any marker. JFIF (FF E0) and Exif (FF E1) are both valid,
+                // and other application markers are in use, so only the first 3 bytes are common to every JPEG file.
+                await ValidateMagicNumber(context, realPath, [0xFF, 0xD8, 0xFF], extension, "JPEG").ConfigureAwait(false);
             }
             else
             {

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Meziantou.Framework.NuGetPackageValidation.Rules;
 
 namespace Meziantou.Framework.NuGetPackageValidation.Tests;
@@ -122,6 +123,78 @@ public sealed class NuGetPackageValidatorTests
     {
         var result = await ValidateAsync("Release_Icon_IconUrl.1.0.0.nupkg", NuGetPackageValidationRules.IconMustBeSet);
         AssertNoErrors(result);
+    }
+
+    /// <summary>Builds a package declaring <paramref name="iconPath"/> as its icon, with <paramref name="iconContent"/> as
+    /// the content of that file, and validates it with the icon rule.</summary>
+    private static async Task<NuGetPackageValidationResult> ValidateIconAsync(string iconPath, byte[] iconContent)
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var packagePath = temporaryDirectory / "package.nupkg";
+
+        await using (var stream = File.Create(packagePath))
+        {
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+            await using (var nuspec = archive.CreateEntry("Sample.nuspec").Open())
+            {
+                await using var writer = new StreamWriter(nuspec);
+                await writer.WriteAsync($"""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+                      <metadata>
+                        <id>Sample</id>
+                        <version>1.0.0</version>
+                        <authors>Sample author</authors>
+                        <description>Sample description</description>
+                        <icon>{iconPath}</icon>
+                      </metadata>
+                    </package>
+                    """);
+            }
+
+            await using var iconEntry = archive.CreateEntry(iconPath).Open();
+            await iconEntry.WriteAsync(iconContent);
+        }
+
+        return await ValidateAsync(packagePath, excludedRuleIds: null, NuGetPackageValidationRules.IconMustBeSet);
+    }
+
+    [Theory]
+    // The extension is compared without case sensitivity
+    [InlineData("images/icon.png")]
+    [InlineData("images/icon.PNG")]
+    public async Task Validate_Icon_Png(string iconPath)
+    {
+        var result = await ValidateIconAsync(iconPath, [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        AssertNoErrors(result);
+    }
+
+    [Theory]
+    // JFIF
+    [InlineData("images/icon.jpg", (byte)0xE0)]
+    // Exif
+    [InlineData("images/icon.jpg", (byte)0xE1)]
+    // Raw JPEG stream starting with a quantization table
+    [InlineData("images/icon.jpg", (byte)0xDB)]
+    [InlineData("images/icon.JPEG", (byte)0xE1)]
+    public async Task Validate_Icon_Jpeg(string iconPath, byte marker)
+    {
+        var result = await ValidateIconAsync(iconPath, [0xFF, 0xD8, 0xFF, marker, 0x00, 0x10]);
+        AssertNoErrors(result);
+    }
+
+    [Fact]
+    public async Task Validate_Icon_ContentDoesNotMatchTheExtension()
+    {
+        var result = await ValidateIconAsync("images/icon.jpg", [0x89, 0x50, 0x4E, 0x47]);
+        AssertHasError(result, ErrorCodes.IconFileInvalidExtension);
+    }
+
+    [Fact]
+    public async Task Validate_Icon_UnsupportedFormat()
+    {
+        var result = await ValidateIconAsync("images/icon.gif", [0x47, 0x49, 0x46, 0x38]);
+        AssertHasError(result, ErrorCodes.IconFileFormatNotSupported);
     }
 
     [Fact]


### PR DESCRIPTION
`IconMustBeSet` rejected two classes of perfectly valid icons. It is a default rule, so both were hard failures with a message that contradicted the file on disk.

## The defects

**Case-sensitive extension.** `extension is ".png"` and `extension is ".jpg" or ".jpeg"` are ordinal comparisons against `Path.GetExtension(icon)`, which preserves the case written in the nuspec. An icon declared as `images/Icon.PNG` matched neither branch and fell through to `IconFileFormatNotSupported` — "Icon file must be PNG or JPG" — for a file that is a PNG. Every other extension comparison in the project is already `OrdinalIgnoreCase` (`AssembliesMustBeOptimized…:13-14`, `SymbolsValidationRule.cs:42`).

**JPEG detection only matched JFIF.** The expected magic number was `FF D8 FF E0`, the JFIF APP0 marker. That is one of several valid JPEG openings: Exif files — anything from a camera, and most editor exports — start `FF D8 FF E1`, and `FF D8 FF DB` / `FF D8 FF EE` also occur. Sampling the JPEGs on one machine, **13 of 38 started `FF D8 FF E1`**. Each would have been reported as `IconFileInvalidExtension`: "Icon file has extension '.jpg' but the file is not a JPEG".

## The change

- Compare icon extensions with `OrdinalIgnoreCase`.
- Match only the three bytes every JPEG shares — `FF D8` (start of image) followed by `FF`, the start of whichever marker segment comes next — instead of pinning the fourth byte to the JFIF marker.

The PNG signature check, the file-size limit, and the unsupported-format path are unchanged.

## Tests

`ValidateIconAsync` builds a package in a temporary directory declaring a given icon path with given bytes, so icon detection can be exercised without adding binary fixtures.

- `Validate_Icon_Png` — `icon.png` and `icon.PNG`.
- `Validate_Icon_Jpeg` — the `E0` (JFIF), `E1` (Exif) and `DB` markers, plus an uppercase `.JPEG` extension.
- `Validate_Icon_ContentDoesNotMatchTheExtension` — PNG bytes in a `.jpg` still reports `IconFileInvalidExtension`.
- `Validate_Icon_UnsupportedFormat` — `.gif` still reports `IconFileFormatNotSupported`.

Verified in both directions: with the fix the full suite passes (76/76); against the previous code 8 of the 28 icon cases fail — the uppercase extensions and the non-JFIF markers.
