### PR TITLE
Propagate cancellation instead of turning it into validation errors

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidationContext.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidationContext.cs
@@ -109,6 +109,10 @@ public sealed class NuGetPackageValidationContext : IDisposable
             using var response = await SendHttpRequestAsync(request, cancellationToken).ConfigureAwait(false);
             return response.IsSuccessStatusCode;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch
         {
             return false;

--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
@@ -286,9 +286,13 @@ internal sealed partial class SymbolsValidationRule : NuGetPackageValidationRule
                                         }
                                     }
                                 }
+                                catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+                                {
+                                    throw;
+                                }
                                 catch (Exception ex)
                                 {
-                                    context.ReportError(ErrorCodes.UrlIsNotAccessible, $"Source file '{url}' is not accessible: {ex}", fileName: item);
+                                    context.ReportError(ErrorCodes.UrlIsNotAccessible, $"Source file '{url}' is not accessible: {ex.Message}", fileName: item);
                                 }
                             }
                         }

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -258,6 +258,20 @@ public sealed class NuGetPackageValidatorTests
     }
 
     [Fact]
+    public async Task Validate_CancellationIsNotReportedAsAValidationError()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // The package has a project url, so the rule performs an HTTP request that observes the token
+        var path = FullPath.FromPath(typeof(NuGetPackageValidatorTests).Assembly.Location).Parent / "Packages" / "meziantou.framework.2.6.0.nupkg";
+        var options = new NuGetPackageValidationOptions();
+        options.Rules.Add(NuGetPackageValidationRules.ProjectUrlMustBeSet);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => NuGetPackageValidator.ValidateAsync(path, options, cts.Token));
+    }
+
+    [Fact]
     public async Task Validate_WithSymbolsServer()
     {
         // Downloading symbols can be flaky on CI


### PR DESCRIPTION
Cancelling a validation run produced fabricated package defects instead of aborting.

## The defect

`NuGetPackageValidationContext.IsUrlAccessible` caught everything and returned `false`, so a cancelled request was indistinguishable from an unreachable URL. Validation carried on to the next rule, and the caller got a result full of "not accessible" errors that say nothing about the package.

`SymbolsValidationRule` was worse: its source-file check caught `Exception ex` and reported `UrlIsNotAccessible` with `{ex}` interpolated — the exception type, message **and stack trace** — so cancelling during a source-file check wrote a `TaskCanceledException` dump into the JSON that CI parses, and the tool exited 1 as though the package had failed.

`System.CommandLine` wires process termination to the token passed to `SetAction`, so this is the ordinary Ctrl+C path for the CLI.

## The change

Both handlers now rethrow when the caller's token is the one that fired:

```csharp
catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
{
    throw;
}
```

The filter matters: `HttpClient` raises `TaskCanceledException` for its own 100 s timeout too, and that carries a *different* token. Those keep being treated as "not accessible", which is the existing and correct behaviour — only genuine caller cancellation propagates.

The `SymbolsValidationRule` handler also now reports `ex.Message` rather than `{ex}`. A stack trace in a validation error tells the package author nothing, and it leaks internal detail into output that is often published.

## Tests

`Validate_CancellationIsNotReportedAsAValidationError` runs `ProjectUrlMustBeSet` against `meziantou.framework.2.6.0.nupkg` — a package with a project URL, so the rule performs a real request that observes the token — with an already-cancelled token, and asserts `OperationCanceledException` propagates.

Verified in both directions: with the fix the full suite passes (62/62); against the previous code the new test fails on both target frameworks, because the run completed and returned errors instead of throwing.
