### PR TITLE
Remove the empty verified file left behind by an abandoned merge

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -416,30 +416,33 @@ internal static class SnapshotEngine
         ArgumentNullException.ThrowIfNull(filesToUpdate);
         ArgumentNullException.ThrowIfNull(filesToDelete);
 
+        // A strategy that needs the verified file to exist - a merge tool needs two sides to compare - creates
+        // it itself, so that it also owns removing it when the update does not happen. The engine only makes
+        // sure the directory is there, as MoveFile does not create it.
         foreach (var fileToUpdate in filesToUpdate)
         {
             fileToUpdate.VerifiedPath.CreateParentDirectory();
-            if (!File.Exists(fileToUpdate.VerifiedPath))
+        }
+
+        try
+        {
+            settings.SnapshotUpdateStrategy.UpdateFiles(
+                settings,
+                [.. filesToUpdate.Select(item => new SnapshotUpdateFile(item.VerifiedPath, item.ActualPath))],
+                [.. filesToDelete.Select(item => item.Value)]);
+        }
+        finally
+        {
+            // A strategy that fails part way through has still changed the set of verified files.
+            foreach (var fileToUpdate in filesToUpdate)
             {
-                using (File.Create(fileToUpdate.VerifiedPath))
-                {
-                }
+                InvalidateVerifiedSnapshotFiles(fileToUpdate.VerifiedPath.Parent);
             }
-        }
 
-        settings.SnapshotUpdateStrategy.UpdateFiles(
-            settings,
-            [.. filesToUpdate.Select(item => new SnapshotUpdateFile(item.VerifiedPath, item.ActualPath))],
-            [.. filesToDelete.Select(item => item.Value)]);
-
-        foreach (var fileToUpdate in filesToUpdate)
-        {
-            InvalidateVerifiedSnapshotFiles(fileToUpdate.VerifiedPath.Parent);
-        }
-
-        foreach (var fileToDelete in filesToDelete)
-        {
-            InvalidateVerifiedSnapshotFiles(fileToDelete.Parent);
+            foreach (var fileToDelete in filesToDelete)
+            {
+                InvalidateVerifiedSnapshotFiles(fileToDelete.Parent);
+            }
         }
     }
 

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategies/BlockingDiffToolStrategy.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategies/BlockingDiffToolStrategy.cs
@@ -10,7 +10,17 @@ internal sealed class BlockingDiffToolStrategy : MergeToolStrategyBase
 
     public override void UpdateFile(SnapshotSettings settings, string currentFilePath, string newFilePath)
     {
-        using var process = LaunchMergeTool(settings, currentFilePath, newFilePath);
-        process.WaitForExit();
+        var placeholder = VerifiedFilePlaceholder.TryCreate(currentFilePath);
+        try
+        {
+            using var process = LaunchMergeTool(settings, currentFilePath, newFilePath);
+            process.WaitForExit();
+        }
+        finally
+        {
+            // The merge tool has exited, so a placeholder that is still untouched means the developer closed
+            // the tool without saving.
+            placeholder?.DeleteIfUnused();
+        }
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategies/MergeToolStrategy.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategies/MergeToolStrategy.cs
@@ -6,8 +6,22 @@ internal sealed class MergeToolStrategy : MergeToolStrategyBase
     public override bool MustReportError(SnapshotSettings settings, string path) => true;
     public override void UpdateFile(SnapshotSettings settings, string currentFilePath, string newFilePath)
     {
-        using (LaunchMergeTool(settings, currentFilePath, newFilePath))
+        var placeholder = VerifiedFilePlaceholder.TryCreate(currentFilePath);
+        try
         {
+            using (LaunchMergeTool(settings, currentFilePath, newFilePath))
+            {
+            }
         }
+        catch
+        {
+            placeholder?.DeleteIfUnused();
+            throw;
+        }
+
+        // The merge tool runs without blocking the test, so it is still open and expects to write to the
+        // verified file when the developer saves. The placeholder can only be cleaned up once the process is
+        // over.
+        placeholder?.DeleteOnProcessExitIfUnused();
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategies/VerifiedFilePlaceholder.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategies/VerifiedFilePlaceholder.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using Meziantou.Framework.SnapshotTesting.Utils;
+
+namespace Meziantou.Framework.SnapshotTesting.SnapshotUpdateStrategies;
+
+/// <summary>
+/// An empty verified file created so a merge tool has two sides to compare when a snapshot has no verified
+/// file yet. It is only a scaffold: a merge that is abandoned or that never starts must not leave it behind,
+/// or the next run would compare against it and silently record "empty" as the expectation of the test.
+/// </summary>
+internal sealed class VerifiedFilePlaceholder
+{
+    /// <summary>
+    /// The timestamp given to a placeholder. Writing the file - even with no content, which is a meaningful
+    /// snapshot - moves its timestamp to the present, so an untouched placeholder can be recognized without
+    /// depending on the resolution of the file system clock.
+    /// </summary>
+    private static readonly DateTime PlaceholderLastWriteTimeUtc = DateTime.UnixEpoch;
+
+    private static readonly ConcurrentQueue<VerifiedFilePlaceholder> PlaceholdersToDeleteOnProcessExit = new();
+    private static int s_processExitHandlerRegistered;
+
+    private readonly string _path;
+    private readonly DateTime _lastWriteTimeUtc;
+
+    private VerifiedFilePlaceholder(string path, DateTime lastWriteTimeUtc)
+    {
+        _path = path;
+        _lastWriteTimeUtc = lastWriteTimeUtc;
+    }
+
+    /// <summary>
+    /// Creates an empty verified file when there is none. Returns <see langword="null" /> when the file
+    /// already exists, as its content is the recorded expectation and must be left untouched, or when the
+    /// file cannot be created, in which case the merge tool reports the missing file itself.
+    /// </summary>
+    public static VerifiedFilePlaceholder? TryCreate(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                return null;
+
+            new FileInfo(path).Directory?.Create();
+            using (File.Create(path))
+            {
+            }
+
+            File.SetLastWriteTimeUtc(path, PlaceholderLastWriteTimeUtc);
+            return new VerifiedFilePlaceholder(path, File.GetLastWriteTimeUtc(path));
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Removes the placeholder unless the merge tool wrote to it.</summary>
+    public void DeleteIfUnused()
+    {
+        try
+        {
+            var fileInfo = new FileInfo(_path);
+            if (!fileInfo.Exists || fileInfo.Length != 0 || fileInfo.LastWriteTimeUtc != _lastWriteTimeUtc)
+                return;
+
+            fileInfo.TrySetReadOnly(false);
+            fileInfo.Delete();
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Defers <see cref="DeleteIfUnused" /> to the end of the process. A merge tool that runs without
+    /// blocking the test is still open when the assertion returns and expects to write to the verified file
+    /// when the developer saves, so the placeholder cannot be removed right away. Removing it when the
+    /// process ends is enough to keep an abandoned merge from leaving one behind for the next run, and a
+    /// merge that is saved afterwards recreates the file.
+    /// </summary>
+    public void DeleteOnProcessExitIfUnused()
+    {
+        PlaceholdersToDeleteOnProcessExit.Enqueue(this);
+        if (Interlocked.Exchange(ref s_processExitHandlerRegistered, 1) == 0)
+        {
+            AppDomain.CurrentDomain.ProcessExit += DeletePendingPlaceholders;
+        }
+    }
+
+    private static void DeletePendingPlaceholders(object? sender, EventArgs e)
+    {
+        while (PlaceholdersToDeleteOnProcessExit.TryDequeue(out var placeholder))
+        {
+            placeholder.DeleteIfUnused();
+        }
+    }
+}

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
+using Meziantou.Framework.SnapshotTesting.SnapshotUpdateStrategies;
 using Xunit.Sdk;
 
 namespace Meziantou.Framework.SnapshotTesting.Tests;
@@ -1512,6 +1513,105 @@ public sealed partial class SnapshotTests
 
     [GeneratedRegex("^[A-Za-z0-9._-]+_[0-9a-f]{8}_2\\.verified\\.png$", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 1000)]
     private static partial Regex SnapshotNameWithHashAndIndexRegex();
+
+    [Theory]
+    [InlineData(nameof(SnapshotUpdateStrategy.MergeTool))]
+    [InlineData(nameof(SnapshotUpdateStrategy.MergeToolSync))]
+    public void Validate_MergeToolStrategy_DoesNotLeaveAnEmptyVerifiedFileWhenTheMergeToolCannotStart(string strategyName)
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateDeterministicSnapshotSettings(directory, "sample") with
+        {
+            SnapshotUpdateStrategy = GetSnapshotUpdateStrategy(strategyName),
+            MergeTools = [],
+        };
+
+        Assert.Throws<SnapshotException>(() => Snapshot.Validate("value", settings));
+
+        // An empty verified file would become the expectation of the test on the next run.
+        Assert.False(File.Exists(directory / "snapshot.verified.txt"));
+        Assert.Equal("sample", File.ReadAllText(directory / "snapshot.actual.txt"));
+    }
+
+    [Theory]
+    [InlineData(nameof(SnapshotUpdateStrategy.MergeTool))]
+    [InlineData(nameof(SnapshotUpdateStrategy.MergeToolSync))]
+    public void Validate_MergeToolStrategy_KeepsTheVerifiedFileWhenTheMergeToolCannotStart(string strategyName)
+    {
+        using var directory = TemporaryDirectory.Create();
+        var verifiedPath = directory / "snapshot.verified.txt";
+        File.WriteAllText(verifiedPath, "recorded");
+
+        var settings = CreateDeterministicSnapshotSettings(directory, "sample") with
+        {
+            SnapshotUpdateStrategy = GetSnapshotUpdateStrategy(strategyName),
+            MergeTools = [],
+        };
+
+        Assert.Throws<SnapshotException>(() => Snapshot.Validate("value", settings));
+
+        Assert.Equal("recorded", File.ReadAllText(verifiedPath));
+    }
+
+    [Fact]
+    public void VerifiedFilePlaceholder_DeletesTheFileWhenTheMergeToolDidNotWriteIt()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var path = directory / "snapshot.verified.txt";
+
+        var placeholder = VerifiedFilePlaceholder.TryCreate(path);
+
+        Assert.NotNull(placeholder);
+        Assert.Empty(File.ReadAllBytes(path));
+
+        placeholder.DeleteIfUnused();
+
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void VerifiedFilePlaceholder_KeepsTheFileWhenTheMergeToolWroteIt()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var path = directory / "snapshot.verified.txt";
+
+        var placeholder = VerifiedFilePlaceholder.TryCreate(path);
+        Assert.NotNull(placeholder);
+        File.WriteAllText(path, "merged");
+
+        placeholder.DeleteIfUnused();
+
+        Assert.Equal("merged", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void VerifiedFilePlaceholder_KeepsTheFileWhenTheMergeToolSavedAnEmptySnapshot()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var path = directory / "snapshot.verified.txt";
+
+        var placeholder = VerifiedFilePlaceholder.TryCreate(path);
+        Assert.NotNull(placeholder);
+
+        // An empty snapshot is a meaningful expectation, so saving one must not be mistaken for an
+        // untouched placeholder.
+        File.WriteAllBytes(path, []);
+
+        placeholder.DeleteIfUnused();
+
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void VerifiedFilePlaceholder_DoesNotTouchAnExistingVerifiedFile()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var path = directory / "snapshot.verified.txt";
+        File.WriteAllText(path, "recorded");
+
+        Assert.Null(VerifiedFilePlaceholder.TryCreate(path));
+        Assert.Equal("recorded", File.ReadAllText(path));
+    }
 
     [GeneratedRegex("Line[2]", RegexOptions.None, matchTimeoutMilliseconds: 10000)]
     private static partial Regex Line2Regex();


### PR DESCRIPTION
Fixes #2199

## The problem

Before handing off to the update strategy, `SnapshotEngine.ApplySnapshotUpdates` created an empty verified file so the diff tools have two sides to show. Nothing removed it again.

With `SnapshotUpdateStrategy.MergeTool` the launch is non-blocking, so if the developer closes the diff tool without saving — or if no merge tool can be started at all — a zero-byte `*.verified.*` file is left behind. The next run compares against it and reports an ordinary content mismatch rather than "snapshot missing", and if it gets committed the test's recorded expectation is "empty", which is easy to wave through in review.

## The fix

The placeholder now belongs to the strategies that need it, rather than to the engine. A merge tool is the only thing that needs both sides to exist, and the merge tool strategies are also the ones that know whether the handoff finished:

- **`MergeToolSync`** (blocking) removes an untouched placeholder in a `finally` once the tool has exited.
- **`MergeTool`** (non-blocking) cannot remove it right away — the tool is still open and expects to write to that path when the developer saves — so it defers the cleanup to `ProcessExit`. A save that lands after the test host is gone simply recreates the file.
- A **failure to start a tool** removes the placeholder before the exception propagates.

The two directions I ruled out are written up in the issue. Deleting the placeholder as soon as `UpdateFiles` returns is wrong for the non-blocking strategy, and treating a zero-byte verified file as missing at load time conflicts with the deliberate decision that an empty snapshot is meaningful (`DiagnosticSnapshotSerializer.cs:34`).

That second point is what the timestamp is for. `VerifiedFilePlaceholder` stamps the file with a fixed timestamp when it creates it, and only removes it while it still carries that stamp. Any write moves the timestamp to the present — including saving a deliberately empty snapshot — so a saved empty snapshot is told apart from an untouched placeholder without depending on the resolution of the file system clock.

The engine still creates the parent directory, as `MoveFile` does not, and it now invalidates the cached listing of verified files even when a strategy fails part way through.

## For the reviewer

Two things worth a look:

- **Behavior change for third-party strategies.** A custom `SnapshotUpdateStrategy` could previously rely on the engine having created the verified file before `UpdateFile` was called. That was never documented, and the built-in `Overwrite`/`OverwriteWithoutFailure` overwrite it anyway, but it is a change.
- **The `ProcessExit` path has no automated test.** `MergeTool.Launch` short-circuits under `BuildServerDetector`/`LLMEnvironmentDetector`, so no real merge tool can be launched from CI. The delete/keep decision itself is covered by direct unit tests on `VerifiedFilePlaceholder`; the "abandoned async merge on a developer machine" scenario is only covered by reasoning.

## Tests

Added to `SnapshotTests.cs`:

- `Validate_MergeToolStrategy_DoesNotLeaveAnEmptyVerifiedFileWhenTheMergeToolCannotStart` and `..._KeepsTheVerifiedFileWhenTheMergeToolCannotStart`, both for `MergeTool` and `MergeToolSync`. These run the same way everywhere, since an empty `MergeTools` list makes `Launch` return null regardless of the environment.
- Four unit tests on `VerifiedFilePlaceholder` covering the delete/keep decision, including the saved-empty-snapshot case.

I confirmed the engine-level tests genuinely fail against the pre-fix code by temporarily reverting it.

Full suite passes: 350/350 on net10.0 and net11.0, in Debug and again in Release with `IsOfficialBuild=true`. `dotnet run ./eng/update-all.cs` produced no changes, and there is no public API change so `ref/` is untouched.
