### PR TITLE
Keep the start delimiter when a code block is unterminated

### DIFF
--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -135,13 +135,15 @@ public class Template
                 break;
 
             AddBlock(blocks, codeBlock: false, span, ref position, delimiterOffset, ref blockIndex);
-            position.Advance(startCodeBlockDelimiter);
 
-            // Code up to the next end delimiter. An unterminated block falls back to a text block.
-            remaining = span[position.Index..];
+            // Code up to the next end delimiter. An unterminated block falls back to a text block. The end delimiter is
+            // searched for before consuming the start delimiter, so that fallback keeps the start delimiter in the text.
+            remaining = span[(position.Index + startCodeBlockDelimiter.Length)..];
             delimiterOffset = remaining.IndexOf(endCodeBlockDelimiter, StringComparison.Ordinal);
             if (delimiterOffset < 0)
                 break;
+
+            position.Advance(startCodeBlockDelimiter);
 
             var canTrimLeadingWhitespaceForLineOnlyBlock = TryGetTrailingLineWhitespaceLengthFromLastTextBlock(blocks, out var trailingWhitespaceLength);
             var block = AddBlock(blocks, codeBlock: true, span, ref position, delimiterOffset, ref blockIndex);

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -731,7 +731,7 @@ public class TemplateTest
     }
 
     [Fact]
-    public void Template_UnterminatedCodeBlock_IsParsedAsText()
+    public void Template_UnterminatedCodeBlock_IsParsedAsTextKeepingTheStartDelimiter()
     {
         var template = new Template();
         template.Load("a<% var x = 0;");
@@ -739,7 +739,28 @@ public class TemplateTest
         Assert.Collection(
             template.Blocks,
             block => Assert.Equal("a", Assert.IsType<TextBlock>(block).Text),
-            block => Assert.Equal(" var x = 0;", Assert.IsType<TextBlock>(block).Text));
+            block => Assert.Equal("<% var x = 0;", Assert.IsType<TextBlock>(block).Text));
+
+        Assert.Equal("a<% var x = 0;", template.Run());
+    }
+
+    [Fact]
+    public void Template_UnterminatedCodeBlockAfterATerminatedOne_KeepsTheStartDelimiter()
+    {
+        var template = new Template();
+        template.Load("a<%= 1 %>b<% var x = 0;");
+
+        Assert.Equal("a1b<% var x = 0;", template.Run());
+    }
+
+    [Fact]
+    public void Template_UnterminatedCodeBlock_ReportsThePositionOfTheStartDelimiter()
+    {
+        var template = new Template();
+        template.Load("a\n<% var x = 0;");
+
+        var block = Assert.IsType<TextBlock>(template.Blocks[^1]);
+        Assert.Equal(new TextPosition(line: 2, column: 1, index: 2), block.Start);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2705

## What changed

`Template.LoadCore` advanced `position` past the start code block delimiter *before* searching for the end delimiter. When no end delimiter was found, the `break` fired on the already-advanced position, so the remainder was emitted as a text block **minus** the `<%`:

```csharp
var template = new Template();
template.Load("a<% var x = 0;");
template.Run();   // "a var x = 0;"  — the "<%" was gone
```

The end delimiter is now searched for *before* consuming the start delimiter, so the fallback break leaves `position` sitting on the delimiter and the trailing text block keeps it:

```csharp
template.Run();   // "a<% var x = 0;"
```

`TextPositionTracker` only moves forward (it tracks line/column incrementally), so this looks ahead rather than rewinding.

## Why

An unclosed block is the template author's mistake, but silently swallowing the delimiter turns a mis-resolved delimiter pair into *plausible-looking* output instead of visible garbage — the amplifier behind both CLI bugs fixed in #2695. Keeping the delimiter makes the mistake show up in the output.

The alternative direction discussed in the issue — throwing a `TemplateException` — was deliberately not taken: it is a hard breaking change for templates that parse today. This change keeps `Load` non-throwing.

## Reviewer notes

- **Terminated blocks are unaffected.** The end-delimiter search still starts at `Index + startDelimiter.Length`, which is what the self-overlapping-delimiter case (`Template_SelfOverlappingDelimiter_IsMatched`) relies on. `position.Index + startCodeBlockDelimiter.Length` is always in bounds, since the start delimiter was located with `IndexOf` and is fully present in the span.
- **Behavior change, pinned by an existing test.** `Template_UnterminatedCodeBlock_IsParsedAsText` asserted the old lossy output; it is renamed to `Template_UnterminatedCodeBlock_IsParsedAsTextKeepingTheStartDelimiter` and updated on purpose. Two cases were added: an unterminated block following a terminated one, and the reported `Start` position of the fallback block.
- No public API surface change, so `ref/Meziantou.Framework.Templating.cs` is unchanged.

## Verification

- `dotnet build` of `Meziantou.Framework.Templating`, Debug and `-c Release /p:IsOfficialBuild=true`, both with `/p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors.
- `Meziantou.Framework.Templating.Tests`: 138/138 pass (69 per TFM, net10.0 and net11.0); the three new/renamed tests confirmed present in the TRX.
- Downstream consumers also pass: `Meziantou.Framework.Templating.Html.Tests` (32) and `Meziantou.Framework.Templating.Tool.Tests` (36).
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.
