### PR TITLE
Give each cache file save its own temporary file

### DIFF
--- a/src/Meziantou.Framework.Http.Caching.InMemory/InMemoryHttpCacheStore.cs
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/InMemoryHttpCacheStore.cs
@@ -35,10 +35,11 @@ public sealed class InMemoryHttpCacheStore : IHttpCacheStore
             Directory.CreateDirectory(directoryPath);
         }
 
-        var tempFilePath = filePath + ".tmp";
+        // The temporary name is unique so that two concurrent saves to the same path do not collide on it.
+        var tempFilePath = filePath + "." + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture) + ".tmp";
         try
         {
-            await using (var stream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous))
+            await using (var stream = new FileStream(tempFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous))
             {
                 await JsonSerializer.SerializeAsync(stream, snapshot, InMemorySerializationContext.Default.InMemoryHttpCachePersistenceData, cancellationToken).ConfigureAwait(false);
             }
@@ -47,9 +48,17 @@ public sealed class InMemoryHttpCacheStore : IHttpCacheStore
         }
         finally
         {
-            if (File.Exists(tempFilePath))
+            // Cleaning up must not replace the exception that is being propagated, and the file is already
+            // gone on the success path.
+            try
             {
                 File.Delete(tempFilePath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
             }
         }
     }

--- a/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
@@ -523,6 +523,63 @@ public class PersistenceProvidersTests
         }
     }
 
+    [Fact]
+    public async Task InMemoryProviderConcurrentSavesToTheSamePathAllSucceed()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "meziantou-http-cache", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        var filePath = Path.Combine(tempDirectory, "http-cache.json");
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        try
+        {
+            Directory.CreateDirectory(tempDirectory);
+
+            var provider = new InMemoryHttpCacheStore();
+            await provider.SetEntryAsync("http://example.com/a", CreatePersistenceEntry(now, maxAge: TimeSpan.FromHours(1), mustRevalidate: false), CancellationToken.None);
+
+            // A fixed ".tmp" name made two concurrent saves collide on FileShare.None.
+            var saves = Enumerable.Range(0, 8).Select(_ => provider.SaveToFileAsync(filePath, CancellationToken.None).AsTask());
+            await Task.WhenAll(saves);
+
+            var reloaded = new InMemoryHttpCacheStore();
+            await reloaded.LoadFromFileAsync(filePath, CancellationToken.None);
+            Assert.Single(await reloaded.GetEntriesAsync("http://example.com/a", CancellationToken.None));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task InMemoryProviderSaveLeavesNoTemporaryFileBehind()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "meziantou-http-cache", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        var filePath = Path.Combine(tempDirectory, "http-cache.json");
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        try
+        {
+            Directory.CreateDirectory(tempDirectory);
+
+            var provider = new InMemoryHttpCacheStore();
+            await provider.SetEntryAsync("http://example.com/a", CreatePersistenceEntry(now, maxAge: TimeSpan.FromHours(1), mustRevalidate: false), CancellationToken.None);
+            await provider.SaveToFileAsync(filePath, CancellationToken.None);
+
+            Assert.Equal([filePath], Directory.GetFiles(tempDirectory));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
     private static HttpCachePersistenceEntry CreatePersistenceEntry(
         DateTimeOffset now,
         TimeSpan maxAge,


### PR DESCRIPTION
Two small problems in `InMemoryHttpCacheStore.SaveToFileAsync`, both in the write-then-rename sequence at `InMemoryHttpCacheStore.cs:38-54`.

## Concurrent saves to the same path collide

The temporary file name was a fixed `filePath + ".tmp"`, so two overlapping calls for the same path fought over one file. Eight concurrent saves on `main` fail with:

```
System.IO.FileNotFoundException : Could not find file '…/http-cache.json.tmp'
```

— one call's `File.Move` renames the temp file out from under another's. The `FileShare.None` handle collides too.

The temporary name now includes a GUID, so each save owns its own file, and `FileMode.CreateNew` makes any remaining collision loud instead of silently truncating someone else's work.

## Cleanup could replace the real exception

The `finally` block did `File.Exists` then `File.Delete`. If the delete threw — a lock, a permission change, or just the gap between the two calls — that exception replaced whatever failure was actually being propagated, so the caller saw a confusing error about a `.tmp` file instead of the real cause (a serialization failure, a full disk).

The delete is now guarded and the redundant `File.Exists` is gone: on the success path the file has already been renamed away, and a delete of a missing file is not an error.

## Scope

This does not make `SaveToFileAsync` safe to call concurrently in a useful sense — the snapshot is still taken per call and last writer wins. It makes concurrent calls stop *failing*, which is what the fixed temp name caused.

## Verification

Two tests added to `PersistenceProvidersTests`:

- `InMemoryProviderConcurrentSavesToTheSamePathAllSucceed` — eight concurrent saves all complete and the file reloads correctly. **Fails on `main`** with the `FileNotFoundException` above.
- `InMemoryProviderSaveLeavesNoTemporaryFileBehind` — the directory contains only the target file afterwards.

Full suite on both target frameworks: 388 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
