### PR TITLE
Isolate the request path from cache store failures

### DIFF
--- a/ref/Meziantou.Framework.Http.Caching.cs
+++ b/ref/Meziantou.Framework.Http.Caching.cs
@@ -49,6 +49,7 @@ namespace Meziantou.Framework.Http.Caching
     {
         public System.TimeProvider TimeProvider { get => throw null; set { } }
         public long? MaximumResponseSize { get => throw null; set { } }
+        public System.Action<System.Exception>? OnStoreError { get => throw null; set { } }
         public System.Func<System.Net.Http.HttpResponseMessage, bool>? ShouldCacheResponse { get => throw null; set { } }
     }
 

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -8,6 +8,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 {
     private readonly HttpCache _cache;
     private readonly TimeProvider _timeProvider;
+    private readonly Action<Exception>? _onStoreError;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpCachingDelegateHandler"/> class.
@@ -20,6 +21,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         var resolvedOptions = options ?? new();
 
         _timeProvider = resolvedOptions.TimeProvider;
+        _onStoreError = resolvedOptions.OnStoreError;
         _cache = new HttpCache(store, resolvedOptions);
     }
 
@@ -36,6 +38,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         var resolvedOptions = options ?? new();
 
         _timeProvider = resolvedOptions.TimeProvider;
+        _onStoreError = resolvedOptions.OnStoreError;
         _cache = new HttpCache(store, resolvedOptions);
     }
 
@@ -52,8 +55,15 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             // RFC 7234 Section 4.4: Invalidation on unsafe methods
             if (!IsMethodSafe(request.Method) && IsNonErrorStatusCode(response.StatusCode))
             {
-                await _cache.InvalidateAsync(request.RequestUri, cancellationToken).ConfigureAwait(false);
-                await InvalidateLocationHeadersAsync(response, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _cache.InvalidateAsync(request.RequestUri, cancellationToken).ConfigureAwait(false);
+                    await InvalidateLocationHeadersAsync(response, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (IsStoreFailure(ex, cancellationToken))
+                {
+                    ReportStoreError(ex);
+                }
             }
 
             // Set RequestMessage if it's not already set by the base handler
@@ -95,7 +105,17 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         }
 
         // Try to get a cached response
-        var cacheResult = await _cache.TryGetAsync(request, cancellationToken).ConfigureAwait(false);
+        CacheEntry? cacheResult;
+        try
+        {
+            cacheResult = await _cache.TryGetAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsStoreFailure(ex, cancellationToken))
+        {
+            // A store that cannot be read is a cache miss, not a failed request.
+            ReportStoreError(ex);
+            cacheResult = null;
+        }
 
         if (cacheResult is not null)
         {
@@ -233,7 +253,16 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                     {
                         // Update cached entry with new headers from 304 response
                         await cacheResult.UpdateFromValidationResponse(conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
-                        await _cache.PersistEntryAsync(request.Method, request.RequestUri, cacheResult, cancellationToken).ConfigureAwait(false);
+                        try
+                        {
+                            await _cache.PersistEntryAsync(request.Method, request.RequestUri, cacheResult, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex) when (IsStoreFailure(ex, cancellationToken))
+                        {
+                            // The refreshed entry could not be written back. The response it validated is
+                            // still correct, so it is served anyway.
+                            ReportStoreError(ex);
+                        }
 
                         conditionalResponse.Dispose();
 
@@ -253,7 +282,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
                     // Use fresh response and cache it. The timing of the validation request is used so the
                     // stored entry is not aged by the time the previous entry spent in the cache.
-                    await _cache.StoreAsync(request, conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
+                    await StoreAsync(request, conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
                     conditionalResponse.RequestMessage ??= request;
                     return conditionalResponse;
                 }
@@ -293,11 +322,43 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
         var freshResponseTime = _timeProvider.GetUtcNow();
 
-        await _cache.StoreAsync(request, freshResponse, requestTime, freshResponseTime, cancellationToken).ConfigureAwait(false);
+        await StoreAsync(request, freshResponse, requestTime, freshResponseTime, cancellationToken).ConfigureAwait(false);
 
         // Set RequestMessage if it's not already set by the base handler
         freshResponse.RequestMessage ??= request;
         return freshResponse;
+    }
+
+    /// <summary>Stores the response, reporting rather than propagating a store failure.</summary>
+    private async ValueTask StoreAsync(HttpRequestMessage request, HttpResponseMessage response, DateTimeOffset requestTime, DateTimeOffset responseTime, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _cache.StoreAsync(request, response, requestTime, responseTime, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsStoreFailure(ex, cancellationToken))
+        {
+            // The origin answered. Failing to remember the answer must not turn that into a failed request.
+            ReportStoreError(ex);
+        }
+        catch
+        {
+            // The caller cancelled while the body was being read for storage, so the response is no longer
+            // usable and nothing else will dispose it.
+            response.Dispose();
+            throw;
+        }
+    }
+
+    private static bool IsStoreFailure(Exception exception, CancellationToken cancellationToken)
+    {
+        // A cancellation requested by the caller is not a store failure and must propagate.
+        return exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested;
+    }
+
+    private void ReportStoreError(Exception exception)
+    {
+        _onStoreError?.Invoke(exception);
     }
 
     private static bool IsMethodSafe(HttpMethod method)

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingOptions.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingOptions.cs
@@ -15,6 +15,15 @@ public sealed class HttpCachingOptions
     public long? MaximumResponseSize { get; set; } = 5 * 1024 * 1024; // 5 MB default
 
     /// <summary>
+    /// Gets or sets a callback invoked when the cache store fails.
+    /// A store failure never fails the request: the lookup is treated as a miss and the write is skipped, so
+    /// a degraded store degrades to no caching rather than to a broken <see cref="HttpClient"/>. This
+    /// callback is the only way to observe that, so set it if you need the failures to be visible.
+    /// Default is null (store failures are silently ignored).
+    /// </summary>
+    public Action<Exception>? OnStoreError { get; set; }
+
+    /// <summary>
     /// Gets or sets a predicate that determines whether a response should be cached.
     /// When the predicate returns true, normal caching logic applies.
     /// When the predicate returns false, the response is not cached.

--- a/src/Meziantou.Framework.Http.Caching/readme.md
+++ b/src/Meziantou.Framework.Http.Caching/readme.md
@@ -275,6 +275,21 @@ This is particularly useful for versioned resources (e.g., `/assets/script.v123.
 | `No-Vary-Search` | `key-order`, `params`, `except` | Query parameters that do not affect the response |
 | `Age` | `<seconds>` | Age of cached response (added when serving from cache) |
 
+## Cache Store Failures
+
+A failing `IHttpCacheStore` never fails the request. A lookup that throws is treated as a cache miss, and a write
+that throws is skipped, so a Redis outage or a locked SQLite file degrades to *no caching* rather than to a broken
+`HttpClient`. Set `OnStoreError` to observe those failures:
+
+```csharp
+var options = new HttpCachingOptions
+{
+    OnStoreError = ex => logger.LogWarning(ex, "HTTP cache store failure"),
+};
+```
+
+A cancellation requested by the caller is not a store failure and still propagates.
+
 ## Thread Safety
 
 The `HttpCachingDelegateHandler` is thread-safe and can be used concurrently across multiple threads.

--- a/tests/Meziantou.Framework.Http.Caching.Tests/StoreFailureTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/StoreFailureTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
+
+namespace Meziantou.Framework.Http.Caching.Tests;
+
+/// <summary>Tests that a failing <see cref="IHttpCacheStore"/> degrades to no caching, not to a failed request.</summary>
+public sealed class StoreFailureTests
+{
+    [Fact]
+    public async Task WhenSetEntryThrowsThenTheOriginResponseIsStillReturned()
+    {
+        var errors = new List<Exception>();
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new ThrowingStore(failWrites: true), new HttpCachingOptions { OnStoreError = errors.Add });
+        using var client = new HttpClient(handler);
+
+        var body = await client.GetStringAsync("http://example.com/resource", CancellationToken.None);
+
+        Assert.Equal("from-origin", body);
+        Assert.Single(errors);
+        Assert.IsType<IOException>(errors[0]);
+    }
+
+    [Fact]
+    public async Task WhenGetEntriesThrowsThenTheRequestGoesToTheOrigin()
+    {
+        var errors = new List<Exception>();
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new ThrowingStore(failReads: true), new HttpCachingOptions { OnStoreError = errors.Add });
+        using var client = new HttpClient(handler);
+
+        var body = await client.GetStringAsync("http://example.com/resource", CancellationToken.None);
+
+        Assert.Equal("from-origin", body);
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public async Task WhenRemoveEntriesThrowsThenTheUnsafeRequestStillSucceeds()
+    {
+        var errors = new List<Exception>();
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new ThrowingStore(failRemoves: true), new HttpCachingOptions { OnStoreError = errors.Add });
+        using var client = new HttpClient(handler);
+
+        using var content = new StringContent("payload");
+        using var response = await client.PostAsync("http://example.com/resource", content, CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public async Task WhenTheStoreFailsAndNoCallbackIsSetThenTheRequestStillSucceeds()
+    {
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new ThrowingStore(failWrites: true));
+        using var client = new HttpClient(handler);
+
+        Assert.Equal("from-origin", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenTheCallerCancelsThenTheCancellationIsNotReportedAsAStoreFailure()
+    {
+        var errors = new List<Exception>();
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new CancellingStore(), new HttpCachingOptions { OnStoreError = errors.Add });
+        using var client = new HttpClient(handler);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync("http://example.com/resource", cancellationTokenSource.Token));
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public async Task WhenTheStoreRecoversThenCachingResumes()
+    {
+        var store = new FlakyStore();
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        store.Fail = true;
+        Assert.Equal("from-origin", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+
+        store.Fail = false;
+        Assert.Equal("from-origin", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+
+        // The write that followed the recovery landed, so the third request is a hit.
+        Assert.Equal(2, innerHandler.Count);
+        Assert.Equal("from-origin", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+        Assert.Equal(2, innerHandler.Count);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public int Count { get; private set; }
+
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Count++;
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("from-origin") };
+            response.Headers.TryAddWithoutValidation("Cache-Control", "max-age=3600");
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ThrowingStore(bool failReads = false, bool failWrites = false, bool failRemoves = false) : IHttpCacheStore
+    {
+        public ValueTask<IReadOnlyCollection<HttpCachePersistenceEntry>> GetEntriesAsync(string primaryKey, CancellationToken cancellationToken)
+        {
+            if (failReads)
+                throw new IOException("store is down");
+
+            return ValueTask.FromResult<IReadOnlyCollection<HttpCachePersistenceEntry>>([]);
+        }
+
+        public ValueTask SetEntryAsync(string primaryKey, HttpCachePersistenceEntry entry, CancellationToken cancellationToken)
+        {
+            return failWrites ? throw new IOException("store is down") : ValueTask.CompletedTask;
+        }
+
+        public ValueTask RemoveEntriesAsync(string primaryKey, CancellationToken cancellationToken)
+        {
+            return failRemoves ? throw new IOException("store is down") : ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CancellingStore : IHttpCacheStore
+    {
+        public ValueTask<IReadOnlyCollection<HttpCachePersistenceEntry>> GetEntriesAsync(string primaryKey, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IReadOnlyCollection<HttpCachePersistenceEntry>>([]);
+        }
+
+        public ValueTask SetEntryAsync(string primaryKey, HttpCachePersistenceEntry entry, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask RemoveEntriesAsync(string primaryKey, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+
+    private sealed class FlakyStore : IHttpCacheStore
+    {
+        private readonly InMemoryHttpCacheStore _inner = new();
+
+        public bool Fail { get; set; }
+
+        public ValueTask<IReadOnlyCollection<HttpCachePersistenceEntry>> GetEntriesAsync(string primaryKey, CancellationToken cancellationToken)
+        {
+            return Fail ? throw new IOException("store is down") : _inner.GetEntriesAsync(primaryKey, cancellationToken);
+        }
+
+        public ValueTask SetEntryAsync(string primaryKey, HttpCachePersistenceEntry entry, CancellationToken cancellationToken)
+        {
+            return Fail ? throw new IOException("store is down") : _inner.SetEntryAsync(primaryKey, entry, cancellationToken);
+        }
+
+        public ValueTask RemoveEntriesAsync(string primaryKey, CancellationToken cancellationToken)
+        {
+            return Fail ? throw new IOException("store is down") : _inner.RemoveEntriesAsync(primaryKey, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
None of the handler's interactions with `IHttpCacheStore` were guarded, so a store failure propagated straight out of `SendAsync` and failed a request the origin had already answered successfully.

## The failure

`HttpCachingDelegateHandler.cs:98` (lookup), `:236`, `:256`, `:296` (writes), `:55-56` (invalidation).

With a store whose `SetEntryAsync` throws `IOException("store is down")`, `client.GetStringAsync(...)` failed with that `IOException` — even though the inner handler returned `200 OK` with a complete body.

Redis and SQLite are exactly the backends where transient failures are expected: a dropped connection, a locked database file, a full disk. Each of them turned a degraded cache into a total outage for the application, which is a worse failure mode than having no cache at all.

Two secondary consequences on the same lines: `freshResponse` and `conditionalResponse` were never disposed when the store threw, leaking the response and its connection; and because `cancellationToken` is threaded into `StoreAsync` → the body read, a caller cancelling while the body was being buffered for storage produced the same leak.

## The change

Every store interaction is now best-effort:

- a lookup that fails is a **cache miss** — the request goes to the origin;
- a write that fails is **skipped** — the origin's response is returned unchanged;
- an invalidation that fails is **skipped** — the unsafe request still succeeds.

A cancellation requested by the caller is explicitly *not* treated as a store failure and still propagates; on that path the response is disposed, which fixes the leak.

Silent failures are hard to notice, so this is not silent by default-only: the new `HttpCachingOptions.OnStoreError` callback receives every swallowed exception.

```csharp
var options = new HttpCachingOptions
{
    OnStoreError = ex => logger.LogWarning(ex, "HTTP cache store failure"),
};
```

## Public API

One added member, `HttpCachingOptions.OnStoreError`. `ref/Meziantou.Framework.Http.Caching.cs` is regenerated and the diff is exactly that one line. An `Action<Exception>` rather than an `ILogger` keeps the package free of a logging dependency and stays AOT-friendly.

## Verification

New `StoreFailureTests`, 6 tests:

- `WhenSetEntryThrowsThenTheOriginResponseIsStillReturned` — **fails on `main`** with the store's `IOException`; the callback receives it here.
- `WhenGetEntriesThrowsThenTheRequestGoesToTheOrigin`
- `WhenRemoveEntriesThrowsThenTheUnsafeRequestStillSucceeds`
- `WhenTheStoreFailsAndNoCallbackIsSetThenTheRequestStillSucceeds` — the callback is optional.
- `WhenTheCallerCancelsThenTheCancellationIsNotReportedAsAStoreFailure` — cancellation still propagates and is not reported as a store error.
- `WhenTheStoreRecoversThenCachingResumes` — a store that fails and then recovers starts caching again; nothing is latched.

Full suite on both target frameworks: 396 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
