### PR TITLE
Do not store responses that declare Vary: *

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -167,6 +167,12 @@ internal sealed class HttpCache
         if (!IsCacheableStatusCode(response.StatusCode))
             return false;
 
+        // RFC 9111 Section 4.1: a stored response with "Vary: *" can never be selected for any request, so
+        // storing it is pure waste. This is checked before the body is read rather than after.
+        var vary = response.Headers.Vary;
+        if (vary.Count > 0 && vary.Contains("*"))
+            return false;
+
         var requestCacheControl = request.Headers.CacheControl;
         var responseCacheControl = response.Headers.CacheControl;
 

--- a/tests/Meziantou.Framework.Http.Caching.Tests/VaryHeaderTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/VaryHeaderTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
 
 namespace Meziantou.Framework.Http.Caching.Tests;
 
@@ -371,6 +372,34 @@ public sealed class VaryHeaderTests
                 Content-Type: text/plain; charset=utf-8
               Value: second
             """);
+    }
+
+    [Fact]
+    public async Task WhenVaryStarThenTheResponseIsNotStored()
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        _ = await response.Content.ReadAsStringAsync(CancellationToken.None);
+
+        // RFC 9111 Section 4.1: an entry stored under "Vary: *" can never be selected for any request, so
+        // storing it only takes up room that nothing will ever reclaim.
+        Assert.Empty(await store.GetEntriesAsync("GET http://example.com/resource", CancellationToken.None));
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("content") };
+            response.Headers.TryAddWithoutValidation("Cache-Control", "max-age=3600");
+            response.Headers.TryAddWithoutValidation("Vary", "*");
+            return Task.FromResult(response);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
**Stack 2 of 4** · merges into #2905 · merge after #2905, before #2907 and #2908

A response carrying `Vary: *` was stored, and could never be read back.

## The failure

`CacheEntry.cs:181-183` maps `Vary: *` to `CacheEntrySecondaryKey.MatchNone`, whose `MatchRequest` returns `false` unconditionally — correctly, per RFC 9111 Section 4.1, which says such a response never matches a subsequent request.

But `HttpCache.IsCacheable` had no matching check, so the response was serialized and written to the store anyway. The entry then sat there permanently: unreadable by construction, and — since it carries whatever validators the origin sent — often not reclaimable by `PruneObsoleteEntriesAsync` either.

## The change

`IsCacheable` rejects `Vary: *`. The check is placed before the body is read, so the response is never buffered or serialized in the first place.

## Scope: what I looked at and did not do

The review this came from also proposed skipping responses that arrive with **zero freshness lifetime and no validator** — a bare `404` or `301`, which are cacheable by default but were being stored with nothing to make them servable.

I implemented that and it is wrong. An existing test caught it:

```
failed ThreadSafetyTests.WhenConcurrentRequestsWithMaxStaleThenStaleResponsesAreReturnedSafely
```

A `max-age=0` entry with no validator *can* be served — to a request that sends `max-stale`, which is a request directive the cache cannot know about at store time. So "stale on arrival" does not mean "can never be served", and those entries have to stay. That half is dropped; only the `Vary: *` case, which genuinely can never match any request, is fixed here.

## Verification

`WhenVaryStarThenTheResponseIsNotStored` added to `VaryHeaderTests`: after a request whose response declares `Vary: *`, the store holds no entry for that key.

The existing `WhenVaryStarThenEachRequestUnique` is untouched and still passes — the observable behavior (every request goes to the origin) is unchanged; only the wasted write is gone.

Full suite on both target frameworks: 392 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
