### PR TITLE
Add an opt-in check for missing named template arguments

### DIFF
--- a/ref/Meziantou.Framework.Templating.cs
+++ b/ref/Meziantou.Framework.Templating.cs
@@ -177,6 +177,7 @@ namespace Meziantou.Framework.Templating
         public Meziantou.Framework.Templating.AssemblyReferenceCollection AssemblyReferences { get => throw null; }
         public Meziantou.Framework.Templating.FileReferenceCollection IncludedSourceFiles { get => throw null; }
         public bool Debug { get => throw null; set { } }
+        public bool ThrowOnMissingArgument { get => throw null; set { } }
         public void Load(string text) { }
         public void Load(System.IO.TextReader reader) { }
         public void Build(System.Threading.CancellationToken cancellationToken) { }

--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -90,6 +90,9 @@ public class Template
     /// <summary>Gets or sets a value indicating whether to compile the template in debug mode.</summary>
     public bool Debug { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether running the template with named parameters throws when an argument has no value. When <see langword="false" /> (the default), a missing argument gets the default value of its type.</summary>
+    public bool ThrowOnMissingArgument { get; set; }
+
     /// <summary>Loads the template from a string.</summary>
     /// <param name="text">The template text containing code blocks.</param>
     public void Load(string text)
@@ -945,6 +948,7 @@ public class Template
     /// <param name="writer">The text writer for output.</param>
     /// <param name="parameters">A dictionary of parameter names and values.</param>
     /// <returns>An array of method parameters.</returns>
+    /// <exception cref="TemplateException"><see cref="ThrowOnMissingArgument" /> is <see langword="true" /> and an argument has no value in <paramref name="parameters" />.</exception>
     protected virtual object?[] CreateMethodParameters(TextWriter writer, IReadOnlyDictionary<string, object?> parameters)
     {
         if (!IsBuilt)
@@ -960,12 +964,13 @@ public class Template
             {
                 p[pi.Position] = CreateOutput(writer);
             }
-            else
+            else if (parameters.TryGetValue(pi.Name!, out var value))
             {
-                if (parameters.TryGetValue(pi.Name!, out var value))
-                {
-                    p[pi.Position] = value;
-                }
+                p[pi.Position] = value;
+            }
+            else if (ThrowOnMissingArgument)
+            {
+                throw new TemplateException($"No value was provided for the argument '{pi.Name}'.");
             }
         }
 

--- a/src/Meziantou.Framework.Templating/readme.md
+++ b/src/Meziantou.Framework.Templating/readme.md
@@ -59,6 +59,19 @@ var result = template.Run(arguments);
 // result: "Hello Meziantou!"
 ```
 
+An argument that is missing from the dictionary gets the default value of its type (`null`, `0`,
+`false`, …). Set `ThrowOnMissingArgument` to get a `TemplateException` naming the argument instead,
+so a typo in a key does not silently produce a wrong document:
+
+```csharp
+var template = new Template { ThrowOnMissingArgument = true };
+template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
+template.Load("Hello <%=Name%>!");
+
+// throws TemplateException: No value was provided for the argument 'Name'.
+template.Run(new Dictionary<string, object?>());
+```
+
 ### Code Blocks
 
 Templates support four types of code blocks:

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -928,6 +928,47 @@ public class TemplateTest
         Assert.False(template.IsBuilt);
     }
 
+    [Fact]
+    public void Template_RunWithNamedParameters_MissingArgumentUsesDefaultValue()
+    {
+        var template = new Template();
+        template.Arguments.Add(new TemplateArgument("n", typeof(int)));
+        template.Load("<%= n %>");
+
+        Assert.Equal("0", template.Run(new Dictionary<string, object?>(StringComparer.Ordinal)));
+    }
+
+    [Fact]
+    public void Template_RunWithNamedParameters_MissingArgumentThrowsWhenEnabled()
+    {
+        var template = new Template { ThrowOnMissingArgument = true };
+        template.Arguments.Add(new TemplateArgument("n", typeof(int)));
+        template.Load("<%= n %>");
+
+        var exception = Assert.Throws<TemplateException>(() => template.Run(new Dictionary<string, object?>(StringComparer.Ordinal)));
+        Assert.Contains("'n'", exception.Message);
+    }
+
+    [Fact]
+    public void Template_RunWithNamedParameters_ProvidedArgumentDoesNotThrowWhenEnabled()
+    {
+        var template = new Template { ThrowOnMissingArgument = true };
+        template.Arguments.Add(new TemplateArgument("n", typeof(int)));
+        template.Load("<%= n %>");
+
+        Assert.Equal("42", template.Run(new Dictionary<string, object?>(StringComparer.Ordinal) { { "n", 42 } }));
+    }
+
+    [Fact]
+    public void Template_RunWithNamedParameters_NullArgumentValueDoesNotThrowWhenEnabled()
+    {
+        var template = new Template { ThrowOnMissingArgument = true };
+        template.Arguments.Add(new TemplateArgument("name", typeof(string)));
+        template.Load("<%= name is null ? \"<null>\" : name %>");
+
+        Assert.Equal("<null>", template.Run(new Dictionary<string, object?>(StringComparer.Ordinal) { { "name", null } }));
+    }
+
     private sealed class TemplateWithCountingStringWriter : Template
     {
         public int CreateStringWriterCallCount { get; private set; }


### PR DESCRIPTION
Fixes #2704

## What changed

`Template.CreateMethodParameters(TextWriter, IReadOnlyDictionary<string, object?>)` had no terminal branch after its `TryGetValue`, so an argument absent from the dictionary left the array slot `null` — and `MethodInfo.Invoke` converts `null` to the default value for the parameter type:

```csharp
var template = new Template();
template.Arguments.Add(new TemplateArgument("n", typeof(int)));
template.Load("<%= n %>");

template.Run(new Dictionary<string, object?>());   // "0" — no exception
```

A typo in a key (`"userName"` vs `"username"`) therefore produced a plausible-looking wrong document — a `0` price, an empty name, a `01/01/0001` date — rather than an error.

- **`ThrowOnMissingArgument`** (new property on `Template`): when set, a missing argument throws `TemplateException("No value was provided for the argument 'n'.")` instead of defaulting.
- The property defaults to `false`, so **the behaviour of existing callers is unchanged**. The default can be flipped in the next major version without further API work.
- `ref/Meziantou.Framework.Templating.cs` regenerated.
- The named-parameters section of the package readme documents both the defaulting behaviour and the opt-in.

## For reviewers

- A key that is present with a `null` value is a legitimate value and does not throw — only an absent key does. There is a test for this.
- The check lives in `CreateMethodParameters`, which is `protected virtual`; the `<exception>` doc was added to it accordingly.
- The positional `Run(params object?[])` overload is untouched — it has no name matching and so no equivalent failure mode.

## Testing

4 tests added to `TemplateTest`: the defaulting repro from the issue, the throw when enabled (asserting the argument name is in the message), a provided argument passing through, and an explicit `null` value not throwing.

- Release build with `IsOfficialBuild=true` and `TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- `Templating` 146/146, `Templating.Html` 32/32, `Templating.Tool` 36/36 — all passing on net10.0 and net11.0.
- `dotnet run ./eng/update-all.cs` ran clean and produced no further changes.