### PR TITLE
Cover the untested rules and let the symbol server test fail

### DIFF
--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -181,6 +181,53 @@ public sealed class NuGetPackageValidatorTests
     }
 
     [Fact]
+    public async Task Validate_Repository_NotSet()
+    {
+        // NuspecReader.GetRepositoryMetadata returns an empty instance rather than null when the element is missing,
+        // so the individual fields are reported instead of ErrorCodes.RepositoryNotSet
+        var result = await ValidateAsync("Release.1.0.0.nupkg", NuGetPackageValidationRules.RepositoryMustBeSet);
+        AssertHasError(result, ErrorCodes.RepositoryTypeNotSet);
+        AssertHasError(result, ErrorCodes.RepositoryUrlNotSet);
+        AssertHasError(result, ErrorCodes.RepositoryCommitNotSet);
+    }
+
+    [Fact]
+    public async Task Validate_Repository_TypeOnly()
+    {
+        var result = await ValidateAsync("Release_RepositoryType.1.0.0.nupkg", NuGetPackageValidationRules.RepositoryMustBeSet);
+        AssertHasError(result, ErrorCodes.RepositoryUrlNotSet);
+        AssertHasError(result, ErrorCodes.RepositoryCommitNotSet);
+    }
+
+    [Fact]
+    public async Task Validate_Repository_TypeUrlAndCommit()
+    {
+        var result = await ValidateAsync("Release_RepositoryType_RepositoryUrl_RepositoryCommit.1.0.0.nupkg", NuGetPackageValidationRules.RepositoryMustBeSet);
+        AssertNoErrors(result);
+    }
+
+    [Fact]
+    public async Task Validate_RepositoryBranch_NotSet()
+    {
+        var result = await ValidateAsync("Release_RepositoryType_RepositoryUrl_RepositoryCommit.1.0.0.nupkg", NuGetPackageValidationRules.RepositoryBranchMustBeSet);
+        AssertHasError(result, ErrorCodes.RepositoryBranchNotSet);
+    }
+
+    [Fact]
+    public async Task Validate_RepositoryBranch_Set()
+    {
+        var result = await ValidateAsync("Release_RepositoryType_RepositoryUrl_RepositoryCommit_RepositoryBranch.1.0.0.nupkg", NuGetPackageValidationRules.RepositoryBranchMustBeSet);
+        AssertNoErrors(result);
+    }
+
+    [Fact]
+    public async Task Validate_Tags_NotSet()
+    {
+        var result = await ValidateAsync("Release.1.0.0.nupkg", NuGetPackageValidationRules.TagsMustBeSet);
+        AssertHasError(result, ErrorCodes.TagsNotSet);
+    }
+
+    [Fact]
     public async Task Validate_Deterministic_NonDeterministic()
     {
         var result = await ValidateAsync("Release_NonDeterministic_Pdb.1.0.0.nupkg", NuGetPackageValidationRules.Symbols);
@@ -260,8 +307,9 @@ public sealed class NuGetPackageValidatorTests
     [Fact]
     public async Task Validate_WithSymbolsServer()
     {
-        // Downloading symbols can be flaky on CI
-        for (var i = 0; i < 10; i++)
+        // Downloading symbols can be flaky on CI, but the last attempt must report its failure
+        const int MaxAttempts = 10;
+        for (var i = 1; ; i++)
         {
             try
             {
@@ -270,7 +318,7 @@ public sealed class NuGetPackageValidatorTests
                 AssertNoErrors(result);
                 return;
             }
-            catch
+            catch when (i < MaxAttempts)
             {
                 await Task.Delay(TimeSpan.FromSeconds(1), XunitCancellationToken);
             }


### PR DESCRIPTION
Five of the thirteen rules had no test, and the one test covering the symbol server download path was structurally incapable of failing. Between them, that is what let the defects fixed in the other PRs in this batch ship.

## `Validate_WithSymbolsServer` could not fail

```csharp
for (var i = 0; i < 10; i++)
{
    try { …; AssertNoErrors(result); return; }
    catch { await Task.Delay(TimeSpan.FromSeconds(1), XunitCancellationToken); }
}
```

When all ten iterations threw — including when `AssertNoErrors` itself threw, the only way the test could detect a defect — the loop simply ended and the method returned normally. The test passed.

The retry is worth keeping, since downloading symbols really is flaky on CI. It is now `catch when (i < MaxAttempts)`, so the last attempt propagates its failure.

## Rules with no test

No test referenced `RepositoryMustBeSet`, `RepositoryBranchMustBeSet` or `TagsMustBeSet`. (`ProjectUrlMustBeSet` and `PackageIdAvailableOnNuGetOrg` are covered by the other PRs in this batch.) The fixtures for them were already in the corpus, built and committed, but referenced by nothing:

- `Validate_Repository_NotSet` — `Release.1.0.0.nupkg`
- `Validate_Repository_TypeOnly` — `Release_RepositoryType.1.0.0.nupkg`, reports the missing url and commit
- `Validate_Repository_TypeUrlAndCommit` — `Release_RepositoryType_RepositoryUrl_RepositoryCommit.1.0.0.nupkg`, clean
- `Validate_RepositoryBranch_NotSet` — the same package, reports the missing branch
- `Validate_RepositoryBranch_Set` — `Release_RepositoryType_RepositoryUrl_RepositoryCommit_RepositoryBranch.1.0.0.nupkg`, clean
- `Validate_Tags_NotSet` — `Release.1.0.0.nupkg`

Three of those four fixture packages had never been used by a test.

## One thing the new tests turned up

`Validate_Repository_NotSet` was written to expect `ErrorCodes.RepositoryNotSet` (71) and failed: `NuspecReader.GetRepositoryMetadata()` returns an **empty instance** rather than `null` when the `<repository>` element is absent, so `repo == null` in `RepositoryInfoMustBeSetValidationRule` is never true and error 71 is unreachable — the individual field errors 72/73/74 are reported instead.

The test now asserts the actual behaviour, with a comment explaining why. Changing the rule is out of scope for a test-only PR: either 71 should be raised when every field is empty, or the code and its `readme.md` entry should be retired. Worth deciding separately.

Full suite passes (72/72). No production code is touched by this PR.
