### PR TITLE
Add IndentBlockSequences and StringStyle options to the YAML serializer

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -246,6 +246,7 @@ namespace Meziantou.Framework.Yaml
     {
         public bool PreferPlainStyle { get => throw null; init { } }
         public bool PreferQuotedForAmbiguousScalars { get => throw null; init { } }
+        public Meziantou.Framework.Yaml.ScalarStyle StringStyle { get => throw null; init { } }
     }
 
     public enum YamlSchemaKind
@@ -1038,11 +1039,19 @@ namespace Meziantou.Framework.Yaml.Serialization
         public string? SourceName { get => throw null; set { } }
         public bool PreferPlainStyle { get => throw null; set { } }
         public bool PreferQuotedForAmbiguousScalars { get => throw null; set { } }
+        public Meziantou.Framework.Yaml.ScalarStyle StringStyle { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlTypeDiscriminatorStyle DiscriminatorStyle { get => throw null; set { } }
         public string? TypeDiscriminatorPropertyName { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get => throw null; set { } }
         public bool InferClosedTypePolymorphism { get => throw null; set { } }
         public System.Type[]? Converters { get => throw null; set { } }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class YamlStringStyleAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
+    {
+        public Meziantou.Framework.Yaml.ScalarStyle Style { get => throw null; }
+        public YamlStringStyleAttribute(Meziantou.Framework.Yaml.ScalarStyle style) { }
     }
 
     public enum YamlTokenType
@@ -1137,6 +1146,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public YamlWriter(System.IO.TextWriter writer, Meziantou.Framework.Yaml.YamlSerializerOptions? options = null) : base(default(Meziantou.Framework.Yaml.YamlSerializerOptions)) { }
         public YamlWriter(System.Text.StringBuilder stringBuilder, Meziantou.Framework.Yaml.YamlSerializerOptions? options = null) : base(default(Meziantou.Framework.Yaml.YamlSerializerOptions)) { }
         public BlockSequenceItemStyleScope PushBlockSequenceItemStyle(Meziantou.Framework.Yaml.YamlSequenceItemStyle mappingStyle, Meziantou.Framework.Yaml.YamlSequenceItemStyle sequenceStyle) => throw null;
+        public StringStyleScope PushStringStyle(Meziantou.Framework.Yaml.ScalarStyle style) => throw null;
         public bool TryWriteReference(object? value) => throw null;
         public void WriteTag(string tag) { }
         public void WriteAnchor(string anchor) { }
@@ -1182,6 +1192,10 @@ namespace Meziantou.Framework.Yaml.Serialization
         public void WriteScalar<T>(T value) where T : System.IFormattable { }
         public void WriteNullValue() { }
         public readonly struct BlockSequenceItemStyleScope : System.IDisposable
+        {
+            public void Dispose() { }
+        }
+        public readonly struct StringStyleScope : System.IDisposable
         {
             public void Dispose() { }
         }

--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -350,6 +350,7 @@ namespace Meziantou.Framework.Yaml
         public Meziantou.Framework.Yaml.YamlIgnoreCondition DefaultIgnoreCondition { get => throw null; init { } }
         public bool WriteIndented { get => throw null; init { } }
         public int IndentSize { get => throw null; init { } }
+        public bool IndentBlockSequences { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlMappingOrderPolicy MappingOrder { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlSequenceItemStyle BlockSequenceMappingStyle { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlSequenceItemStyle BlockSequenceSequenceStyle { get => throw null; init { } }
@@ -1013,6 +1014,7 @@ namespace Meziantou.Framework.Yaml.Serialization
     {
         public bool WriteIndented { get => throw null; set { } }
         public int IndentSize { get => throw null; set { } }
+        public bool IndentBlockSequences { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlKnownNamingPolicy PropertyNamingPolicy { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlKnownNamingPolicy DictionaryKeyPolicy { get => throw null; set { } }
         public bool PropertyNameCaseInsensitive { get => throw null; set { } }

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/MemberModel.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/MemberModel.cs
@@ -16,6 +16,7 @@ internal sealed class MemberModel
         string? objectCreationHandling,
         string? blockSequenceMappingStyle,
         string? blockSequenceSequenceStyle,
+        string? stringStyle,
         bool isRequired,
         bool isIgnoredOnRead,
         bool isInitOnly,
@@ -40,6 +41,7 @@ internal sealed class MemberModel
         ObjectCreationHandling = objectCreationHandling;
         BlockSequenceMappingStyle = blockSequenceMappingStyle;
         BlockSequenceSequenceStyle = blockSequenceSequenceStyle;
+        StringStyle = stringStyle;
         IsRequired = isRequired;
         IsIgnoredOnRead = isIgnoredOnRead;
         IsInitOnly = isInitOnly;
@@ -69,6 +71,7 @@ internal sealed class MemberModel
     public string? ObjectCreationHandling { get; }
     public string? BlockSequenceMappingStyle { get; }
     public string? BlockSequenceSequenceStyle { get; }
+    public string? StringStyle { get; }
     public bool IsRequired { get; }
     public bool IsIgnoredOnRead { get; }
     public bool IsInitOnly { get; }

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/SourceGenerationOptionsModel.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/SourceGenerationOptionsModel.cs
@@ -7,6 +7,7 @@ internal sealed class SourceGenerationOptionsModel
 {
     public bool? WriteIndented { get; set; }
     public int? IndentSize { get; set; }
+    public bool? IndentBlockSequences { get; set; }
     public bool? PropertyNameCaseInsensitive { get; set; }
     public bool? IncludeFields { get; set; }
     public bool? IgnoreReadOnlyFields { get; set; }
@@ -40,6 +41,7 @@ internal sealed class SourceGenerationOptionsModel
     {
         if (other.WriteIndented.HasValue) WriteIndented = other.WriteIndented;
         if (other.IndentSize.HasValue) IndentSize = other.IndentSize;
+        if (other.IndentBlockSequences.HasValue) IndentBlockSequences = other.IndentBlockSequences;
         if (other.PropertyNameCaseInsensitive.HasValue) PropertyNameCaseInsensitive = other.PropertyNameCaseInsensitive;
         if (other.IncludeFields.HasValue) IncludeFields = other.IncludeFields;
         if (other.IgnoreReadOnlyFields.HasValue) IgnoreReadOnlyFields = other.IgnoreReadOnlyFields;

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/SourceGenerationOptionsModel.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/SourceGenerationOptionsModel.cs
@@ -8,6 +8,7 @@ internal sealed class SourceGenerationOptionsModel
     public bool? WriteIndented { get; set; }
     public int? IndentSize { get; set; }
     public bool? IndentBlockSequences { get; set; }
+    public string? StringStyle { get; set; }
     public bool? PropertyNameCaseInsensitive { get; set; }
     public bool? IncludeFields { get; set; }
     public bool? IgnoreReadOnlyFields { get; set; }
@@ -42,6 +43,7 @@ internal sealed class SourceGenerationOptionsModel
         if (other.WriteIndented.HasValue) WriteIndented = other.WriteIndented;
         if (other.IndentSize.HasValue) IndentSize = other.IndentSize;
         if (other.IndentBlockSequences.HasValue) IndentBlockSequences = other.IndentBlockSequences;
+        if (!string.IsNullOrEmpty(other.StringStyle)) StringStyle = other.StringStyle;
         if (other.PropertyNameCaseInsensitive.HasValue) PropertyNameCaseInsensitive = other.PropertyNameCaseInsensitive;
         if (other.IncludeFields.HasValue) IncludeFields = other.IncludeFields;
         if (other.IgnoreReadOnlyFields.HasValue) IgnoreReadOnlyFields = other.IgnoreReadOnlyFields;

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -6327,6 +6327,13 @@ public sealed partial class YamlSerializerContextGenerator
                 .AppendLine(",");
         }
 
+        if (options.IndentBlockSequences.HasValue)
+        {
+            builder.Append("            IndentBlockSequences = ")
+                .Append(options.IndentBlockSequences.Value ? "true" : "false")
+                .AppendLine(",");
+        }
+
         if (options.PropertyNameCaseInsensitive.HasValue)
         {
             builder.Append("            PropertyNameCaseInsensitive = ")

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -2220,6 +2220,7 @@ public sealed partial class YamlSerializerContextGenerator
                 member.ObjectCreationHandling,
                 member.BlockSequenceMappingStyle,
                 member.BlockSequenceSequenceStyle,
+                member.StringStyle,
                 member.IsRequired,
                 member.IsIgnoredOnRead,
                 member.IsInitOnly,
@@ -2379,6 +2380,7 @@ public sealed partial class YamlSerializerContextGenerator
                 member.ObjectCreationHandling,
                 member.BlockSequenceMappingStyle,
                 member.BlockSequenceSequenceStyle,
+                member.StringStyle,
                 member.IsRequired,
                 member.IsIgnoredOnRead,
                 member.IsInitOnly,
@@ -3728,7 +3730,8 @@ public sealed partial class YamlSerializerContextGenerator
 
         if (member.Type.SpecialType == SpecialType.System_String)
         {
-            builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
+            // WriteString applies the scalar style preferences; WriteScalar would write the raw text.
+            builder.Append(indent).Append("writer.WriteString(").Append(valueExpression).AppendLine(");");
             return;
         }
 
@@ -3964,7 +3967,7 @@ public sealed partial class YamlSerializerContextGenerator
 
     private static void EmitWriteMemberValueWithCustomConverter(StringBuilder builder, MemberModel member, Dictionary<ITypeSymbol, int> indexByType, string valueExpression, string indent, SourceGenerationOptionsModel sourceGenerationOptions)
     {
-        if (member.BlockSequenceMappingStyle is not null || member.BlockSequenceSequenceStyle is not null)
+        if (member.BlockSequenceMappingStyle is not null || member.BlockSequenceSequenceStyle is not null || member.StringStyle is not null)
         {
             var mappingStyle = member.BlockSequenceMappingStyle is null
                 ? "global::Meziantou.Framework.Yaml.YamlSequenceItemStyle.Default"
@@ -3979,6 +3982,13 @@ public sealed partial class YamlSerializerContextGenerator
                 .Append(", ")
                 .Append(sequenceStyle)
                 .AppendLine(");");
+            if (member.StringStyle is not null)
+            {
+                builder.Append(indent).Append("    using var stringStyleScope = writer.PushStringStyle(global::Meziantou.Framework.Yaml.ScalarStyle.")
+                    .Append(member.StringStyle)
+                    .AppendLine(");");
+            }
+
             EmitWriteMemberValueWithCustomConverterCore(builder, member, indexByType, valueExpression, indent + "    ", sourceGenerationOptions);
             builder.Append(indent).AppendLine("}");
             return;
@@ -6481,7 +6491,7 @@ public sealed partial class YamlSerializerContextGenerator
                 .AppendLine(",");
         }
 
-        if (options.PreferPlainStyle.HasValue || options.PreferQuotedForAmbiguousScalars.HasValue)
+        if (options.PreferPlainStyle.HasValue || options.PreferQuotedForAmbiguousScalars.HasValue || !string.IsNullOrEmpty(options.StringStyle))
         {
             builder.AppendLine("            ScalarStylePreferences = new global::Meziantou.Framework.Yaml.YamlScalarStylePreferences");
             builder.AppendLine("            {");
@@ -6496,6 +6506,13 @@ public sealed partial class YamlSerializerContextGenerator
             {
                 builder.Append("                PreferQuotedForAmbiguousScalars = ")
                     .Append(options.PreferQuotedForAmbiguousScalars.Value ? "true" : "false")
+                    .AppendLine(",");
+            }
+
+            if (!string.IsNullOrEmpty(options.StringStyle))
+            {
+                builder.Append("                StringStyle = global::Meziantou.Framework.Yaml.ScalarStyle.")
+                    .Append(options.StringStyle)
                     .AppendLine(",");
             }
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1791,6 +1791,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         var converterTypeName = GetYamlConverterAttributeTypeName(member, type);
         var objectCreationHandling = GetObjectCreationHandling(member);
         var (blockSequenceMappingStyle, blockSequenceSequenceStyle) = GetBlockSequenceItemStyles(member);
+        var stringStyle = GetStringStyle(member);
         var isRequiredKeyword = member is IPropertySymbol { IsRequired: true } or IFieldSymbol { IsRequired: true };
         var isRequired = isRequiredKeyword || HasAttribute(member, "Meziantou.Framework.Yaml.Serialization.YamlRequiredAttribute");
         var isIgnoredOnRead = memberIgnoreCondition == IgnoreWhenReading;
@@ -1803,7 +1804,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         var numberHandling = converterTypeName is null ? GetNumberHandlingValue(member, type) : null;
         var enumCustomNames = converterTypeName is null ? GetEnumCustomNames(type) : null;
         var skipObjectInitializer = usesAccessorForWrite || RequiresConstructorAccessor(declaringType, accessors);
-        return new MemberModel(member, type, nameForRead, nameForWrite, accessExpression, assign, memberIgnoreCondition, converterTypeName, objectCreationHandling, blockSequenceMappingStyle, blockSequenceSequenceStyle, isRequired, isIgnoredOnRead, isInitOnly, isRequiredKeyword, requiresIncludeFields, disallowNull, disallowNull, isReadOnlyProperty, isReadOnlyField, skipObjectInitializer, numberHandling, enumCustomNames);
+        return new MemberModel(member, type, nameForRead, nameForWrite, accessExpression, assign, memberIgnoreCondition, converterTypeName, objectCreationHandling, blockSequenceMappingStyle, blockSequenceSequenceStyle, stringStyle, isRequired, isIgnoredOnRead, isInitOnly, isRequiredKeyword, requiresIncludeFields, disallowNull, disallowNull, isReadOnlyProperty, isReadOnlyField, skipObjectInitializer, numberHandling, enumCustomNames);
     }
 
     /// <summary>
@@ -3490,6 +3491,9 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 case "IndentBlockSequences":
                     model.IndentBlockSequences = argument.Value.Value as bool?;
                     break;
+                case "StringStyle":
+                    model.StringStyle = NormalizeEnumName(argument.Value.ToCSharpString());
+                    break;
                 case "PropertyNameCaseInsensitive":
                     model.PropertyNameCaseInsensitive = argument.Value.Value as bool?;
                     break;
@@ -3691,6 +3695,24 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
 
         return (null, null);
+    }
+
+    private static string? GetStringStyle(ISymbol member)
+    {
+        foreach (var attribute in member.GetAttributes())
+        {
+            if (!string.Equals(attribute.AttributeClass?.ToDisplayString(), "Meziantou.Framework.Yaml.Serialization.YamlStringStyleAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 1)
+            {
+                return NormalizeEnumName(attribute.ConstructorArguments[0].ToCSharpString());
+            }
+        }
+
+        return null;
     }
 
     private static string? TryGetObjectCreationHandlingOverride(INamedTypeSymbol typeSymbol)

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -3487,6 +3487,9 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 case "IndentSize":
                     model.IndentSize = argument.Value.Value as int?;
                     break;
+                case "IndentBlockSequences":
+                    model.IndentBlockSequences = argument.Value.Value as bool?;
+                    break;
                 case "PropertyNameCaseInsensitive":
                     model.PropertyNameCaseInsensitive = argument.Value.Value as bool?;
                     break;

--- a/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
+++ b/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <Description>A high-performance .NET YAML library providing parsing and serialization of object graphs, NativeAOT ready.</Description>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -1632,6 +1632,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             writer.WritePropertyName(member.Name);
             var converter = member.Converter ??= writer.GetConverter(member.MemberType);
             using var styleScope = writer.PushBlockSequenceItemStyle(member.BlockSequenceMappingStyle, member.BlockSequenceSequenceStyle);
+            using var stringStyleScope = writer.PushStringStyle(member.StringStyle);
             converter.Write(writer, memberValue);
         }
 
@@ -1783,6 +1784,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             writer.WritePropertyName(member.Name);
             var converter = member.Converter ??= writer.GetConverter(member.MemberType);
             using var styleScope = writer.PushBlockSequenceItemStyle(member.BlockSequenceMappingStyle, member.BlockSequenceSequenceStyle);
+            using var stringStyleScope = writer.PushStringStyle(member.StringStyle);
             converter.Write(writer, memberValue);
         }
 
@@ -1915,6 +1917,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
                 var token = property.MetadataToken;
 
                 var (mappingStyle, sequenceStyle) = GetBlockSequenceItemStyles(property);
+                var stringStyle = GetStringStyle(property);
                 var member = new Member(
                     name,
                     order,
@@ -1927,6 +1930,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
                     GetObjectCreationHandling(property),
                     mappingStyle,
                     sequenceStyle,
+                    stringStyle,
                     DisallowNullOnSerialize(nullabilityContext, property),
                     DisallowNullOnDeserialize(nullabilityContext, property),
                     isReadOnlyProperty: !canWrite);
@@ -1981,6 +1985,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
                 var token = field.MetadataToken;
 
                 var (mappingStyle, sequenceStyle) = GetBlockSequenceItemStyles(field);
+                var stringStyle = GetStringStyle(field);
                 var member = new Member(
                     name,
                     order,
@@ -1993,6 +1998,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
                     GetObjectCreationHandling(field),
                     mappingStyle,
                     sequenceStyle,
+                    stringStyle,
                     DisallowNullOnSerialize(nullabilityContext, field),
                     DisallowNullOnDeserialize(nullabilityContext, field),
                     isReadOnlyField: field.IsInitOnly);
@@ -2706,6 +2712,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             YamlObjectCreationHandling? objectCreationHandling,
             YamlSequenceItemStyle blockSequenceMappingStyle = YamlSequenceItemStyle.Default,
             YamlSequenceItemStyle blockSequenceSequenceStyle = YamlSequenceItemStyle.Default,
+            ScalarStyle stringStyle = ScalarStyle.Any,
             bool disallowNullOnSerialize = false,
             bool disallowNullOnDeserialize = false,
             bool isReadOnlyProperty = false)
@@ -2723,6 +2730,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             ObjectCreationHandling = objectCreationHandling;
             BlockSequenceMappingStyle = blockSequenceMappingStyle;
             BlockSequenceSequenceStyle = blockSequenceSequenceStyle;
+            StringStyle = stringStyle;
             DisallowNullOnSerialize = disallowNullOnSerialize;
             DisallowNullOnDeserialize = disallowNullOnDeserialize;
             IsReadOnlyProperty = isReadOnlyProperty;
@@ -2740,6 +2748,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             YamlObjectCreationHandling? objectCreationHandling,
             YamlSequenceItemStyle blockSequenceMappingStyle = YamlSequenceItemStyle.Default,
             YamlSequenceItemStyle blockSequenceSequenceStyle = YamlSequenceItemStyle.Default,
+            ScalarStyle stringStyle = ScalarStyle.Any,
             bool disallowNullOnSerialize = false,
             bool disallowNullOnDeserialize = false,
             bool isReadOnlyField = false)
@@ -2757,6 +2766,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             ObjectCreationHandling = objectCreationHandling;
             BlockSequenceMappingStyle = blockSequenceMappingStyle;
             BlockSequenceSequenceStyle = blockSequenceSequenceStyle;
+            StringStyle = stringStyle;
             DisallowNullOnSerialize = disallowNullOnSerialize;
             DisallowNullOnDeserialize = disallowNullOnDeserialize;
             IsReadOnlyField = isReadOnlyField;
@@ -2781,6 +2791,8 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         public YamlSequenceItemStyle BlockSequenceMappingStyle { get; }
 
         public YamlSequenceItemStyle BlockSequenceSequenceStyle { get; }
+
+        public ScalarStyle StringStyle { get; }
 
         public YamlIgnoreCondition? IgnoreCondition { get; }
 
@@ -3340,6 +3352,19 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         YamlSerializerOptions.ValidateSequenceItemStyle(attribute.MappingStyle, nameof(YamlBlockSequenceItemStyleAttribute.MappingStyle));
         YamlSerializerOptions.ValidateSequenceItemStyle(attribute.SequenceStyle, nameof(YamlBlockSequenceItemStyleAttribute.SequenceStyle));
         return (attribute.MappingStyle, attribute.SequenceStyle);
+    }
+
+    private static ScalarStyle GetStringStyle(MemberInfo member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+        var attribute = member.GetCustomAttribute<YamlStringStyleAttribute>(inherit: true);
+        if (attribute is null)
+        {
+            return ScalarStyle.Any;
+        }
+
+        YamlSerializerOptions.ValidateScalarStyle(attribute.Style, nameof(YamlStringStyleAttribute.Style));
+        return attribute.Style;
     }
 
     private static YamlConverter? CreateConverterFromAttribute(MemberInfo member, Type memberType, YamlSerializerOptions options)

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
@@ -29,6 +29,15 @@ public sealed class YamlSourceGenerationOptionsAttribute : YamlAttribute
     /// </summary>
     public int IndentSize { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a block sequence that is the value of a mapping key is indented
+    /// relative to that mapping.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="YamlSerializerOptions.IndentBlockSequences"/>.
+    /// </remarks>
+    public bool IndentBlockSequences { get; set; }
+
     /// <summary>Gets or sets the policy used to convert CLR property names.</summary>
     public YamlKnownNamingPolicy PropertyNamingPolicy { get; set; }
 

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
@@ -113,6 +113,10 @@ public sealed class YamlSourceGenerationOptionsAttribute : YamlAttribute
     /// <summary>Gets or sets a value indicating whether quoted scalar style should be preferred for ambiguous scalars.</summary>
     public bool PreferQuotedForAmbiguousScalars { get; set; }
 
+    /// <summary>Gets or sets the style used to emit string values.</summary>
+    /// <remarks>See <see cref="YamlScalarStylePreferences.StringStyle"/>.</remarks>
+    public ScalarStyle StringStyle { get; set; }
+
     /// <summary>Gets or sets how type discriminators are represented during polymorphic serialization.</summary>
     public YamlTypeDiscriminatorStyle DiscriminatorStyle { get; set; }
 

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlStringStyleAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlStringStyleAttribute.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Overrides the style used to emit the string values written by the attributed member.</summary>
+/// <remarks>
+/// Apply this attribute to a property or field whose value is a string or contains strings. The override is scoped
+/// to the serialization of that member value and affects the strings encountered below it, which includes the items
+/// of a collection and the values of a nested object. It does not affect mapping keys.
+/// See <see cref="YamlScalarStylePreferences.StringStyle"/>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+public sealed class YamlStringStyleAttribute : YamlAttribute
+{
+    /// <summary>Initializes a new instance of the <see cref="YamlStringStyleAttribute"/> class.</summary>
+    /// <param name="style">The style to use for string values.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="style"/> is not a defined <see cref="ScalarStyle"/>.</exception>
+    public YamlStringStyleAttribute(ScalarStyle style)
+    {
+        YamlSerializerOptions.ValidateScalarStyle(style, nameof(style));
+        Style = style;
+    }
+
+    /// <summary>Gets the style to use for string values.</summary>
+    public ScalarStyle Style { get; }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -825,7 +825,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
                 }
 
                 pendingStart = PendingStartKind.MappingValue;
-                indent = parent.Indent + GetIndentStep(kind);
+                indent = parent.Indent + GetMappingValueIndentStep(kind);
                 if (_pendingAnchor is not null || _pendingTag is not null)
                 {
                     WriteNodeProperties(writeLeadingSpace: true, writeTrailingSpace: false);
@@ -957,6 +957,24 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         return kind == ContainerKind.Sequence ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Gets the number of columns a block collection written as a mapping value is indented by, relative to the mapping
+    /// that contains it.
+    /// </summary>
+    /// <remarks>
+    /// A block sequence that is the value of a mapping key does not need its own indentation level, so
+    /// <see cref="YamlSerializerOptions.IndentBlockSequences"/> can keep its dashes aligned with the parent mapping.
+    /// </remarks>
+    private int GetMappingValueIndentStep(ContainerKind kind)
+    {
+        if (kind == ContainerKind.Sequence && !Options.IndentBlockSequences)
+        {
+            return 0;
+        }
+
+        return GetIndentStep(kind);
     }
 
     private void WriteNewLine()

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -19,6 +19,8 @@ public sealed class YamlWriter : YamlReaderWriterBase
     private char _lastWrittenChar;
     private YamlSequenceItemStyle _blockSequenceMappingStyle;
     private YamlSequenceItemStyle _blockSequenceSequenceStyle;
+    private ScalarStyle _stringStyle;
+    private bool _suppressNextNewLine;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="YamlWriter"/> class.
@@ -86,6 +88,27 @@ public sealed class YamlWriter : YamlReaderWriterBase
         if (sequenceStyle != YamlSequenceItemStyle.Default)
         {
             _blockSequenceSequenceStyle = sequenceStyle;
+        }
+
+        return scope;
+    }
+
+    /// <summary>Temporarily overrides the style used to write string values.</summary>
+    /// <param name="style">The style override, or <see cref="ScalarStyle.Any"/> to keep the current style.</param>
+    /// <returns>A scope that restores the previous style when disposed.</returns>
+    /// <remarks>
+    /// The style applies to string values only. It is ignored for a value that cannot be represented in it, and for
+    /// mapping keys.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="style"/> is not a defined <see cref="ScalarStyle"/>.</exception>
+    public StringStyleScope PushStringStyle(ScalarStyle style)
+    {
+        YamlSerializerOptions.ValidateScalarStyle(style, nameof(style));
+
+        var scope = new StringStyleScope(this, _stringStyle);
+        if (style != ScalarStyle.Any)
+        {
+            _stringStyle = style;
         }
 
         return scope;
@@ -979,6 +1002,13 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
     private void WriteNewLine()
     {
+        // A "keep" block scalar already wrote the line break that separates it from the next node.
+        if (_suppressNextNewLine)
+        {
+            _suppressNextNewLine = false;
+            return;
+        }
+
         Write('\n');
     }
 
@@ -986,6 +1016,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
     {
         _blockSequenceMappingStyle = ResolveOptionStyle(Options.BlockSequenceMappingStyle, YamlSequenceItemStyle.Compact);
         _blockSequenceSequenceStyle = ResolveOptionStyle(Options.BlockSequenceSequenceStyle, YamlSequenceItemStyle.Expanded);
+        _stringStyle = Options.ScalarStylePreferences.StringStyle;
     }
 
     private bool ShouldCompactSequenceItem(ContainerKind kind)
@@ -1002,6 +1033,11 @@ public sealed class YamlWriter : YamlReaderWriterBase
     {
         _blockSequenceMappingStyle = mappingStyle;
         _blockSequenceSequenceStyle = sequenceStyle;
+    }
+
+    private void RestoreStringStyle(ScalarStyle style)
+    {
+        _stringStyle = style;
     }
 
     private static YamlSequenceItemStyle ResolveOptionStyle(YamlSequenceItemStyle style, YamlSequenceItemStyle fallback)
@@ -1078,6 +1114,11 @@ public sealed class YamlWriter : YamlReaderWriterBase
             return;
         }
 
+        if (!isKey && TryWriteStyledString(value))
+        {
+            return;
+        }
+
         if (ShouldQuoteAmbiguousScalar(value))
         {
             Write('"');
@@ -1087,6 +1128,228 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         WriteScalarCore(value, isKey);
+    }
+
+    /// <summary>Writes <paramref name="value"/> using the requested string style.</summary>
+    /// <param name="value">The string value to write.</param>
+    /// <returns>
+    /// <see langword="true"/> when the value was written; <see langword="false"/> when the requested style cannot
+    /// represent it and the automatic style must be used instead.
+    /// </returns>
+    private bool TryWriteStyledString(ReadOnlySpan<char> value)
+    {
+        switch (_stringStyle)
+        {
+            case ScalarStyle.Literal or ScalarStyle.Folded:
+                return TryWriteBlockScalar(value, _stringStyle);
+
+            case ScalarStyle.SingleQuoted:
+                return TryWriteSingleQuotedScalar(value);
+
+            case ScalarStyle.DoubleQuoted:
+                Write('"');
+                WriteEscaped(value);
+                Write('"');
+                return true;
+
+            case ScalarStyle.Plain when IsPlainSafe(value, isKey: false):
+                Write(value);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private bool TryWriteSingleQuotedScalar(ReadOnlySpan<char> value)
+    {
+        foreach (var c in value)
+        {
+            // A line break inside a single-quoted scalar is folded when it is read back, and a control character
+            // can only be represented by a double-quoted escape.
+            if (IsLineBreak(c) || (c != '\t' && !Emitter.IsPrintable(c)))
+            {
+                return false;
+            }
+        }
+
+        Write('\'');
+        foreach (var c in value)
+        {
+            if (c == '\'')
+            {
+                Write("''");
+            }
+            else
+            {
+                Write(c);
+            }
+        }
+
+        Write('\'');
+        return true;
+    }
+
+    /// <summary>Writes <paramref name="value"/> using the literal (<c>|</c>) or folded (<c>&gt;</c>) block style.</summary>
+    /// <returns><see langword="true"/> when the value was written as a block scalar.</returns>
+    private bool TryWriteBlockScalar(ReadOnlySpan<char> value, ScalarStyle style)
+    {
+        // A block scalar spans several lines, so it has no meaning inside a flow collection.
+        if (IsFlow || !TryAnalyzeBlockScalar(value, style, out var body, out var trailingBreaks, out var needsIndentIndicator))
+        {
+            return false;
+        }
+
+        Write(style == ScalarStyle.Literal ? '|' : '>');
+
+        if (needsIndentIndicator)
+        {
+            Write((char)('0' + Options.IndentSize));
+        }
+
+        if (trailingBreaks == 0)
+        {
+            Write('-');
+        }
+        else if (trailingBreaks > 1)
+        {
+            Write('+');
+        }
+
+        var parentIndent = _depth == 0 ? 0 : _frames[_depth - 1].Indent;
+        WriteBlockScalarBody(body, style, parentIndent + Options.IndentSize);
+
+        if (trailingBreaks > 1)
+        {
+            // A "keep" block scalar owns every trailing line break, including the one that separates it from the
+            // node that follows, so that separator is written here instead.
+            for (var i = 0; i < trailingBreaks; i++)
+            {
+                Write('\n');
+            }
+
+            _suppressNextNewLine = true;
+        }
+
+        return true;
+    }
+
+    /// <summary>Determines whether <paramref name="value"/> round-trips through a block scalar.</summary>
+    /// <param name="value">The string value to write.</param>
+    /// <param name="style">The block style to use.</param>
+    /// <param name="body">The value without its trailing line breaks.</param>
+    /// <param name="trailingBreaks">The number of line breaks at the end of the value, which selects the chomping indicator.</param>
+    /// <param name="needsIndentIndicator">Whether the content indentation must be stated explicitly.</param>
+    private bool TryAnalyzeBlockScalar(ReadOnlySpan<char> value, ScalarStyle style, out ReadOnlySpan<char> body, out int trailingBreaks, out bool needsIndentIndicator)
+    {
+        needsIndentIndicator = false;
+        trailingBreaks = 0;
+        body = value;
+
+        while (body.Length > 0 && body[^1] == '\n')
+        {
+            body = body[..^1];
+            trailingBreaks++;
+        }
+
+        // A block scalar needs at least one content line, and a blank at the very end would be read back as
+        // trailing whitespace that a reader is free to drop.
+        if (body.Length == 0 || body[^1] is ' ' or '\t')
+        {
+            return false;
+        }
+
+        var isLineStart = true;
+        for (var i = 0; i < body.Length; i++)
+        {
+            var c = body[i];
+            if (c == '\n')
+            {
+                if (i > 0 && body[i - 1] is ' ' or '\t')
+                {
+                    return false;
+                }
+
+                isLineStart = true;
+                continue;
+            }
+
+            // Any other line break is normalized to a line feed when the block scalar is read back, and a
+            // control character can only be represented by a double-quoted escape.
+            if (IsLineBreak(c) || (c != '\t' && !Emitter.IsPrintable(c)))
+            {
+                return false;
+            }
+
+            if (isLineStart)
+            {
+                // Indentation is written with spaces, and a reader stops at a tab where it expects one.
+                if (c == '\t')
+                {
+                    return false;
+                }
+
+                // A folded scalar reads a more-indented line literally and stops folding around it, so a line
+                // that starts with a blank would not round-trip.
+                if (c == ' ' && style == ScalarStyle.Folded)
+                {
+                    return false;
+                }
+            }
+
+            isLineStart = false;
+        }
+
+        // The content indentation is detected from the first non-empty line, so a value that starts with a blank
+        // or with an empty line has to state it explicitly. YAML writes that indicator as a single digit.
+        if (body[0] is ' ' or '\n')
+        {
+            if (style == ScalarStyle.Folded || Options.IndentSize > 9)
+            {
+                return false;
+            }
+
+            needsIndentIndicator = true;
+        }
+
+        return true;
+    }
+
+    private void WriteBlockScalarBody(ReadOnlySpan<char> body, ScalarStyle style, int contentIndent)
+    {
+        var isFirstLine = true;
+        var previousLineWasEmpty = false;
+
+        for (var start = 0; ;)
+        {
+            var index = body[start..].IndexOf('\n');
+            var end = index < 0 ? body.Length : start + index;
+            var line = body[start..end];
+
+            // Folding turns a single line break into a space, so a line break in the value is written as a blank
+            // line unless the previous line was already blank.
+            var breaks = !isFirstLine && style == ScalarStyle.Folded && !previousLineWasEmpty ? 2 : 1;
+            for (var i = 0; i < breaks; i++)
+            {
+                Write('\n');
+            }
+
+            // An empty line is left empty so the document carries no trailing whitespace.
+            if (!line.IsEmpty)
+            {
+                WriteIndent(contentIndent);
+                Write(line);
+            }
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            isFirstLine = false;
+            previousLineWasEmpty = line.IsEmpty;
+            start = end + 1;
+        }
     }
 
     private bool ShouldQuoteAmbiguousScalar(ReadOnlySpan<char> value)
@@ -1107,7 +1370,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
                YamlScalar.TryParseDouble(value, out _);
     }
 
-    private static bool IsPlainSafe(ReadOnlySpan<char> value, bool isKey)
+    private bool IsPlainSafe(ReadOnlySpan<char> value, bool isKey)
     {
         _ = isKey; // Currently unused, but may be used in future for stricter key rules.
 
@@ -1122,11 +1385,13 @@ public sealed class YamlWriter : YamlReaderWriterBase
             return false;
         }
 
+        var isFlow = IsFlow;
+
         // Disallow YAML special characters and common ambiguities.
         for (var i = 0; i < value.Length; i++)
         {
             var c = value[i];
-            if (c is '\n' or '\r' or '\t')
+            if (c == '\t' || IsLineBreak(c))
             {
                 return false;
             }
@@ -1140,6 +1405,13 @@ public sealed class YamlWriter : YamlReaderWriterBase
             {
                 return false;
             }
+
+            // Inside a flow collection a '?' ends the plain scalar, wherever it appears: a leading one is the
+            // key indicator, and a later one is a scalar terminator.
+            if (isFlow && c == '?')
+            {
+                return false;
+            }
         }
 
         // A leading '-' or '?' followed by separation/end is a collection/key indicator, not a plain scalar.
@@ -1150,6 +1422,13 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
         return true;
     }
+
+    /// <summary>Gets a value indicating whether a YAML reader breaks a line on <paramref name="c"/>.</summary>
+    /// <remarks>
+    /// U+0085, U+2028, and U+2029 are line breaks to a YAML reader but are not control characters, and
+    /// <see cref="Emitter.IsPrintable"/> accepts them. A style that writes text verbatim has to reject them.
+    /// </remarks>
+    private static bool IsLineBreak(char c) => c is '\n' or '\r' or '\u0085' or '\u2028' or '\u2029';
 
     private void WriteEscaped(ReadOnlySpan<char> value)
     {
@@ -1174,7 +1453,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
                     Write("\\t");
                     break;
                 default:
-                    if (char.IsControl(c))
+                    if (char.IsControl(c) || IsLineBreak(c))
                     {
                         Write("\\u");
                         Write(((int)c).ToString("X4", CultureInfo.InvariantCulture));
@@ -1330,6 +1609,25 @@ public sealed class YamlWriter : YamlReaderWriterBase
         public void Dispose()
         {
             _writer?.RestoreBlockSequenceItemStyle(_mappingStyle, _sequenceStyle);
+        }
+    }
+
+    /// <summary>Restores the string style that was active before a <see cref="PushStringStyle"/> call.</summary>
+    public readonly struct StringStyleScope : IDisposable
+    {
+        private readonly YamlWriter? _writer;
+        private readonly ScalarStyle _style;
+
+        internal StringStyleScope(YamlWriter writer, ScalarStyle style)
+        {
+            _writer = writer;
+            _style = style;
+        }
+
+        /// <summary>Restores the previously active string style.</summary>
+        public void Dispose()
+        {
+            _writer?.RestoreStringStyle(_style);
         }
     }
 

--- a/src/Meziantou.Framework.Yaml/YamlScalarStylePreferences.cs
+++ b/src/Meziantou.Framework.Yaml/YamlScalarStylePreferences.cs
@@ -8,5 +8,39 @@ public sealed class YamlScalarStylePreferences
 
     /// <summary>Gets or sets a value indicating whether quoted style should be preferred for ambiguous scalars.</summary>
     public bool PreferQuotedForAmbiguousScalars { get; init; } = true;
+
+    /// <summary>Gets or sets the style used to emit string values.</summary>
+    /// <remarks>
+    /// <para>
+    /// The default is <see cref="ScalarStyle.Any"/>, which lets the writer pick between the plain and the
+    /// double-quoted style. Any other value asks for that style, for example <see cref="ScalarStyle.Literal"/> to
+    /// emit a block scalar (<c>|</c>):
+    /// </para>
+    /// <code>
+    /// script: |-
+    ///   echo one
+    ///   echo two
+    /// </code>
+    /// <para>
+    /// The requested style is used only when the value round-trips through it. A literal or folded scalar cannot
+    /// represent an empty value, a carriage return, a control character, or a line that ends with a blank, and no
+    /// block scalar can be written inside a flow collection. When the style does not fit, the value is written
+    /// using the automatic style instead.
+    /// </para>
+    /// <para>
+    /// This applies to string values. Mapping keys and non-string scalars such as numbers, booleans, and dates keep
+    /// their own representation.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Value is not a defined <see cref="ScalarStyle"/>.</exception>
+    public ScalarStyle StringStyle
+    {
+        get;
+        init
+        {
+            YamlSerializerOptions.ValidateScalarStyle(value, nameof(value));
+            field = value;
+        }
+    } = ScalarStyle.Any;
 }
 

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -162,6 +162,24 @@ public sealed record YamlSerializerOptions
         }
     } = 2;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a block sequence that is the value of a mapping key is indented
+    /// relative to that mapping.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A block sequence used as a mapping value does not need its own indentation level: YAML allows the sequence
+    /// dashes to sit at the indentation of the parent mapping. When <see langword="false"/>, the dashes are written
+    /// at the indentation of the parent mapping instead of being indented by <see cref="IndentSize"/> columns.
+    /// </para>
+    /// <para>
+    /// This option only affects sequences written as a mapping value. A sequence nested inside another sequence is
+    /// always indented past its parent dash, because YAML has no unindented form for it. This option is ignored when
+    /// <see cref="WriteIndented"/> is disabled, because the flow style has no sequence dash.
+    /// </para>
+    /// </remarks>
+    public bool IndentBlockSequences { get; init; } = true;
+
     /// <summary>Gets or sets member ordering behavior for emitted mappings.</summary>
     public YamlMappingOrderPolicy MappingOrder { get; init; } = YamlMappingOrderPolicy.Declaration;
 

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -367,4 +367,12 @@ public sealed record YamlSerializerOptions
             throw new ArgumentOutOfRangeException(paramName, value, "The YAML sequence item style is not valid.");
         }
     }
+
+    internal static void ValidateScalarStyle(ScalarStyle value, string paramName)
+    {
+        if (value is not (ScalarStyle.Any or ScalarStyle.Plain or ScalarStyle.SingleQuoted or ScalarStyle.DoubleQuoted or ScalarStyle.Literal or ScalarStyle.Folded))
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, "The YAML scalar style is not valid.");
+        }
+    }
 }

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -154,6 +154,7 @@ exposes the default instance.
 | --- | --- | --- |
 | `WriteIndented` | `true` | Writes block collections indented by `IndentSize`. When disabled, collections use the flow style and the document stays on a single line. |
 | `IndentSize` | `2` | Number of spaces per indentation level. Ignored when `WriteIndented` is disabled. |
+| `IndentBlockSequences` | `true` | Indents a block sequence that is the value of a mapping key. When disabled, the sequence dashes stay at the indentation of the parent mapping. |
 | `MappingOrder` | `Declaration` | `Declaration` or `Sorted`. |
 | `BlockSequenceMappingStyle` | `Compact` | How a mapping inside a block sequence is emitted. |
 | `BlockSequenceSequenceStyle` | `Expanded` | How a nested sequence inside a block sequence is emitted. |
@@ -173,6 +174,24 @@ items:
     id: 1
     name: first
 ```
+
+`IndentBlockSequences` controls whether a sequence used as a mapping value gets its own indentation level:
+
+```yaml
+# IndentBlockSequences = true
+product:
+  tags:
+    - new
+    - sale
+
+# IndentBlockSequences = false
+product:
+  tags:
+  - new
+  - sale
+```
+
+A sequence nested inside another sequence is always indented past its parent dash, because YAML has no unindented form for it.
 
 Block YAML expresses nesting through indentation, so `WriteIndented = false` switches collections to the flow style instead of writing block collections without indentation. The whole document stays on a single line, and `IndentSize`, `BlockSequenceMappingStyle`, and `BlockSequenceSequenceStyle` no longer apply:
 

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -158,7 +158,7 @@ exposes the default instance.
 | `MappingOrder` | `Declaration` | `Declaration` or `Sorted`. |
 | `BlockSequenceMappingStyle` | `Compact` | How a mapping inside a block sequence is emitted. |
 | `BlockSequenceSequenceStyle` | `Expanded` | How a nested sequence inside a block sequence is emitted. |
-| `ScalarStylePreferences` | `PreferPlainStyle = true`, `PreferQuotedForAmbiguousScalars = true` | Quotes scalars that would otherwise resolve to a boolean, a number, or null. |
+| `ScalarStylePreferences` | `PreferPlainStyle = true`, `PreferQuotedForAmbiguousScalars = true`, `StringStyle = Any` | Quotes scalars that would otherwise resolve to a boolean, a number, or null, and selects the style used for string values. |
 
 `BlockSequenceMappingStyle` controls whether the first key of a mapping shares the line of its sequence dash:
 
@@ -209,6 +209,52 @@ product:
 ```
 
 Flow output is read back by the deserializer like any other YAML, and scalars containing a flow indicator such as `,`, `:`, `[`, or `{` are quoted so the round-trip stays faithful.
+
+`StringStyle` selects the style used for string values. The default, `Any`, lets the writer choose between the plain
+and the double-quoted style. `Literal` writes a block scalar instead:
+
+```csharp
+var options = new YamlSerializerOptions
+{
+    ScalarStylePreferences = new YamlScalarStylePreferences { StringStyle = ScalarStyle.Literal },
+};
+
+YamlSerializer.Serialize(new { Script = "echo one\necho two\n" }, options);
+```
+
+```yaml
+Script: |
+  echo one
+  echo two
+```
+
+The chomping indicator follows the value: `|-` when it has no trailing line break, `|` for one, and `|+` for more.
+`Folded` writes `>` instead, and `Plain`, `SingleQuoted`, and `DoubleQuoted` ask for those styles.
+
+The requested style is used only when the value round-trips through it. A block scalar cannot represent an empty
+value, a carriage return, a control character, a line that ends with a blank, or a line that starts with a tab, and
+none can be written inside a flow collection; a folded scalar additionally cannot hold a line that starts with a
+space. When the style does not fit, the value falls back to the automatic style. The style applies to string values
+only — mapping keys and non-string scalars such as numbers, booleans, and dates keep their own representation.
+
+`[YamlStringStyle]` overrides the style for one member and for the strings below it:
+
+```csharp
+internal sealed class Job
+{
+    [YamlStringStyle(ScalarStyle.Literal)]
+    public string? Script { get; set; }
+
+    public string? Name { get; set; }
+}
+```
+
+```yaml
+Script: |-
+  echo one
+  echo two
+Name: build
+```
 
 `PreferQuotedForAmbiguousScalars` keeps a round-trip faithful when a string looks like another type:
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -1244,6 +1244,7 @@ internal sealed partial class TestYamlSerializerContext : YamlSerializerContext
 
 [YamlSourceGenerationOptions(
     WriteIndented = false,
+    IndentBlockSequences = false,
     PropertyNameCaseInsensitive = true,
     DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingNull,
     BlockSequenceMappingStyle = YamlSequenceItemStyle.Expanded,
@@ -1915,6 +1916,7 @@ public class YamlSerializerSourceGenerationTests
         var options = context.GeneratedWithDefaultOptions.Options;
 
         Assert.False(options.WriteIndented);
+        Assert.False(options.IndentBlockSequences);
         Assert.True(options.PropertyNameCaseInsensitive);
         Assert.Equal(YamlIgnoreCondition.WhenWritingNull, options.DefaultIgnoreCondition);
         Assert.Equal(YamlSequenceItemStyle.Expanded, options.BlockSequenceMappingStyle);

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -100,6 +100,19 @@ internal sealed class GeneratedNullableAnnotationsPayload
     public string? Optional { get; set; }
 }
 
+internal sealed class GeneratedLiteralStrings
+{
+    public string? Text { get; set; }
+}
+
+internal sealed class GeneratedScriptStrings
+{
+    [YamlStringStyle(ScalarStyle.Literal)]
+    public string? Script { get; set; }
+
+    public string? Description { get; set; }
+}
+
 internal sealed class GeneratedNamingPolicyPayload
 {
     public string URLValue { get; set; } = string.Empty;
@@ -1265,6 +1278,17 @@ internal sealed partial class TestYamlSerializerContextWithOptions : YamlSeriali
     }
 }
 
+[YamlSourceGenerationOptions(StringStyle = ScalarStyle.Literal)]
+[YamlSerializable(typeof(GeneratedLiteralStrings))]
+internal sealed partial class TestYamlSerializerContextWithLiteralStrings : YamlSerializerContext
+{
+}
+
+[YamlSerializable(typeof(GeneratedScriptStrings))]
+internal sealed partial class TestYamlSerializerContextWithStringStyleAttribute : YamlSerializerContext
+{
+}
+
 [YamlSourceGenerationOptions(PropertyNamingPolicy = YamlKnownNamingPolicy.SnakeCaseLower)]
 [YamlSerializable(typeof(GeneratedNamingPolicyPayload))]
 internal sealed partial class TestYamlSerializerContextWithSnakeCaseNamingPolicy : YamlSerializerContext
@@ -1943,6 +1967,40 @@ public class YamlSerializerSourceGenerationTests
 
         Assert.Contains("displayName: Ada", yaml);
         Assert.DoesNotContain("optional:", yaml);
+    }
+
+    [Fact]
+    public void GeneratedContextQuotesAStringThatWouldResolveToAnotherType()
+    {
+        var typeInfo = TestYamlSerializerContextWithStringStyleAttribute.Default.GeneratedScriptStrings;
+        var yaml = YamlSerializer.Serialize(new GeneratedScriptStrings { Description = "true" }, typeInfo);
+
+        Assert.Equal("Script: null\nDescription: \"true\"\n", yaml);
+        Assert.Equal("true", YamlSerializer.Deserialize(yaml, typeInfo)?.Description);
+    }
+
+    [Fact]
+    public void GeneratedContextAppliesTheStringStyleOption()
+    {
+        var typeInfo = TestYamlSerializerContextWithLiteralStrings.Default.GeneratedLiteralStrings;
+        Assert.Equal(ScalarStyle.Literal, typeInfo.Options.ScalarStylePreferences.StringStyle);
+
+        var yaml = YamlSerializer.Serialize(new GeneratedLiteralStrings { Text = "a\nb" }, typeInfo);
+        Assert.Equal("Text: |-\n  a\n  b\n", yaml);
+        Assert.Equal("a\nb", YamlSerializer.Deserialize(yaml, typeInfo)?.Text);
+    }
+
+    [Fact]
+    public void GeneratedContextAppliesTheStringStyleAttribute()
+    {
+        var typeInfo = TestYamlSerializerContextWithStringStyleAttribute.Default.GeneratedScriptStrings;
+        var yaml = YamlSerializer.Serialize(new GeneratedScriptStrings { Script = "a\nb", Description = "c\nd" }, typeInfo);
+
+        Assert.Equal("Script: |-\n  a\n  b\nDescription: \"c\\nd\"\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize(yaml, typeInfo);
+        Assert.Equal("a\nb", roundTrip?.Script);
+        Assert.Equal("c\nd", roundTrip?.Description);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
@@ -406,6 +406,340 @@ public sealed class YamlWriterTests
         Assert.Equal("{Items: [{A: 1, B: 2}]}\n", yaml);
     }
 
+    [Fact]
+    public void StringStyle_DefaultsToAny()
+    {
+        Assert.Equal(ScalarStyle.Any, new YamlSerializerOptions().ScalarStylePreferences.StringStyle);
+    }
+
+    [Fact]
+    public void StringStyle_WithUndefinedValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new YamlScalarStylePreferences { StringStyle = (ScalarStyle)42 });
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateWriter(new YamlSerializerOptions(), out _).PushStringStyle((ScalarStyle)42));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new YamlStringStyleAttribute((ScalarStyle)42));
+    }
+
+    [Fact]
+    public void StringStyle_Literal_WritesBlockScalarAndRoundTrips()
+    {
+        var value = new TextContainer { Text = "line1\nline2", Other = "end" };
+        var yaml = YamlSerializer.Serialize(value, StringStyleOptions(ScalarStyle.Literal));
+
+        Assert.Equal("Text: |-\n  line1\n  line2\nOther: |-\n  end\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TextContainer>(yaml, StringStyleOptions(ScalarStyle.Literal));
+        Assert.Equal("line1\nline2", roundTrip?.Text);
+        Assert.Equal("end", roundTrip?.Other);
+    }
+
+    [Fact]
+    public void StringStyle_Literal_PicksTheChompingIndicatorFromTheTrailingLineBreaks()
+    {
+        var cases = new (string Value, string ExpectedIndicator)[]
+        {
+            ("a\nb", "|-"),
+            ("a\nb\n", "|"),
+            ("a\nb\n\n", "|+"),
+            ("a\nb\n\n\n", "|+"),
+        };
+
+        foreach (var @case in cases)
+        {
+            var options = StringStyleOptions(ScalarStyle.Literal);
+            var yaml = YamlSerializer.Serialize(new TextContainer { Text = @case.Value }, options);
+
+            Assert.StartsWith("Text: " + @case.ExpectedIndicator + "\n", yaml);
+            Assert.Equal(@case.Value, YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+        }
+    }
+
+    [Fact]
+    public void StringStyle_Literal_KeepChompingRoundTripsBeforeAnotherKeyAndAtTheEndOfTheDocument()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal);
+
+        var tail = YamlSerializer.Serialize(new TextContainer { Text = "a\n\n" }, options);
+        Assert.Equal("Text: |+\n  a\n\nOther: null\n", tail);
+        Assert.Equal("a\n\n", YamlSerializer.Deserialize<TextContainer>(tail, options)?.Text);
+
+        var followed = YamlSerializer.Serialize(new TextContainer { Other = "a\n\n" }, options);
+        Assert.Equal("Text: null\nOther: |+\n  a\n\n", followed);
+        Assert.Equal("a\n\n", YamlSerializer.Deserialize<TextContainer>(followed, options)?.Other);
+    }
+
+    [Fact]
+    public void StringStyle_Literal_WithLeadingBlank_WritesAnIndentationIndicator()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "  indented\nplain" }, options);
+
+        Assert.Equal("Text: |2-\n    indented\n  plain\nOther: null\n", yaml);
+        Assert.Equal("  indented\nplain", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_Literal_KeepsMoreIndentedLinesAndBlankLines()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "if x:\n  y\n\nz" }, options);
+
+        Assert.Equal("Text: |-\n  if x:\n    y\n\n  z\nOther: null\n", yaml);
+        Assert.Equal("if x:\n  y\n\nz", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_Literal_WithValueThatWouldNotRoundTrip_FallsBackToTheAutomaticStyle()
+    {
+        // An empty value, a blank at the end of a line, a carriage return, a control character, and a line that
+        // starts with a tab all lose information when they are written as a block scalar.
+        var cases = new[] { "", "a \nb", "a\nb ", "a\r\nb", "a\n\u0001", "a\n\tb" };
+
+        foreach (var value in cases)
+        {
+            var options = StringStyleOptions(ScalarStyle.Literal);
+            var yaml = YamlSerializer.Serialize(new TextContainer { Text = value }, options);
+
+            Assert.DoesNotContain("Text: |", yaml);
+            Assert.Equal(value, YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+        }
+    }
+
+    [Fact]
+    public void StringStyle_Literal_InSequenceItemsAndNestedMappings_RoundTrips()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal);
+        var yaml = YamlSerializer.Serialize(new StringsContainer { Items = ["a\nb", "c"], Nested = new TextContainer { Text = "d\ne" } }, options);
+
+        Assert.Equal("Items:\n  - |-\n    a\n    b\n  - |-\n    c\nNested:\n  Text: |-\n    d\n    e\n  Other: null\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<StringsContainer>(yaml, options);
+        Assert.Equal(["a\nb", "c"], roundTrip?.Items);
+        Assert.Equal("d\ne", roundTrip?.Nested?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_Literal_WithIndentSizeGreaterThanTwo_IndentsTheContent()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal) with { IndentSize = 4 };
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "a\nb" }, options);
+
+        Assert.Equal("Text: |-\n    a\n    b\nOther: null\n", yaml);
+        Assert.Equal("a\nb", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_Folded_WritesBlankLinesForTheLineBreaksAndRoundTrips()
+    {
+        var options = StringStyleOptions(ScalarStyle.Folded);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "a\nb\n\nc" }, options);
+
+        Assert.Equal("Text: >-\n  a\n\n  b\n\n\n  c\nOther: null\n", yaml);
+        Assert.Equal("a\nb\n\nc", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_Folded_WithAMoreIndentedLine_FallsBackToTheAutomaticStyle()
+    {
+        // Folding stops around a more indented line, which reads it back literally.
+        var options = StringStyleOptions(ScalarStyle.Folded);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "a\n  b" }, options);
+
+        Assert.Equal("Text: \"a\\n  b\"\nOther: null\n", yaml);
+        Assert.Equal("a\n  b", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_SingleQuoted_DoublesTheEmbeddedQuotes()
+    {
+        var options = StringStyleOptions(ScalarStyle.SingleQuoted);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "it's #1", Other = "plain" }, options);
+
+        Assert.Equal("Text: 'it''s #1'\nOther: 'plain'\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TextContainer>(yaml, options);
+        Assert.Equal("it's #1", roundTrip?.Text);
+        Assert.Equal("plain", roundTrip?.Other);
+    }
+
+    [Fact]
+    public void StringStyle_SingleQuoted_WithALineBreak_FallsBackToTheAutomaticStyle()
+    {
+        var options = StringStyleOptions(ScalarStyle.SingleQuoted);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "a\nb" }, options);
+
+        Assert.Equal("Text: \"a\\nb\"\nOther: null\n", yaml);
+        Assert.Equal("a\nb", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyle_DoubleQuoted_QuotesEveryStringValue()
+    {
+        var options = StringStyleOptions(ScalarStyle.DoubleQuoted);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "plain", Other = "a\nb" }, options);
+
+        Assert.Equal("Text: \"plain\"\nOther: \"a\\nb\"\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TextContainer>(yaml, options);
+        Assert.Equal("plain", roundTrip?.Text);
+        Assert.Equal("a\nb", roundTrip?.Other);
+    }
+
+    [Fact]
+    public void StringStyle_Plain_LeavesAnAmbiguousScalarUnquoted()
+    {
+        var options = StringStyleOptions(ScalarStyle.Plain);
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "yes", Other = "a: b" }, options);
+
+        // "a: b" cannot be written plain, so it keeps the automatic style.
+        Assert.Equal("Text: yes\nOther: \"a: b\"\n", yaml);
+    }
+
+    [Fact]
+    public void StringStyle_IsIgnoredForMappingKeysAndNonStringScalars()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal);
+        var yaml = YamlSerializer.Serialize(new KeyedContainer { Map = new Dictionary<string, int>(StringComparer.Ordinal) { ["key"] = 1 }, Count = 2 }, options);
+
+        Assert.Equal("Map:\n  key: 1\nCount: 2\n", yaml);
+    }
+
+    [Fact]
+    public void StringStyle_WithoutIndentation_IsIgnoredForBlockStyles()
+    {
+        var options = StringStyleOptions(ScalarStyle.Literal) with { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "a\nb", Other = "c" }, options);
+
+        Assert.Equal("{Text: \"a\\nb\", Other: c}\n", yaml);
+        Assert.Equal("a\nb", YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+    }
+
+    [Fact]
+    public void StringStyleAttribute_OverridesTheStyleForTheAttributedMember()
+    {
+        var yaml = YamlSerializer.Serialize(new ScriptContainer { Script = "echo one\necho two", Description = "a\nb" });
+
+        Assert.Equal("Script: |-\n  echo one\n  echo two\nDescription: \"a\\nb\"\nSteps: null\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ScriptContainer>(yaml);
+        Assert.Equal("echo one\necho two", roundTrip?.Script);
+        Assert.Equal("a\nb", roundTrip?.Description);
+    }
+
+    [Fact]
+    public void StringStyleAttribute_AppliesToTheStringsBelowTheAttributedMember()
+    {
+        var yaml = YamlSerializer.Serialize(new ScriptContainer { Steps = ["a\nb"] });
+
+        Assert.Equal("Script: null\nDescription: null\nSteps:\n  - |-\n    a\n    b\n", yaml);
+        Assert.Equal(["a\nb"], YamlSerializer.Deserialize<ScriptContainer>(yaml)?.Steps);
+    }
+
+    [Fact]
+    public void PushStringStyle_RestoresThePreviousStyleWhenDisposed()
+    {
+        var writer = CreateWriter(new YamlSerializerOptions(), out var buffer);
+
+        writer.WriteStartMapping();
+        writer.WritePropertyName("a");
+        using (writer.PushStringStyle(ScalarStyle.Literal))
+        {
+            writer.WriteString("x\ny");
+        }
+
+        writer.WritePropertyName("b");
+        writer.WriteString("x\ny");
+        writer.WriteEndMapping();
+
+        Assert.Equal("a: |-\n  x\n  y\nb: \"x\\ny\"", buffer.ToString());
+    }
+
+    [Fact]
+    public void FlowStyle_QuotesAQuestionMarkThatWouldEndThePlainScalar()
+    {
+        // Inside a flow collection a '?' ends a plain scalar wherever it appears, so it has to be quoted.
+        var cases = new (string Value, string ExpectedYaml)[]
+        {
+            ("?b", "{Text: \"?b\", Other: null}\n"),
+            ("a?", "{Text: \"a?\", Other: null}\n"),
+            ("a?b", "{Text: \"a?b\", Other: null}\n"),
+            ("a? b", "{Text: \"a? b\", Other: null}\n"),
+        };
+
+        foreach (var @case in cases)
+        {
+            var options = new YamlSerializerOptions { WriteIndented = false };
+            var yaml = YamlSerializer.Serialize(new TextContainer { Text = @case.Value }, options);
+
+            Assert.Equal(@case.ExpectedYaml, yaml);
+            Assert.Equal(@case.Value, YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+        }
+    }
+
+    [Fact]
+    public void BlockStyle_LeavesAQuestionMarkUnquoted()
+    {
+        // A '?' only ends a plain scalar in the flow context, so block output keeps it plain.
+        var yaml = YamlSerializer.Serialize(new TextContainer { Text = "why?", Other = "a?b" });
+
+        Assert.Equal("Text: why?\nOther: a?b\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TextContainer>(yaml);
+        Assert.Equal("why?", roundTrip?.Text);
+        Assert.Equal("a?b", roundTrip?.Other);
+    }
+
+    [Fact]
+    public void FlowStyle_QuotesTheOtherFlowIndicators()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var value = new StringsContainer { Items = ["a,b", "a[b", "a]b", "a{b", "a}b", "a?b"] };
+        var yaml = YamlSerializer.Serialize(value, options);
+
+        Assert.Equal("{Items: [\"a,b\", \"a[b\", \"a]b\", \"a{b\", \"a}b\", \"a?b\"], Nested: null}\n", yaml);
+        Assert.Equal(value.Items, YamlSerializer.Deserialize<StringsContainer>(yaml, options)?.Items);
+    }
+
+    [Fact]
+    public void UnicodeLineSeparators_AreEscapedAndRoundTrip()
+    {
+        // U+0085, U+2028, and U+2029 are line breaks to a YAML reader even though they are not control characters.
+        var cases = new (string Value, string ExpectedYaml)[]
+        {
+            ("a\u0085b", "Text: \"a\\u0085b\"\nOther: null\n"),
+            ("a\u2028b", "Text: \"a\\u2028b\"\nOther: null\n"),
+            ("a\u2029b", "Text: \"a\\u2029b\"\nOther: null\n"),
+        };
+
+        foreach (var @case in cases)
+        {
+            var yaml = YamlSerializer.Serialize(new TextContainer { Text = @case.Value });
+
+            Assert.Equal(@case.ExpectedYaml, yaml);
+            Assert.Equal(@case.Value, YamlSerializer.Deserialize<TextContainer>(yaml)?.Text);
+        }
+    }
+
+    [Fact]
+    public void UnicodeLineSeparators_AreRejectedByTheVerbatimStringStyles()
+    {
+        // A block, single-quoted, or plain scalar writes its content verbatim, so these would come back as breaks.
+        foreach (var style in new[] { ScalarStyle.Literal, ScalarStyle.Folded, ScalarStyle.SingleQuoted, ScalarStyle.Plain })
+        {
+            foreach (var value in new[] { "a\u0085b", "a\u2028b", "a\u2029b" })
+            {
+                var options = StringStyleOptions(style);
+                var yaml = YamlSerializer.Serialize(new TextContainer { Text = value }, options);
+
+                Assert.StartsWith("Text: \"", yaml);
+                Assert.Equal(value, YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+            }
+        }
+    }
+
+    private static YamlSerializerOptions StringStyleOptions(ScalarStyle style)
+        => new() { ScalarStylePreferences = new YamlScalarStylePreferences { StringStyle = style } };
+
     private static YamlWriter CreateWriter(YamlSerializerOptions options, out StringWriter buffer)
     {
         buffer = new StringWriter();
@@ -463,6 +797,31 @@ public sealed class YamlWriterTests
         public string? Text { get; set; }
 
         public string? Other { get; set; }
+    }
+
+    private sealed class StringsContainer
+    {
+        public List<string>? Items { get; set; }
+
+        public TextContainer? Nested { get; set; }
+    }
+
+    private sealed class KeyedContainer
+    {
+        public Dictionary<string, int>? Map { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    private sealed class ScriptContainer
+    {
+        [YamlStringStyle(ScalarStyle.Literal)]
+        public string? Script { get; set; }
+
+        public string? Description { get; set; }
+
+        [YamlStringStyle(ScalarStyle.Literal)]
+        public List<string>? Steps { get; set; }
     }
 
     private sealed class TagsContainer

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
@@ -318,6 +318,94 @@ public sealed class YamlWriterTests
         Assert.Equal((1, 2), (roundTrip.Items[0].A, roundTrip.Items[0].B));
     }
 
+    [Fact]
+    public void IndentBlockSequences_IsEnabledByDefault()
+    {
+        Assert.True(new YamlSerializerOptions().IndentBlockSequences);
+    }
+
+    [Fact]
+    public void MappingValueSequence_WithIndentBlockSequencesDisabled_WritesDashesAtParentIndentation()
+    {
+        var options = new YamlSerializerOptions { IndentBlockSequences = false };
+        var writer = CreateWriter(options, out var buffer);
+
+        writer.WriteStartMapping();
+        writer.WritePropertyName("tags");
+        writer.WriteStartSequence();
+        writer.WriteScalar("a");
+        writer.WriteScalar("b");
+        writer.WriteEndSequence();
+        writer.WriteEndMapping();
+
+        Assert.Equal("tags:\n- a\n- b", buffer.ToString());
+    }
+
+    [Fact]
+    public void MappingValueSequence_WithIndentBlockSequencesDisabled_KeepsMappingsIndentedAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { IndentBlockSequences = false };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [new Item { A = 1, B = 2 }] }, options);
+
+        Assert.Equal("Items:\n- A: 1\n  B: 2\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        var item = Assert.Single(roundTrip.Items);
+        Assert.Equal((1, 2), (item.A, item.B));
+    }
+
+    [Fact]
+    public void MappingValueSequence_WithIndentBlockSequencesDisabledAndLargeIndentSize_IgnoresIndentSizeForSequences()
+    {
+        var options = new YamlSerializerOptions { IndentBlockSequences = false, IndentSize = 4 };
+        var yaml = YamlSerializer.Serialize(new Outer { Child = new Inner { Value = 1 }, Count = 2 }, options);
+
+        Assert.Equal("Child:\n    Value: 1\nCount: 2\n", yaml);
+
+        var listYaml = YamlSerializer.Serialize(new MapsContainer { List = [1, 2] }, options);
+        Assert.Equal("Map: null\nList:\n- 1\n- 2\n", listYaml);
+    }
+
+    [Fact]
+    public void NestedSequence_WithIndentBlockSequencesDisabled_IsStillIndentedAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { IndentBlockSequences = false };
+        var yaml = YamlSerializer.Serialize(new RowsContainer { Rows = [[1, 2], [3]] }, options);
+
+        Assert.Equal("Rows:\n-\n  - 1\n  - 2\n-\n  - 3\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<RowsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Rows);
+        Assert.HasCount(2, roundTrip.Rows);
+        Assert.Equal([1, 2], roundTrip.Rows[0]);
+        Assert.Equal([3], roundTrip.Rows[1]);
+    }
+
+    [Fact]
+    public void SequenceInsideCompactSequenceItem_WithIndentBlockSequencesDisabled_AlignsWithItsMappingAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { IndentBlockSequences = false };
+        var yaml = YamlSerializer.Serialize(new TagsContainer { Items = [new TaggedItem { Name = "a", Tags = ["x", "y"] }] }, options);
+
+        Assert.Equal("Items:\n- Name: a\n  Tags:\n  - x\n  - y\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TagsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        var item = Assert.Single(roundTrip.Items);
+        Assert.Equal("a", item.Name);
+        Assert.Equal(["x", "y"], item.Tags);
+    }
+
+    [Fact]
+    public void IndentBlockSequences_WithoutIndentation_IsIgnored()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false, IndentBlockSequences = false };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [new Item { A = 1, B = 2 }] }, options);
+
+        Assert.Equal("{Items: [{A: 1, B: 2}]}\n", yaml);
+    }
+
     private static YamlWriter CreateWriter(YamlSerializerOptions options, out StringWriter buffer)
     {
         buffer = new StringWriter();
@@ -375,5 +463,17 @@ public sealed class YamlWriterTests
         public string? Text { get; set; }
 
         public string? Other { get; set; }
+    }
+
+    private sealed class TagsContainer
+    {
+        public List<TaggedItem>? Items { get; set; }
+    }
+
+    private sealed class TaggedItem
+    {
+        public string? Name { get; set; }
+
+        public List<string>? Tags { get; set; }
     }
 }


### PR DESCRIPTION
Two emitter options for `Meziantou.Framework.Yaml`, plus three round-trip fixes found along the way.

## `IndentBlockSequences`

`YamlSerializerOptions.IndentBlockSequences` (default `true`, so existing output is unchanged) controls whether a block sequence that is the value of a mapping key gets its own indentation level:

```yaml
# IndentBlockSequences = false
Items:
- A: 1
  B: 2
```

Scoped to sequences written as a mapping value. A sequence nested inside another sequence is still indented past its parent dash, since YAML has no unindented form there, and the option is inert under `WriteIndented = false` because the flow style has no dash.

## `StringStyle`

`YamlScalarStylePreferences.StringStyle` selects the style used for string values, and `[YamlStringStyle]` overrides it for one member and the strings below it:

```csharp
var options = new YamlSerializerOptions
{
    ScalarStylePreferences = new YamlScalarStylePreferences { StringStyle = ScalarStyle.Literal },
};
```

```yaml
Script: |-
  echo one
  echo two
```

All six `ScalarStyle` values are supported. The chomping indicator follows the value — `|-` for no trailing line break, `|` for one, `|+` for more — and an indentation indicator (`|2-`) is written when the value starts with a blank or an empty line.

The rule is that the requested style is used **only when the value round-trips through it**, otherwise the automatic style is kept. A block scalar cannot represent an empty value, a line break other than a line feed, a control character, a line ending with a blank, or a line starting with a tab, and none can be written inside a flow collection; a folded scalar additionally cannot hold a line starting with a space. The style applies to string values only — mapping keys and non-string scalars keep their own representation.

Both options are available on `[YamlSourceGenerationOptions]`, and the generator honors `[YamlStringStyle]`.

## Fixes

Three pre-existing round-trip bugs, each with a regression test:

- **Source-generated contexts skipped the scalar style preferences.** The generator emitted `WriteScalar` for `string` members where the reflection path uses `WriteString`, so `PreferQuotedForAmbiguousScalars` never applied. The string `"true"` was written as a bare `true` and read back as a **boolean**. This also blocked `StringStyle` under source generation.
- **`?` was not quoted in flow style.** Inside a flow collection the reader ends a plain scalar at `?` wherever it appears (matching libyaml, which is stricter than the spec here), so `{Text: a?b}` failed to parse. `IsPlainSafe` is now aware of the flow context; block output still writes `Text: why?` unquoted. Note `,`, `[`, `]`, `{`, `}` were already rejected — `?` was the only gap.
- **U+0085, U+2028, and U+2029 were written raw.** They are line breaks to a YAML reader but are not control characters, so they slipped through both the plain-scalar check and `WriteEscaped`, corrupting the value or breaking the parse. They are now escaped, and rejected by the styles that write content verbatim.

Only the emitter changed; the scanner is untouched.

## For the reviewer

- The trickiest part is `|+` (keep) chomping. A keep-chomped block scalar owns every trailing line break *including* the one separating it from the next node, so `YamlWriter` writes them itself and suppresses the separator that would normally follow (`_suppressNextNewLine`). This is covered by tests for both positions: followed by another key, and last in the document.
- `IsPlainSafe` became an instance method because it now needs `IsFlow`. Its `isKey` parameter is still unused, as before.
- The package version bump to `1.0.6` was applied automatically by the SDK when the public API changed.

## Verification

- **1936/1936 tests passing** on net10.0 and net11.0 with `TreatWarningsAsErrors=true`; 34 new tests.
- **Randomized round-trip run: 144,000 documents, zero failures** — 6 string styles x 3 indent sizes x `IndentBlockSequences` x block/flow, over an alphabet including `?`, all flow indicators, quotes, tab/CR/LF, U+0001, U+0085, U+00A0, U+2028, U+2029, `---` and `...`. The same run reported 98 failures before these fixes.
- Exhaustive sweep of every printable ASCII character in five positions, both modes: zero failures.
- `dotnet run ./eng/update-all.cs` exits 0 with no file changes; `ref/` regenerated via a Release `IsOfficialBuild` build.
