### PR TITLE
Apply MaxReadLength to CopyTo and dispose the wrapped stream once

### DIFF
--- a/src/Meziantou.Framework/RestrictedStream.cs
+++ b/src/Meziantou.Framework/RestrictedStream.cs
@@ -5,6 +5,8 @@ namespace Meziantou.Framework;
 /// <param name="options">The options that control which operations are allowed.</param>
 public sealed class RestrictedStream(Stream stream, RestrictedStreamOptions options) : Stream
 {
+    private bool _disposed;
+
     /// <inheritdoc />
     public override bool CanRead => stream.CanRead && options.AllowReading;
 
@@ -89,6 +91,15 @@ public sealed class RestrictedStream(Stream stream, RestrictedStreamOptions opti
     {
         ThrowIfSynchronousCallNotAllowed();
         ThrowIfReadingNotAllowed();
+
+        // Copying through the base implementation routes every read through this stream, so the
+        // per-read cap still applies. Delegating to the wrapped stream would bypass it.
+        if (options.MaxReadLength > 0)
+        {
+            base.CopyTo(destination, bufferSize);
+            return;
+        }
+
         stream.CopyTo(destination, bufferSize);
     }
 
@@ -97,6 +108,11 @@ public sealed class RestrictedStream(Stream stream, RestrictedStreamOptions opti
     {
         ThrowIfAsynchronousCallNotAllowed();
         ThrowIfReadingNotAllowed();
+
+        // See CopyTo: the base implementation reads through this stream so the cap is honored
+        if (options.MaxReadLength > 0)
+            return base.CopyToAsync(destination, bufferSize, cancellationToken);
+
         return stream.CopyToAsync(destination, bufferSize, cancellationToken);
     }
 
@@ -104,13 +120,25 @@ public sealed class RestrictedStream(Stream stream, RestrictedStreamOptions opti
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        stream.Dispose();
+
+        if (!_disposed)
+        {
+            _disposed = true;
+            stream.Dispose();
+        }
     }
 
     /// <inheritdoc />
     public async override ValueTask DisposeAsync()
     {
-        await stream.DisposeAsync().ConfigureAwait(false);
+        // Stream.DisposeAsync calls Dispose, so the flag keeps the wrapped stream from being
+        // disposed a second time through that path.
+        if (!_disposed)
+        {
+            _disposed = true;
+            await stream.DisposeAsync().ConfigureAwait(false);
+        }
+
         await base.DisposeAsync().ConfigureAwait(false);
     }
 

--- a/tests/Meziantou.Framework.Tests/RestrictedStreamTests.cs
+++ b/tests/Meziantou.Framework.Tests/RestrictedStreamTests.cs
@@ -895,6 +895,8 @@ public sealed class RestrictedStreamTests
 
     private sealed class CountingStream(Stream inner) : Stream
     {
+        private bool _insideDisposeAsync;
+
         public int MaxReadRequested { get; private set; }
         public int DisposeCount { get; private set; }
 
@@ -934,15 +936,27 @@ public sealed class RestrictedStreamTests
 
         protected override void Dispose(bool disposing)
         {
-            DisposeCount++;
+            // Stream.DisposeAsync routes through Dispose, so that inner call is not counted twice
+            if (!_insideDisposeAsync)
+            {
+                DisposeCount++;
+            }
+
             base.Dispose(disposing);
         }
 
-        public override ValueTask DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             DisposeCount++;
-            GC.SuppressFinalize(this);
-            return default;
+            _insideDisposeAsync = true;
+            try
+            {
+                await base.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _insideDisposeAsync = false;
+            }
         }
     }
 }

--- a/tests/Meziantou.Framework.Tests/RestrictedStreamTests.cs
+++ b/tests/Meziantou.Framework.Tests/RestrictedStreamTests.cs
@@ -833,4 +833,116 @@ public sealed class RestrictedStreamTests
         Assert.Equal(3, bytesRead3);
         Assert.Equal([1, 2, 3, 4, 5, 6, 7, 8, 9], buffer.AsSpan(0, 9));
     }
+
+    [Fact]
+    public void CopyTo_HonorsMaxReadLength()
+    {
+        var inner = new CountingStream(new MemoryStream(new byte[1000]));
+        using var stream = new RestrictedStream(inner, new RestrictedStreamOptions
+        {
+            AllowSynchronousCalls = true,
+            AllowReading = true,
+            MaxReadLength = 10,
+        });
+
+        using var destination = new MemoryStream();
+        stream.CopyTo(destination, bufferSize: 256);
+
+        Assert.Equal(1000, destination.Length);
+        Assert.True(inner.MaxReadRequested <= 10, $"A single read asked for {inner.MaxReadRequested} bytes, above the 10-byte cap");
+    }
+
+    [Fact]
+    public async Task CopyToAsync_HonorsMaxReadLength()
+    {
+        var inner = new CountingStream(new MemoryStream(new byte[1000]));
+        await using var stream = new RestrictedStream(inner, new RestrictedStreamOptions
+        {
+            AllowAsynchronousCalls = true,
+            AllowReading = true,
+            MaxReadLength = 10,
+        });
+
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination, bufferSize: 256);
+
+        Assert.Equal(1000, destination.Length);
+        Assert.True(inner.MaxReadRequested <= 10, $"A single read asked for {inner.MaxReadRequested} bytes, above the 10-byte cap");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesTheWrappedStreamOnce()
+    {
+        var inner = new CountingStream(new MemoryStream());
+        var stream = new RestrictedStream(inner, new RestrictedStreamOptions { AllowReading = true });
+
+        await stream.DisposeAsync();
+
+        Assert.Equal(1, inner.DisposeCount);
+    }
+
+    [Fact]
+    public void Dispose_DisposesTheWrappedStreamOnce()
+    {
+        var inner = new CountingStream(new MemoryStream());
+        var stream = new RestrictedStream(inner, new RestrictedStreamOptions { AllowReading = true });
+
+        stream.Dispose();
+        stream.Dispose();
+
+        Assert.Equal(1, inner.DisposeCount);
+    }
+
+    private sealed class CountingStream(Stream inner) : Stream
+    {
+        public int MaxReadRequested { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+        public override long Position { get => inner.Position; set => inner.Position = value; }
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+        public override void SetLength(long value) => inner.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            MaxReadRequested = Math.Max(MaxReadRequested, count);
+            return inner.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            MaxReadRequested = Math.Max(MaxReadRequested, buffer.Length);
+            return inner.Read(buffer);
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            MaxReadRequested = Math.Max(MaxReadRequested, buffer.Length);
+            return inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            MaxReadRequested = Math.Max(MaxReadRequested, count);
+            return inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            GC.SuppressFinalize(this);
+            return default;
+        }
+    }
 }


### PR DESCRIPTION
## The bugs

Two holes in a type whose whole purpose is to impose restrictions.

**`CopyTo`/`CopyToAsync` bypassed `MaxReadLength`.** They delegated straight to the wrapped stream
(`RestrictedStream.cs:88-101`), so the per-read cap enforced on every other read path did not apply
to a copy. A path that bypasses a restriction is a correctness hole in the type's stated purpose, and
it was not documented.

**`DisposeAsync` disposed the wrapped stream twice.** It disposed the inner stream and then called
`base.DisposeAsync()`, whose default implementation calls `Dispose()` → `Dispose(bool)` → the
override, which disposes the inner stream again (`:104-115`). Most streams tolerate a double dispose;
custom ones need not.

## The change

- `CopyTo`/`CopyToAsync` route through `base.CopyTo`/`base.CopyToAsync` when a cap is configured. The
  base implementation reads through *this* stream, so `ApplyMaxReadLength` applies to every read. With
  no cap they still delegate to the wrapped stream, keeping whatever `CopyTo` optimization it has.
- A `_disposed` flag makes the wrapped stream's disposal idempotent across both paths.

## Not in this PR

`RestrictedStream` has no `leaveOpen` option — disposing it always disposes the stream you handed it,
unlike `CryptoStream`, `GZipStream` or `StreamReader`. That makes it awkward for the "restrict a
stream someone else owns" case it is named for, but adding a constructor parameter is an API decision
rather than a bug fix, so I left it for you. Same for the unvalidated primary-constructor parameters
at line 6.

## Verification

Four tests added to `RestrictedStreamTests` with an instrumented inner stream that records the largest
read it was asked for and how many times it was disposed. Confirmed all four fail on `main` and pass
with the fix; all 71 tests in the class pass.
