### PR TITLE
Escape every character unsafe in an HTML attribute in #attr

### DIFF
--- a/src/Meziantou.Framework.Templating.Html/HtmlEmailOutput.cs
+++ b/src/Meziantou.Framework.Templating.Html/HtmlEmailOutput.cs
@@ -8,6 +8,7 @@ namespace Meziantou.Framework.Templating;
 /// <code>
 /// var output = new HtmlEmailOutput(template, writer);
 /// output.WriteHtmlEncode("&lt;b&gt;text&lt;/b&gt;"); // Outputs: &amp;lt;b&amp;gt;text&amp;lt;/b&amp;gt;
+/// output.WriteHtmlAttributeEncode("a b"); // Outputs: a&amp;#x20;b
 /// output.WriteUrlEncode("value&amp;param"); // Outputs: value%26param
 /// output.WriteContentIdentifier("logo.png"); // Outputs: cid:logo.png
 /// </code>
@@ -16,6 +17,9 @@ public class HtmlEmailOutput(Template template, TextWriter writer) : Output(temp
 {
     /// <summary>The name of the section used for the email title.</summary>
     public const string TitleSectionName = "title";
+
+    private static readonly HtmlEncoder HtmlAttributeEncoder = CreateHtmlAttributeEncoder();
+
     private readonly HtmlEncoder _htmlEncoder = HtmlEncoder.Default;
     private readonly UrlEncoder _urlEncoder = UrlEncoder.Default;
 
@@ -88,7 +92,17 @@ public class HtmlEmailOutput(Template template, TextWriter writer) : Output(temp
     /// <summary>Writes a formatted HTML attribute-encoded string to the output.</summary>
     public virtual void WriteHtmlAttributeEncode(string format, params object?[] args)
     {
-        Write(_htmlEncoder.Encode(string.Format(provider: null, format, args)));
+        Write(HtmlAttributeEncoder.Encode(string.Format(provider: null, format, args)));
+    }
+
+    /// <summary>Creates an encoder that escapes every character outside <c>[0-9A-Za-z]</c>. Unlike <see cref="HtmlEncoder.Default"/>, it also escapes the characters that terminate an unquoted attribute value, such as the space, so the result is safe in quoted and unquoted HTML attributes alike.</summary>
+    private static HtmlEncoder CreateHtmlAttributeEncoder()
+    {
+        var settings = new TextEncoderSettings();
+        settings.AllowCodePoints(Enumerable.Range('0', count: 10));
+        settings.AllowCodePoints(Enumerable.Range('A', count: 26));
+        settings.AllowCodePoints(Enumerable.Range('a', count: 26));
+        return HtmlEncoder.Create(settings);
     }
 
     /// <summary>Writes a URL-encoded value to the output.</summary>

--- a/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
@@ -67,6 +67,26 @@ public class EmailTemplateTest
     }
 
     [Fact]
+    public void EmailTemplate_HtmlAttributeEncode_EscapesCharactersThatEndAnUnquotedAttribute()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("<a href={{#attr \"x onmouseover=alert(1)\" }}>");
+
+        var result = template.Run(out _);
+        Assert.Equal("<a href=x&#x20;onmouseover&#x3D;alert&#x28;1&#x29;>", result);
+    }
+
+    [Fact]
+    public void EmailTemplate_HtmlAttributeEncode_EscapesEverythingOutsideAlphanumerics()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("{{#attr \"a-z_0.9 \\t`'\\\"<>&\u00e9\" }}");
+
+        var result = template.Run(out _);
+        Assert.Equal("a&#x2D;z&#x5F;0&#x2E;9&#x20;&#x9;&#x60;&#x27;&quot;&lt;&gt;&amp;&#xE9;", result);
+    }
+
+    [Fact]
     public void EmailTemplate_HtmlCode_01()
     {
         // Arrange


### PR DESCRIPTION
## Summary

`#attr` gave no attribute-safety guarantee over `#html`. `HtmlEmailOutput.WriteHtmlAttributeEncode` was character-for-character identical to `WriteHtmlEncode` — both called `HtmlEncoder.Default.Encode`.

That encoder escapes `"` and `'`, so **quoted** attributes were already safe. It does not escape the space, so **unquoted** ones were not:

```csharp
template.Load("<a href={{#attr \"x onmouseover=alert(1)\" }}>");
template.Run(out _);
// before: <a href=x onmouseover=alert(1)>
// after:  <a href=x&#x20;onmouseover&#x3D;alert&#x28;1&#x29;>
```

## What changed

- `WriteHtmlAttributeEncode` now uses its own encoder, built from `HtmlEncoder.Create` with only `[0-9A-Za-z]` allowed. Every other character is escaped, so nothing that can terminate an unquoted attribute value survives.
- `WriteHtmlEncode` and `WriteUrlEncode` are untouched, and the public API is unchanged (no `ref/` diff).

This changes the output of existing templates — `&` becomes `&amp;` as before, but `-`, `.`, `_`, spaces and non-ASCII now come out as numeric character references. Nothing renders differently in a browser.

The readme's `#attr` example is unaffected: `Sample&Sample` still encodes to `Sample&amp;Sample`.

## Validation

- Two tests added to `EmailTemplateTest`: the unquoted-attribute breakout above, and a character-class sweep pinning the exact escapes (`&`, `<`, `>`, `"` keep their named entities; everything else becomes `&#xHH;`).
- `dotnet test tests/Meziantou.Framework.Templating.Html.Tests` — 36/36 pass (18 per TFM, up from 16).
- `dotnet build -c Release -p:IsOfficialBuild=true -p:TreatWarningsAsErrors=true` — 0 warnings.
- `dotnet run ./eng/update-all.cs` — no file changes.

## Linked issues

Addresses the `#attr` half of #2703. The two other problems reported there are deliberately left open: there is still no helper that emits a safe URL, and the encode helpers still format through the current culture.

Fix #2703
