### PR TITLE
Report what a log wait strategy gave up on, and skip MongoDB on kernel 6.19+

### DIFF
--- a/src/Meziantou.Framework.Http.Caching.InMemory/InMemoryHttpCacheStore.cs
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/InMemoryHttpCacheStore.cs
@@ -44,7 +44,7 @@ public sealed class InMemoryHttpCacheStore : IHttpCacheStore
                 await JsonSerializer.SerializeAsync(stream, snapshot, InMemorySerializationContext.Default.InMemoryHttpCachePersistenceData, cancellationToken).ConfigureAwait(false);
             }
 
-            File.Move(tempFilePath, filePath, overwrite: true);
+            await MoveOverwritingWithRetryAsync(tempFilePath, filePath, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -59,6 +59,27 @@ public sealed class InMemoryHttpCacheStore : IHttpCacheStore
             }
             catch (UnauthorizedAccessException)
             {
+            }
+        }
+    }
+
+    /// <summary>Replaces the destination, waiting out the concurrent saves that are replacing it at the same time.</summary>
+    private static async Task MoveOverwritingWithRetryAsync(string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken)
+    {
+        // Replacing a file is atomic on Unix, but Windows denies access to the destination while another move is
+        // replacing it, so concurrent saves to the same path have to wait for each other instead of failing.
+        const int MaxAttempts = 50;
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                File.Move(sourceFilePath, destinationFilePath, overwrite: true);
+                return;
+            }
+            catch (Exception ex) when (attempt < MaxAttempts && ex is UnauthorizedAccessException or (IOException and not (FileNotFoundException or DirectoryNotFoundException)))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(20), cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Meziantou.Framework.TemporaryContainers/Strategies/LogMessageWaitStrategy.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Strategies/LogMessageWaitStrategy.cs
@@ -1,16 +1,28 @@
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Meziantou.Framework.TemporaryContainers.Strategies;
 
 internal sealed class LogMessageWaitStrategy(Regex pattern, int occurrences) : IWaitStrategy
 {
+    // A container that dies while starting up closes its log stream, so the wait ends without the message it was
+    // looking for. Only the tail is kept: it is where the failure is reported, and a chatty image must not be
+    // buffered whole just to describe a failure that may never happen.
+    private const int MaxReportedLines = 20;
+
     public async Task WaitAsync(TemporaryContainer container, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(container);
 
         var count = 0;
+        var tail = new Queue<string>(MaxReportedLines);
         await foreach (var entry in container.GetLogsAsync(cancellationToken).ConfigureAwait(false))
         {
+            if (tail.Count == MaxReportedLines)
+                tail.Dequeue();
+
+            tail.Enqueue(entry.Stream is LogStream.Stderr ? "[stderr] " + entry.Message : entry.Message);
+
             if (pattern.IsMatch(entry.Message))
             {
                 count++;
@@ -19,6 +31,58 @@ internal sealed class LogMessageWaitStrategy(Regex pattern, int occurrences) : I
             }
         }
 
-        throw new InvalidOperationException(string.Create(CultureInfo.InvariantCulture, $"The log pattern '{pattern}' matched {count} time(s) before the log stream ended (expected {occurrences})."));
+        throw new InvalidOperationException(await BuildFailureMessageAsync(container, count, tail).ConfigureAwait(false));
+    }
+
+    /// <summary>Describes the failure with everything that explains it: what the container exited with, and what it printed before it did.</summary>
+    private async Task<string> BuildFailureMessageAsync(TemporaryContainer container, int count, Queue<string> tail)
+    {
+        var message = new StringBuilder();
+        message.Append(CultureInfo.InvariantCulture, $"The log pattern '{pattern}' matched {count} time(s) before the log stream ended (expected {occurrences}).");
+
+        if (await TryInspectAsync(container).ConfigureAwait(false) is { } info)
+        {
+            message.Append(CultureInfo.InvariantCulture, $" The container is {info.State}");
+            if (info.ExitCode is { } exitCode)
+            {
+                message.Append(CultureInfo.InvariantCulture, $" with exit code {exitCode}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(info.Status))
+            {
+                message.Append(CultureInfo.InvariantCulture, $" ({info.Status})");
+            }
+
+            message.Append('.');
+        }
+
+        if (tail.Count == 0)
+        {
+            message.Append(" The container did not write anything to its log streams.");
+            return message.ToString();
+        }
+
+        message.Append(CultureInfo.InvariantCulture, $" Last {tail.Count} log line(s):");
+        foreach (var line in tail)
+        {
+            message.Append(CultureInfo.InvariantCulture, $"{Environment.NewLine}  {line}");
+        }
+
+        return message.ToString();
+    }
+
+    /// <summary>Inspects the container without ever throwing: the container may already be gone, and a failure to
+    /// describe it must not replace the log-pattern failure with an unrelated one.</summary>
+    private static async Task<ContainerInfo?> TryInspectAsync(TemporaryContainer container)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            return await container.InspectAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -513,6 +513,41 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
         Assert.Contains(exception.Command, exception.Message);
     }
 
+    /// <summary>Shared assertion that a container dying before its ready message fails with what it printed (called
+    /// from the relevant subclasses). It is not run for every runtime: apple/container keeps the log stream open after
+    /// the container exits, so the wait times out instead of ending.</summary>
+    protected async Task AssertStartFailureReportsContainerOutputAsync()
+    {
+        var definition = new ContainerDefinition(new RegistryImage(ContainerImage))
+        {
+            Runtime = Runtime,
+        };
+        if (UseWindowsContainerImages)
+        {
+            definition.Command.Add("powershell");
+            definition.Command.Add("-NoProfile");
+            definition.Command.Add("-Command");
+            definition.Command.Add("Write-Output 'the entrypoint gave up'; exit 3");
+        }
+        else
+        {
+            definition.Command.Add("sh");
+            definition.Command.Add("-c");
+            definition.Command.Add("echo 'the entrypoint gave up'; exit 3");
+        }
+
+        definition.WaitStrategies.Add(Wait.ForLogMessage("SERVER READY"));
+
+        await using var container = definition.CreateContainer();
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await container.StartAsync(XunitCancellationToken));
+
+        // A container that dies during startup is the common case, and what it printed on the way out is the only
+        // thing that explains why. Reporting nothing but the missing pattern leaves a CI failure undiagnosable.
+        Assert.Contains("the entrypoint gave up", exception.Message);
+        Assert.Contains(ContainerState.Exited.ToString(), exception.Message);
+        Assert.Contains("exit code 3", exception.Message);
+    }
+
     /// <summary>Shared pause/unpause assertion for runtimes that support it (called from the relevant subclasses).</summary>
     protected async Task AssertPauseUnpauseAsync()
     {

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
@@ -7,4 +7,7 @@ public sealed class DockerContainerTests() : ContainerRuntimeTestsBase(Container
 {
     [Fact]
     public Task PauseAndUnpause() => AssertPauseUnpauseAsync();
+
+    [Fact]
+    public Task StartAsync_ContainerExitsBeforeTheReadyMessage_ReportsWhatTheContainerPrinted() => AssertStartFailureReportsContainerOutputAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
@@ -13,6 +13,12 @@ public sealed class MongoDbContainerTests
     {
         if (!OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions())
             global::Xunit.Assert.Skip("Only runs on Linux.");
+
+        // mongod refuses to start on Linux 6.19 and newer (https://jira.mongodb.org/browse/SERVER-121912), and 8.3.8,
+        // the newest image there is, still carries the guard. A Linux container shares the host kernel, so the host
+        // version is the one that decides; elsewhere the container runs in a VM whose kernel is its own.
+        if (OperatingSystem.IsLinux() && Environment.OSVersion.Version >= new Version(6, 19))
+            global::Xunit.Assert.Skip("The MongoDB image cannot start on Linux kernel 6.19 or newer (SERVER-121912).");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

`Wait.ForLogMessage` failed with nothing but the pattern it was looking for and how many times it matched:

> The log pattern 'Waiting\ for\ connections' matched 0 time(s) before the log stream ended (expected 2).

That says the wait failed, not why. The container's own output and its exit status were both discarded — [`LogMessageWaitStrategy`](src/Meziantou.Framework.TemporaryContainers/Strategies/LogMessageWaitStrategy.cs) never inspected the container, and log forwarding only happens when `definition.Logging.Logger` is set, which the database container tests do not do.

This came out of trying to diagnose the intermittent `MongoDbContainerTests` failures on the Linux CI runners. With only the message above it was impossible to tell whether mongod had crashed, been killed, or never started.

## Reporting the failure

The strategy now keeps the tail of the log stream it consumed (last 20 lines, so a chatty image is not buffered whole) and inspects the container when the stream ends, so the failure reports the container state, its exit code, and what it printed. The inspection is best-effort: a container that is already gone must not replace the log-pattern failure with an unrelated one.

No behaviour change on the success path, and no public API change (the type is internal, so `ref/` is untouched).

## What it found, on the first CI run

> The container is Exited with exit code 1 (exited). Last 1 log line(s):
>   {"s":"F", "c":"CONTROL", "id":12257600, "ctx":"main","msg":"MongoDB cannot start: Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB. See https://jira.mongodb.org/browse/SERVER-121912 for more information."}

So the MongoDB failures were never flaky. GitHub's runner pool is being rolled over to kernel 6.19+, which is why a *different* matrix leg fails on each pull request, why every retry inside a job fails the same way, why re-running never clears it, and why Redis and PostgreSQL pass in the very same jobs. It reproduces on x64 and arm64 alike and not at all locally, where Docker Desktop's VM kernel is older.

## Skipping it

There is no image to move to: `mongo:8`, `mongo:8.3.8` and `mongo:latest` resolve to the same manifest, and 8.3.8 is the newest MongoDB release — it is the one carrying the guard. So the three container-starting tests are gated on the kernel version, the same way `SqlServerContainerTests` already gates on globalization support and on ARM64. The gate is limited to Linux hosts, where the container shares the host kernel; everywhere else the container runs in a VM with a kernel of its own. The other MongoDB tests, which only build a definition, still run everywhere.

## Tests

`DockerContainerTests.StartAsync_ContainerExitsBeforeTheReadyMessage_ReportsWhatTheContainerPrinted` starts a container that prints a line and exits 3 while the strategy waits for a message that never comes, then asserts the printed line, the state and the exit code all reach the exception message.

It hangs off `DockerContainerTests` rather than the shared `ContainerRuntimeTestsBase` because apple/container keeps the log stream open after the container exits, so the wait there times out instead of ending — a separate pre-existing defect, left alone here.

## Validation

- `dotnet build -c Debug /p:TreatWarningsAsErrors=true` — clean
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatWarningsAsErrors=true` — clean
- Docker + definition tests, both TFMs: 71/71 passing on each
- `dotnet run ./eng/update-all.cs` — no changes
- The kernel gate itself can only be exercised on Linux, so CI is what validates it