### PR TITLE
Select the cache entry before deserializing it

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -56,45 +56,69 @@ internal sealed class HttpCache
         if (persistedEntries.Count is 0)
             return null;
 
-        // Find the best matching entry considering Vary headers
-        CacheEntry? bestMatch = null;
-        DateTimeOffset latestDate = DateTimeOffset.MinValue;
+        // Find the matching entries considering Vary headers.
+        // The match is decided on the persisted entry: building a CacheEntry copies the whole serialized
+        // response and scans it to check that it is well-formed, and most candidates are about to be
+        // rejected. Only the selected one is materialized, below.
+        List<HttpCachePersistenceEntry>? candidates = null;
 
         foreach (var persistedEntry in persistedEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            CacheEntry entry;
-            try
-            {
-                entry = CacheEntry.FromPersistenceEntry(persistedEntry);
-            }
-            catch (JsonException)
-            {
-                // The stored payload is corrupted: ignore the entry and treat it as a miss.
-                continue;
-            }
-
             // Check secondary key (Vary headers) match
-            if (!entry.SecondaryKey.MatchRequest(request))
+            if (!MatchesSecondaryKey(persistedEntry, request))
                 continue;
 
             // draft-ietf-httpbis-no-vary-search Section 6: the entries stored under this key were kept for
             // other queries of the same path, and only answer requests for an equivalent URL.
-            if (matchQuery && !entry.MatchesQuery(uri))
+            if (matchQuery && !MatchesQuery(persistedEntry, uri))
                 continue;
 
-            // RFC 7234 Section 4: Use most recent response by Date header
-            // draft-ietf-httpbis-no-vary-search Section 7: preferring the most recent Date also makes caches
-            // converge on the latest config when several of them are stored.
-            if (entry.ResponseDate > latestDate)
+            candidates ??= [];
+            candidates.Add(persistedEntry);
+        }
+
+        if (candidates is null)
+            return null;
+
+        // RFC 7234 Section 4: Use most recent response by Date header
+        // draft-ietf-httpbis-no-vary-search Section 7: preferring the most recent Date also makes caches
+        // converge on the latest config when several of them are stored.
+        if (candidates.Count > 1)
+        {
+            candidates.Sort(static (left, right) => right.ResponseDate.CompareTo(left.ResponseDate));
+        }
+
+        foreach (var candidate in candidates)
+        {
+            try
             {
-                latestDate = entry.ResponseDate;
-                bestMatch = entry;
+                return CacheEntry.FromPersistenceEntry(candidate);
+            }
+            catch (JsonException)
+            {
+                // The stored payload is corrupted: ignore the entry and fall back to the next best match.
             }
         }
 
-        return bestMatch;
+        return null;
+    }
+
+    private static bool MatchesSecondaryKey(HttpCachePersistenceEntry entry, HttpRequestMessage request)
+    {
+        return CacheEntrySecondaryKey.Create(entry.SecondaryKeyMatchNone, entry.SecondaryKeyHeaders).MatchRequest(request);
+    }
+
+    private static bool MatchesQuery(HttpCachePersistenceEntry entry, Uri uri)
+    {
+        // An entry whose config is the default one does not belong to the query-independent key, and never
+        // matches. Only the queries remain to be compared: the rest of the URL is part of the storage key.
+        if (entry.NoVarySearch is null)
+            return false;
+
+        var query = UrlVariationConfig.Parse(entry.NoVarySearch).NormalizeQuery(uri.Query);
+        return string.Equals(query, entry.NormalizedQuery, StringComparison.Ordinal);
     }
 
     public async ValueTask StoreAsync(HttpRequestMessage request, HttpResponseMessage response, DateTimeOffset requestTime, DateTimeOffset responseTime, CancellationToken cancellationToken)

--- a/tests/Meziantou.Framework.Http.Caching.Tests/CacheEntrySelectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/CacheEntrySelectionTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
+
+namespace Meziantou.Framework.Http.Caching.Tests;
+
+/// <summary>Tests for how one entry is selected among the ones stored under a primary key.</summary>
+public sealed class CacheEntrySelectionTests
+{
+    private const string PrimaryKey = "GET http://example.com/resource";
+
+    [Fact]
+    public async Task WhenSeveralVariantsAreStoredThenTheMatchingOneIsSelected()
+    {
+        var store = new FixedStore(
+            await CreateEntryAsync("english", ("Accept-Language", "en-US")),
+            await CreateEntryAsync("french", ("Accept-Language", "fr-FR")),
+            await CreateEntryAsync("german", ("Accept-Language", "de-DE")));
+
+        using var innerHandler = new UnreachableHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request.Headers.Add("Accept-Language", "fr-FR");
+        using var response = await client.SendAsync(request, CancellationToken.None);
+
+        Assert.Equal("french", await response.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenSeveralEntriesMatchThenTheMostRecentByDateIsSelected()
+    {
+        // The Date offsets stay small so that every entry is still fresh; only their order matters.
+        var older = await CreateEntryAsync("older");
+        older.ResponseDate = older.ResponseTime - TimeSpan.FromSeconds(10);
+        var newer = await CreateEntryAsync("newer");
+        newer.ResponseDate = newer.ResponseTime;
+        var oldest = await CreateEntryAsync("oldest");
+        oldest.ResponseDate = oldest.ResponseTime - TimeSpan.FromSeconds(20);
+
+        // Deliberately not in date order, so the selection cannot come from the enumeration order.
+        var store = new FixedStore(older, newer, oldest);
+
+        using var innerHandler = new UnreachableHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        Assert.Equal("newer", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenTheMostRecentEntryIsCorruptedThenTheNextBestIsUsed()
+    {
+        var corrupted = await CreateEntryAsync("ignored");
+        corrupted.ResponseDate = corrupted.ResponseTime;
+        corrupted.SerializedResponse = "{ this is not valid json"u8.ToArray();
+
+        var usable = await CreateEntryAsync("fallback");
+        usable.ResponseDate = usable.ResponseTime - TimeSpan.FromSeconds(10);
+
+        var store = new FixedStore(corrupted, usable);
+
+        using var innerHandler = new UnreachableHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        Assert.Equal("fallback", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenEveryEntryIsCorruptedThenTheRequestGoesToTheOrigin()
+    {
+        var first = await CreateEntryAsync("ignored");
+        first.SerializedResponse = "{ this is not valid json"u8.ToArray();
+        var second = await CreateEntryAsync("ignored");
+        second.SerializedResponse = "also not json"u8.ToArray();
+
+        var store = new FixedStore(first, second);
+
+        using var innerHandler = new StubHandler();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        Assert.Equal("from-origin", await client.GetStringAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    /// <summary>Produces a real stored entry by running one request through the handler.</summary>
+    private static async Task<HttpCachePersistenceEntry> CreateEntryAsync(string body, params (string Name, string Value)[] varyHeaders)
+    {
+        var store = new InMemoryHttpCacheStore();
+        using var innerHandler = new SingleResponseHandler(body, varyHeaders);
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        foreach (var (name, value) in varyHeaders)
+        {
+            request.Headers.Add(name, value);
+        }
+
+        using var response = await client.SendAsync(request, CancellationToken.None);
+        _ = await response.Content.ReadAsStringAsync(CancellationToken.None);
+
+        return Assert.Single(await store.GetEntriesAsync(PrimaryKey, CancellationToken.None));
+    }
+
+    private sealed class SingleResponseHandler(string body, (string Name, string Value)[] varyHeaders) : HttpMessageHandler
+    {
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) };
+            response.Headers.TryAddWithoutValidation("Cache-Control", "max-age=3600");
+            foreach (var (name, _) in varyHeaders)
+            {
+                response.Headers.TryAddWithoutValidation("Vary", name);
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class FixedStore(params HttpCachePersistenceEntry[] entries) : IHttpCacheStore
+    {
+        public ValueTask<IReadOnlyCollection<HttpCachePersistenceEntry>> GetEntriesAsync(string primaryKey, CancellationToken cancellationToken)
+        {
+            var result = string.Equals(primaryKey, PrimaryKey, StringComparison.Ordinal) ? entries : [];
+            return ValueTask.FromResult<IReadOnlyCollection<HttpCachePersistenceEntry>>(result);
+        }
+
+        public ValueTask SetEntryAsync(string primaryKey, HttpCachePersistenceEntry entry, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask RemoveEntriesAsync(string primaryKey, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+
+    private sealed class UnreachableHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("The request should have been served from the cache");
+        }
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("from-origin") };
+            response.Headers.TryAddWithoutValidation("Cache-Control", "max-age=3600");
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
**Stack 3 of 4** · merges into #2906 · merge after #2905 and #2906, before #2908

A performance change. No behavior change is intended, and the tests added here exist to pin that down.

## The cost

`HttpCache.TryGetAsync` materialized a full `CacheEntry` for **every** entry stored under the primary key before testing whether it matched:

```csharp
entry = CacheEntry.FromPersistenceEntry(persistedEntry);   // copies the body, scans the whole payload
if (!entry.SecondaryKey.MatchRequest(request)) continue;   // …then rejects it
if (matchQuery && !entry.MatchesQuery(uri)) continue;
```

`FromPersistenceEntry` does `SerializedResponse.ToArray()` — a full copy of the body — and `ResponseSerializer.EnsureWellFormed`, which runs a `Utf8JsonReader` over the entire Base64-encoded payload. Both happen before the Vary key or the No-Vary-Search query is looked at, so every variant that is about to be discarded is paid for in full.

Serving one hit from a URL with three 5 MB variants meant three copies and three full JSON scans to return one of them — and that is on top of the copy the store itself makes and the parse in `CreateCachedResponse`.

## The change

Matching is done against `HttpCachePersistenceEntry`, which already exposes everything the match needs — `SecondaryKeyMatchNone`, `SecondaryKeyHeaders`, `NoVarySearch`, `NormalizedQuery`. Candidates are collected, ordered by `ResponseDate` descending, and only the selected one is materialized.

Cost for a lookup over N variants goes from N body copies + N payload scans to one of each.

## Behavior preserved

Two details that had to be kept:

- **Most recent `Date` wins** — previously a running max during iteration, now an explicit sort. The test feeds entries in a deliberately wrong order so the result cannot come from enumeration order.
- **A corrupt payload falls back to the next best match** — previously `catch (JsonException) { continue; }` inside the loop. Now the candidates are tried in order until one materializes, so a corrupt newest entry still falls back to an older valid one rather than turning into a miss.

## Verification

New `CacheEntrySelectionTests`, 4 tests, all built through the public API (a custom `IHttpCacheStore` returning a fixed set of entries):

- the matching Vary variant is selected out of three;
- the most recent by `Date` is selected, from an unordered input;
- a corrupt newest entry falls back to the next best;
- all entries corrupt means the request goes to the origin.

These **pass both before and after** this change — deliberately. This is a refactor, so the tests are there to prove it did not alter selection, not to demonstrate a fix.

Full suite on both target frameworks: 400 passed, 0 failed, 6 skipped (the skips are the container-backed Redis tests, 3 per framework).
