### PR TITLE
Support Uri and CultureInfo as built-in YAML scalars

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -977,6 +977,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public static bool TryParseDecimal(System.ReadOnlySpan<char> value, out decimal result) => throw null;
         public static bool TryParseInt64(System.ReadOnlySpan<char> value, out long result) => throw null;
         public static bool TryParseDouble(System.ReadOnlySpan<char> value, out double result) => throw null;
+        public static bool TryParseCultureInfo(string? value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Globalization.CultureInfo? result) => throw null;
         #if NET11_0
         public static bool TryParseIeee754<T>(System.ReadOnlySpan<char> value, out T result) where T : struct, System.Numerics.IFloatingPointIeee754<T> => throw null;
         #endif

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -501,6 +501,14 @@ public sealed partial class YamlSerializerContextGenerator
             {
                 builder.AppendLine("            writer.WritePropertyName(pair.Key.ToString(\"c\", global::System.Globalization.CultureInfo.InvariantCulture));");
             }
+            else if (IsUriType(dictionaryKeyType))
+            {
+                builder.AppendLine("            writer.WritePropertyName(pair.Key.OriginalString);");
+            }
+            else if (IsCultureInfoType(dictionaryKeyType))
+            {
+                builder.AppendLine("            writer.WritePropertyName(pair.Key.Name);");
+            }
             else
             {
                 builder.AppendLine("            writer.WritePropertyName(((global::System.IFormattable)pair.Key).ToString(null, global::System.Globalization.CultureInfo.InvariantCulture));");
@@ -3943,6 +3951,14 @@ public sealed partial class YamlSerializerContextGenerator
             {
                 builder.Append(innerIndent + "        ").AppendLine("writer.WritePropertyName(pair.Key.ToString(\"c\", global::System.Globalization.CultureInfo.InvariantCulture));");
             }
+            else if (IsUriType(dictionaryKeyType))
+            {
+                builder.Append(innerIndent + "        ").AppendLine("writer.WritePropertyName(pair.Key.OriginalString);");
+            }
+            else if (IsCultureInfoType(dictionaryKeyType))
+            {
+                builder.Append(innerIndent + "        ").AppendLine("writer.WritePropertyName(pair.Key.Name);");
+            }
             else
             {
                 builder.Append(innerIndent + "        ").AppendLine("writer.WritePropertyName(((global::System.IFormattable)pair.Key).ToString(null, global::System.Globalization.CultureInfo.InvariantCulture));");
@@ -4090,6 +4106,27 @@ public sealed partial class YamlSerializerContextGenerator
             builder.AppendLine("                else");
             builder.AppendLine("                {");
             builder.Append("                    ").Append(member.AssignExpression("reader.ScalarValue ?? string.Empty")).AppendLine(";");
+            builder.AppendLine("                    reader.Read();");
+            builder.AppendLine("                }");
+            return;
+        }
+
+        if (IsUriType(member.Type) || IsCultureInfoType(member.Type))
+        {
+            builder.AppendLine("                if (reader.TokenType != global::Meziantou.Framework.Yaml.Serialization.YamlTokenType.Scalar)");
+            builder.AppendLine("                {");
+            builder.AppendLine("                    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowExpectedScalar(reader);");
+            builder.AppendLine("                }");
+            builder.AppendLine("                if (global::Meziantou.Framework.Yaml.Serialization.YamlScalar.IsNull(reader))");
+            builder.AppendLine("                {");
+            EmitThrowIfNullForNonNullableMemberOnRead(builder, member, "null", "                    ");
+            builder.Append("                    ").Append(member.AssignExpression(GetDefaultMemberAssignmentExpression(member))).AppendLine(";");
+            builder.AppendLine("                    reader.Read();");
+            builder.AppendLine("                }");
+            builder.AppendLine("                else");
+            builder.AppendLine("                {");
+            EmitReadScalar(builder, member.Type, "value", indent: "                    ");
+            builder.Append("                    ").Append(member.AssignExpression("value")).AppendLine(";");
             builder.AppendLine("                    reader.Read();");
             builder.AppendLine("                }");
             return;
@@ -5179,6 +5216,22 @@ public sealed partial class YamlSerializerContextGenerator
         return true;
     }
 
+    private static void EmitParseUri(StringBuilder builder, string textExpression, string indent)
+    {
+        builder.Append(indent).Append("if (!global::System.Uri.TryCreate(").Append(textExpression).AppendLine(", global::System.UriKind.RelativeOrAbsolute, out var parsedUri))");
+        builder.Append(indent).AppendLine("{");
+        builder.Append(indent).AppendLine("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalidUriScalar(reader);");
+        builder.Append(indent).AppendLine("}");
+    }
+
+    private static void EmitParseCultureInfo(StringBuilder builder, string textExpression, string indent)
+    {
+        builder.Append(indent).Append("if (!global::Meziantou.Framework.Yaml.Serialization.YamlScalar.TryParseCultureInfo(").Append(textExpression).AppendLine(", out var parsedCultureInfo))");
+        builder.Append(indent).AppendLine("{");
+        builder.Append(indent).AppendLine("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalidCultureInfoScalar(reader);");
+        builder.Append(indent).AppendLine("}");
+    }
+
     private static bool TryEmitWriteScalar(StringBuilder builder, ITypeSymbol typeSymbol, string valueExpression, string indent)
     {
         if (typeSymbol.SpecialType == SpecialType.System_String)
@@ -5240,6 +5293,18 @@ public sealed partial class YamlSerializerContextGenerator
         if (GetIeee754TypeName(typeSymbol) is not null)
         {
             builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
+            return true;
+        }
+
+        if (IsUriType(typeSymbol))
+        {
+            builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine("?.OriginalString);");
+            return true;
+        }
+
+        if (IsCultureInfoType(typeSymbol))
+        {
+            builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine("?.Name);");
             return true;
         }
 
@@ -5456,6 +5521,20 @@ public sealed partial class YamlSerializerContextGenerator
             builder.Append(indent).Append("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalid").Append(ieee754Type).AppendLine("Scalar(reader);");
             builder.Append(indent).AppendLine("}");
             builder.Append(indent).Append("var ").Append(valueVarName).Append(" = parsed").Append(ieee754Type).AppendLine(";");
+            return;
+        }
+
+        if (IsUriType(typeSymbol))
+        {
+            EmitParseUri(builder, textExpression, indent);
+            builder.Append(indent).Append("var ").Append(valueVarName).AppendLine(" = parsedUri;");
+            return;
+        }
+
+        if (IsCultureInfoType(typeSymbol))
+        {
+            EmitParseCultureInfo(builder, textExpression, indent);
+            builder.Append(indent).Append("var ").Append(valueVarName).AppendLine(" = parsedCultureInfo;");
             return;
         }
 
@@ -5742,6 +5821,20 @@ public sealed partial class YamlSerializerContextGenerator
             builder.Append(indent).Append("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalid").Append(ieee754Type).AppendLine("Scalar(reader);");
             builder.Append(indent).AppendLine("}");
             builder.Append(indent).Append(targetExpression).Append(" = parsed").Append(ieee754Type).AppendLine(";");
+            return;
+        }
+
+        if (IsUriType(typeSymbol))
+        {
+            EmitParseUri(builder, textExpression, indent);
+            builder.Append(indent).Append(targetExpression).AppendLine(" = parsedUri;");
+            return;
+        }
+
+        if (IsCultureInfoType(typeSymbol))
+        {
+            EmitParseCultureInfo(builder, textExpression, indent);
+            builder.Append(indent).Append(targetExpression).AppendLine(" = parsedCultureInfo;");
             return;
         }
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1507,14 +1507,16 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
     }
 
     private static bool IsCSharpUnionStringLikeSystemType(ITypeSymbol type)
-        => type is INamedTypeSymbol systemType &&
+        => IsUriType(type) ||
+           IsCultureInfoType(type) ||
+           (type is INamedTypeSymbol systemType &&
            string.Equals(systemType.ContainingNamespace?.ToDisplayString(), "System", StringComparison.Ordinal) &&
            (string.Equals(systemType.Name, "DateTime", StringComparison.Ordinal) ||
             string.Equals(systemType.Name, "DateTimeOffset", StringComparison.Ordinal) ||
             string.Equals(systemType.Name, "Guid", StringComparison.Ordinal) ||
             string.Equals(systemType.Name, "TimeSpan", StringComparison.Ordinal) ||
             string.Equals(systemType.Name, "DateOnly", StringComparison.Ordinal) ||
-            string.Equals(systemType.Name, "TimeOnly", StringComparison.Ordinal));
+            string.Equals(systemType.Name, "TimeOnly", StringComparison.Ordinal)));
 
     private static ImmutableArray<CSharpUnionCaseModel> CollapseCSharpUnionNullableOverloads(ImmutableArray<CSharpUnionCaseModel> cases)
     {
@@ -1621,6 +1623,16 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             _ => "untyped",
         };
 
+    private static bool IsUriType(ITypeSymbol type)
+        => type is INamedTypeSymbol named &&
+           string.Equals(named.Name, "Uri", StringComparison.Ordinal) &&
+           string.Equals(named.ContainingNamespace?.ToDisplayString(), "System", StringComparison.Ordinal);
+
+    private static bool IsCultureInfoType(ITypeSymbol type)
+        => type is INamedTypeSymbol named &&
+           string.Equals(named.Name, "CultureInfo", StringComparison.Ordinal) &&
+           string.Equals(named.ContainingNamespace?.ToDisplayString(), "System.Globalization", StringComparison.Ordinal);
+
     private static bool IsKnownScalar(ITypeSymbol type)
     {
         if (type is INamedTypeSymbol nullableType && nullableType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
@@ -1634,6 +1646,11 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
 
         if (GetIeee754TypeName(type) is not null)
+        {
+            return true;
+        }
+
+        if (IsUriType(type) || IsCultureInfoType(type))
         {
             return true;
         }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
@@ -324,6 +324,8 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
             runtimeType == typeof(TimeSpan) ||
             runtimeType == typeof(DateOnly) ||
             runtimeType == typeof(TimeOnly) ||
+            runtimeType == typeof(Uri) ||
+            runtimeType == typeof(CultureInfo) ||
             runtimeType.IsEnum)
         {
             return UnionCaseKind.String;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCultureInfoConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCultureInfoConverter.cs
@@ -1,0 +1,34 @@
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlCultureInfoConverter : YamlConverter<CultureInfo?>
+{
+    public static YamlCultureInfoConverter Instance { get; } = new();
+
+    public override CultureInfo? Read(YamlReader reader)
+    {
+        if (reader.TokenType != YamlTokenType.Scalar)
+        {
+            throw YamlThrowHelper.ThrowExpectedScalar(reader);
+        }
+
+        if (YamlScalar.IsNull(reader))
+        {
+            reader.Read();
+            return null;
+        }
+
+        var text = reader.ScalarValue;
+        if (!YamlScalar.TryParseCultureInfo(text, out var result))
+        {
+            throw YamlThrowHelper.ThrowInvalidCultureInfoScalar(reader);
+        }
+
+        reader.Read();
+        return result;
+    }
+
+    public override void Write(YamlWriter writer, CultureInfo? value)
+    {
+        writer.WriteScalar(value?.Name);
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryConverterHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryConverterHelper.cs
@@ -154,6 +154,16 @@ internal static class YamlDictionaryConverterHelper
             return timeOnly.ToString("O", CultureInfo.InvariantCulture);
         }
 
+        if (key is Uri uri)
+        {
+            return uri.OriginalString;
+        }
+
+        if (key is CultureInfo culture)
+        {
+            return culture.Name;
+        }
+
         if (key is IFormattable formattable)
         {
             return formattable.ToString(format: null, CultureInfo.InvariantCulture) ?? string.Empty;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlUriConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlUriConverter.cs
@@ -1,0 +1,34 @@
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlUriConverter : YamlConverter<Uri?>
+{
+    public static YamlUriConverter Instance { get; } = new();
+
+    public override Uri? Read(YamlReader reader)
+    {
+        if (reader.TokenType != YamlTokenType.Scalar)
+        {
+            throw YamlThrowHelper.ThrowExpectedScalar(reader);
+        }
+
+        if (YamlScalar.IsNull(reader))
+        {
+            reader.Read();
+            return null;
+        }
+
+        var text = reader.ScalarValue;
+        if (!Uri.TryCreate(text, UriKind.RelativeOrAbsolute, out var result))
+        {
+            throw YamlThrowHelper.ThrowInvalidUriScalar(reader);
+        }
+
+        reader.Read();
+        return result;
+    }
+
+    public override void Write(YamlWriter writer, Uri? value)
+    {
+        writer.WriteScalar(value?.OriginalString);
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlBuiltInTypeInfoResolver.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlBuiltInTypeInfoResolver.cs
@@ -116,6 +116,16 @@ internal static class YamlBuiltInTypeInfoResolver
             return YamlTimeSpanConverter.Instance;
         }
 
+        if (type == typeof(Uri))
+        {
+            return YamlUriConverter.Instance;
+        }
+
+        if (type == typeof(CultureInfo))
+        {
+            return YamlCultureInfoConverter.Instance;
+        }
+
         if (type == typeof(DateOnly))
         {
             return YamlDateOnlyConverter.Instance;

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
@@ -339,6 +339,16 @@ public abstract class YamlReaderWriterBase
                 return YamlTimeSpanConverter.Instance;
             }
 
+            if (typeToConvert == typeof(Uri))
+            {
+                return YamlUriConverter.Instance;
+            }
+
+            if (typeToConvert == typeof(CultureInfo))
+            {
+                return YamlCultureInfoConverter.Instance;
+            }
+
             if (typeToConvert == typeof(DateOnly))
             {
                 return YamlDateOnlyConverter.Instance;

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlScalar.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlScalar.cs
@@ -326,6 +326,31 @@ public static class YamlScalar
         return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
     }
 
+    /// <summary>
+    /// Parses a YAML scalar as a <see cref="CultureInfo"/> from its culture name (for example <c language="yaml">fr-FR</c>).
+    /// </summary>
+    /// <param name="value">The culture name to parse. An empty name resolves to <see cref="CultureInfo.InvariantCulture"/>.</param>
+    /// <param name="result">The parsed culture.</param>
+    public static bool TryParseCultureInfo(string? value, [NotNullWhen(true)] out CultureInfo? result)
+    {
+        if (value is null)
+        {
+            result = null;
+            return false;
+        }
+
+        try
+        {
+            result = CultureInfo.GetCultureInfo(value);
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            result = null;
+            return false;
+        }
+    }
+
 #if NET11_0_OR_GREATER
     /// <summary>
     /// Parses a YAML floating-point scalar into an IEEE 754 floating-point type, including <c>.inf</c> and <c>.nan</c>.

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlThrowHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlThrowHelper.cs
@@ -127,6 +127,14 @@ internal static class YamlThrowHelper
     public static YamlException ThrowInvalidGuidScalar(YamlReader reader)
         => ThrowInvalidScalar(reader, $"Invalid Guid scalar '{reader.ScalarValue}'.");
 
+    /// <summary>Throws an exception for invalid <see cref="Uri"/> Scalar.</summary>
+    public static YamlException ThrowInvalidUriScalar(YamlReader reader)
+        => ThrowInvalidScalar(reader, $"Invalid Uri scalar '{reader.ScalarValue}'.");
+
+    /// <summary>Throws an exception for invalid <see cref="CultureInfo"/> Scalar.</summary>
+    public static YamlException ThrowInvalidCultureInfoScalar(YamlReader reader)
+        => ThrowInvalidScalar(reader, $"Invalid CultureInfo scalar '{reader.ScalarValue}'.");
+
     /// <summary>Throws an exception for invalid <see cref="TimeSpan"/> Scalar.</summary>
     public static YamlException ThrowInvalidTimeSpanScalar(YamlReader reader)
         => ThrowInvalidScalar(reader, $"Invalid TimeSpan scalar '{reader.ScalarValue}'.");

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -107,7 +107,7 @@ When a stream contains several documents, `YamlSerializer.Deserialize` binds the
 | Integers | `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `nint`, `nuint`, `Int128`, `UInt128` |
 | Floating point | `float`, `double`, `decimal`, `Half` |
 | Date and time | `DateTime`, `DateTimeOffset`, `DateOnly`, `TimeOnly`, `TimeSpan` |
-| Other scalars | `Guid`, enums |
+| Other scalars | `Guid`, `Uri`, `CultureInfo`, enums |
 | net11.0 only | `BFloat16`, `Decimal32`, `Decimal64`, `Decimal128` |
 | Collections | arrays, `List<>`, `HashSet<>`, `ImmutableArray<>`, `ImmutableList<>`, `ImmutableHashSet<>`, `IEnumerable<>`, `ICollection<>`, `IList<>`, `IReadOnlyCollection<>`, `IReadOnlyList<>`, `ISet<>`, `IReadOnlySet<>` |
 | Dictionaries | `Dictionary<,>`, `OrderedDictionary<,>`, `IDictionary<,>`, `IReadOnlyDictionary<,>`, with `string` or non-`string` keys |
@@ -121,6 +121,10 @@ mapping of its properties, using the object contract described below.
 
 Enums are written using their member name and read case-insensitively, with a numeric fallback. Use
 `YamlEnumMemberNameAttribute` to control the name of an individual member.
+
+`Uri` is written using its original string and read with `UriKind.RelativeOrAbsolute`, so both absolute and relative
+URIs round-trip. `CultureInfo` is written using its culture name (`CultureInfo.InvariantCulture` writes an empty
+name), and read back through `CultureInfo.GetCultureInfo`.
 
 Object contracts support parameterless constructors, parameterized constructors, records, `init` accessors, the
 `required` keyword, and non-public members annotated with `YamlIncludeAttribute`. When a type declares several public

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -183,6 +183,14 @@ internal sealed class GeneratedWellKnownScalars
     public TimeSpan Duration { get; set; }
 }
 
+internal sealed class GeneratedUriAndCultureScalars
+{
+    public Uri? Absolute { get; set; }
+    public Uri? Relative { get; set; }
+    public CultureInfo? Culture { get; set; }
+    public Dictionary<Uri, string>? ByUri { get; set; }
+}
+
 internal sealed class GeneratedNullableScalars
 {
     public DateTimeOffset? PublishDate { get; set; }
@@ -1143,6 +1151,7 @@ internal sealed class GeneratedYamlIgnoreConditions
 [YamlSerializable(typeof(GeneratedContainer))]
 [YamlSerializable(typeof(GeneratedPrimitives))]
 [YamlSerializable(typeof(GeneratedWellKnownScalars))]
+[YamlSerializable(typeof(GeneratedUriAndCultureScalars))]
 [YamlSerializable(typeof(GeneratedNullableScalars))]
 [YamlSerializable(typeof(GeneratedModernScalars))]
 [YamlSerializable(typeof(GeneratedColor))]
@@ -1815,6 +1824,66 @@ public class YamlSerializerSourceGenerationTests
         Assert.Equal(payload.OptionalMedium, roundTrip.OptionalMedium);
     }
 #endif
+
+    [Fact]
+    public void GeneratedContext_UriAndCultureInfo_RoundTrip()
+    {
+        var payload = new GeneratedUriAndCultureScalars
+        {
+            Absolute = new Uri("https://example.com/path?query=1#fragment", UriKind.Absolute),
+            Relative = new Uri("path/to/resource", UriKind.Relative),
+            Culture = CultureInfo.InvariantCulture,
+            ByUri = new Dictionary<Uri, string> { [new Uri("https://example.com/", UriKind.Absolute)] = "root" },
+        };
+
+        var context = TestYamlSerializerContext.Default;
+        var typeInfo = context.GeneratedUriAndCultureScalars;
+
+        var yaml = YamlSerializer.Serialize(payload, typeInfo);
+        var roundTrip = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal(payload.Absolute, roundTrip.Absolute);
+        Assert.Equal(payload.Relative, roundTrip.Relative);
+        Assert.Equal(CultureInfo.InvariantCulture, roundTrip.Culture);
+        Assert.Equal(payload.ByUri, roundTrip.ByUri);
+    }
+
+    [Fact]
+    public void GeneratedContext_NullUriAndCultureInfo_RoundTrip()
+    {
+        var context = TestYamlSerializerContext.Default;
+        var typeInfo = context.GeneratedUriAndCultureScalars;
+
+        var yaml = YamlSerializer.Serialize(new GeneratedUriAndCultureScalars(), typeInfo);
+        var roundTrip = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.NotNull(roundTrip);
+        Assert.Null(roundTrip.Absolute);
+        Assert.Null(roundTrip.Relative);
+        Assert.Null(roundTrip.Culture);
+        Assert.Null(roundTrip.ByUri);
+    }
+
+    [Fact]
+    public void GeneratedContext_InvalidUri_ShouldThrowYamlException()
+    {
+        var context = TestYamlSerializerContext.Default;
+        var typeInfo = context.GeneratedUriAndCultureScalars;
+
+        var ex = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize("Absolute: \"http://\"", typeInfo));
+        Assert.Contains("Uri", ex.Message);
+    }
+
+    [Fact]
+    public void GeneratedContext_InvalidCultureInfo_ShouldThrowYamlException()
+    {
+        var context = TestYamlSerializerContext.Default;
+        var typeInfo = context.GeneratedUriAndCultureScalars;
+
+        var ex = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize("Culture: not a culture!", typeInfo));
+        Assert.Contains("CultureInfo", ex.Message);
+    }
 
     [Fact]
     public void GeneratedContextExposesDefaultTypeInfoPropertyNames()

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -1,6 +1,7 @@
 #if NET11_0_OR_GREATER
 using System.Numerics;
 #endif
+using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Yaml.Tests.Serialization;
 public sealed class YamlWellKnownScalarConverterTests
@@ -32,6 +33,13 @@ public sealed class YamlWellKnownScalarConverterTests
         public Decimal64? OptionalMedium { get; set; }
     }
 #endif
+
+    private sealed class UriAndCulturePayload
+    {
+        public Uri? Absolute { get; set; }
+        public Uri? Relative { get; set; }
+        public CultureInfo? Culture { get; set; }
+    }
 
     private sealed class NullablePayload
     {
@@ -186,6 +194,88 @@ public sealed class YamlWellKnownScalarConverterTests
         Assert.Contains("BFloat16", ex.Message);
     }
 #endif
+
+    [Fact]
+    public void RoundTrip_UriAndCultureInfo_ShouldSucceed()
+    {
+        var payload = new UriAndCulturePayload
+        {
+            Absolute = new Uri("https://example.com/path?query=1#fragment", UriKind.Absolute),
+            Relative = new Uri("path/to/resource", UriKind.Relative),
+            Culture = CultureInfo.InvariantCulture,
+        };
+
+        var yaml = YamlSerializer.Serialize(payload);
+        var roundTrip = YamlSerializer.Deserialize<UriAndCulturePayload>(yaml);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal(payload.Absolute, roundTrip.Absolute);
+        Assert.Equal(payload.Relative, roundTrip.Relative);
+        Assert.Equal(CultureInfo.InvariantCulture, roundTrip.Culture);
+    }
+
+    [Fact]
+    public void Serialize_Uri_ShouldUseOriginalString()
+    {
+        var yaml = YamlSerializer.Serialize(new Uri("https://example.com/a%20b", UriKind.Absolute));
+
+        Assert.Equal("\"https://example.com/a%20b\"\n", yaml, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void RoundTrip_NullUriAndCultureInfo_ShouldSucceed()
+    {
+        var yaml = YamlSerializer.Serialize(new UriAndCulturePayload());
+        var roundTrip = YamlSerializer.Deserialize<UriAndCulturePayload>(yaml);
+
+        Assert.NotNull(roundTrip);
+        Assert.Null(roundTrip.Absolute);
+        Assert.Null(roundTrip.Relative);
+        Assert.Null(roundTrip.Culture);
+    }
+
+    [Fact]
+    public void RoundTrip_UriDictionaryKey_ShouldSucceed()
+    {
+        var payload = new Dictionary<Uri, string>
+        {
+            [new Uri("https://example.com/", UriKind.Absolute)] = "root",
+            [new Uri("relative", UriKind.Relative)] = "other",
+        };
+
+        var yaml = YamlSerializer.Serialize(payload);
+        var roundTrip = YamlSerializer.Deserialize<Dictionary<Uri, string>>(yaml);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal(payload, roundTrip);
+    }
+
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void RoundTrip_SpecificCulture_ShouldSucceed()
+    {
+        var yaml = YamlSerializer.Serialize(CultureInfo.GetCultureInfo("fr-FR"));
+
+        Assert.Equal("fr-FR\n", yaml, ignoreLineEndingDifferences: true);
+        Assert.Equal(CultureInfo.GetCultureInfo("fr-FR"), YamlSerializer.Deserialize<CultureInfo>(yaml));
+    }
+
+    [Fact]
+    public void Deserialize_InvalidUri_ShouldThrowYamlExceptionWithContext()
+    {
+        var ex = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<Uri>("\"http://\""));
+        Assert.Contains("Uri", ex.Message);
+        Assert.Contains("Lin:", ex.Message);
+        Assert.Contains("Col:", ex.Message);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidCultureInfo_ShouldThrowYamlExceptionWithContext()
+    {
+        var ex = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<CultureInfo>("not a culture!"));
+        Assert.Contains("CultureInfo", ex.Message);
+        Assert.Contains("Lin:", ex.Message);
+        Assert.Contains("Col:", ex.Message);
+    }
 
     [Fact]
     public void Serialize_NullableDateTimeOffsetAndBoolean_ShouldRemainPlain()


### PR DESCRIPTION
## What

`Uri` and `CultureInfo` are now handled as built-in scalar types by the YAML serializer, in both the reflection-based path and the source generator.

- **`Uri`** — written using `OriginalString`, read with `UriKind.RelativeOrAbsolute`, so both absolute and relative URIs round-trip.
- **`CultureInfo`** — written using its culture name, read back through `CultureInfo.GetCultureInfo` (exposed as a new public `YamlScalar.TryParseCultureInfo`). `CultureInfo.InvariantCulture` writes an empty name.

Both accept and emit YAML `null`, work as dictionary keys, and are classified as string-like C# union cases. Invalid input throws `YamlException` with line/column context instead of a raw `UriFormatException` / `CultureNotFoundException`.

## Why

Previously these types fell through to the object contract and were serialized as a mapping of their properties, which does not round-trip.

## Changes

**Library**
- New `YamlUriConverter` and `YamlCultureInfoConverter`, registered in `YamlBuiltInTypeInfoResolver` and `YamlReaderWriterBase`.
- New `YamlScalar.TryParseCultureInfo` (only public API addition — see the `ref/` diff).
- New `ThrowInvalidUriScalar` / `ThrowInvalidCultureInfoScalar` throw helpers.
- Dictionary key formatting and C# union case classification updated for both types.
- `readme.md` supported-types table updated.

**Source generator**
- Both types added to `IsKnownScalar`, so they are no longer expanded into property mappings.
- Emit support for member read/write, standalone scalar read/write, and dictionary key formatting. Without the key-formatting change the generator would have emitted an invalid `(IFormattable)` cast for these key types.

## Note for reviewers

No `WriteScalar(Uri)` / `WriteScalar(CultureInfo)` overloads were added to `YamlWriter`: they would make the existing `WriteScalar(null)` call ambiguous with `WriteScalar(string?)`, a source-breaking change for consumers. The converters format to a string and go through `WriteScalar(string?)` instead. A visible consequence is that URIs are emitted double-quoted (`"https://example.com/"`), since `:` and `%` are never plain-safe in this writer.

## Verification

- 1958 tests pass on `net10.0` and `net11.0`, including 6 new reflection-path and 4 new source-generated tests (round-trip, nulls, dictionary keys, invalid input, and an `fr-FR` case gated with `[RunIf(NotInvariant)]` for the invariant-globalization CI leg).
- `Release` + `IsOfficialBuild=true` builds clean for the library and the generator.
- `ref/Meziantou.Framework.Yaml.cs` regenerated and committed.
- `dotnet run ./eng/update-all.cs` produced no further changes.