### PR TITLE
Record headers absent from the request in the Vary secondary key

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -191,6 +191,11 @@ internal sealed class CacheEntry
                     secondaryKey.Add(headerName, value);
                 }
             }
+            else
+            {
+                // RFC 9111 Section 4.1: the field being absent is part of the key, not the absence of a key.
+                secondaryKey.AddAbsent(headerName);
+            }
         }
 
         return secondaryKey;

--- a/src/Meziantou.Framework.Http.Caching/CacheEntrySecondaryKey.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntrySecondaryKey.cs
@@ -10,6 +10,10 @@ internal readonly struct CacheEntrySecondaryKey : IEquatable<CacheEntrySecondary
     public static CacheEntrySecondaryKey MatchAll => new();
     public static CacheEntrySecondaryKey MatchNone { get; }
 
+    // RFC 9110 Section 5.5: a field value is made of visible ASCII characters, spaces and horizontal tabs,
+    // so NUL can never appear in one and is safe as a marker.
+    private const string AbsentValue = "\u0000";
+
     private readonly Dictionary<string, string>? _headers;
 
     private CacheEntrySecondaryKey(Dictionary<string, string> headers)
@@ -35,6 +39,21 @@ internal readonly struct CacheEntrySecondaryKey : IEquatable<CacheEntrySecondary
             return MatchAll;
 
         return new CacheEntrySecondaryKey(new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Records that a header nominated by <c>Vary</c> was absent from the request.</summary>
+    /// <remarks>
+    /// RFC 9111 Section 4.1: a nominated field matches when it is absent from both the stored request and
+    /// the presented one, or present in both with the same value. Absence therefore has to be recorded.
+    /// Leaving it out made the key of a request that carried none of the nominated headers indistinguishable
+    /// from the key of a response with no <c>Vary</c> at all, which matches every request.
+    /// </remarks>
+    public void AddAbsent(string name)
+    {
+        if (_headers is null)
+            return;
+
+        _headers.TryAdd(name, AbsentValue);
     }
 
     public void Add(string name, string value)
@@ -84,6 +103,10 @@ internal readonly struct CacheEntrySecondaryKey : IEquatable<CacheEntrySecondary
                 {
                     requestKey.Add(headerName, value);
                 }
+            }
+            else
+            {
+                requestKey.AddAbsent(headerName);
             }
         }
 

--- a/tests/Meziantou.Framework.Http.Caching.Tests/VaryHeaderTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/VaryHeaderTests.cs
@@ -250,6 +250,130 @@ public sealed class VaryHeaderTests
     }
 
     [Fact]
+    public async Task WhenVaryHeaderAbsentInCacheButPresentInRequestThenFetchesNewResponse()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "without-language",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept-Language"));
+        context.AddResponse(HttpStatusCode.OK, "french",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept-Language"));
+
+        // Stored for a request that carried none of the nominated headers.
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        await context.SnapshotResponse(request1, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 16
+                Content-Type: text/plain; charset=utf-8
+              Value: without-language
+            """);
+
+        // RFC 9111 Section 4.1: a nominated field absent from one request and present in the other does not
+        // match, so this must not be served the entry above.
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request2.Headers.Add("Accept-Language", "fr-FR");
+        await context.SnapshotResponse(request2, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: french
+            """);
+    }
+
+    [Fact]
+    public async Task WhenVaryHeaderAbsentInBothThenUsesCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "without-language",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept-Language"));
+
+        // Absent from both requests is a match, so the second one is a hit.
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 16
+                Content-Type: text/plain; charset=utf-8
+              Value: without-language
+            """);
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 16
+                Content-Type: text/plain; charset=utf-8
+              Value: without-language
+            """);
+    }
+
+    [Fact]
+    public async Task WhenSomeVaryHeadersAbsentThenOnlyAnIdenticalRequestMatches()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept, Accept-Language"));
+        context.AddResponse(HttpStatusCode.OK, "second",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept, Accept-Language"));
+
+        // Accept present, Accept-Language absent.
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request1.Headers.Add("Accept", "text/plain");
+        await context.SnapshotResponse(request1, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary:
+                - Accept
+                - Accept-Language
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        // Same Accept, but Accept-Language is now present: not a match.
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request2.Headers.Add("Accept", "text/plain");
+        request2.Headers.Add("Accept-Language", "en-US");
+        await context.SnapshotResponse(request2, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              Vary:
+                - Accept
+                - Accept-Language
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+
+    [Fact]
     public async Task WhenVaryHeaderCaseInsensitiveThenMatches()
     {
         await using var context = new HttpTestContext();


### PR DESCRIPTION
**Stack 1 of 4** · merges into `main` · must merge before #2906, #2907, #2908

A response stored for a request that carried **none** of the headers nominated by `Vary` matched every subsequent request, whatever those headers said.

## The failure

`CacheEntry.cs:172-197` (`BuildSecondaryKey`) recorded only the nominated headers that were *present* on the storing request. When the request had none of them, the resulting key was an empty dictionary — which is exactly how `MatchAll` is represented — and `CacheEntrySecondaryKey.cs:72-73` short-circuits an empty key to "matches everything".

Concretely: a request to `/x` with no `Accept-Language` gets `Cache-Control: max-age=3600, Vary: Accept-Language` and body `body1`. A second request to `/x` with `Accept-Language: fr-FR` is served `body1` from cache — one origin request total, and the caller silently gets the wrong variant.

RFC 9111 Section 4.1 requires a nominated field to be absent from **both** requests, or present in both with the same value. Absent-in-one is not a match.

The opposite direction was already correct and already covered by `WhenVaryHeaderAbsentInRequestButPresentInCacheThenFetchesNewResponse`. This direction had no test.

It is also more likely than it looks: when the inner handler has `AutomaticDecompression` enabled, `Accept-Encoding` is added *below* this handler, so a `Vary: Accept-Encoding` response — very common — always produced an empty secondary key here.

## The change

Absence is now recorded explicitly. A nominated header the request did not carry is stored under a NUL sentinel, which RFC 9110 Section 5.5 guarantees cannot appear in a real field value. `MatchRequest` builds the request's key the same way, so presence is compared as well as value.

An empty secondary key now means what it always should have: the response carried no `Vary` at all.

## Compatibility

This changes the shape of the persisted secondary key, so `ComputeSecondaryKeyHash` produces different output and entries written by an older version keep their old (over-matching) key until they expire or are evicted. That is acceptable for a cache, but worth a line in the release notes.

## Verification

Three tests added to `VaryHeaderTests`:

- `WhenVaryHeaderAbsentInCacheButPresentInRequestThenFetchesNewResponse` — the failure above. **Fails on `main`.**
- `WhenSomeVaryHeadersAbsentThenOnlyAnIdenticalRequestMatches` — `Vary: Accept, Accept-Language` with `Accept` present and `Accept-Language` absent does not match a request that has both. **Fails on `main`.**
- `WhenVaryHeaderAbsentInBothThenUsesCache` — absent from both is still a match, so this stays a cache hit. Guards against over-correcting.

Full suite on both target frameworks: 390 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
