### PR TITLE
Keep listening after a connection the client never completed

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -36,6 +36,11 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     // Upper bound on the number of arguments accepted from the pipe. The message is
     // sender-controlled, so the count is validated before allocating from it.
     private const int MaxArgumentCount = 64 * 1024;
+    // Arming the next listener can lose a race against the teardown of the previous one, so it is retried rather
+    // than abandoned. The bound keeps a genuinely unusable pipe from spinning a thread pool thread.
+    private const int MaxListenerArmAttempts = 5;
+    private static readonly TimeSpan ListenerArmRetryDelay = TimeSpan.FromMilliseconds(20);
+
     private readonly Lock _lock = new();
     private NamedPipeServerStream? _server;
     private Mutex? _mutex;
@@ -132,32 +137,61 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
         }
     }
 
+    /// <summary>Arms the listener that replaces the one that has just been consumed, and keeps trying for as long as it is worth it.</summary>
+    private void ReplaceListener()
+    {
+        // Another instance of the pipe can be refused while the previous one is still being torn down. Losing that
+        // race used to end the server for good, which is all a client needs to silence an application for the rest
+        // of its life: connect, disconnect, and never be heard from again.
+        for (var attempt = 1; attempt <= MaxListenerArmAttempts; attempt++)
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                    return;
+            }
+
+            try
+            {
+                StartNamedPipeServer();
+                return;
+            }
+            catch (Exception)
+            {
+                // Runs on a thread pool thread, so the exception must not escape. The wait is short and bounded:
+                // the process is deaf until a listener is armed again.
+                Thread.Sleep(ListenerArmRetryDelay);
+            }
+        }
+    }
+
     private void Listen(IAsyncResult ar)
     {
         var server = (NamedPipeServerStream)ar.AsyncState!;
 
+        var connected = false;
         try
         {
             server.EndWaitForConnection(ar);
+            connected = true;
         }
         catch (Exception)
         {
-            // The server was disposed while waiting, or the connection failed. Do not re-arm:
-            // the application is either shutting down or the pipe is unusable.
+            // Either Dispose ran while this listener was waiting, or the client gave up before the connection was
+            // established. Only the first means the application is going away, so this listener is replaced like any
+            // other; ReplaceListener is what tells the two apart.
+        }
+
+        if (!connected)
+        {
             server.Dispose();
+            ReplaceListener();
             return;
         }
 
         // Re-arm before reading, so a malformed or truncated message cannot stop the
         // application from accepting notifications from later instances.
-        try
-        {
-            StartNamedPipeServer();
-        }
-        catch (Exception)
-        {
-            // Keep handling the current connection even if the next listener could not start.
-        }
+        ReplaceListener();
 
         SingleInstanceEventArgs? eventArgs;
         try


### PR DESCRIPTION
## Why

`SingleInstanceTests.TestSingleInstance_MalformedMessagesDoNotStopTheServer` fails on **every** Windows CI leg — three consecutive runs of #2805, then all three Windows legs of #2806:

> System.TimeoutException : The operation has timed out.
>   at System.IO.Pipes.NamedPipeClientStream.ConnectInternal(...)

The timeout is on the *client* side, in the `NotifyFirstInstance` at the end of the test. Nothing was listening any more — which is exactly what the test is named for.

It only shows up on pull requests that make every test project affected, which is why it never blocked a delta-scoped push build on `main`, and why it looks like flakiness when it is not.

## What was wrong

Two paths left the process without a listener:

- `EndWaitForConnection` failing returned without arming a replacement. The comment assumed such a failure means "the application is either shutting down or the pipe is unusable", but it also fails when a client abandons the connection before it is established — and connecting and disconnecting without writing anything is the very first thing the test does.
- When arming the replacement threw, the exception was swallowed with "keep handling the current connection even if the next listener could not start", leaving nothing armed afterwards.

Either one silences the application permanently. That is a cheap thing for a client to do by accident, and a cheaper thing to do on purpose.

## What changed

Both paths now go through `ReplaceListener`, which arms the next listener unless the instance has been disposed, and retries creating another instance of the pipe when it loses the race against the teardown of the previous one. The retry is bounded so a genuinely unusable pipe cannot spin a thread pool thread, and nothing escapes to the thread pool.

No public API change, so `ref/` is untouched.

## Tests

The existing `TestSingleInstance_MalformedMessagesDoNotStopTheServer` is the regression test — it already reproduces this on Windows.

**This cannot be validated on a non-Windows host.** Communication between instances is Windows-only, so the three relevant tests skip on Linux and macOS. Locally the suite is 5 passed / 3 skipped both before and after, which says nothing about the fix. CI on `windows-2025-vs2026` is what actually exercises it.

## Validation

- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatWarningsAsErrors=true` — clean
- `dotnet build -c Debug /p:TreatWarningsAsErrors=true` — clean
- SingleInstance tests, both TFMs: 5 passed / 3 skipped (the skipped ones are the Windows-only tests)
- `dotnet run ./eng/update-all.cs` — no changes