### PR TITLE
Add an option to set the Unix permissions of the log files

### DIFF
--- a/ref/Meziantou.Extensions.Logging.FileLogger.cs
+++ b/ref/Meziantou.Extensions.Logging.FileLogger.cs
@@ -38,6 +38,7 @@ namespace Meziantou.Extensions.Logging
         public Meziantou.Extensions.Logging.RollInterval RollInterval { get => throw null; set { } }
         public long? MaxFileSizeInBytes { get => throw null; set { } }
         public int? MaxRetainedFiles { get => throw null; set { } }
+        public System.IO.UnixFileMode? UnixCreateMode { get => throw null; set { } }
         public Meziantou.Extensions.Logging.LogFileCompression Compression { get => throw null; set { } }
         public Meziantou.Extensions.Logging.LogFileCompressionMode CompressionMode { get => throw null; set { } }
         public System.IO.Compression.CompressionLevel CompressionLevel { get => throw null; set { } }

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
@@ -81,6 +81,13 @@ public sealed class FileLoggerOptions
         }
     }
 
+    /// <summary>Gets or sets the Unix file mode applied to the log files when they are created. Defaults to <see langword="null" />, which uses the default mode of the platform.</summary>
+    /// <remarks>
+    /// The default mode of most Unix systems makes the log files readable by every local user. Set this option to <see cref="System.IO.UnixFileMode.UserRead" /> | <see cref="System.IO.UnixFileMode.UserWrite" /> when the messages can contain sensitive data.
+    /// The value is ignored on Windows, and the mode is still filtered by the umask of the process. The mode of the directory is not changed.
+    /// </remarks>
+    public UnixFileMode? UnixCreateMode { get; set; }
+
     /// <summary>Gets or sets the algorithm used to compress the log files. Defaults to <see cref="LogFileCompression.None" />.</summary>
     public LogFileCompression Compression { get; set; }
 

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
@@ -108,7 +108,7 @@ internal sealed class LogFileWriter : IDisposable
             {
                 // Opening the file with FileShare.Read allows other processes to read the log file while it is being written,
                 // and prevents 2 providers from writing to the same file
-                stream = new FileStream(path, append ? FileMode.Append : FileMode.CreateNew, FileAccess.Write, FileShare.Read | FileShare.Delete);
+                stream = new FileStream(path, CreateStreamOptions(append ? FileMode.Append : FileMode.CreateNew, FileShare.Read | FileShare.Delete));
                 _writer = new StreamWriter(_compressWhileWriting ? CreateCompressionStream(stream) : stream, Utf8NoBom) { AutoFlush = false };
                 _fileStream = stream;
                 _currentFileSize = stream.Length;
@@ -126,6 +126,24 @@ internal sealed class LogFileWriter : IDisposable
         }
 
         throw lastException ?? new IOException("Cannot create a log file in " + _directory);
+    }
+
+    private FileStreamOptions CreateStreamOptions(FileMode mode, FileShare share)
+    {
+        var streamOptions = new FileStreamOptions
+        {
+            Mode = mode,
+            Access = FileAccess.Write,
+            Share = share,
+        };
+
+        // Setting UnixCreateMode throws on Windows, where the value has no meaning
+        if (!OperatingSystem.IsWindows() && _options.UnixCreateMode is { } unixCreateMode)
+        {
+            streamOptions.UnixCreateMode = unixCreateMode;
+        }
+
+        return streamOptions;
     }
 
     private Stream CreateCompressionStream(Stream stream) => _options.Compression switch
@@ -197,7 +215,7 @@ internal sealed class LogFileWriter : IDisposable
         try
         {
             using (var source = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-            using (var destination = new FileStream(path + GetCompressionExtension(_options.Compression), FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var destination = new FileStream(path + GetCompressionExtension(_options.Compression), CreateStreamOptions(FileMode.Create, FileShare.None)))
             using (var compressedStream = CreateCompressionStream(destination))
             {
                 source.CopyTo(compressedStream);

--- a/src/Meziantou.Extensions.Logging.FileLogger/readme.md
+++ b/src/Meziantou.Extensions.Logging.FileLogger/readme.md
@@ -87,6 +87,16 @@ options.CompressionMode = LogFileCompressionMode.Continuous;
 
 `MaxFileSizeInBytes` is compared to the size of the file on disk, so it accounts for the compression. As the compressed size is only known once the data is flushed, the file may be rolled slightly before the limit.
 
+## Permissions
+
+On Unix, the log files are created with the default mode of the platform, which usually makes them readable by every local user. Set `UnixCreateMode` when the messages can contain sensitive data:
+
+```c#
+options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+```
+
+The value is ignored on Windows, and it is still filtered by the umask of the process. The mode of the directory is not changed, so create the directory yourself when it must be private too.
+
 ## Formatters
 
 `SimpleFileFormatter` (default) writes one human-readable line per entry:

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Meziantou.Xunit;
 using Microsoft.Extensions.Time.Testing;
 
 #pragma warning disable CA1848 // Use the LoggerMessage delegates
@@ -407,6 +408,38 @@ public sealed class FileLoggerProviderTests
 
         var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
         Assert.Equal([$"2024-01-05-{pid}.log.gz", $"2024-01-06-{pid}.log.gz"], GetFileNames(tempDirectory));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public async Task UnixCreateModeIsAppliedToTheLogFiles()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite,
+            RollInterval = RollInterval.Daily,
+            Compression = LogFileCompression.GZip,
+            CompressionMode = LogFileCompressionMode.OnRoll,
+        }, timeProvider);
+
+        var logger = provider.CreateLogger("Test");
+        logger.LogInformation("First day");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        // Roll, so the file created by the compression is checked too
+        timeProvider.Advance(TimeSpan.FromDays(1));
+        logger.LogInformation("Second day");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var files = new DirectoryInfo(tempDirectory.FullPath).GetFiles();
+        Assert.NotEmpty(files);
+        foreach (var file in files)
+        {
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(file.FullName));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
`Directory.CreateDirectory` and `FileStream` use the platform defaults (`LogFileWriter.cs:94` and `:111`). Measured on macOS: the log file is created `0644` — readable by every local user. There is no option to restrict it, and `FileStreamOptions` is not used.

### Why it matters

Application logs routinely carry PII, session identifiers, tokens in exception messages, and request URLs. On a shared or multi-tenant host this is a local information disclosure that the application author cannot close through this library — `chmod`-ing behind its back does not survive, because the file is recreated on every roll.

### What changed

New `FileLoggerOptions.UnixCreateMode` (`UnixFileMode?`), passed through `FileStreamOptions` when the log file is created:

```c#
options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
```

- Defaults to `null`, which keeps the current platform behavior — **no behavioral change for existing users**.
- The mode is applied to the files created on roll as well, and to the compressed file produced by `CompressionMode.OnRoll`. A private log whose gzip archive is world-readable would defeat the point.
- Setting `FileStreamOptions.UnixCreateMode` throws on Windows, so it is only assigned when the platform is not Windows.
- The name follows the BCL precedent (`FileStreamOptions.UnixCreateMode`) rather than inventing one.

The directory mode is deliberately **not** changed. A `0600` file is protected regardless of the directory's mode — reading it requires read permission on the file itself — and deriving a sensible directory mode from a file mode would be guesswork. This is stated in the option's documentation and in the readme.

`FileShare` is unchanged: the log file keeps `FileShare.Read | FileShare.Delete` and the compression target keeps `FileShare.None`. The refactor to `FileStreamOptions` takes the share mode as a parameter specifically so it did not quietly change.

### On the default

My review suggested defaulting to owner-only would be the safer default for a logging library. I did not do that here: it is a behavioral change on a published v3 package, and it would break anyone whose log shipper runs as a different user. Flipping the default is a one-line follow-up if you want it for the next major.

### Verification

New test `UnixCreateModeIsAppliedToTheLogFiles` sets `0600`, drives a daily roll with `CompressionMode.OnRoll`, then asserts **every** file left in the directory — the current log, the rolled one and the `.gz` — has exactly that mode. Gated with `[RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]`; it runs on 3 of the 4 CI legs.

`ref/Meziantou.Extensions.Logging.FileLogger.cs` regenerated (Release + `IsOfficialBuild`); the diff is the single new property. Full suite 57/57 green on net10.0 and net11.0; `dotnet run ./eng/update-all.cs` reports no further changes.
