### PR TITLE
Keep following container logs when the runtime ends the stream early

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/Strategies/LogMessageWaitStrategy.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Strategies/LogMessageWaitStrategy.cs
@@ -10,37 +10,67 @@ internal sealed class LogMessageWaitStrategy(Regex pattern, int occurrences) : I
     // buffered whole just to describe a failure that may never happen.
     private const int MaxReportedLines = 20;
 
-    public async Task WaitAsync(TemporaryContainer container, CancellationToken cancellationToken)
+    // A log stream that ends is not proof that the container is done: '<runtime> logs -f' exits with code 0 and the
+    // 'follow' response body ends when the runtime drops the attachment, both of which happen right after start,
+    // before the container has written a single line. Re-attaching is the only way to tell that apart from a
+    // container that died, so the wait keeps re-attaching while the container runs. The delay backs off so a runtime
+    // that keeps ending the stream at once does not re-attach hundreds of times for the whole startup timeout.
+    private const int InitialReattachDelayInMilliseconds = 100;
+    private const int MaxReattachDelayInMilliseconds = 1000;
+
+    public Task WaitAsync(TemporaryContainer container, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(container);
 
-        var count = 0;
-        var tail = new Queue<string>(MaxReportedLines);
-        await foreach (var entry in container.GetLogsAsync(cancellationToken).ConfigureAwait(false))
+        return WaitCoreAsync(container.GetLogsAsync, () => TryInspectAsync(container), cancellationToken);
+    }
+
+    /// <summary>The wait itself, taking the log stream and the container state as delegates so both can be faked.</summary>
+    internal async Task WaitCoreAsync(Func<CancellationToken, IAsyncEnumerable<LogEntry>> getLogs, Func<Task<ContainerInfo?>> inspect, CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; ; attempt++)
         {
-            if (tail.Count == MaxReportedLines)
-                tail.Dequeue();
-
-            tail.Enqueue(entry.Stream is LogStream.Stderr ? "[stderr] " + entry.Message : entry.Message);
-
-            if (pattern.IsMatch(entry.Message))
+            // Attaching to the logs replays them from the beginning, so every attempt counts the matches from scratch.
+            var count = 0;
+            var tail = new Queue<string>(MaxReportedLines);
+            await foreach (var entry in getLogs(cancellationToken).ConfigureAwait(false))
             {
-                count++;
-                if (count >= occurrences)
-                    return;
-            }
-        }
+                if (tail.Count == MaxReportedLines)
+                    tail.Dequeue();
 
-        throw new InvalidOperationException(await BuildFailureMessageAsync(container, count, tail).ConfigureAwait(false));
+                tail.Enqueue(entry.Stream is LogStream.Stderr ? "[stderr] " + entry.Message : entry.Message);
+
+                if (pattern.IsMatch(entry.Message))
+                {
+                    count++;
+                    if (count >= occurrences)
+                        return;
+                }
+            }
+
+            var info = await inspect().ConfigureAwait(false);
+            if (info?.State is not ContainerState.Running)
+                throw new InvalidOperationException(BuildFailureMessage(info, count, tail));
+
+            // The container is still alive, so the message it was supposed to print may still come: re-attach and
+            // keep waiting until the startup timeout cancels the wait or the container actually exits.
+            await Task.Delay(GetReattachDelay(attempt), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static TimeSpan GetReattachDelay(int attempt)
+    {
+        var delay = InitialReattachDelayInMilliseconds << Math.Min(attempt, 4);
+        return TimeSpan.FromMilliseconds(Math.Min(delay, MaxReattachDelayInMilliseconds));
     }
 
     /// <summary>Describes the failure with everything that explains it: what the container exited with, and what it printed before it did.</summary>
-    private async Task<string> BuildFailureMessageAsync(TemporaryContainer container, int count, Queue<string> tail)
+    private string BuildFailureMessage(ContainerInfo? info, int count, Queue<string> tail)
     {
         var message = new StringBuilder();
         message.Append(CultureInfo.InvariantCulture, $"The log pattern '{pattern}' matched {count} time(s) before the log stream ended (expected {occurrences}).");
 
-        if (await TryInspectAsync(container).ConfigureAwait(false) is { } info)
+        if (info is not null)
         {
             message.Append(CultureInfo.InvariantCulture, $" The container is {info.State}");
             if (info.ExitCode is { } exitCode)

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.Logging.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.Logging.cs
@@ -4,6 +4,13 @@ namespace Meziantou.Framework.TemporaryContainers;
 
 public partial class TemporaryContainer
 {
+    // A log stream that ends is not proof that the container is done: '<runtime> logs -f' exits with code 0 and the
+    // 'follow' response body ends when the runtime drops the attachment, both of which happen while the container is
+    // perfectly healthy. The pump re-attaches so a container does not stop logging for the rest of its life, backing
+    // off so a runtime that keeps ending the stream at once is not re-attached to in a tight loop.
+    private const int InitialReattachDelayInMilliseconds = 100;
+    private const int MaxReattachDelayInMilliseconds = 5000;
+
     private void StartForwardingLogs()
     {
         if (_forwardLogsTask is not null)
@@ -47,28 +54,86 @@ public partial class TemporaryContainer
 
     private async Task ForwardLogsAsync(string id, ILogger logger, CancellationToken cancellationToken)
     {
-        try
+        var consumedCount = 0;
+        var attempt = 0;
+        while (!cancellationToken.IsCancellationRequested)
         {
-            await foreach (var entry in Runtime.GetLogsAsync(id, cancellationToken).ConfigureAwait(false))
+            var consumedBeforeAttach = consumedCount;
+            try
             {
-                if (entry.Stream is LogStream.Stdout && _definition.Logging.CaptureStandardOutput)
+                var index = 0;
+                await foreach (var entry in Runtime.GetLogsAsync(id, cancellationToken).ConfigureAwait(false))
                 {
-                    logger.LogInformation("{ContainerLog}", entry.Message);
-                }
-                else if (entry.Stream is LogStream.Stderr && _definition.Logging.CaptureStandardError)
-                {
-                    logger.LogError("{ContainerLog}", entry.Message);
+                    // Attaching to the logs replays them from the beginning, so the lines consumed by a previous
+                    // attach have to be dropped: the logger must not see the whole log again on every re-attach.
+                    if (index++ < consumedCount)
+                        continue;
+
+                    consumedCount = index;
+
+                    if (entry.Stream is LogStream.Stdout && _definition.Logging.CaptureStandardOutput)
+                    {
+                        logger.LogInformation("{ContainerLog}", entry.Message);
+                    }
+                    else if (entry.Stream is LogStream.Stderr && _definition.Logging.CaptureStandardError)
+                    {
+                        logger.LogError("{ContainerLog}", entry.Message);
+                    }
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Expected: the container is stopping.
+                return;
+            }
+            catch
+            {
+                // The runtime stopped streaming, or the logger itself threw. A logger backed by a test output helper does
+                // that as soon as the test that owns it completes, which is exactly when the container is being disposed.
+                return;
+            }
+
+            // The stream ended on its own. The container may still have a whole life to log, so the only reason to
+            // stop pumping is the container itself being done.
+            if (!await IsRunningOrPausedAsync(id, cancellationToken).ConfigureAwait(false))
+                return;
+
+            // A stream that carried something was a working one, so the next attach is worth making right away.
+            attempt = consumedCount > consumedBeforeAttach ? 0 : attempt + 1;
+
+            try
+            {
+                await Task.Delay(GetReattachDelay(attempt), cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    }
+
+    /// <summary>Determines whether the container may still write logs, without ever throwing: forwarding logs is
+    /// best-effort, so a container that cannot be inspected simply ends the pump.</summary>
+    private async Task<bool> IsRunningOrPausedAsync(string id, CancellationToken cancellationToken)
+    {
+        try
         {
-            // Expected: the container is stopping.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+            var info = await Runtime.InspectAsync(id, cts.Token).ConfigureAwait(false);
+
+            // A paused container is not done: it keeps its logs and resumes writing to them once it is unpaused.
+            return info.State is ContainerState.Running or ContainerState.Paused;
         }
         catch
         {
-            // The runtime stopped streaming, or the logger itself threw. A logger backed by a test output helper does
-            // that as soon as the test that owns it completes, which is exactly when the container is being disposed.
+            return false;
         }
+    }
+
+    private static TimeSpan GetReattachDelay(int attempt)
+    {
+        var delay = InitialReattachDelayInMilliseconds << Math.Min(attempt, 6);
+        return TimeSpan.FromMilliseconds(Math.Min(delay, MaxReattachDelayInMilliseconds));
     }
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerDefinitionTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerDefinitionTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.TemporaryContainers.Tests;
@@ -179,9 +178,64 @@ public sealed class ContainerDefinitionTests
         Assert.DoesNotContain(logger.Messages, message => string.Equals(message, "after-stop", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task StartAsync_ReattachesWhenTheLogStreamEndsWhileTheContainerIsRunning()
+    {
+        var runtime = new InMemoryRuntime();
+        var logger = new ListLogger();
+        var definition = new ContainerDefinition(ImageSource.FromExisting("sha256:test"))
+        {
+            Runtime = runtime,
+        };
+        definition.Logging.Logger = logger;
+
+        await using var container = definition.CreateContainer();
+        await container.StartAsync();
+
+        runtime.Emit(LogStream.Stdout, "before-the-stream-ended");
+        await logger.WaitForMessageAsync("before-the-stream-ended");
+
+        // The runtimes end the log stream on their own while the container is running. Stopping there leaves the
+        // container silent for the rest of its life.
+        runtime.EndLogStream();
+        runtime.Emit(LogStream.Stdout, "after-the-stream-ended");
+        await logger.WaitForMessageAsync("after-the-stream-ended");
+
+        // Attaching replays the log from the beginning, so what was already forwarded must not be logged twice.
+        Assert.Equal(1, logger.Messages.Count(message => string.Equals(message, "before-the-stream-ended", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task StartAsync_StopsForwardingWhenTheLogStreamEndsAndTheContainerIsNoLongerRunning()
+    {
+        var runtime = new InMemoryRuntime();
+        var logger = new ListLogger();
+        var definition = new ContainerDefinition(ImageSource.FromExisting("sha256:test"))
+        {
+            Runtime = runtime,
+        };
+        definition.Logging.Logger = logger;
+
+        await using var container = definition.CreateContainer();
+        await container.StartAsync();
+
+        runtime.Emit(LogStream.Stdout, "before-the-container-exited");
+        await logger.WaitForMessageAsync("before-the-container-exited");
+
+        runtime.State = ContainerState.Exited;
+        runtime.EndLogStream();
+        runtime.Emit(LogStream.Stdout, "after-the-container-exited");
+        await Task.Delay(500);
+
+        Assert.DoesNotContain(logger.Messages, message => string.Equals(message, "after-the-container-exited", StringComparison.Ordinal));
+        Assert.Equal(1, runtime.LogAttachCount);
+    }
+
     private sealed class InMemoryRuntime : ContainerRuntime
     {
-        private readonly Channel<LogEntry> _logs = Channel.CreateUnbounded<LogEntry>();
+        private readonly List<LogEntry> _logs = [];
+        private int _logStreamGeneration;
+        private int _logAttachCount;
 
         public InMemoryRuntime()
             : base("InMemory")
@@ -189,6 +243,9 @@ public sealed class ContainerDefinitionTests
         }
 
         public ContainerState State { get; set; } = ContainerState.Created;
+
+        /// <summary>Gets the number of times the log stream has been attached to.</summary>
+        public int LogAttachCount => Volatile.Read(ref _logAttachCount);
 
         public override Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
 
@@ -229,8 +286,31 @@ public sealed class ContainerDefinitionTests
 
         internal override async IAsyncEnumerable<LogEntry> GetLogsAsync(string id, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            await foreach (var item in _logs.Reader.ReadAllAsync(cancellationToken))
-                yield return item;
+            // Mimics the real runtimes: every attach replays the log from the beginning, and the stream can end on
+            // its own while the container is still running.
+            Interlocked.Increment(ref _logAttachCount);
+            var generation = Volatile.Read(ref _logStreamGeneration);
+            var index = 0;
+            while (Volatile.Read(ref _logStreamGeneration) == generation)
+            {
+                LogEntry? entry = null;
+                lock (_logs)
+                {
+                    if (index < _logs.Count)
+                    {
+                        entry = _logs[index];
+                        index++;
+                    }
+                }
+
+                if (entry is null)
+                {
+                    await Task.Delay(10, cancellationToken);
+                    continue;
+                }
+
+                yield return entry;
+            }
         }
 
         internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition)
@@ -240,7 +320,16 @@ public sealed class ContainerDefinitionTests
 
         public void Emit(LogStream stream, string message)
         {
-            _logs.Writer.TryWrite(new LogEntry(stream, message, Timestamp: null));
+            lock (_logs)
+            {
+                _logs.Add(new LogEntry(stream, message, Timestamp: null));
+            }
+        }
+
+        /// <summary>Ends the current log stream, as the runtimes do while the container is still running.</summary>
+        public void EndLogStream()
+        {
+            Interlocked.Increment(ref _logStreamGeneration);
         }
     }
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/LogMessageWaitStrategyTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/LogMessageWaitStrategyTests.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+using Meziantou.Framework.TemporaryContainers.Strategies;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+public sealed class LogMessageWaitStrategyTests
+{
+    private static readonly ContainerInfo RunningContainer = new() { Id = "id", Name = "name", State = ContainerState.Running, Status = "running" };
+    private static readonly ContainerInfo ExitedContainer = new() { Id = "id", Name = "name", State = ContainerState.Exited, Status = "exited", ExitCode = 3 };
+
+    [Fact]
+    public async Task WaitAsync_ReattachesWhenTheLogStreamEndsWhileTheContainerIsRunning()
+    {
+        // The runtimes end the log stream on their own while the container is starting: 'docker logs -f' exits with
+        // code 0 and the 'follow' response body ends, both without a single line. Giving up there fails a container
+        // that is perfectly healthy.
+        var attachCount = 0;
+        var strategy = CreateStrategy("SERVER READY", occurrences: 1);
+
+        await strategy.WaitCoreAsync(
+            _ =>
+            {
+                attachCount++;
+                return attachCount < 3 ? CreateLogsAsync() : CreateLogsAsync("SERVER READY");
+            },
+            () => Task.FromResult<ContainerInfo?>(RunningContainer),
+            XunitCancellationToken);
+
+        Assert.Equal(3, attachCount);
+    }
+
+    [Fact]
+    public async Task WaitAsync_CountsTheOccurrencesOfEachAttachFromScratch()
+    {
+        // Attaching to the logs replays them from the beginning, so counting the matches of a new attach on top of
+        // the previous ones would report a container as ready after a single occurrence seen twice.
+        var attachCount = 0;
+        var strategy = CreateStrategy("SERVER READY", occurrences: 2);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await strategy.WaitCoreAsync(
+            _ =>
+            {
+                attachCount++;
+                return CreateLogsAsync("SERVER READY");
+            },
+            () => Task.FromResult<ContainerInfo?>(attachCount < 2 ? RunningContainer : ExitedContainer),
+            XunitCancellationToken));
+
+        Assert.Equal(2, attachCount);
+        Assert.Contains("matched 1 time(s)", exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitAsync_ReportsWhatTheContainerExitedWithAndPrinted()
+    {
+        var strategy = CreateStrategy("SERVER READY", occurrences: 1);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await strategy.WaitCoreAsync(
+            _ => CreateLogsAsync("the entrypoint gave up"),
+            () => Task.FromResult<ContainerInfo?>(ExitedContainer),
+            XunitCancellationToken));
+
+        Assert.Contains("matched 0 time(s)", exception.Message);
+        Assert.Contains("Exited", exception.Message);
+        Assert.Contains("exit code 3", exception.Message);
+        Assert.Contains("the entrypoint gave up", exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitAsync_KeepsWaitingUntilTheWaitIsCancelled()
+    {
+        // The startup timeout is what bounds the wait of a container that runs but never prints the message.
+        var attachCount = 0;
+        var strategy = CreateStrategy("SERVER READY", occurrences: 1);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(XunitCancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await strategy.WaitCoreAsync(
+            _ =>
+            {
+                attachCount++;
+                return CreateLogsAsync();
+            },
+            () => Task.FromResult<ContainerInfo?>(RunningContainer),
+            cts.Token));
+
+        Assert.True(attachCount > 1, $"The log stream was attached {attachCount} time(s).");
+    }
+
+    [Fact]
+    public async Task WaitAsync_ReportsAContainerThatCannotBeInspected()
+    {
+        var strategy = CreateStrategy("SERVER READY", occurrences: 1);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await strategy.WaitCoreAsync(
+            _ => CreateLogsAsync(),
+            () => Task.FromResult<ContainerInfo?>(null),
+            XunitCancellationToken));
+
+        Assert.Contains("The container did not write anything to its log streams.", exception.Message);
+    }
+
+    private static LogMessageWaitStrategy CreateStrategy(string substring, int occurrences)
+        => new(new Regex(Regex.Escape(substring), RegexOptions.None, TimeSpan.FromSeconds(1)), occurrences);
+
+    private static async IAsyncEnumerable<LogEntry> CreateLogsAsync(params string[] messages)
+    {
+        foreach (var message in messages)
+        {
+            await Task.Yield();
+            yield return new LogEntry(LogStream.Stdout, message, Timestamp: null);
+        }
+    }
+}


### PR DESCRIPTION
## What

`Wait.ForLogMessage` and the log forwarding pump both treated "the log stream ended" as "the container is done". Neither is true: both runtimes end a stream without an error while the container is perfectly healthy.

- `ExecutableContainerRuntime.GetLogsAsync` completes as soon as `<runtime> logs -f` exits — exit code 0 with no output is indistinguishable from "the container produced no output".
- `DockerApiRuntime.GetLogsAsync` ends when the `follow=1` response body ends.

Both now re-attach with a backoff while the container is still running, and stop only when it is actually done.

## Why

The diagnostics added in #2915 showed the real failure mode behind the intermittent `MongoDbContainerTests` failures on the Linux runners — three tests × two TFMs, all four retry attempts failing in ~0.5s each, while the Redis and PostgreSQL container tests pass in the same job:

```
The log pattern 'Waiting\ for\ connections' matched 0 time(s) before the log stream ended (expected 2).
The container is Running (running). The container did not write anything to its log streams.
```

The container is healthy; the log stream just returned nothing. The forwarding pump has the same weakness with a quieter symptom — it exits for good, so the container stops logging to `ContainerLoggingOptions.Logger` for the rest of its life.

## Changes

**`LogMessageWaitStrategy`** — when the stream ends, the strategy inspects the container. While it is `Running` it re-attaches after a backing-off delay (100ms → capped at 1s) and keeps waiting until the startup timeout cancels the wait or the container exits. Any other state, or an inspect that fails, throws the #2915 diagnostic message unchanged. Each attach counts its occurrences from scratch, because attaching replays the log from the beginning — accumulating across attaches would report a single occurrence seen twice as two.

**`TemporaryContainer.ForwardLogsAsync`** — same treatment, re-attaching while the container is `Running` or `Paused` (a paused container resumes writing, and `PauseAsync` never stopped forwarding before), with the backoff capped at 5s since the pump is not bounded by a timeout. Cancellation, a runtime failure and a throwing logger end the pump exactly as before. De-duplication is positional: the pump tracks how many entries it consumed and skips them on the replayed stream, otherwise every re-attach would log the whole history again. The counter tracks position in the log, not what reached the logger, so a line filtered out by `CaptureStandardOutput`/`CaptureStandardError` still advances it.

## Notes for the reviewer

- **Why positional de-duplication and not timestamps or `since`:** `LogEntry.Timestamp` is nullable — it depends on the runtime emitting timestamps — and several lines can share one timestamp, which would drop real lines. A `since` filter would mean changing the runtime API in two places for the same result.
- The wait strategy's loop body moved into an internal `WaitCoreAsync(getLogs, inspect, cancellationToken)` so the log stream and the container state can be driven directly from tests. The pump needed no such seam: the `InMemoryRuntime` fake in `ContainerDefinitionTests` covers it.
- A container that runs but never prints the message now ends as the usual `TimeoutException` from `WaitUntilReadyAsync` after `StartupTimeout`, instead of failing fast with the log-pattern message.
- `GetReattachDelay` is duplicated between the two files with different caps. Extracting it would mean a new internal helper type for three lines.

## Tests

- New `LogMessageWaitStrategyTests` (5 cases): re-attach after an empty stream while running, per-attach occurrence counting, the exited-container diagnostics, the un-inspectable container, and staying alive until cancelled.
- Two cases added to `ContainerDefinitionTests` for the pump: a line emitted after the stream ends still reaches the logger *and* the replayed line is not logged twice; and the pump stops (single attach, nothing forwarded) once the container is no longer running. The `InMemoryRuntime` fake now models the real runtimes — every attach replays the whole log, `EndLogStream()` ends an attach while the container keeps running.
- Both pump tests are mutation-checked: never re-attaching fails the first, and removing the skip-what-was-consumed logic fails its duplicate assertion.

Verified locally with `/p:TreatWarningsAsErrors=true`: the whole `Meziantou.Framework.TemporaryContainers.Tests` project is green on net10.0 and net11.0 (212 passed, 42 skipped for the podman/wslc runtimes that are not installed), except the two `SqlServerContainerTests`, which fail on this arm64 machine with `image ... does not support required platforms` — the mssql image has no arm64 variant, and they fail at `container create`, before any wait strategy runs. `dotnet run ./eng/update-all.cs` reports no changes.
