### PR TITLE
Match the GitHub raw host on label boundaries and dedupe package paths per platform

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
@@ -82,27 +82,26 @@ internal static partial class Program
                     if (host is null)
                         return;
 
-                    if (host.EndsWith("raw.githubusercontent.com", StringComparison.OrdinalIgnoreCase))
+                    if (IsGitHubRawHost(host))
                     {
                         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", githubToken);
                     }
                 };
             }
 
-            var packageResults = new Dictionary<string, NuGetPackageValidationResult>(capacity: paths is null ? 0 : paths.Length, StringComparer.Ordinal);
-            if (paths is not null)
+            var packageResults = new Dictionary<string, NuGetPackageValidationResult>(capacity: paths.Length, StringComparer.Ordinal);
+            var validatedPaths = new HashSet<FullPath>(capacity: paths.Length);
+            foreach (var path in paths)
             {
-                foreach (var path in paths)
-                {
-                    var packagePath = FullPath.FromPath(path);
-                    if (packageResults.ContainsKey(packagePath))
-                        continue;
+                // FullPath knows whether the file system is case-sensitive, a plain string comparison does not
+                var packagePath = FullPath.FromPath(path);
+                if (!validatedPaths.Add(packagePath))
+                    continue;
 
-                    var packageResult = await NuGetPackageValidator.ValidateAsync(packagePath, options, cancellationToken).ConfigureAwait(false);
+                var packageResult = await NuGetPackageValidator.ValidateAsync(packagePath, options, cancellationToken).ConfigureAwait(false);
 
-                    if (!packageResult.IsValid || !onlyReportErrors)
-                        packageResults.Add(packagePath, packageResult);
-                }
+                if (!packageResult.IsValid || !onlyReportErrors)
+                    packageResults.Add(packagePath, packageResult);
             }
 
             var result = new Result(packageResults);
@@ -126,6 +125,16 @@ internal static partial class Program
         var invocationConfiguration = new InvocationConfiguration();
         configure?.Invoke(invocationConfiguration);
         return rootCommand.Parse(args).InvokeAsync(invocationConfiguration);
+    }
+
+    /// <summary>Checks the host is raw.githubusercontent.com or one of its subdomains. A plain EndsWith would also
+    /// match a host such as "notraw.githubusercontent.com".</summary>
+    internal static bool IsGitHubRawHost(string host)
+    {
+        const string GitHubRawHost = "raw.githubusercontent.com";
+
+        return string.Equals(host, GitHubRawHost, StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith("." + GitHubRawHost, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string GetRulesDescription()

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
@@ -58,6 +58,36 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
         Assert.Contains(result.ValidationResults.Packages[path2].Errors, item => item.ErrorCode == 101);
     }
 
+    [Theory]
+    [InlineData("raw.githubusercontent.com", true)]
+    [InlineData("RAW.GITHUBUSERCONTENT.COM", true)]
+    [InlineData("cdn.raw.githubusercontent.com", true)]
+    [InlineData("notraw.githubusercontent.com", false)]
+    [InlineData("raw.githubusercontent.com.example.com", false)]
+    [InlineData("github.com", false)]
+    public void IsGitHubRawHost(string host, bool expected)
+    {
+        Assert.Equal(expected, Program.IsGitHubRawHost(host));
+    }
+
+    [Fact]
+    public async Task TestPackage_DuplicatePathsAreValidatedOnce()
+    {
+        var path = FullPath.FromPath("Packages/Debug.1.0.0.nupkg");
+        var result = await RunValidation(path, path);
+        Assert.HasCount(1, result.ValidationResults!.Packages);
+    }
+
+    [Fact]
+    public async Task TestPackage_DuplicatePathsDifferingByCaseAreValidatedOnce()
+    {
+        var result = await RunValidation("Packages/Debug.1.0.0.nupkg", "Packages/debug.1.0.0.NUPKG");
+
+        // On a case-sensitive file system the two paths are different files, so both are validated
+        var expectedCount = FullPathComparer.Default.IsCaseSensitive ? 2 : 1;
+        Assert.HasCount(expectedCount, result.ValidationResults!.Packages);
+    }
+
     [Fact]
     public async Task ExcludedRuleIds()
     {


### PR DESCRIPTION
Two independent one-line defects in the CLI, both in `Program.cs`. They are unrelated to each other; they are batched because splitting one file into two PRs for two one-liners costs the reviewer more than it saves. Happy to split if preferred.

## 1. `--github-token` host match has no label boundary

`host.EndsWith("raw.githubusercontent.com", OrdinalIgnoreCase)` also matches `notraw.githubusercontent.com`, so the bearer token would be attached to a request for such a host. Every name of that shape lives in a zone GitHub controls, so this is not exploitable today — but the host comes from a Source Link URL inside the package being validated, which is attacker-controlled input, and the pattern should not be copied to a domain the project does not own.

Now `IsGitHubRawHost` matches the host exactly, or as a subdomain with the leading dot.

## 2. Duplicate package paths were deduped with an ordinal string comparison

The results dictionary used `StringComparer.Ordinal`, so `Pkg.nupkg` and `pkg.nupkg` were validated twice on Windows and macOS — the same file, done twice, and then `packageResults.Add` on the second would have thrown had the keys collided. `FullPath` already knows whether the file system is case-sensitive, so deduping goes through a `HashSet<FullPath>` while the JSON output keeps its string keys.

While in those lines: `paths` is checked for null and returned on at the top of the action, so the `paths is null ? 0 : paths.Length` and `if (paths is not null)` below it were unreachable. Removed, per the repo convention of trusting the null annotations.

## Tests

- `IsGitHubRawHost` — the exact host, an uppercase spelling, a subdomain, plus `notraw.githubusercontent.com`, `raw.githubusercontent.com.example.com` and `github.com`.
- `TestPackage_DuplicatePathsAreValidatedOnce` — the same path twice yields one result.
- `TestPackage_DuplicatePathsDifferingByCaseAreValidatedOnce` — asserts one result on a case-insensitive file system and two on a case-sensitive one, since there the paths really are different files.

Verified in both directions: with the fixes all 30 tool tests pass; against the previous code 4 of the new cases fail.
