### PR TITLE
Remove the match timeout from UrlPattern component regexes

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlPatternComponent.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlPatternComponent.cs
@@ -56,7 +56,7 @@ internal sealed class UrlPatternComponent
         Regex regularExpression;
         try
         {
-            regularExpression = new Regex(regexpString, regexOptions, TimeSpan.FromSeconds(1));
+            regularExpression = new Regex(regexpString, regexOptions, Timeout.InfiniteTimeSpan);
         }
         catch (ArgumentException ex)
         {

--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -274,7 +274,6 @@ public sealed class UrlPattern
     /// <see href="https://urlpattern.spec.whatwg.org/#dom-urlpattern-test">WHATWG URL Pattern Spec - test method</see>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/test">MDN - URLPattern.test()</see>
     /// </remarks>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public bool IsMatch(string url)
     {
@@ -285,7 +284,6 @@ public sealed class UrlPattern
     /// <param name="url">The URL string to test.</param>
     /// <param name="baseUrl">The base URL to use for resolving relative URLs.</param>
     /// <returns><see langword="true"/> if the pattern matches the URL; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public bool IsMatch(string url, string? baseUrl)
     {
@@ -301,7 +299,6 @@ public sealed class UrlPattern
     /// <summary>Indicates whether the pattern finds a match in the specified URL.</summary>
     /// <param name="url">The URL to test.</param>
     /// <returns><see langword="true"/> if the pattern matches the URL; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public bool IsMatch(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -311,7 +308,6 @@ public sealed class UrlPattern
     /// <summary>Indicates whether the pattern finds a match in the specified URL input.</summary>
     /// <param name="input">The URL input dictionary to test.</param>
     /// <returns><see langword="true"/> if the pattern matches the input; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public bool IsMatch(UrlPatternInit input)
     {
         ArgumentNullException.ThrowIfNull(input);
@@ -326,7 +322,6 @@ public sealed class UrlPattern
     /// <see href="https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec">WHATWG URL Pattern Spec - exec method</see>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/exec">MDN - URLPattern.exec()</see>
     /// </remarks>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public UrlPatternResult? Match(string url)
     {
@@ -337,7 +332,6 @@ public sealed class UrlPattern
     /// <param name="url">The URL string to match.</param>
     /// <param name="baseUrl">The base URL to use for resolving relative URLs.</param>
     /// <returns>A <see cref="UrlPatternResult"/> containing the match result, or <see langword="null"/> if no match.</returns>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public UrlPatternResult? Match(string url, string? baseUrl)
     {
@@ -353,7 +347,6 @@ public sealed class UrlPattern
     /// <summary>Searches the specified URL for the first occurrence of the pattern and returns the match result with captured groups.</summary>
     /// <param name="url">The URL to match.</param>
     /// <returns>A <see cref="UrlPatternResult"/> containing the match result, or <see langword="null"/> if no match.</returns>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public UrlPatternResult? Match(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -363,7 +356,6 @@ public sealed class UrlPattern
     /// <summary>Searches the specified URL input for the first occurrence of the pattern and returns the match result with captured groups.</summary>
     /// <param name="input">The URL input dictionary to match.</param>
     /// <returns>A <see cref="UrlPatternResult"/> containing the match result, or <see langword="null"/> if no match.</returns>
-    /// <exception cref="RegexMatchTimeoutException">A component pattern took more than one second to match.</exception>
     public UrlPatternResult? Match(UrlPatternInit input)
     {
         ArgumentNullException.ThrowIfNull(input);


### PR DESCRIPTION
## What changed

`UrlPatternComponent.Compile` built each component regex with a 1-second match timeout. It now uses `Timeout.InfiniteTimeSpan`. The eight now-unreachable `<exception cref="RegexMatchTimeoutException">` doc tags on `UrlPattern.IsMatch`/`UrlPattern.Match` are removed.

## Why

CI was flaky. In [this run](https://github.com/meziantou/Meziantou.Framework/actions/runs/33703887834/job/100488955117), `UrlPatternTests.IsMatch_LiteralFollowingAGroup_ShouldMatch(pathname: "/assets/*.png", url: "https://example.com/assets/logo.png")` failed with `RegexMatchTimeoutException`. The pattern is trivial and cannot backtrack meaningfully; the runner was simply slow enough that the 1-second budget expired (the test took 7.9s wall clock).

## Reviewer notes

Pattern strings can embed arbitrary regex groups (e.g. `/books/:id(\d+)`), so a caller compiling an attacker-supplied *pattern* no longer has a timeout backstop against catastrophic backtracking. This matches the JS `URLPattern`, which has no timeout, and the 1-second timeout was a weak guard anyway (it is only checked between backtracking steps). If a guard is preferred over removal, a much larger value such as 30 seconds would have fixed the flake without dropping it.

## Verification

- `dotnet build src/Meziantou.Framework.Uri` with `/p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors
- `dotnet test tests/Meziantou.Framework.Uri.Tests -f net10.0`: 331 passed, 0 failed
- `dotnet run ./eng/update-all.cs`: exit 0, no generated file changes (the `ref/` API surface is unaffected)