### PR TITLE
Escape reserved device names with extensions and trailing periods and spaces

### DIFF
--- a/src/Meziantou.Framework/IOUtilities.cs
+++ b/src/Meziantou.Framework/IOUtilities.cs
@@ -61,17 +61,31 @@ static partial class IOUtilities
 
         ArgumentNullException.ThrowIfNull(reservedCharFormat);
 
-        if (ReservedFileNames.ContainsIgnoreCase(fileName) || IsAllDots(fileName))
+        // Windows reserves a device name with any extension, so "con.txt" is as reserved as "con".
+        // The device name is the part before the first period.
+        var dotIndex = fileName.IndexOf('.', StringComparison.Ordinal);
+        var deviceName = dotIndex < 0 ? fileName : fileName[..dotIndex];
+        if (ReservedFileNames.ContainsIgnoreCase(deviceName) || IsAllDots(fileName))
         {
             return string.Format(CultureInfo.InvariantCulture, reservedNameFormat, fileName);
         }
 
         var invalid = Path.GetInvalidFileNameChars();
 
-        var sb = new StringBuilder(fileName.Length);
-        foreach (var c in fileName)
+        // Windows silently strips trailing periods and spaces, so a name keeping them would be
+        // created under a different name than the caller was given. They are escaped like any other
+        // character that cannot be used as-is.
+        var trailingStart = fileName.Length;
+        while (trailingStart > 0 && fileName[trailingStart - 1] is '.' or ' ')
         {
-            if (Array.IndexOf(invalid, c) >= 0)
+            trailingStart--;
+        }
+
+        var sb = new StringBuilder(fileName.Length);
+        for (var i = 0; i < fileName.Length; i++)
+        {
+            var c = fileName[i];
+            if (Array.IndexOf(invalid, c) >= 0 || i >= trailingStart)
             {
                 sb.AppendFormat(CultureInfo.InvariantCulture, reservedCharFormat, (short)c);
             }

--- a/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
@@ -7,6 +7,15 @@ public class IOUtilitiesTests
     [InlineData("sample.txt", "sample.txt")]
     [InlineData("sample/.txt", "sample_x47_.txt")]
     [InlineData("COM1", "_COM1_")]
+    // A device name is reserved with any extension
+    [InlineData("con.txt", "_con.txt_")]
+    [InlineData("NUL.log.bak", "_NUL.log.bak_")]
+    [InlineData("console.txt", "console.txt")]
+    // Windows strips trailing periods and spaces
+    [InlineData("report.", "report_x46_")]
+    [InlineData("report ", "report_x32_")]
+    [InlineData("report.. ", "report_x46__x46__x32_")]
+    [InlineData("...", "_..._")]
     public void ToValidFileName(string fileName, string expectedResult)
     {
         var result = IOUtilities.ToValidFileName(fileName);


### PR DESCRIPTION
## The bug

`ToValidFileName` (`IOUtilities.cs:56-102`) misses two classes of name that Windows will not create
as given:

- **Reserved device names with an extension.** The check compared the whole input against
  `ReservedFileNames`, but Windows reserves `con.txt`, `nul.log.bak` and so on — any name whose part
  before the first period is a device name. `ToValidFileName("con.txt")` returned `"con.txt"`.
- **Trailing periods and spaces.** Windows strips them, so `ToValidFileName("report.")` and
  `ToValidFileName("report ")` returned their input unchanged and the file is then created under a
  different name than the caller was told. `IsAllDots` only caught names that are *entirely* dots,
  and `Path.GetInvalidFileNameChars()` covers neither.

The method's contract is "converts a text into a valid file name", so callers stop checking. The
result then fails to create, or creates under another name — which breaks any subsequent lookup by
the name they were handed. This matters most when the input is user- or data-derived, which is the
only reason to call the method.

## The change

- The reserved-name check uses the segment before the first period, matching how Windows resolves
  device names. The existing `reservedNameFormat` is still applied to the whole input, so
  `con.txt` becomes `_con.txt_`.
- Trailing periods and spaces are escaped with the existing `reservedCharFormat`, the same mechanism
  already used for invalid characters, so `report.` becomes `report_x46_`.

The three existing theory cases are unchanged by this.

## Not in this PR

`ReservedFileNames` also lists `com0` and `lpt0`, which are not actually reserved on Windows, and
omits `CONIN$`/`CONOUT$`. Both are worth a look but neither is a correctness failure of the kind
above.

## Verification

Seven theory cases added to the existing `ToValidFileName` test, covering device names with
extensions, a name that merely starts like one (`console.txt`), and trailing periods and spaces.
Confirmed they fail on `main` and pass with the fix.
