### PR TITLE
Re-read every Cache-Control directive from a 304 response

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -335,29 +335,27 @@ internal sealed class CacheEntry
     {
         // RFC 7234 Section 4.3.4: Update metadata from 304 response
 
-        // Update cache control if provided
+        // Update cache control if provided.
+        // RFC 7234 Section 4.3.4: the 304 replaces the stored Cache-Control header, so every directive
+        // derived from it is re-read from the new value. A directive missing from it is gone, not retained:
+        // a server that stops sending `immutable` or `stale-if-error` has to be able to take that back.
+        // A 304 that carries no Cache-Control at all leaves the stored directives untouched.
         var cacheControl = validationResponse.Headers.CacheControl;
         var updatedMaxAge = false;
         if (cacheControl is not null)
         {
-            if (cacheControl.MaxAge is not null && cacheControl.MaxAge != MaxAge)
-            {
-                MaxAge = cacheControl.MaxAge;
-                updatedMaxAge = true;
-            }
+            updatedMaxAge = cacheControl.MaxAge != MaxAge || cacheControl.SharedMaxAge != SharedMaxAge;
 
-            if (cacheControl.SharedMaxAge is not null && cacheControl.SharedMaxAge != SharedMaxAge)
-            {
-                SharedMaxAge = cacheControl.SharedMaxAge;
-                updatedMaxAge = true;
-            }
-
+            MaxAge = cacheControl.MaxAge;
+            SharedMaxAge = cacheControl.SharedMaxAge;
             MustRevalidate = cacheControl.MustRevalidate;
             ProxyRevalidate = cacheControl.ProxyRevalidate;
             ResponseNoCache = cacheControl.NoCache;
             Public = cacheControl.Public;
             Private = cacheControl.Private;
             NoTransform = cacheControl.NoTransform;
+            Immutable = HasImmutableDirective(cacheControl);
+            StaleIfError = ParseStaleIfErrorDirective(cacheControl);
         }
 
         // If the 304 response provides a new max-age, treat it as a fresh revalidation

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Response304UpdateTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Response304UpdateTests.cs
@@ -178,6 +178,106 @@ public class Response304UpdateTests
     }
 
     [Fact]
+    public async Task When304ResponseDropsImmutableThenTheEntryIsRevalidatedAgain()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content", ("Cache-Control", "max-age=1, immutable"), ("ETag", "\"v1\""));
+        context.AddResponse(HttpStatusCode.NotModified, ("Cache-Control", "max-age=600"), ("ETag", "\"v1\""));
+        context.AddNotModifiedResponse([("If-None-Match", "\"v1\"")], ("Cache-Control", "max-age=600"), ("ETag", "\"v1\""));
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=1, immutable
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        // Stale, so it revalidates; the 304 replaces the stored Cache-Control, which no longer has immutable.
+        context.TimeProvider.Advance(TimeSpan.FromSeconds(5));
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=600
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        // RFC 8246: immutable suppresses revalidation for a fresh entry. It is gone now, so a no-cache
+        // request revalidates instead of being served straight from the cache.
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue { NoCache = true };
+        await context.SnapshotResponse(request, """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=600
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task When304ResponseDropsStaleIfErrorThenTheWindowIsGone()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content", ("Cache-Control", "max-age=1, stale-if-error=600"), ("ETag", "\"v1\""));
+        context.AddResponse(HttpStatusCode.NotModified, ("Cache-Control", "max-age=1"), ("ETag", "\"v1\""));
+        context.AddResponse(HttpStatusCode.ServiceUnavailable, "unavailable");
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=1, stale-if-error=600
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        // The 304 repeats the same max-age and carries no Date, so the entry keeps accumulating age.
+        context.TimeProvider.Advance(TimeSpan.FromSeconds(5));
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 5
+              Cache-Control: max-age=1
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        // The stale-if-error window was dropped by the 304, so a failing origin is no longer masked.
+        context.TimeProvider.Advance(TimeSpan.FromSeconds(5));
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 503 (ServiceUnavailable)
+            Content:
+              Headers:
+                Content-Length: 11
+                Content-Type: text/plain; charset=utf-8
+              Value: unavailable
+            """);
+    }
+
+    [Fact]
     public async Task When304ResponseDoesNotHaveCacheControlThenOriginalPreserved()
     {
         await using var context = new HttpTestContext();


### PR DESCRIPTION
`UpdateFromValidationResponse` reassigned some `Cache-Control`-derived properties from a `304` and conditionally kept others, so a server could not take a directive back.

## The failure

`CacheEntry.cs:339-361`.

`MustRevalidate`, `ProxyRevalidate`, `ResponseNoCache`, `Public`, `Private` and `NoTransform` were reassigned, but `Immutable` and `StaleIfError` were never touched, and `MaxAge`/`SharedMaxAge` were only assigned when the new value was non-null.

`Cache-Control` is a single header field, and RFC 7234 Section 4.3.4 has the `304` replace the stored one wholesale. A directive absent from the new value is gone — it does not survive from the old one.

The sharp case is `immutable`. A resource served as `Cache-Control: max-age=1, immutable` that later revalidates with plain `Cache-Control: max-age=600` kept `Immutable = true` forever. And `immutable` explicitly defeats a client's `no-cache` (`HttpCachingDelegateHandler.cs:108-114`), so the caller had no escape hatch either: the resource could not be forced to revalidate again for the rest of its freshness lifetime.

`stale-if-error` had the same problem in the other direction — a window the server had withdrawn kept masking origin failures.

## The change

When the `304` carries a `Cache-Control`, every directive derived from it is re-read from the new value, including `Immutable` and `StaleIfError`, and `MaxAge`/`SharedMaxAge` are assigned unconditionally.

A `304` with **no** `Cache-Control` still leaves the stored directives untouched, which is the merge rule for header fields the `304` does not mention. `When304ResponseDoesNotHaveCacheControlThenOriginalPreserved` covers that and is unchanged.

## Correcting something from the review

The review that produced this also flagged `Expires` as never being cleared. That turns out to be **correct as written** and is not changed here: `Expires` is its own header field, and Section 4.3.4 merges header fields rather than replacing the whole set, so a field the `304` omits keeps its stored value. Only `Cache-Control`, being one field carrying many directives, has the replace-wholesale behavior.

## Verification

Two tests added to `Response304UpdateTests`:

- `When304ResponseDropsImmutableThenTheEntryIsRevalidatedAgain` — after a `304` without `immutable`, a `no-cache` request revalidates instead of being served straight from the cache.
- `When304ResponseDropsStaleIfErrorThenTheWindowIsGone` — after a `304` without `stale-if-error`, a `503` from the origin reaches the caller instead of being masked by the stored body.

Both fail on `main` and pass here.

One thing worth knowing if you read the second test: its middle assertion expects `Age: 5`, not `Age: 0`. That is correct — the `304` repeats the same `max-age` and the test server sends no `Date` on it, so the entry keeps accumulating age rather than being re-based.

Full suite on both target frameworks: 388 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
