### PR TITLE
Report validation errors in the order they are found

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidationContext.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/NuGetPackageValidationContext.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using NuGet.Packaging;
 
 namespace Meziantou.Framework.NuGetPackageValidation;
@@ -6,7 +5,8 @@ namespace Meziantou.Framework.NuGetPackageValidation;
 /// <summary>Provides context information and methods for validating a NuGet package.</summary>
 public sealed class NuGetPackageValidationContext : IDisposable
 {
-    private readonly ConcurrentBag<NuGetPackageValidationError> _errors = [];
+    private readonly List<NuGetPackageValidationError> _errors = [];
+    private readonly Lock _errorsLock = new();
     private readonly NuGetPackageValidationOptions _options;
 
     internal NuGetPackageValidationContext(FullPath file, NuGetPackageValidationOptions options, CancellationToken cancellationToken)
@@ -58,7 +58,16 @@ public sealed class NuGetPackageValidationContext : IDisposable
         }
     }
 
-    internal IReadOnlyCollection<NuGetPackageValidationError> Errors => _errors;
+    internal IReadOnlyCollection<NuGetPackageValidationError> Errors
+    {
+        get
+        {
+            lock (_errorsLock)
+            {
+                return _errors.ToArray();
+            }
+        }
+    }
 
     /// <summary>Determines whether a specific validation rule is excluded from validation.</summary>
     /// <param name="ruleId">The error code of the rule to check.</param>
@@ -84,7 +93,11 @@ public sealed class NuGetPackageValidationContext : IDisposable
         if (_options.ExcludedRuleIds.Contains(errorCode))
             return;
 
-        _errors.Add(new NuGetPackageValidationError(errorCode, message, helpText, fileName));
+        var error = new NuGetPackageValidationError(errorCode, message, helpText, fileName);
+        lock (_errorsLock)
+        {
+            _errors.Add(error);
+        }
     }
 
     /// <summary>Sends an HTTP request using the configured HTTP client and request configuration.</summary>

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -258,6 +258,14 @@ public sealed class NuGetPackageValidatorTests
     }
 
     [Fact]
+    public async Task Validate_ErrorsKeepTheOrderTheyAreReportedIn()
+    {
+        // The package sets the repository type but neither the url nor the commit
+        var result = await ValidateAsync("Release_RepositoryType.1.0.0.nupkg", NuGetPackageValidationRules.RepositoryMustBeSet);
+        Assert.Equal([ErrorCodes.RepositoryUrlNotSet, ErrorCodes.RepositoryCommitNotSet], result.Errors.Select(item => item.ErrorCode));
+    }
+
+    [Fact]
     public async Task Validate_WithSymbolsServer()
     {
         // Downloading symbols can be flaky on CI


### PR DESCRIPTION
Validation errors came out in reverse order.

## The defect

`NuGetPackageValidationContext._errors` was a `ConcurrentBag<T>`, which enumerates LIFO. Rules run strictly sequentially (`NuGetPackageValidator.cs`), so the bag bought no concurrency and cost deterministic ordering. Validating `Debug.1.0.0.nupkg` reported:

```
101, 131, 111, 74, 73, 72, 61, 51, 21, …
```

— exactly the reverse of the order the rules ran and the order the errors were found. Reports read backwards, and the CLI's JSON output is not stable across runs, which makes it awkward to diff or snapshot.

## The change

`_errors` is a `List<T>`, so errors keep insertion order. `ReportError` is public and a custom rule is free to call it from several threads, so the list is guarded by a `Lock` and `Errors` returns a snapshot rather than the live list. The lock is uncontended in the sequential case, and it is a smaller cost than what `ConcurrentBag` was already paying.

## Tests

`Validate_ErrorsKeepTheOrderTheyAreReportedIn` runs `RepositoryMustBeSet` against `Release_RepositoryType.1.0.0.nupkg` — a fixture that sets the repository type but neither the URL nor the commit, so one rule reports two errors in a known source order — and asserts the sequence is `RepositoryUrlNotSet` then `RepositoryCommitNotSet`.

That fixture was in the corpus but referenced by no test until now.

Verified in both directions: with the fix the full suite passes (62/62); against the previous code the new test fails on both target frameworks, with the two codes reversed.
