### PR TITLE
Implement ISupportExternalScope consistently across logger providers

### DIFF
--- a/common/MutableExternalScopeProvider.cs
+++ b/common/MutableExternalScopeProvider.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.Logging;
-
-namespace Meziantou.Extensions.Logging.InMemory;
+namespace Microsoft.Extensions.Logging;
 
 // ILoggerFactory hands a provider its own scope provider through ISupportExternalScope, but only
 // once the provider is registered. Loggers therefore hold this indirection instead of a specific

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
@@ -33,8 +33,9 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
     private readonly Thread? _writerThread;
     private readonly TaskCompletionSource? _writerCompletion;
 
+    private readonly MutableExternalScopeProvider _scopeProvider = new(new LoggerExternalScopeProvider());
+
     private FileLoggerOptions _options;
-    private IExternalScopeProvider _scopeProvider = new LoggerExternalScopeProvider();
     private int _disposed;
 
     /// <summary>Gets the path of the file the messages are currently written to, or <see langword="null" /> when the log file could not be created.</summary>
@@ -45,7 +46,7 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
 
     internal FileLoggerOptions CurrentOptions => Volatile.Read(ref _options);
 
-    internal IExternalScopeProvider ScopeProvider => Volatile.Read(ref _scopeProvider);
+    internal IExternalScopeProvider ScopeProvider => _scopeProvider;
 
     /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class that writes to the specified directory.</summary>
     /// <param name="logsDirectory">The directory where log files will be written.</param>
@@ -160,10 +161,16 @@ public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope,
         return new FileLogger(this, categoryName);
     }
 
-    /// <inheritdoc/>
+    /// <summary>Sets the external scope provider supplied by the logger factory.</summary>
+    /// <param name="scopeProvider">The scope provider the factory uses to track scopes.</param>
+    /// <remarks>
+    /// Implementing <see cref="ISupportExternalScope"/> is what makes the factory route its scopes
+    /// through this provider, including the ones it synthesises from the current activity when
+    /// <c>LoggerFactoryOptions.ActivityTrackingOptions</c> is set.
+    /// </remarks>
     public void SetScopeProvider(IExternalScopeProvider scopeProvider)
     {
-        Volatile.Write(ref _scopeProvider, scopeProvider ?? new LoggerExternalScopeProvider());
+        _scopeProvider.Current = scopeProvider;
     }
 
     internal void WriteLog(string message, DateTimeOffset timestamp)

--- a/src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj
+++ b/src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../../common/MutableExternalScopeProvider.cs" Link="MutableExternalScopeProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.11" />
   </ItemGroup>

--- a/src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj
+++ b/src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../../common/MutableExternalScopeProvider.cs" Link="MutableExternalScopeProvider.cs" />
     <Compile Include="../../common/TypeNameHelper.cs" Link="TypeNameHelper.cs" />
   </ItemGroup>
 

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../../common/MutableExternalScopeProvider.cs" Link="MutableExternalScopeProvider.cs" />
     <Compile Include="../../common/TypeNameHelper.cs" Link="TypeNameHelper.cs" />
   </ItemGroup>
 

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
@@ -24,13 +24,7 @@ public class XUnitLogger : ILogger
     private readonly ITestOutputHelper? _testOutputHelper;
     private readonly string? _categoryName;
     private readonly XUnitLoggerOptions _options;
-    private IExternalScopeProvider _scopeProvider;
-
-    internal IExternalScopeProvider ScopeProvider
-    {
-        get => Volatile.Read(ref _scopeProvider);
-        set => Volatile.Write(ref _scopeProvider, value);
-    }
+    private readonly IExternalScopeProvider _scopeProvider;
 
     /// <summary>Creates a new logger instance without a test output helper.</summary>
     /// <returns>A new <see cref="ILogger"/> instance.</returns>
@@ -112,7 +106,7 @@ public class XUnitLogger : ILogger
     public bool IsEnabled(LogLevel logLevel) => logLevel is not LogLevel.None;
 
     /// <inheritdoc/>
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => ScopeProvider.Push(state);
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => _scopeProvider.Push(state);
 
     /// <inheritdoc/>
     [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs")]
@@ -147,7 +141,7 @@ public class XUnitLogger : ILogger
         // Append scopes before the exception, so a long stack trace does not push them out of view
         if (_options.IncludeScopes)
         {
-            ScopeProvider.ForEachScope((scope, state) =>
+            _scopeProvider.ForEachScope((scope, state) =>
             {
                 state.Append(Environment.NewLine).Append(" => ");
                 state.Append(scope);

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLoggerProvider.cs
@@ -28,9 +28,7 @@ public sealed class XUnitLoggerProvider : ILoggerProvider, ISupportExternalScope
     private readonly XUnitLoggerOptions _options;
     private readonly ConcurrentDictionary<string, XUnitLogger> _loggers = new(StringComparer.Ordinal);
 
-    private IExternalScopeProvider _scopeProvider = new LoggerExternalScopeProvider();
-
-    private IExternalScopeProvider ScopeProvider => Volatile.Read(ref _scopeProvider);
+    private readonly MutableExternalScopeProvider _scopeProvider = new(new LoggerExternalScopeProvider());
 
     /// <summary>Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.</summary>
     public XUnitLoggerProvider()
@@ -72,18 +70,19 @@ public sealed class XUnitLoggerProvider : ILoggerProvider, ISupportExternalScope
     /// <inheritdoc/>
     public ILogger CreateLogger(string categoryName)
     {
-        return _loggers.GetOrAdd(categoryName, static (name, state) => new XUnitLogger(state._testOutputHelper, state.ScopeProvider, name, state._options), this);
+        return _loggers.GetOrAdd(categoryName, static (name, state) => new XUnitLogger(state._testOutputHelper, state._scopeProvider, name, state._options), this);
     }
 
-    /// <inheritdoc/>
+    /// <summary>Sets the external scope provider supplied by the logger factory.</summary>
+    /// <param name="scopeProvider">The scope provider the factory uses to track scopes.</param>
+    /// <remarks>
+    /// Implementing <see cref="ISupportExternalScope"/> is what makes the factory route its scopes
+    /// through this provider, including the ones it synthesises from the current activity when
+    /// <c>LoggerFactoryOptions.ActivityTrackingOptions</c> is set.
+    /// </remarks>
     public void SetScopeProvider(IExternalScopeProvider scopeProvider)
     {
-        Volatile.Write(ref _scopeProvider, scopeProvider);
-
-        foreach (var logger in _loggers)
-        {
-            logger.Value.ScopeProvider = scopeProvider;
-        }
+        _scopeProvider.Current = scopeProvider;
     }
 
     /// <inheritdoc/>

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -173,6 +173,31 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
+    public async Task SetScopeProviderUpdatesExistingAndNewLoggers()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, IncludeScopes = true });
+        var loggerCreatedBeforeSet = provider.CreateLogger("before");
+
+        var scopeProvider = new LoggerExternalScopeProvider();
+        ((ISupportExternalScope)provider).SetScopeProvider(scopeProvider);
+
+        var loggerCreatedAfterSet = provider.CreateLogger("after");
+
+        using (scopeProvider.Push("external scope"))
+        {
+            loggerCreatedBeforeSet.LogInformation("Test");
+            loggerCreatedAfterSet.LogInformation("Test");
+        }
+
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var lines = (await ReadLogFileAsync(provider.LogFilePath)).Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.HasCount(2, lines);
+        Assert.All(lines, line => Assert.Contains("=> external scope", line));
+    }
+
+    [Fact]
     public async Task IncludeEventIdThreadIdAndActivity()
     {
         using var tempDirectory = TemporaryDirectory.Create();

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -142,6 +142,28 @@ public sealed partial class InMemoryLoggerTests
     }
 
     [Fact]
+    public void SetScopeProviderUpdatesExistingAndNewLoggers()
+    {
+        using var provider = new InMemoryLoggerProvider();
+        var loggerCreatedBeforeSet = provider.CreateLogger("before");
+
+        var scopeProvider = new LoggerExternalScopeProvider();
+        ((ISupportExternalScope)provider).SetScopeProvider(scopeProvider);
+
+        var loggerCreatedAfterSet = provider.CreateLogger("after");
+
+        using (scopeProvider.Push("external scope"))
+        {
+            loggerCreatedBeforeSet.LogInformation("Test");
+            loggerCreatedAfterSet.LogInformation("Test");
+        }
+
+        var logs = provider.Logs.Informations.ToArray();
+        Assert.HasCount(2, logs);
+        Assert.All(logs, log => Assert.Equivalent(new object[] { "external scope" }, log.Scopes));
+    }
+
+    [Fact]
     public void WithScope()
     {
         using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());


### PR DESCRIPTION
## What

`FileLoggerProvider`, `InMemoryLoggerProvider` and `XUnitLoggerProvider` all implement `ISupportExternalScope`, but each did it differently:

| Provider | Before |
|---|---|
| `FileLoggerProvider` | volatile `IExternalScopeProvider` field the loggers re-read on every call; `SetScopeProvider` had a `?? new LoggerExternalScopeProvider()` fallback for a non-nullable parameter |
| `XUnitLoggerProvider` | stored the provider *and* pushed it into every cached `XUnitLogger` through an internal mutable property |
| `InMemoryLoggerProvider` | wrapped it in a private `MutableExternalScopeProvider` indirection so loggers observe the hand-off automatically |

This aligns them on the `MutableExternalScopeProvider` approach — the simplest of the three, and the only one that needs neither a logger cache to walk nor an indirection through the provider.

`MutableExternalScopeProvider` moved to `common/MutableExternalScopeProvider.cs` (namespace `Microsoft.Extensions.Logging`) and is linked into the three projects the way `common/TypeNameHelper.cs` already is. Each provider now holds `private readonly MutableExternalScopeProvider _scopeProvider = new(new LoggerExternalScopeProvider());`, passes that instance to the loggers it creates, and implements the interface identically:

```csharp
public void SetScopeProvider(IExternalScopeProvider scopeProvider)
{
    _scopeProvider.Current = scopeProvider;
}
```

with the same summary/remarks doc block on all three.

Knock-on simplifications:

- `XUnitLoggerProvider.SetScopeProvider` no longer walks `_loggers`.
- `XUnitLogger._scopeProvider` became a plain `readonly` field; its internal settable `ScopeProvider` property is gone.
- `FileLoggerProvider.ScopeProvider` is a straight field read, and the null fallback is dropped per AGENTS.md ("trust the null annotations").

## Tests

`SetScopeProviderUpdatesExistingAndNewLoggers` only existed for xUnit; the equivalent is added to `FileLoggerProviderTests` and `InMemoryLoggerTests`, so all three now prove a logger created *before* the factory's hand-off still sees the external scopes.

InMemory 76, xUnit.v3 50, FileLogger 89 — all passing on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

## Notes for reviewers

- Public API is unchanged (`ref/` needs no update); `dotnet run ./eng/update-all.cs` produced no changes.
- `XUnitLogger`'s public constructors still take an `IExternalScopeProvider` directly — user-created loggers keep whatever they are given, only the provider-created ones follow the factory.