### PR TITLE
Make the snapshot settings collections safe to read while being mutated

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.Roslyn/SnapshotSettingsRoslynExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.Roslyn/SnapshotSettingsRoslynExtensions.cs
@@ -27,11 +27,15 @@ public static class SnapshotSettingsRoslynExtensions
             snapshotSettings.Serializers.Add(DiagnosticSnapshotSerializer.Instance);
 
             // Roslyn values nested inside another snapshot are written by the human-readable serializer.
-            snapshotSettings.AddConverter(new DiagnosticHumanReadableConverter());
-            snapshotSettings.AddConverter(new LocationHumanReadableConverter());
-            snapshotSettings.AddConverter(new TextSpanHumanReadableConverter());
-            snapshotSettings.AddConverter(new LinePositionHumanReadableConverter());
-            snapshotSettings.AddConverter(new LinePositionSpanHumanReadableConverter());
+            // They are registered in a single call so the human-readable serializer is cloned only once.
+            snapshotSettings.ConfigureHumanReadableSerializer(options =>
+            {
+                options.Converters.Add(new DiagnosticHumanReadableConverter());
+                options.Converters.Add(new LocationHumanReadableConverter());
+                options.Converters.Add(new TextSpanHumanReadableConverter());
+                options.Converters.Add(new LinePositionHumanReadableConverter());
+                options.Converters.Add(new LinePositionSpanHumanReadableConverter());
+            });
         }
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/CopyOnWriteList.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/CopyOnWriteList.cs
@@ -1,0 +1,110 @@
+namespace Meziantou.Framework.SnapshotTesting;
+
+/// <summary>
+/// A list that publishes a new array on every mutation instead of updating one in place. Readers observe a stable
+/// snapshot, so a registration happening on another thread can neither break an enumeration nor be observed halfway.
+/// </summary>
+internal sealed class CopyOnWriteList<T> : IList<T>
+{
+    private readonly Lock _lock = new();
+    private T[] _items;
+
+    public CopyOnWriteList() => _items = [];
+
+    public CopyOnWriteList(IEnumerable<T> items) => _items = [.. items];
+
+    private T[] Current => Volatile.Read(ref _items);
+
+    public T this[int index]
+    {
+        get => Current[index];
+        set
+        {
+            lock (_lock)
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _items.Length);
+
+                T[] updated = [.. _items];
+                updated[index] = value;
+                Volatile.Write(ref _items, updated);
+            }
+        }
+    }
+
+    public int Count => Current.Length;
+
+    public bool IsReadOnly => false;
+
+    public void Add(T item)
+    {
+        lock (_lock)
+        {
+            Volatile.Write(ref _items, [.. _items, item]);
+        }
+    }
+
+    public void Insert(int index, T item)
+    {
+        lock (_lock)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _items.Length);
+
+            var updated = new T[_items.Length + 1];
+            _items.AsSpan(0, index).CopyTo(updated);
+            updated[index] = item;
+            _items.AsSpan(index).CopyTo(updated.AsSpan(index + 1));
+            Volatile.Write(ref _items, updated);
+        }
+    }
+
+    public bool Remove(T item)
+    {
+        lock (_lock)
+        {
+            var index = Array.IndexOf(_items, item);
+            if (index < 0)
+                return false;
+
+            RemoveAtCore(index);
+            return true;
+        }
+    }
+
+    public void RemoveAt(int index)
+    {
+        lock (_lock)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _items.Length);
+
+            RemoveAtCore(index);
+        }
+    }
+
+    private void RemoveAtCore(int index)
+    {
+        var updated = new T[_items.Length - 1];
+        _items.AsSpan(0, index).CopyTo(updated);
+        _items.AsSpan(index + 1).CopyTo(updated.AsSpan(index));
+        Volatile.Write(ref _items, updated);
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            Volatile.Write(ref _items, []);
+        }
+    }
+
+    public bool Contains(T item) => Array.IndexOf(Current, item) >= 0;
+
+    public int IndexOf(T item) => Array.IndexOf(Current, item);
+
+    public void CopyTo(T[] array, int arrayIndex) => Current.CopyTo(array, arrayIndex);
+
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)Current).GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotComparerCollection.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotComparerCollection.cs
@@ -2,7 +2,10 @@ namespace Meziantou.Framework.SnapshotTesting;
 
 public sealed class SnapshotComparerCollection : IEnumerable<KeyValuePair<SnapshotType, ISnapshotComparer>>
 {
-    private readonly Dictionary<SnapshotType, ISnapshotComparer> _comparers;
+    private readonly Lock _lock = new();
+
+    // Copy-on-write: the published dictionary is never mutated, so a lookup can run while another thread registers a comparer.
+    private Dictionary<SnapshotType, ISnapshotComparer> _comparers;
 
     public SnapshotComparerCollection()
     {
@@ -11,36 +14,65 @@ public sealed class SnapshotComparerCollection : IEnumerable<KeyValuePair<Snapsh
 
     internal SnapshotComparerCollection(SnapshotComparerCollection source)
     {
-        _comparers = new Dictionary<SnapshotType, ISnapshotComparer>(source._comparers);
+        _comparers = new Dictionary<SnapshotType, ISnapshotComparer>(source.Current);
     }
 
-    public int Count => _comparers.Count;
+    private Dictionary<SnapshotType, ISnapshotComparer> Current => Volatile.Read(ref _comparers);
+
+    public int Count => Current.Count;
 
     public void Set(SnapshotType type, ISnapshotComparer comparer)
     {
         ArgumentNullException.ThrowIfNull(type);
         ArgumentNullException.ThrowIfNull(comparer);
-        _comparers[type] = comparer;
+        lock (_lock)
+        {
+            var updated = new Dictionary<SnapshotType, ISnapshotComparer>(_comparers)
+            {
+                [type] = comparer,
+            };
+
+            Volatile.Write(ref _comparers, updated);
+        }
     }
 
     /// <summary>Looks up a comparer registered for exactly this type, without falling back to a default.</summary>
-    internal bool TryGet(SnapshotType type, [NotNullWhen(true)] out ISnapshotComparer? comparer) => _comparers.TryGetValue(type, out comparer);
+    internal bool TryGet(SnapshotType type, [NotNullWhen(true)] out ISnapshotComparer? comparer) => Current.TryGetValue(type, out comparer);
 
     public ISnapshotComparer Get(SnapshotType type)
     {
-        if (_comparers.TryGetValue(type, out var comparer))
+        var comparers = Current;
+        if (comparers.TryGetValue(type, out var comparer))
             return comparer;
 
-        if (_comparers.TryGetValue(SnapshotType.None, out var defaultComparer))
+        if (comparers.TryGetValue(SnapshotType.None, out var defaultComparer))
             return defaultComparer;
 
         return ByteArraySnapshotComparer.Instance;
     }
 
-    public bool Remove(SnapshotType type) => _comparers.Remove(type);
+    public bool Remove(SnapshotType type)
+    {
+        lock (_lock)
+        {
+            if (!_comparers.ContainsKey(type))
+                return false;
 
-    public void Clear() => _comparers.Clear();
+            var updated = new Dictionary<SnapshotType, ISnapshotComparer>(_comparers);
+            updated.Remove(type);
+            Volatile.Write(ref _comparers, updated);
+            return true;
+        }
+    }
 
-    public IEnumerator<KeyValuePair<SnapshotType, ISnapshotComparer>> GetEnumerator() => _comparers.GetEnumerator();
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            Volatile.Write(ref _comparers, []);
+        }
+    }
+
+    public IEnumerator<KeyValuePair<SnapshotType, ISnapshotComparer>> GetEnumerator() => ((IEnumerable<KeyValuePair<SnapshotType, ISnapshotComparer>>)Current).GetEnumerator();
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSerializerCollection.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSerializerCollection.cs
@@ -2,7 +2,11 @@ namespace Meziantou.Framework.SnapshotTesting;
 
 public sealed class SnapshotSerializerCollection : IEnumerable<ISnapshotSerializer>
 {
-    private readonly List<ISnapshotSerializer> _serializers;
+    private readonly Lock _lock = new();
+
+    // Copy-on-write: readers take the current array without locking, writers publish a new one under the lock.
+    // Serialization stays allocation-free while a registration on another thread cannot be observed halfway.
+    private ISnapshotSerializer[] _serializers;
 
     public SnapshotSerializerCollection()
     {
@@ -11,26 +15,73 @@ public sealed class SnapshotSerializerCollection : IEnumerable<ISnapshotSerializ
 
     internal SnapshotSerializerCollection(SnapshotSerializerCollection source)
     {
-        _serializers = [.. source._serializers];
+        _serializers = source.Current;
     }
 
-    public int Count => _serializers.Count;
+    private ISnapshotSerializer[] Current => Volatile.Read(ref _serializers);
+
+    public int Count => Current.Length;
 
     /// <summary>Adds an untyped serializer. Untyped serializers are matched using <see cref="ISnapshotSerializer.TrySerialize"/>.</summary>
     public void Add(ISnapshotSerializer serializer)
     {
         ArgumentNullException.ThrowIfNull(serializer);
-        _serializers.Add(serializer);
+        lock (_lock)
+        {
+            Volatile.Write(ref _serializers, [.. _serializers, serializer]);
+        }
     }
 
-    public bool Remove(ISnapshotSerializer serializer) => _serializers.Remove(serializer);
-    public void Clear() => _serializers.Clear();
+    public bool Remove(ISnapshotSerializer serializer)
+    {
+        lock (_lock)
+        {
+            var index = Array.IndexOf(_serializers, serializer);
+            if (index < 0)
+                return false;
+
+            var updated = new ISnapshotSerializer[_serializers.Length - 1];
+            _serializers.AsSpan(0, index).CopyTo(updated);
+            _serializers.AsSpan(index + 1).CopyTo(updated.AsSpan(index));
+            Volatile.Write(ref _serializers, updated);
+            return true;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            Volatile.Write(ref _serializers, []);
+        }
+    }
+
+    /// <summary>Replaces <paramref name="oldSerializer"/> with <paramref name="newSerializer"/>, or appends it when the old one is no longer registered.</summary>
+    /// <remarks>Replacing in place avoids the window where a clear-then-refill would expose a partial collection to a concurrent serialization.</remarks>
+    internal void Replace(ISnapshotSerializer oldSerializer, ISnapshotSerializer newSerializer)
+    {
+        lock (_lock)
+        {
+            var index = Array.IndexOf(_serializers, oldSerializer);
+            if (index < 0)
+            {
+                Volatile.Write(ref _serializers, [.. _serializers, newSerializer]);
+            }
+            else
+            {
+                ISnapshotSerializer[] updated = [.. _serializers];
+                updated[index] = newSerializer;
+                Volatile.Write(ref _serializers, updated);
+            }
+        }
+    }
 
     public SerializedSnapshot Serialize(SnapshotType type, object? value)
     {
-        for (var i = _serializers.Count - 1; i >= 0; i--)
+        var serializers = Current;
+        for (var i = serializers.Length - 1; i >= 0; i--)
         {
-            var serializer = _serializers[i];
+            var serializer = serializers[i];
             if (!serializer.TrySerialize(type, value, out var result))
                 continue;
 
@@ -43,6 +94,6 @@ public sealed class SnapshotSerializerCollection : IEnumerable<ISnapshotSerializ
         throw new InvalidOperationException($"No suitable serializer found for '{type.DisplayName}' and value type '{value?.GetType()}'.");
     }
 
-    public IEnumerator<ISnapshotSerializer> GetEnumerator() => _serializers.GetEnumerator();
+    public IEnumerator<ISnapshotSerializer> GetEnumerator() => ((IEnumerable<ISnapshotSerializer>)Current).GetEnumerator();
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
@@ -103,7 +103,7 @@ public sealed record SnapshotSettings
         ];
         Comparers = new SnapshotComparerCollection();
         Comparers.Set(SnapshotType.None, ByteArraySnapshotComparer.Instance);
-        Scrubbers = [];
+        Scrubbers = new CopyOnWriteList<Scrubber>();
         SnapshotUpdateStrategy = SnapshotUpdateStrategy.Default;
         AssertionExceptionCreator = AssertionExceptionBuilder.Default;
         MaxSnapshotFileNameLength = 128;
@@ -117,11 +117,7 @@ public sealed record SnapshotSettings
         ArgumentNullException.ThrowIfNull(options);
         Serializers = new SnapshotSerializerCollection(options.Serializers);
         Comparers = new SnapshotComparerCollection(options.Comparers);
-        Scrubbers = [];
-        foreach (var scrubber in options.Scrubbers)
-        {
-            Scrubbers.Add(scrubber);
-        }
+        Scrubbers = new CopyOnWriteList<Scrubber>(options.Scrubbers);
 
         AutoDetectContinuousEnvironment = options.AutoDetectContinuousEnvironment;
         ForceUpdateSnapshots = options.ForceUpdateSnapshots;

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsHumanReadableSerializerExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsHumanReadableSerializerExtensions.cs
@@ -11,21 +11,13 @@ public static class SnapshotSettingsHumanReadableSerializerExtensions
             if (options is null)
                 return;
 
-            var serializers = settings.Serializers.ToList();
-            var index = serializers.FindIndex(serializer => serializer is HumanReadableSnapshotSerializer);
-            if (index < 0)
+            var serializer = settings.Serializers.OfType<HumanReadableSnapshotSerializer>().FirstOrDefault();
+            if (serializer is null)
                 return;
 
-            var serializer = (HumanReadableSnapshotSerializer)serializers[index];
             var clone = new HumanReadableSnapshotSerializer(serializer.Options with { });
             options(clone.Options);
-
-            serializers[index] = clone;
-            settings.Serializers.Clear();
-            foreach (var item in serializers)
-            {
-                settings.Serializers.Add(item);
-            }
+            settings.Serializers.Replace(serializer, clone);
         }
 
         public void AddConverter(HumanReadableConverter converter)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1501,6 +1501,162 @@ public sealed partial class SnapshotTests
         }
     }
 
+    [Fact]
+    public void Serializers_TheLastRegisteredSerializerWins()
+    {
+        var settings = new SnapshotSettings();
+        settings.Serializers.Add(new FixedSnapshotSerializer("first"));
+        settings.Serializers.Add(new FixedSnapshotSerializer("second"));
+
+        var data = Assert.Single(settings.Serializers.Serialize(SnapshotType.None, new SerializerProbe()).Data);
+        Assert.Equal("second", Encoding.UTF8.GetString(data.Data));
+    }
+
+    [Fact]
+    public void ConfigureHumanReadableSerializer_ReplacesTheSerializerInPlace()
+    {
+        var settings = new SnapshotSettings();
+        var initialCount = settings.Serializers.Count;
+        var initialOrder = settings.Serializers.Select(serializer => serializer.GetType()).ToList();
+
+        settings.ConfigureHumanReadableSerializer(options => options.MaxDepth = 3);
+
+        Assert.Equal(initialCount, settings.Serializers.Count);
+        Assert.Equal(initialOrder, settings.Serializers.Select(serializer => serializer.GetType()).ToList());
+        Assert.Equal(3, settings.Serializers.OfType<HumanReadableSnapshotSerializer>().Single().Options.MaxDepth);
+    }
+
+    [Fact]
+    public void Serializers_SerializeIsNotBrokenByAConcurrentRegistration()
+    {
+        var settings = new SnapshotSettings();
+        RunConcurrently(
+            writer: () =>
+            {
+                var serializer = new NeverMatchingSnapshotSerializer();
+                settings.Serializers.Add(serializer);
+                settings.Serializers.Remove(serializer);
+                settings.ConfigureHumanReadableSerializer(options => options.MaxDepth = 32);
+            },
+            reader: () => settings.Serializers.Serialize(SnapshotType.None, new { A = 1 }));
+    }
+
+    [Fact]
+    public void Comparers_GetIsNotBrokenByAConcurrentRegistration()
+    {
+        var settings = new SnapshotSettings();
+        RunConcurrently(
+            writer: () =>
+            {
+                settings.Comparers.Set(SnapshotType.Png, ByteArraySnapshotComparer.Instance);
+                settings.Comparers.Remove(SnapshotType.Png);
+            },
+            reader: () =>
+            {
+                _ = settings.Comparers.Get(SnapshotType.Png);
+                _ = settings.Comparers.ToList();
+            });
+    }
+
+    [Fact]
+    public void Scrubbers_EnumerationIsNotBrokenByAConcurrentRegistration()
+    {
+        var settings = new SnapshotSettings();
+        var scrubber = new LineFilterScrubber(_ => false);
+        RunConcurrently(
+            writer: () =>
+            {
+                settings.Scrubbers.Add(scrubber);
+                settings.Scrubbers.Remove(scrubber);
+            },
+            reader: () =>
+            {
+                foreach (var item in settings.Scrubbers)
+                {
+                    _ = item;
+                }
+            });
+    }
+
+    [Fact]
+    public void Scrubbers_SupportTheFullListContract()
+    {
+        var settings = new SnapshotSettings();
+        var first = new LineFilterScrubber(_ => false);
+        var second = new LineFilterScrubber(_ => true);
+
+        settings.Scrubbers.Add(first);
+        settings.Scrubbers.Insert(0, second);
+        Assert.Equal([second, first], settings.Scrubbers);
+        Assert.Equal(0, settings.Scrubbers.IndexOf(second));
+        Assert.True(settings.Scrubbers.Contains(first));
+
+        settings.Scrubbers[0] = first;
+        Assert.Equal([first, first], settings.Scrubbers);
+
+        settings.Scrubbers.RemoveAt(0);
+        Assert.Equal([first], settings.Scrubbers);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => settings.Scrubbers.RemoveAt(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => settings.Scrubbers.Insert(2, first));
+
+        settings.Scrubbers.Clear();
+        Assert.Empty(settings.Scrubbers);
+    }
+
+    /// <summary>Runs <paramref name="reader"/> on the current thread while <paramref name="writer"/> keeps mutating the same settings.</summary>
+    private static void RunConcurrently(Action writer, Action reader)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var writerTask = Task.Run(() =>
+        {
+            while (!cancellationTokenSource.IsCancellationRequested)
+            {
+                writer();
+            }
+        });
+
+        try
+        {
+            for (var i = 0; i < 20_000; i++)
+            {
+                reader();
+            }
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+        }
+
+        writerTask.GetAwaiter().GetResult();
+    }
+
+    private sealed class SerializerProbe;
+
+    private sealed class NeverMatchingSnapshotSerializer : ISnapshotSerializer
+    {
+        public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    private sealed class FixedSnapshotSerializer(string content) : ISnapshotSerializer
+    {
+        public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
+        {
+            if (value is not SerializerProbe)
+            {
+                result = null;
+                return false;
+            }
+
+            result = new SerializedSnapshot([new SnapshotData("txt", Encoding.UTF8.GetBytes(content))]);
+            return true;
+        }
+    }
+
     [GeneratedRegex("^[A-Za-z0-9._-]+_2\\.verified\\.png$", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 1000)]
     private static partial Regex SnapshotNameWithIndexRegex();
 


### PR DESCRIPTION
Fixes #2195.

## The problem

`SnapshotSettings.Default` is a shared instance, and `Snapshot.Validate` passes it straight into the engine without cloning (`Snapshot.cs:48`). So every assertion reads its collections *live*, while `AddImageSharp` / `AddSkiaSharp` / `AddRoslyn` mutate those same collections. They were a plain `List<T>` and `Dictionary<>`, so a registration on another thread could be observed halfway:

- `SnapshotSerializerCollection.Serialize` cached `Count` at loop entry and then indexed, so a concurrent `Clear()` threw `ArgumentOutOfRangeException` — and a concurrent `Remove()` threw `NullReferenceException` on the emptied slot, a failure mode the issue didn't mention.
- Any concurrent `Add()` broke an in-flight enumeration with `Collection was modified`. This hit the *guarded* paths too: `AddRoslyn`'s `Any(...)` check and `ConfigureHumanReadableSerializer`'s `ToList()`.
- Concurrent writes to the comparer `Dictionary` could corrupt it outright, which is worse than an exception.
- `Scrubbers` had the same exposure via `SnapshotEngine.ApplyScrubbers`.

## The fix

**Copy-on-write.** Readers take the current array or dictionary with no lock; writers publish a replacement under a `Lock`. Reads stay allocation-free, and a snapshot taken before a mutation stays valid for the whole operation. `Scrubbers` gets the same treatment via a new internal `CopyOnWriteList<T>` — the property type stays `IList<Scrubber>`.

**No more clear-then-refill.** `ConfigureHumanReadableSerializer` built the new list, called `Serializers.Clear()`, then re-added one by one. It now builds the clone outside the lock and swaps it in place through a new internal `Replace`, so there is no window where a concurrent `Serialize` sees a partial or empty collection.

**One clone instead of five.** `AddRoslyn` registered five converters with five `AddConverter` calls, each cloning the whole `HumanReadableSerializerOptions` and the serializer. They now go in a single `ConfigureHumanReadableSerializer` call.

## Notes for the reviewer

**No public API change.** `ref/Meziantou.Framework.SnapshotTesting.cs` is untouched. An earlier revision added a public `AddIfNotPresent` to make the `Add*` extension methods idempotent; that was dropped. Duplicate registration turns out to be behaviourally invisible — serializer lookup iterates in reverse (last-wins) while `HumanReadableSerializerOptions.FindConverter` iterates forward and returns the first hit (first-wins), so a duplicate is inert in either direction. It only costs memory, and `_convertersCache` is keyed by type so list length doesn't affect steady-state serialization. The existing guards in `AddRoslyn` and `AddGifSerializer` are left exactly as they were.

**The mutable `Default` setter is deliberately untouched.** `SnapshotSettings.Default = Default with { ... }` is an atomic reference swap and was never the problem; the repo's own test projects use that pattern. The bug was mutating the collections of whatever instance `Default` points at.

## Verification

The three new concurrency tests were run against the *previous* implementation and all three failed within milliseconds (`Collection was modified` ×2, `NullReferenceException` ×1), so they're real regression protection rather than tests that pass either way.

| | |
|---|---|
| `SnapshotTesting.Tests` (net10 + net11) | 173 + 173 passed |
| `SnapshotTesting.Roslyn.Tests` | 44 passed |
| `QRCode.Tests` / `Avatar.Tests` (`Default` consumers) | 2724 / 52 passed |
| `SnapshotTesting.Tool.Tests` | 8 passed |

`dotnet run ./eng/update-all.cs` exits 0 with no file changes. Release + `IsOfficialBuild=true` builds are clean across all four affected projects with warnings-as-errors.
