### PR TITLE
Canonicalize every URL pattern component per the spec

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/ConstructorStringParser.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/ConstructorStringParser.cs
@@ -427,7 +427,7 @@ internal sealed class ConstructorStringParser
         // Compile a component to test against special schemes
         try
         {
-            var component = UrlPatternComponent.Compile(protocolString, CanonicalizeProtocol, PatternOptions.Default);
+            var component = UrlPatternComponent.Compile(protocolString, UrlCanonicalizer.CanonicalizeProtocol, PatternOptions.Default);
             foreach (var scheme in SpecialSchemes.All)
             {
                 if (component.RegularExpression.IsMatch(scheme))
@@ -443,14 +443,5 @@ internal sealed class ConstructorStringParser
         }
 
         _protocolMatchesSpecialScheme = false;
-    }
-
-    private static string CanonicalizeProtocol(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return value;
-
-        // Protocol should be lowercased
-        return value.ToLowerInvariant();
     }
 }

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/PatternParser.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/PatternParser.cs
@@ -233,20 +233,26 @@ internal sealed class PatternParser
     private void AddPart(string prefix, Token? nameToken, Token? regexpOrWildcardToken, string suffix, Token? modifierToken)
     {
         var modifier = GetModifier(modifierToken);
+
+        if (nameToken is null && regexpOrWildcardToken is null && modifier == PartModifier.None)
+        {
+            // This was a "{foo}" grouping. Buffering it unencoded is what lets it be combined with the text
+            // around it, so that the encoding callback sees "example.com/foo" rather than three fragments
+            _pendingFixedValue.Append(prefix);
+            return;
+        }
+
         MaybeAddPartFromPendingFixedValue();
 
         if (nameToken is null && regexpOrWildcardToken is null)
         {
-            // This was a "{foo}?" grouping
-            if (string.IsNullOrEmpty(suffix) && string.IsNullOrEmpty(prefix))
+            // This was a "{foo}?" grouping. The modifier means it cannot be combined with the text around it
+            if (string.IsNullOrEmpty(prefix))
                 return;
 
-            if (!string.IsNullOrEmpty(prefix))
-            {
-                var encodedValue = Encode(prefix);
-                var part = new Part(PartType.FixedText, encodedValue, modifier);
-                _partList.Add(part);
-            }
+            var encodedValue = Encode(prefix);
+            var part = new Part(PartType.FixedText, encodedValue, modifier);
+            _partList.Add(part);
 
             return;
         }

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/PercentEncodeSet.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/PercentEncodeSet.cs
@@ -1,0 +1,28 @@
+namespace Meziantou.Framework.UrlPatternInternal;
+
+/// <summary>The percent-encode sets of the URL Standard.</summary>
+/// <remarks>
+/// Each set is a superset of the one before it, except that <see cref="Fragment"/> and
+/// <see cref="Query"/> both extend the C0 control set in different directions.
+/// <see href="https://url.spec.whatwg.org/#percent-encoded-bytes">URL Standard - Percent-encoded bytes</see>
+/// </remarks>
+internal enum PercentEncodeSet
+{
+    /// <summary>C0 controls and every code point greater than U+007E (~).</summary>
+    C0Control,
+
+    /// <summary>The C0 control set, plus U+0020 SPACE, '"', '&lt;', '&gt;' and '`'.</summary>
+    Fragment,
+
+    /// <summary>The C0 control set, plus U+0020 SPACE, '"', '#', '&lt;' and '&gt;'.</summary>
+    Query,
+
+    /// <summary>The query set, plus '\''. Used for the query of a URL with a special scheme.</summary>
+    SpecialQuery,
+
+    /// <summary>The query set, plus '?', '`', '{' and '}'.</summary>
+    Path,
+
+    /// <summary>The path set, plus '/', ':', ';', '=', '@', '[', '\\', ']', '^' and '|'.</summary>
+    UserInfo,
+}

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/PercentEncoding.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/PercentEncoding.cs
@@ -1,0 +1,153 @@
+using System.Buffers;
+
+namespace Meziantou.Framework.UrlPatternInternal;
+
+/// <summary>UTF-8 percent-encoding and percent-decoding, as defined by the URL Standard.</summary>
+/// <remarks>
+/// <see href="https://url.spec.whatwg.org/#percent-encoded-bytes">URL Standard - Percent-encoded bytes</see>
+/// </remarks>
+internal static class PercentEncoding
+{
+    private const string HexDigits = "0123456789ABCDEF";
+
+    /// <summary>Percent-encodes the code points of <paramref name="value"/> that belong to <paramref name="set"/>.</summary>
+    /// <remarks>
+    /// U+0025 (%) belongs to none of the sets, so an escape sequence that is already present is left alone
+    /// instead of being doubly encoded.
+    /// <see href="https://url.spec.whatwg.org/#string-utf-8-percent-encode">URL Standard - UTF-8 percent-encode</see>
+    /// </remarks>
+    public static string Encode(string value, PercentEncodeSet set)
+    {
+        var index = IndexOfFirstEncodedCodePoint(value, set);
+        if (index < 0)
+            return value;
+
+        var builder = new StringBuilder(value.Length + 8);
+        builder.Append(value, 0, index);
+        AppendEncoded(builder, value.AsSpan(index), set);
+
+        return builder.ToString();
+    }
+
+    /// <summary>Percent-encodes a single code point, appending the result to <paramref name="builder"/>.</summary>
+    public static void EncodeCodePoint(StringBuilder builder, Rune codePoint, PercentEncodeSet set)
+    {
+        if (codePoint.IsAscii && !ShouldEncode((char)codePoint.Value, set))
+        {
+            builder.Append((char)codePoint.Value);
+            return;
+        }
+
+        Span<byte> utf8 = stackalloc byte[4];
+        var length = codePoint.EncodeToUtf8(utf8);
+        for (var i = 0; i < length; i++)
+        {
+            var b = utf8[i];
+            builder.Append('%');
+            builder.Append(HexDigits[b >> 4]);
+            builder.Append(HexDigits[b & 0xF]);
+        }
+    }
+
+    /// <summary>Percent-decodes every valid escape sequence in <paramref name="value"/>, interpreting the bytes as UTF-8.</summary>
+    /// <remarks>
+    /// A '%' that is not followed by two hexadecimal digits is kept as-is, as the URL Standard requires.
+    /// <see href="https://url.spec.whatwg.org/#percent-decode">URL Standard - Percent-decode</see>
+    /// </remarks>
+    public static string Decode(string value)
+    {
+        if (!value.Contains('%', StringComparison.Ordinal))
+            return value;
+
+        var bytes = new byte[Encoding.UTF8.GetMaxByteCount(value.Length)];
+        var count = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c is '%' && i + 2 < value.Length && char.IsAsciiHexDigit(value[i + 1]) && char.IsAsciiHexDigit(value[i + 2]))
+            {
+                bytes[count++] = (byte)((GetHexValue(value[i + 1]) << 4) | GetHexValue(value[i + 2]));
+                i += 2;
+                continue;
+            }
+
+            // The value is a .NET string, so a non-ASCII code point has to be re-encoded to UTF-8 bytes
+            if (char.IsAscii(c))
+            {
+                bytes[count++] = (byte)c;
+                continue;
+            }
+
+            var charCount = char.IsHighSurrogate(c) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]) ? 2 : 1;
+            count += Encoding.UTF8.GetBytes(value.AsSpan(i, charCount), bytes.AsSpan(count));
+            i += charCount - 1;
+        }
+
+        return Encoding.UTF8.GetString(bytes.AsSpan(0, count));
+    }
+
+    private static void AppendEncoded(StringBuilder builder, ReadOnlySpan<char> value, PercentEncodeSet set)
+    {
+        // A lone surrogate is replaced by U+FFFD, which is how a DOMString becomes a USVString
+        while (!value.IsEmpty)
+        {
+            if (Rune.DecodeFromUtf16(value, out var rune, out var consumed) is not OperationStatus.Done)
+            {
+                rune = Rune.ReplacementChar;
+            }
+
+            EncodeCodePoint(builder, rune, set);
+            value = value[consumed..];
+        }
+    }
+
+    private static int IndexOfFirstEncodedCodePoint(string value, PercentEncodeSet set)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (!char.IsAscii(c) || ShouldEncode(c, set))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static int GetHexValue(char c) => char.IsAsciiDigit(c) ? c - '0' : (char.ToLowerInvariant(c) - 'a' + 10);
+
+    /// <summary>Determines whether an ASCII code point belongs to the specified percent-encode set.</summary>
+    private static bool ShouldEncode(char c, PercentEncodeSet set)
+    {
+        // C0 control percent-encode set: C0 controls and all code points greater than U+007E (~)
+        if (c <= 0x1F || c > '~')
+            return true;
+
+        if (set is PercentEncodeSet.C0Control)
+            return false;
+
+        // Shared by the fragment set and the query set, which the remaining sets extend
+        if (c is ' ' or '"' or '<' or '>')
+            return true;
+
+        // The fragment set is the only one that covers '`' but not '#'
+        if (set is PercentEncodeSet.Fragment)
+            return c is '`';
+
+        if (c is '#')
+            return true;
+
+        if (set is PercentEncodeSet.Query)
+            return false;
+
+        if (set is PercentEncodeSet.SpecialQuery)
+            return c is '\'';
+
+        if (c is '?' or '`' or '{' or '}')
+            return true;
+
+        if (set is PercentEncodeSet.Path)
+            return false;
+
+        return c is '/' or ':' or ';' or '=' or '@' or '[' or '\\' or ']' or '^' or '|';
+    }
+}

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/Tokenizer.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/Tokenizer.cs
@@ -13,7 +13,7 @@ internal ref struct Tokenizer
     private readonly List<Token> _tokenList;
     private int _index;
     private int _nextIndex;
-    private char _codePoint;
+    private int _codePoint;
 
     public Tokenizer(string input, TokenizePolicy policy)
     {
@@ -22,7 +22,7 @@ internal ref struct Tokenizer
         _tokenList = [];
         _index = 0;
         _nextIndex = 0;
-        _codePoint = '\0';
+        _codePoint = 0;
     }
 
     /// <summary>Tokenizes the input pattern string.</summary>
@@ -232,8 +232,11 @@ internal ref struct Tokenizer
     /// </remarks>
     private void GetNextCodePoint()
     {
-        _codePoint = _input[_nextIndex];
-        _nextIndex++;
+        // A pattern string is iterated by code point, so a surrogate pair counts as one step. An unpaired
+        // surrogate decodes to U+FFFD, which matches none of the pattern syntax, and still advances by one
+        Rune.DecodeFromUtf16(_input.AsSpan(_nextIndex), out var rune, out var charsConsumed);
+        _codePoint = rune.Value;
+        _nextIndex += charsConsumed;
     }
 
     /// <summary>Seeks to a specific position and gets the next code point.</summary>
@@ -292,20 +295,50 @@ internal ref struct Tokenizer
 
     /// <summary>Determines if a code point is valid for a name.</summary>
     /// <remarks>
+    /// A name is an ECMAScript identifier, so it is the IdentifierStart set that opens it and the wider
+    /// IdentifierPart set that continues it.
     /// <see href="https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point">WHATWG URL Pattern Spec - Is a valid name code point</see>
     /// </remarks>
-    private static bool IsValidNameCodePoint(char codePoint, bool first)
+    private static bool IsValidNameCodePoint(int codePoint, bool first)
     {
-        // If first is true return the result of checking if code point is contained in the IdentifierStart set of code points.
-        // Otherwise return the result of checking if code point is contained in the IdentifierPart set of code points.
-        // Simplified check using common identifier characters
-        if (first)
-        {
-            return char.IsLetter(codePoint) || codePoint == '_' || codePoint == '$';
-        }
+        // IdentifierStartChar is ID_Start plus "$" and "_"; IdentifierPartChar adds ID_Continue plus the
+        // zero-width non-joiner and the zero-width joiner
+        if (codePoint is '$' or '_')
+            return true;
 
-        return char.IsLetterOrDigit(codePoint) || codePoint == '_' || codePoint == '$';
+        var category = CharUnicodeInfo.GetUnicodeCategory(codePoint);
+        var isIdentifierStart = category
+            is UnicodeCategory.UppercaseLetter
+            or UnicodeCategory.LowercaseLetter
+            or UnicodeCategory.TitlecaseLetter
+            or UnicodeCategory.ModifierLetter
+            or UnicodeCategory.OtherLetter
+            or UnicodeCategory.LetterNumber
+            || IsOtherIdStart(codePoint);
+
+        if (first || isIdentifierStart)
+            return isIdentifierStart;
+
+        return category
+            is UnicodeCategory.NonSpacingMark
+            or UnicodeCategory.SpacingCombiningMark
+            or UnicodeCategory.DecimalDigitNumber
+            or UnicodeCategory.ConnectorPunctuation
+            || codePoint is 0x200C or 0x200D
+            || IsOtherIdContinue(codePoint);
     }
 
-    private static bool IsAscii(char codePoint) => codePoint <= 127;
+    /// <summary>The code points the Other_ID_Start property adds to the letter categories.</summary>
+    private static bool IsOtherIdStart(int codePoint)
+    {
+        return codePoint is 0x1885 or 0x1886 or 0x2118 or 0x212E or 0x309B or 0x309C;
+    }
+
+    /// <summary>The code points the Other_ID_Continue property adds to the mark and digit categories.</summary>
+    private static bool IsOtherIdContinue(int codePoint)
+    {
+        return codePoint is 0x00B7 or 0x0387 or 0x19DA or (>= 0x1369 and <= 0x1371);
+    }
+
+    private static bool IsAscii(int codePoint) => codePoint <= 127;
 }

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlCanonicalizer.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlCanonicalizer.cs
@@ -1,0 +1,516 @@
+using System.Buffers;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Meziantou.Framework.UrlPatternInternal;
+
+/// <summary>Rewrites a component value into the form a parsed URL would have.</summary>
+/// <remarks>
+/// <para>
+/// Every component of a pattern is canonicalized when the pattern is compiled, one fixed-text part at a
+/// time, and the values matched against it are canonicalized the same way. The two are only comparable
+/// because both sides go through these methods.
+/// </para>
+/// <para>
+/// The spec defines each of these in terms of the URL Standard's basic URL parser applied to a dummy
+/// "https://dummy.invalid/" record with a state override. Only the states that a component can reach are
+/// implemented here, which is why the dummy record does not appear.
+/// </para>
+/// <see href="https://urlpattern.spec.whatwg.org/#canon-encoding-callbacks">WHATWG URL Pattern Spec - Encoding callbacks</see>
+/// </remarks>
+internal static class UrlCanonicalizer
+{
+    // AllowUnassigned and UseStd3AsciiRules mirror the "domain to ASCII" parameters of the URL Standard,
+    // which runs Unicode ToASCII with UseSTD3ASCIIRules and VerifyDnsLength both false
+    private static readonly IdnMapping IdnMapping = new() { AllowUnassigned = true, UseStd3AsciiRules = false };
+    private static readonly SearchValues<char> TabsAndNewlines = SearchValues.Create("\t\n\r");
+
+    /// <summary>Canonicalizes a protocol.</summary>
+    /// <remarks>
+    /// The spec parses "&lt;value&gt;://dummy.invalid/" and returns the scheme of the result, which accepts
+    /// exactly the scheme grammar and lowercases it.
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-protocol">WHATWG URL Pattern Spec - Canonicalize a protocol</see>
+    /// </remarks>
+    public static string CanonicalizeProtocol(string value)
+    {
+        if (value.Length == 0)
+            return value;
+
+        // The basic URL parser is entered without a URL record, so it also trims the leading C0 controls and spaces
+        value = TrimLeadingC0ControlsAndSpaces(RemoveTabsAndNewlines(value));
+        if (value.Length == 0)
+            throw new UrlPatternException("A protocol cannot be empty");
+
+        if (!char.IsAsciiLetter(value[0]))
+            throw new UrlPatternException($"Invalid protocol: '{value}' must start with an ASCII letter");
+
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('+' or '-' or '.'))
+                throw new UrlPatternException($"Invalid protocol: '{value}' contains '{c}'");
+        }
+
+        return value.ToLowerInvariant();
+    }
+
+    /// <summary>Canonicalizes a username.</summary>
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-username">WHATWG URL Pattern Spec - Canonicalize a username</see>
+    /// </remarks>
+    public static string CanonicalizeUsername(string value)
+    {
+        // Setting the username of a URL record percent-encodes it, without going through the parser,
+        // so unlike the other components a tab or a newline is encoded rather than removed
+        return PercentEncoding.Encode(value, PercentEncodeSet.UserInfo);
+    }
+
+    /// <summary>Canonicalizes a password.</summary>
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-password">WHATWG URL Pattern Spec - Canonicalize a password</see>
+    /// </remarks>
+    public static string CanonicalizePassword(string value)
+    {
+        return PercentEncoding.Encode(value, PercentEncodeSet.UserInfo);
+    }
+
+    /// <summary>Canonicalizes a hostname.</summary>
+    /// <remarks>
+    /// <para>
+    /// The IPv4 normalization of the URL Standard (which rewrites "0x7f.1" as "127.0.0.1") is deliberately
+    /// not applied: the values a pattern is matched against come from a <see cref="Uri"/>, which does not
+    /// apply it either, so normalizing only the pattern would stop the two from lining up.
+    /// </para>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-hostname">WHATWG URL Pattern Spec - Canonicalize a hostname</see>
+    /// </remarks>
+    public static string CanonicalizeHostname(string value)
+    {
+        if (value.Length == 0)
+            return value;
+
+        value = RemoveTabsAndNewlines(value);
+        if (value.Length == 0)
+            return value;
+
+        // Hostname state stops at whatever would start the next component, and rejects a port
+        var insideBrackets = false;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c is '[')
+            {
+                insideBrackets = true;
+            }
+            else if (c is ']')
+            {
+                insideBrackets = false;
+            }
+            else if (c is ':' && !insideBrackets)
+            {
+                throw new UrlPatternException($"Invalid hostname: '{value}' contains a port");
+            }
+            else if (c is '/' or '?' or '#' or '\\')
+            {
+                value = value[..i];
+                break;
+            }
+        }
+
+        if (value.Length == 0)
+            return value;
+
+        if (value[0] is '[')
+            return CanonicalizeIPv6Hostname(value);
+
+        var domain = PercentEncoding.Decode(value);
+        var asciiDomain = DomainToAscii(domain);
+
+        foreach (var c in asciiDomain)
+        {
+            if (IsForbiddenDomainCodePoint(c))
+                throw new UrlPatternException($"Invalid hostname: '{value}' contains '{c}'");
+        }
+
+        return asciiDomain;
+    }
+
+    /// <summary>Canonicalizes an IPv6 hostname.</summary>
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-an-ipv6-hostname">WHATWG URL Pattern Spec - Canonicalize an IPv6 hostname</see>
+    /// </remarks>
+    public static string CanonicalizeIPv6Hostname(string value)
+    {
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiHexDigit(c) && c is not ('[' or ']' or ':'))
+                throw new UrlPatternException($"Invalid IPv6 hostname: '{value}' contains '{c}'");
+        }
+
+        return value.ToLowerInvariant();
+    }
+
+    /// <summary>Canonicalizes a port, dropping it when it is the default port of <paramref name="protocolValue"/>.</summary>
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-port">WHATWG URL Pattern Spec - Canonicalize a port</see>
+    /// </remarks>
+    public static string CanonicalizePort(string portValue, string? protocolValue = null)
+    {
+        if (portValue.Length == 0)
+            return portValue;
+
+        portValue = RemoveTabsAndNewlines(portValue);
+
+        // Port state stops at the first code point that is not an ASCII digit, because a state override
+        // was given, and keeps whatever digits it had read so far. It only fails when there were none
+        var digitCount = 0;
+        while (digitCount < portValue.Length && char.IsAsciiDigit(portValue[digitCount]))
+        {
+            digitCount++;
+        }
+
+        if (digitCount == 0)
+            throw new UrlPatternException($"Invalid port: '{portValue}' does not start with a digit");
+
+        if (!ushort.TryParse(portValue.AsSpan(0, digitCount), NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+            throw new UrlPatternException($"Invalid port: '{portValue}' is greater than {ushort.MaxValue}");
+
+        var serialized = port.ToString(CultureInfo.InvariantCulture);
+        if (protocolValue is not null &&
+            SpecialSchemes.TryGetDefaultPort(protocolValue, out var defaultPort) &&
+            serialized == defaultPort)
+        {
+            return "";
+        }
+
+        return serialized;
+    }
+
+    /// <summary>Canonicalizes the pathname of a URL with a special scheme.</summary>
+    /// <remarks>
+    /// <para>
+    /// The URL parser prepends a leading "/" to a path, which must not happen here because this runs on
+    /// each fixed-text part of a pattern rather than on the whole pathname: it would turn "/books/:id.json"
+    /// into "/books/:id/.json". The spec sidesteps it by prefixing "/-" and removing it from the result;
+    /// the "-" is there so that a value starting with "." is not read as a "/." segment and collapsed.
+    /// </para>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-pathname">WHATWG URL Pattern Spec - Canonicalize a pathname</see>
+    /// </remarks>
+    public static string CanonicalizePathname(string value)
+    {
+        if (value.Length == 0)
+            return value;
+
+        var leadingSlash = value[0] is '/';
+        var modifiedValue = RemoveTabsAndNewlines(leadingSlash ? value : "/-" + value);
+
+        var result = SerializePath(ParsePath(modifiedValue));
+
+        return leadingSlash ? result : result[2..];
+    }
+
+    /// <summary>Canonicalizes the pathname of a URL whose scheme is not a special scheme.</summary>
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-an-opaque-pathname">WHATWG URL Pattern Spec - Canonicalize an opaque pathname</see>
+    /// </remarks>
+    public static string CanonicalizeOpaquePathname(string value)
+    {
+        if (value.Length == 0)
+            return value;
+
+        value = RemoveTabsAndNewlines(value);
+
+        var builder = new StringBuilder(value.Length);
+        var index = 0;
+        while (index < value.Length)
+        {
+            var c = value[index];
+
+            // Opaque path state moves on to the query or the fragment, neither of which is part of the result
+            if (c is '?' or '#')
+                break;
+
+            if (c is ' ')
+            {
+                // A space is only encoded when it would otherwise end up trailing the path
+                var next = index + 1 < value.Length ? value[index + 1] : '\0';
+                builder.Append(next is '?' or '#' ? "%20" : " ");
+                index++;
+                continue;
+            }
+
+            index += AppendEncodedCodePoint(builder, value.AsSpan(index), PercentEncodeSet.C0Control);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Canonicalizes a search.</summary>
+    /// <remarks>
+    /// The dummy URL record has a special scheme, so the special-query percent-encode set applies and a
+    /// "'" is encoded as well.
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-search">WHATWG URL Pattern Spec - Canonicalize a search</see>
+    /// </remarks>
+    public static string CanonicalizeSearch(string value)
+    {
+        return PercentEncoding.Encode(RemoveTabsAndNewlines(value), PercentEncodeSet.SpecialQuery);
+    }
+
+    /// <summary>Canonicalizes a hash.</summary>
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#canon-a-hash">WHATWG URL Pattern Spec - Canonicalize a hash</see>
+    /// </remarks>
+    public static string CanonicalizeHash(string value)
+    {
+        return PercentEncoding.Encode(RemoveTabsAndNewlines(value), PercentEncodeSet.Fragment);
+    }
+
+    /// <summary>The code points the basic URL parser removes from its input before doing anything else.</summary>
+    private static string RemoveTabsAndNewlines(string value)
+    {
+        if (value.AsSpan().IndexOfAny(TabsAndNewlines) < 0)
+            return value;
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            if (c is not ('\t' or '\n' or '\r'))
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Serializes an IPv6 address the way the URL Standard does.</summary>
+    /// <remarks>
+    /// <see cref="Uri"/> writes the last two pieces of an address such as "::ab:1" in the dotted-decimal
+    /// form ("::0.171.0.1"), which the URL Standard never does, so a host read from a <see cref="Uri"/>
+    /// has to be written out again to be comparable with a pattern.
+    /// <see href="https://url.spec.whatwg.org/#concept-ipv6-serializer">URL Standard - IPv6 serializer</see>
+    /// </remarks>
+    public static string SerializeIPv6Hostname(string value)
+    {
+        var address = value.AsSpan().Trim(['[', ']']);
+        if (!IPAddress.TryParse(address, out var parsed) || parsed.AddressFamily is not AddressFamily.InterNetworkV6)
+            return value.ToLowerInvariant();
+
+        Span<byte> bytes = stackalloc byte[16];
+        if (!parsed.TryWriteBytes(bytes, out _))
+            return value.ToLowerInvariant();
+
+        Span<ushort> pieces = stackalloc ushort[8];
+        for (var i = 0; i < pieces.Length; i++)
+        {
+            pieces[i] = (ushort)((bytes[i * 2] << 8) | bytes[(i * 2) + 1]);
+        }
+
+        // The longest run of zero pieces is replaced by "::", but only when it covers more than one piece
+        var compress = -1;
+        var compressLength = 1;
+        for (var i = 0; i < pieces.Length; i++)
+        {
+            if (pieces[i] is not 0)
+                continue;
+
+            var length = 0;
+            while (i + length < pieces.Length && pieces[i + length] is 0)
+            {
+                length++;
+            }
+
+            if (length > compressLength)
+            {
+                compress = i;
+                compressLength = length;
+            }
+
+            i += length - 1;
+        }
+
+        var builder = new StringBuilder(41).Append('[');
+        var ignoreZeroes = false;
+        for (var i = 0; i < pieces.Length; i++)
+        {
+            if (ignoreZeroes)
+            {
+                if (pieces[i] is 0)
+                    continue;
+
+                ignoreZeroes = false;
+            }
+
+            if (i == compress)
+            {
+                builder.Append(i is 0 ? "::" : ":");
+                ignoreZeroes = true;
+                continue;
+            }
+
+            builder.Append(pieces[i].ToString("x", CultureInfo.InvariantCulture));
+            if (i is not 7)
+            {
+                builder.Append(':');
+            }
+        }
+
+        return builder.Append(']').ToString();
+    }
+
+    /// <summary>Removes the leading C0 controls and spaces, as the basic URL parser does when no URL record is given.</summary>
+    private static string TrimLeadingC0ControlsAndSpaces(string value)
+    {
+        var index = 0;
+        while (index < value.Length && value[index] <= ' ')
+        {
+            index++;
+        }
+
+        return value[index..];
+    }
+
+    /// <summary>Runs the path start state followed by the path state, for a URL with a special scheme.</summary>
+    /// <remarks>
+    /// <see href="https://url.spec.whatwg.org/#path-state">URL Standard - Path state</see>
+    /// </remarks>
+    private static List<string> ParsePath(string input)
+    {
+        var path = new List<string>();
+        var buffer = new StringBuilder();
+        var index = 0;
+
+        // Path start state: the separator that opens the path is consumed here rather than by the path state
+        if (index < input.Length && input[index] is '/' or '\\')
+        {
+            index++;
+        }
+
+        while (true)
+        {
+            if (index >= input.Length)
+            {
+                FlushSegment(path, buffer, atSegmentSeparator: false);
+                break;
+            }
+
+            // A backslash separates segments too, because the dummy URL record has a special scheme
+            if (input[index] is '/' or '\\')
+            {
+                FlushSegment(path, buffer, atSegmentSeparator: true);
+                index++;
+                continue;
+            }
+
+            index += AppendEncodedCodePoint(buffer, input.AsSpan(index), PercentEncodeSet.Path);
+        }
+
+        return path;
+    }
+
+    private static void FlushSegment(List<string> path, StringBuilder buffer, bool atSegmentSeparator)
+    {
+        var segment = buffer.ToString();
+        buffer.Clear();
+
+        if (IsDoubleDotSegment(segment))
+        {
+            if (path.Count > 0)
+            {
+                path.RemoveAt(path.Count - 1);
+            }
+
+            // "/a/.." keeps a trailing empty segment so that it serializes as "/" rather than as nothing
+            if (!atSegmentSeparator)
+            {
+                path.Add("");
+            }
+        }
+        else if (IsSingleDotSegment(segment))
+        {
+            if (!atSegmentSeparator)
+            {
+                path.Add("");
+            }
+        }
+        else
+        {
+            path.Add(segment);
+        }
+    }
+
+    private static string SerializePath(List<string> path)
+    {
+        var builder = new StringBuilder();
+        foreach (var segment in path)
+        {
+            builder.Append('/').Append(segment);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsSingleDotSegment(string segment)
+    {
+        return segment is "." || segment.Equals("%2e", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDoubleDotSegment(string segment)
+    {
+        return segment is ".." ||
+            segment.Equals(".%2e", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("%2e.", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("%2e%2e", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Percent-encodes the code point at the start of <paramref name="value"/> and returns how many chars it spanned.</summary>
+    private static int AppendEncodedCodePoint(StringBuilder builder, ReadOnlySpan<char> value, PercentEncodeSet set)
+    {
+        // An unpaired surrogate decodes to U+FFFD, which is how a DOMString becomes a USVString
+        Rune.DecodeFromUtf16(value, out var rune, out var consumed);
+        PercentEncoding.EncodeCodePoint(builder, rune, set);
+
+        return consumed;
+    }
+
+    /// <summary>Runs the "domain to ASCII" operation of the URL Standard.</summary>
+    /// <remarks>
+    /// Unicode ToASCII is defined label by label, so an empty label (which a fixed-text part such as "."
+    /// consists of) has to stay empty instead of failing.
+    /// <see href="https://url.spec.whatwg.org/#concept-domain-to-ascii">URL Standard - Domain to ASCII</see>
+    /// </remarks>
+    private static string DomainToAscii(string domain)
+    {
+        if (Ascii.IsValid(domain))
+            return domain.ToLowerInvariant();
+
+        var labels = domain.Split('.');
+        for (var i = 0; i < labels.Length; i++)
+        {
+            if (Ascii.IsValid(labels[i]))
+            {
+                labels[i] = labels[i].ToLowerInvariant();
+                continue;
+            }
+
+            try
+            {
+                labels[i] = IdnMapping.GetAscii(labels[i]);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new UrlPatternException($"Invalid hostname: '{domain}'", ex);
+            }
+        }
+
+        return string.Join('.', labels);
+    }
+
+    /// <remarks>
+    /// <see href="https://url.spec.whatwg.org/#forbidden-domain-code-point">URL Standard - Forbidden domain code point</see>
+    /// </remarks>
+    private static bool IsForbiddenDomainCodePoint(char c)
+    {
+        // Forbidden host code points, plus the C0 controls, '%' and U+007F DELETE
+        return c <= 0x20 ||
+            c is '#' or '%' or '/' or ':' or '<' or '>' or '?' or '@' or '[' or '\\' or ']' or '^' or '|' or (char)0x7F;
+    }
+}

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlCanonicalizer.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlCanonicalizer.cs
@@ -485,15 +485,19 @@ internal static class UrlCanonicalizer
         var labels = domain.Split('.');
         for (var i = 0; i < labels.Length; i++)
         {
-            if (Ascii.IsValid(labels[i]))
+            // ToASCII maps a label to lower case before it encodes it. IdnMapping only does so when ICU is
+            // available, so in globalization-invariant mode "CAFÉ" would encode as "xn--caf-pia" instead of
+            // "xn--caf-dma" and stop matching the host a Uri reports. Mapping it here covers both modes
+            var label = labels[i].ToLowerInvariant();
+            if (Ascii.IsValid(label))
             {
-                labels[i] = labels[i].ToLowerInvariant();
+                labels[i] = label;
                 continue;
             }
 
             try
             {
-                labels[i] = IdnMapping.GetAscii(labels[i]);
+                labels[i] = IdnMapping.GetAscii(label);
             }
             catch (ArgumentException ex)
             {

--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -211,12 +211,8 @@ public sealed class UrlPattern
         processedInit.Search ??= "*";
         processedInit.Hash ??= "*";
 
-        // Normalize the port before comparing it to the default port, so that "0443" collapses like "443"
-        processedInit.Port = CanonicalizePort(processedInit.Port);
-
-        // If protocol is a special scheme and port matches its default port, set port to empty string
-        if (SpecialSchemes.Contains(processedInit.Protocol) &&
-            SpecialSchemes.TryGetDefaultPort(processedInit.Protocol, out var defaultPort) &&
+        // A pattern is not canonicalized as a whole, so the port is compared to the default port as written
+        if (SpecialSchemes.TryGetDefaultPort(processedInit.Protocol, out var defaultPort) &&
             processedInit.Port == defaultPort)
         {
             processedInit.Port = "";
@@ -224,37 +220,37 @@ public sealed class UrlPattern
 
         var ignoreCase = options.IgnoreCase;
 
-        // Compile components
-        var protocolComponent = UrlPatternComponent.Compile(processedInit.Protocol, CanonicalizeProtocol, PatternOptions.Default);
-        var usernameComponent = UrlPatternComponent.Compile(processedInit.Username, CanonicalizeUsername, PatternOptions.Default);
-        var passwordComponent = UrlPatternComponent.Compile(processedInit.Password, CanonicalizePassword, PatternOptions.Default);
+        // Compile components. Each callback canonicalizes the fixed-text parts of the pattern, so that the
+        // pattern and the values it is matched against are in the same form
+        var protocolComponent = UrlPatternComponent.Compile(processedInit.Protocol, UrlCanonicalizer.CanonicalizeProtocol, PatternOptions.Default);
+        var usernameComponent = UrlPatternComponent.Compile(processedInit.Username, UrlCanonicalizer.CanonicalizeUsername, PatternOptions.Default);
+        var passwordComponent = UrlPatternComponent.Compile(processedInit.Password, UrlCanonicalizer.CanonicalizePassword, PatternOptions.Default);
 
         UrlPatternComponent hostnameComponent;
         if (IsIPv6Hostname(processedInit.Hostname))
         {
-            hostnameComponent = UrlPatternComponent.Compile(processedInit.Hostname, CanonicalizeIPv6Hostname, PatternOptions.Hostname);
+            hostnameComponent = UrlPatternComponent.Compile(processedInit.Hostname, UrlCanonicalizer.CanonicalizeIPv6Hostname, PatternOptions.Hostname);
         }
         else
         {
-            hostnameComponent = UrlPatternComponent.Compile(processedInit.Hostname, CanonicalizeHostname, PatternOptions.Hostname);
+            hostnameComponent = UrlPatternComponent.Compile(processedInit.Hostname, UrlCanonicalizer.CanonicalizeHostname, PatternOptions.Hostname);
         }
 
-        var portComponent = UrlPatternComponent.Compile(processedInit.Port, CanonicalizePort, PatternOptions.Default);
+        // The single-argument overload leaves the dummy URL record without a scheme, so a value that happens
+        // to be a default port is kept rather than dropped
+        var portComponent = UrlPatternComponent.Compile(processedInit.Port, value => UrlCanonicalizer.CanonicalizePort(value), PatternOptions.Default);
 
         var compileOptions = PatternOptions.Default.WithIgnoreCase(ignoreCase);
         var pathCompileOptions = PatternOptions.Pathname.WithIgnoreCase(ignoreCase);
 
-        // The spec canonicalizes a pathname by percent-encoding it, which this implementation does not do,
-        // so the pathname is matched as written and needs no encoding callback. It must not gain a leading
-        // "/" here: the callback runs on every fixed-text part, so that would insert a separator in front of
-        // any literal following a group, turning "/books/:id.json" into "/books/:id/.json". The spec avoids
-        // the same trap by prefixing "/-" before parsing and stripping it afterwards. Only the compile
-        // options differ between an opaque path and a special-scheme path.
-        var pathnameOptions = ProtocolMatchesSpecialScheme(protocolComponent) ? pathCompileOptions : compileOptions;
-        var pathnameComponent = UrlPatternComponent.Compile(processedInit.Pathname, encodingCallback: null, pathnameOptions);
+        // A pathname is canonicalized differently, and matched with different options, depending on whether
+        // the protocol can be a special scheme: only a special scheme has a "/"-separated path
+        var pathnameComponent = ProtocolMatchesSpecialScheme(protocolComponent)
+            ? UrlPatternComponent.Compile(processedInit.Pathname, UrlCanonicalizer.CanonicalizePathname, pathCompileOptions)
+            : UrlPatternComponent.Compile(processedInit.Pathname, UrlCanonicalizer.CanonicalizeOpaquePathname, compileOptions);
 
-        var searchComponent = UrlPatternComponent.Compile(processedInit.Search, CanonicalizeSearch, compileOptions);
-        var hashComponent = UrlPatternComponent.Compile(processedInit.Hash, CanonicalizeHash, compileOptions);
+        var searchComponent = UrlPatternComponent.Compile(processedInit.Search, UrlCanonicalizer.CanonicalizeSearch, compileOptions);
+        var hashComponent = UrlPatternComponent.Compile(processedInit.Hash, UrlCanonicalizer.CanonicalizeHash, compileOptions);
 
         return new UrlPattern(
             protocolComponent,
@@ -311,8 +307,7 @@ public sealed class UrlPattern
     public bool IsMatch(UrlPatternInit input)
     {
         ArgumentNullException.ThrowIfNull(input);
-        var processed = ProcessUrlPatternInit(input, isPattern: false);
-        return IsMatchInit(processed);
+        return IsMatchInit(input);
     }
 
     /// <summary>Searches the specified URL for the first occurrence of the pattern and returns the match result with captured groups.</summary>
@@ -359,8 +354,7 @@ public sealed class UrlPattern
     public UrlPatternResult? Match(UrlPatternInit input)
     {
         ArgumentNullException.ThrowIfNull(input);
-        var processed = ProcessUrlPatternInit(input, isPattern: false);
-        return MatchInit(processed);
+        return MatchInit(input);
     }
 
     private UrlPatternResult? MatchUrl(Uri url, string originalInput)
@@ -371,49 +365,77 @@ public sealed class UrlPattern
     }
 
     /// <summary>Splits the URL into the eight component values that are matched against the pattern.</summary>
+    /// <remarks>
+    /// <para>
+    /// The components are taken in their least-escaped form and canonicalized again, because
+    /// <see cref="Uri"/> escapes a few code points that the URL Standard leaves alone ("^" and "|") and
+    /// leaves alone one that it escapes ("'" in a query). Running both sides of a match through
+    /// <see cref="UrlCanonicalizer"/> is what makes them comparable.
+    /// </para>
+    /// <para>
+    /// What remains of <see cref="Uri"/>'s own normalization is that it decodes the escape of an unreserved
+    /// code point, so "/%41" arrives as "/A" where the URL Standard would have kept "/%41".
+    /// </para>
+    /// </remarks>
     private static (string Protocol, string Username, string Password, string Hostname, string Port, string Pathname, string Search, string Hash) GetUrlComponents(Uri url)
     {
-        var userInfo = url.UserInfo;
+        // An escaped ":" stays escaped in this form, so the first one is always the separator
+        var userInfo = url.GetComponents(UriComponents.UserInfo, UriFormat.SafeUnescaped);
         var separatorIndex = userInfo.IndexOf(':', StringComparison.Ordinal);
         var username = separatorIndex == -1 ? userInfo : userInfo[..separatorIndex];
         var password = separatorIndex == -1 ? "" : userInfo[(separatorIndex + 1)..];
 
+        // IdnHost is the ASCII form the URL Standard serializes, but it drops the brackets of an IPv6 host
+        var hostname = url.Host.StartsWith('[', StringComparison.Ordinal)
+            ? UrlCanonicalizer.SerializeIPv6Hostname(url.Host)
+            : url.IdnHost;
+
+        var pathname = url.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
+        if (SpecialSchemes.Contains(url.Scheme))
+        {
+            // The path component is reported without its leading separator
+            pathname = UrlCanonicalizer.CanonicalizePathname("/" + pathname);
+        }
+        else
+        {
+            pathname = UrlCanonicalizer.CanonicalizeOpaquePathname(pathname);
+        }
+
         return (
-            url.Scheme,
-            Uri.UnescapeDataString(username),
-            Uri.UnescapeDataString(password),
-            url.Host,
+            UrlCanonicalizer.CanonicalizeProtocol(url.Scheme),
+            UrlCanonicalizer.CanonicalizeUsername(username),
+            UrlCanonicalizer.CanonicalizePassword(password),
+            UrlCanonicalizer.CanonicalizeHostname(hostname),
             url.IsDefaultPort ? "" : url.Port.ToString(CultureInfo.InvariantCulture),
-            url.AbsolutePath,
-            url.Query.TrimStart('?'),
-            url.Fragment.TrimStart('#'));
+            pathname,
+            UrlCanonicalizer.CanonicalizeSearch(url.GetComponents(UriComponents.Query, UriFormat.SafeUnescaped)),
+            UrlCanonicalizer.CanonicalizeHash(url.GetComponents(UriComponents.Fragment, UriFormat.SafeUnescaped)));
     }
 
     private UrlPatternResult? MatchInit(UrlPatternInit init)
     {
-        var (protocol, username, password, hostname, port, pathname, search, hash) = CanonicalizeInitComponents(init);
+        UrlPatternInit processed;
+        try
+        {
+            processed = ProcessUrlPatternInit(init, isPattern: false);
+        }
+        catch (UrlPatternException)
+        {
+            // A component that cannot be canonicalized cannot match anything
+            return null;
+        }
 
-        return MatchComponents(protocol, username, password, hostname, port, pathname, search, hash, originalInput: null, originalInit: init);
-    }
-
-    /// <summary>Canonicalizes the components of an init used as a match input.</summary>
-    /// <remarks>
-    /// The pattern is canonicalized when it is compiled, so an init used as an input has to be
-    /// canonicalized the same way for the two to be comparable. A <see cref="Uri"/> input already
-    /// arrives canonical, which is why <see cref="MatchUrl"/> does not go through this.
-    /// <see href="https://urlpattern.spec.whatwg.org/#canon-processing-for-init">WHATWG URL Pattern Spec - URLPatternInit processing</see>
-    /// </remarks>
-    private static (string Protocol, string Username, string Password, string Hostname, string Port, string Pathname, string Search, string Hash) CanonicalizeInitComponents(UrlPatternInit init)
-    {
-        return (
-            CanonicalizeProtocol(init.Protocol ?? ""),
-            init.Username ?? "",
-            init.Password ?? "",
-            CanonicalizeHostname(init.Hostname ?? ""),
-            init.Port ?? "",
-            init.Pathname ?? "",
-            CanonicalizeSearch(init.Search ?? ""),
-            CanonicalizeHash(init.Hash ?? ""));
+        return MatchComponents(
+            processed.Protocol ?? "",
+            processed.Username ?? "",
+            processed.Password ?? "",
+            processed.Hostname ?? "",
+            processed.Port ?? "",
+            processed.Pathname ?? "",
+            processed.Search ?? "",
+            processed.Hash ?? "",
+            originalInput: null,
+            originalInit: init);
     }
 
     private UrlPatternResult? MatchComponents(string protocol, string username, string password, string hostname, string port, string pathname, string search, string hash, string? originalInput, UrlPatternInit? originalInit = null)
@@ -511,9 +533,26 @@ public sealed class UrlPattern
 
     private bool IsMatchInit(UrlPatternInit init)
     {
-        var (protocol, username, password, hostname, port, pathname, search, hash) = CanonicalizeInitComponents(init);
+        UrlPatternInit processed;
+        try
+        {
+            processed = ProcessUrlPatternInit(init, isPattern: false);
+        }
+        catch (UrlPatternException)
+        {
+            // A component that cannot be canonicalized cannot match anything
+            return false;
+        }
 
-        return IsMatchComponents(protocol, username, password, hostname, port, pathname, search, hash);
+        return IsMatchComponents(
+            processed.Protocol ?? "",
+            processed.Username ?? "",
+            processed.Password ?? "",
+            processed.Hostname ?? "",
+            processed.Port ?? "",
+            processed.Pathname ?? "",
+            processed.Search ?? "",
+            processed.Hash ?? "");
     }
 
     private bool IsMatchComponents(string protocol, string username, string password, string hostname, string port, string pathname, string search, string hash)
@@ -580,24 +619,22 @@ public sealed class UrlPattern
     /// </remarks>
     private static UrlPatternInit ProcessUrlPatternInit(UrlPatternInit init, bool isPattern)
     {
-        var result = new UrlPatternInit
-        {
-            Protocol = init.Protocol,
-            Username = init.Username,
-            Password = init.Password,
-            Hostname = init.Hostname,
-            Port = init.Port,
-            Pathname = init.Pathname,
-            Search = init.Search,
-            Hash = init.Hash,
-        };
+        // A component the init does not specify stays null for a pattern, so that it can be defaulted to a
+        // wildcard, and is the empty string for a match input
+        var result = isPattern
+            ? new UrlPatternInit()
+            : new UrlPatternInit { Protocol = "", Username = "", Password = "", Hostname = "", Port = "", Pathname = "", Search = "", Hash = "" };
 
-        if (!string.IsNullOrEmpty(init.BaseUrl))
+        string? basePathname = null;
+        if (init.BaseUrl is not null)
         {
             if (!Uri.TryCreate(init.BaseUrl, UriKind.Absolute, out var baseUri))
             {
                 throw new UrlPatternException($"Invalid base URL: {init.BaseUrl}");
             }
+
+            var baseComponents = GetUrlComponents(baseUri);
+            basePathname = baseComponents.Pathname;
 
             // A component is inherited only when the init specifies nothing at least as specific as it,
             // following the two orders of the spec:
@@ -612,62 +649,133 @@ public sealed class UrlPattern
 
             if (!hasProtocol)
             {
-                result.Protocol = ProcessBaseUrlString(baseUri.Scheme, isPattern);
+                result.Protocol = ProcessBaseUrlString(baseComponents.Protocol, isPattern);
             }
 
             // The username and password are never inherited when building a pattern
-            if (!isPattern && !hasPort)
+            if (!isPattern && !hasPort && init.Username is null)
             {
-                var userInfo = baseUri.UserInfo;
-                var separatorIndex = userInfo.IndexOf(':', StringComparison.Ordinal);
-                if (init.Username is null)
-                {
-                    result.Username = separatorIndex == -1 ? userInfo : userInfo[..separatorIndex];
+                result.Username = baseComponents.Username;
 
-                    if (init.Password is null)
-                    {
-                        result.Password = separatorIndex == -1 ? "" : userInfo[(separatorIndex + 1)..];
-                    }
+                if (init.Password is null)
+                {
+                    result.Password = baseComponents.Password;
                 }
             }
 
             if (!hasHostname)
             {
-                result.Hostname = ProcessBaseUrlString(baseUri.Host, isPattern);
+                result.Hostname = ProcessBaseUrlString(baseComponents.Hostname, isPattern);
             }
 
             if (!hasPort)
             {
-                result.Port = baseUri.IsDefaultPort ? "" : baseUri.Port.ToString(CultureInfo.InvariantCulture);
+                result.Port = baseComponents.Port;
             }
 
             if (!hasPathname)
             {
-                result.Pathname = ProcessBaseUrlString(baseUri.AbsolutePath, isPattern);
-            }
-            else if (result.Pathname is not null && !IsAbsolutePathname(result.Pathname, isPattern))
-            {
-                // Resolve a relative pathname against the directory of the base URL
-                var basePath = ProcessBaseUrlString(baseUri.AbsolutePath, isPattern);
-                var slashIndex = basePath.LastIndexOf('/', StringComparison.Ordinal);
-                if (slashIndex >= 0)
-                {
-                    result.Pathname = basePath[..(slashIndex + 1)] + result.Pathname;
-                }
+                result.Pathname = ProcessBaseUrlString(basePathname, isPattern);
             }
 
             if (!hasSearch)
             {
-                result.Search = ProcessBaseUrlString(baseUri.Query.TrimStart('?'), isPattern);
+                result.Search = ProcessBaseUrlString(baseComponents.Search, isPattern);
             }
 
             if (!hasHash)
             {
-                result.Hash = ProcessBaseUrlString(baseUri.Fragment.TrimStart('#'), isPattern);
+                result.Hash = ProcessBaseUrlString(baseComponents.Hash, isPattern);
             }
         }
 
+        // Each component the init does specify replaces what the base URL supplied, canonicalized unless a
+        // pattern is being built: a pattern is canonicalized one fixed-text part at a time when it compiles
+        if (init.Protocol is not null)
+        {
+            result.Protocol = ProcessProtocolForInit(init.Protocol, isPattern);
+        }
+
+        if (init.Username is not null)
+        {
+            result.Username = isPattern ? init.Username : UrlCanonicalizer.CanonicalizeUsername(init.Username);
+        }
+
+        if (init.Password is not null)
+        {
+            result.Password = isPattern ? init.Password : UrlCanonicalizer.CanonicalizePassword(init.Password);
+        }
+
+        if (init.Hostname is not null)
+        {
+            result.Hostname = isPattern ? init.Hostname : UrlCanonicalizer.CanonicalizeHostname(init.Hostname);
+        }
+
+        // The protocol decides both the default port and the shape of the pathname, so it has to be the
+        // value the init ended up with rather than the one it came in with
+        var resultProtocol = result.Protocol ?? "";
+
+        if (init.Port is not null)
+        {
+            result.Port = isPattern ? init.Port : UrlCanonicalizer.CanonicalizePort(init.Port, resultProtocol);
+        }
+
+        if (init.Pathname is not null)
+        {
+            var pathname = init.Pathname;
+
+            // Resolve a relative pathname against the directory of the base URL
+            if (basePathname is not null && !IsAbsolutePathname(pathname, isPattern))
+            {
+                var basePath = ProcessBaseUrlString(basePathname, isPattern);
+                var slashIndex = basePath.LastIndexOf('/', StringComparison.Ordinal);
+                if (slashIndex >= 0)
+                {
+                    pathname = basePath[..(slashIndex + 1)] + pathname;
+                }
+            }
+
+            result.Pathname = ProcessPathnameForInit(pathname, resultProtocol, isPattern);
+        }
+
+        if (init.Search is not null)
+        {
+            var strippedValue = init.Search.StartsWith('?', StringComparison.Ordinal) ? init.Search[1..] : init.Search;
+            result.Search = isPattern ? strippedValue : UrlCanonicalizer.CanonicalizeSearch(strippedValue);
+        }
+
+        if (init.Hash is not null)
+        {
+            var strippedValue = init.Hash.StartsWith('#', StringComparison.Ordinal) ? init.Hash[1..] : init.Hash;
+            result.Hash = isPattern ? strippedValue : UrlCanonicalizer.CanonicalizeHash(strippedValue);
+        }
+
         return result;
+    }
+
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#process-protocol-for-init">WHATWG URL Pattern Spec - Process protocol for init</see>
+    /// </remarks>
+    private static string ProcessProtocolForInit(string value, bool isPattern)
+    {
+        var strippedValue = value.EndsWith(':', StringComparison.Ordinal) ? value[..^1] : value;
+
+        return isPattern ? strippedValue : UrlCanonicalizer.CanonicalizeProtocol(strippedValue);
+    }
+
+    /// <remarks>
+    /// <see href="https://urlpattern.spec.whatwg.org/#process-pathname-for-init">WHATWG URL Pattern Spec - Process pathname for init</see>
+    /// </remarks>
+    private static string ProcessPathnameForInit(string value, string protocolValue, bool isPattern)
+    {
+        if (isPattern)
+            return value;
+
+        // An init that says nothing about the protocol is treated as a special scheme, which is the more
+        // common of the two canonicalizations
+        return protocolValue.Length == 0 || SpecialSchemes.Contains(protocolValue)
+            ? UrlCanonicalizer.CanonicalizePathname(value)
+            : UrlCanonicalizer.CanonicalizeOpaquePathname(value);
     }
 
     /// <summary>Prepares a value taken from the base URL for use as a component value.</summary>
@@ -729,86 +837,5 @@ public sealed class UrlPattern
         }
 
         return false;
-    }
-
-    // Canonicalization callbacks
-    // https://urlpattern.spec.whatwg.org/#canon-encoding-callbacks
-    private static string CanonicalizeProtocol(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return value;
-
-        // Remove trailing colon if present
-        if (value.EndsWith(':', StringComparison.Ordinal))
-        {
-            value = value[..^1];
-        }
-
-        return value.ToLowerInvariant();
-    }
-
-    private static string CanonicalizeUsername(string value)
-    {
-        return Uri.EscapeDataString(value);
-    }
-
-    private static string CanonicalizePassword(string value)
-    {
-        return Uri.EscapeDataString(value);
-    }
-
-    private static string CanonicalizeHostname(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return value;
-
-        return value.ToLowerInvariant();
-    }
-
-    private static string CanonicalizeIPv6Hostname(string value)
-    {
-        // IPv6 hostnames are already in a canonical form
-        return value.ToLowerInvariant();
-    }
-
-    private static string CanonicalizePort(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return value;
-
-        // Anything that is not a plain number is a pattern ("*", ":p", "80{80}?") and is matched as written
-        foreach (var c in value)
-        {
-            if (!char.IsAsciiDigit(c))
-                return value;
-        }
-
-        // "0443" and "443" are the same port
-        if (!ushort.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var port))
-            return value;
-
-        return port.ToString(CultureInfo.InvariantCulture);
-    }
-
-    private static string CanonicalizeSearch(string value)
-    {
-        // Remove leading ? if present
-        if (!string.IsNullOrEmpty(value) && value[0] == '?')
-        {
-            return value[1..];
-        }
-
-        return value;
-    }
-
-    private static string CanonicalizeHash(string value)
-    {
-        // Remove leading # if present
-        if (!string.IsNullOrEmpty(value) && value[0] == '#')
-        {
-            return value[1..];
-        }
-
-        return value;
     }
 }

--- a/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
+++ b/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
@@ -13,6 +13,10 @@
     <EmbeddedResource Include="files/public_suffix_tests.txt">
       <LogicalName>%(FileName)%(Extension)</LogicalName>
     </EmbeddedResource>
+    <None Remove="files/urlpatterntestdata.json" />
+    <EmbeddedResource Include="files/urlpatterntestdata.json">
+      <LogicalName>%(FileName)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -704,7 +704,8 @@ public sealed class UrlPatternTests
     [InlineData("https://john@example.com/path", "john", "")]
     [InlineData("https://john:secret@example.com/path", "john", "secret")]
     [InlineData("https://:secret@example.com/path", "", "secret")]
-    [InlineData("https://john:pa:ss@example.com/path", "john", "pa:ss")]
+    // Only the first ":" separates the two; the rest belongs to the password, where it is percent-encoded
+    [InlineData("https://john:pa:ss@example.com/path", "john", "pa%3Ass")]
     public void Match_SplitsTheUserInfoIntoUsernameAndPassword(string url, string expectedUsername, string expectedPassword)
     {
         var result = UrlPattern.Create(new UrlPatternInit()).Match(url);
@@ -1455,41 +1456,42 @@ public sealed class UrlPatternTests
     }
 
     [Fact]
-    public void IsMatch_ComponentWithATrailingNewLine_ShouldNotMatch()
+    public void IsMatch_ComponentWithANewLine_IgnoresIt()
     {
-        Assert.False(UrlPattern.Create(new UrlPatternInit { Pathname = "/admin" })
+        // The basic URL parser removes every tab and newline from its input before it does anything else,
+        // so canonicalizing a component drops them on both sides of a match
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Pathname = "/admin" })
             .IsMatch(new UrlPatternInit { Pathname = "/admin\n" }));
 
-        Assert.False(UrlPattern.Create(new UrlPatternInit { Hostname = "example.com" })
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Pathname = "/admin" })
+            .IsMatch(new UrlPatternInit { Pathname = "\n/admin" }));
+
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Hostname = "example.com" })
             .IsMatch(new UrlPatternInit { Hostname = "example.com\n" }));
 
-        Assert.False(UrlPattern.Create(new UrlPatternInit { Protocol = "https" })
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Protocol = "https" })
             .IsMatch(new UrlPatternInit { Protocol = "https\n" }));
 
-        Assert.False(UrlPattern.Create(new UrlPatternInit { Search = "a=1" })
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Search = "a=1" })
             .IsMatch(new UrlPatternInit { Search = "a=1\n" }));
 
-        Assert.False(UrlPattern.Create(new UrlPatternInit { Hash = "top" })
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Hash = "top" })
             .IsMatch(new UrlPatternInit { Hash = "top\n" }));
+
+        // A username is percent-encoded rather than parsed, so a newline survives as an escape
+        Assert.False(UrlPattern.Create(new UrlPatternInit { Username = "john" })
+            .IsMatch(new UrlPatternInit { Username = "john\n" }));
     }
 
     [Fact]
-    public void IsMatch_TrailingNewLineAfterAGroupsFixedSuffix_ShouldNotMatch()
+    public void IsMatch_TrailingContentAfterAGroupsFixedSuffix_ShouldNotMatch()
     {
-        // The group itself is "[^/]+?", which matches "123\n" in JavaScript too, so the
-        // newline has to be rejected by the trailing literal rather than by the group.
+        // The group itself is "[^/]+?", which matches "123x" in JavaScript too, so the trailing text
+        // has to be rejected by the literal that follows the group rather than by the group.
         var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/books/:id/edit" });
 
         Assert.True(pattern.IsMatch(new UrlPatternInit { Pathname = "/books/123/edit" }));
-        Assert.False(pattern.IsMatch(new UrlPatternInit { Pathname = "/books/123/edit\n" }));
-    }
-
-    [Fact]
-    public void IsMatch_ComponentWithALeadingNewLine_ShouldNotMatch()
-    {
-        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/admin" });
-
-        Assert.False(pattern.IsMatch(new UrlPatternInit { Pathname = "\n/admin" }));
+        Assert.False(pattern.IsMatch(new UrlPatternInit { Pathname = "/books/123/edit/x" }));
     }
 
     [Theory]
@@ -1548,12 +1550,15 @@ public sealed class UrlPatternTests
     }
 
     [Fact]
-    public void Create_PortWithLeadingZeros_CollapsesLikeTheDefaultPort()
+    public void Create_PortWithLeadingZeros_DoesNotCollapseLikeTheDefaultPort()
     {
+        // A pattern is only stripped of a default port when it is written exactly as the default port is,
+        // because the comparison happens before the port component is compiled and canonicalized
         var pattern = UrlPattern.Create(new UrlPatternInit { Protocol = "https", Port = "0443" });
 
-        Assert.Equal("", pattern.Port);
-        Assert.True(pattern.IsMatch("https://example.com/"));
+        Assert.Equal("443", pattern.Port);
+        Assert.False(pattern.IsMatch("https://example.com/"));
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Protocol = "https", Port = "443" }).IsMatch("https://example.com/"));
     }
 
     [Theory]
@@ -1578,12 +1583,316 @@ public sealed class UrlPatternTests
 
     [Theory]
     [InlineData("*")]
-    [InlineData("99999")]
     [InlineData(":p")]
     public void Create_PortThatIsNotAPlainNumber_IsMatchedAsWritten(string port)
     {
+        // These are pattern syntax rather than fixed text, so the encoding callback never sees them
         var pattern = UrlPattern.Create(new UrlPatternInit { Port = port });
 
         Assert.Equal(port, pattern.Port);
+    }
+
+    // Canonicalization
+    // https://urlpattern.spec.whatwg.org/#canon-encoding-callbacks
+
+    [Theory]
+    // The path percent-encode set: C0 controls, anything above "~", and " \" # < > ? ` { }
+    [InlineData("/foo bar", "/foo%20bar")]
+    [InlineData("/café", "/caf%C3%A9")]
+    [InlineData("/\U0001F600", "/%F0%9F%98%80")]
+    [InlineData("/a\"b", "/a%22b")]
+    [InlineData("/a<b>c", "/a%3Cb%3Ec")]
+    [InlineData("/a\\`b", "/a%60b")]
+    [InlineData("/a\\?b", "/a%3Fb")]
+    [InlineData("/a\\#b", "/a%23b")]
+    // "^" and "|" are not in the set, so they stay as written
+    [InlineData("/a^b|c", "/a^b|c")]
+    // An escape that is already present is not encoded a second time
+    [InlineData("/path%20with%20spaces", "/path%20with%20spaces")]
+    public void Create_Pathname_IsPercentEncoded(string pathname, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = pathname });
+
+        Assert.Equal(expected, pattern.Pathname);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/foo bar")]
+    [InlineData("https://example.com/café")]
+    [InlineData("https://example.com/\U0001F600")]
+    [InlineData("https://example.com/a<b>c")]
+    public void IsMatch_PathnameWrittenAsLiteralText_MatchesTheEncodedUrl(string url)
+    {
+        // The pattern is written the way the URL is, and the two only line up because both are canonicalized
+        var pathname = new System.Uri(url).GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/" + pathname });
+
+        Assert.True(pattern.IsMatch(url));
+    }
+
+    [Theory]
+    // A path is parsed, so its dot segments are resolved and a backslash separates segments
+    [InlineData("/a/../b", "/b")]
+    [InlineData("/a/./b", "/a/b")]
+    [InlineData("/a/..", "/")]
+    [InlineData("/a\\\\b", "/a/b")]
+    public void Create_Pathname_ResolvesDotSegments(string pathname, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = pathname });
+
+        Assert.Equal(expected, pattern.Pathname);
+    }
+
+    [Fact]
+    public void Create_PathnameLiteralAfterAGroup_DoesNotGainASeparator()
+    {
+        // The callback runs on each fixed-text part, so ".json" is canonicalized on its own. The spec
+        // prefixes "/-" before parsing it and removes the two code points afterwards, which is what stops
+        // the URL parser from turning "/books/:id.json" into "/books/:id/.json"
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/books/:id.json" });
+
+        Assert.Equal("/books/:id.json", pattern.Pathname);
+        Assert.True(pattern.IsMatch("https://example.com/books/42.json"));
+    }
+
+    [Fact]
+    public void Create_PathnameLiteralAfterAGroup_KeepsALeadingDot()
+    {
+        // The "-" of the "/-" prefix is what keeps ".." from being read as a dot segment of the fake path
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/books/{:id}..json" });
+
+        Assert.Equal("/books/{:id}..json", pattern.Pathname);
+        Assert.True(pattern.IsMatch("https://example.com/books/42..json"));
+    }
+
+    [Fact]
+    public void Create_PathnameOfANonSpecialScheme_UsesTheC0ControlSetOnly()
+    {
+        // An opaque path encodes far less than a "/"-separated one: a space survives as written
+        var pattern = UrlPattern.Create(new UrlPatternInit { Protocol = "data", Pathname = "text/plain;a b" });
+
+        Assert.Equal("text/plain;a b", pattern.Pathname);
+    }
+
+    [Theory]
+    // The special-query percent-encode set, because the URL record the spec canonicalizes against is https
+    [InlineData("a=b c", "a=b%20c")]
+    [InlineData("q='x'", "q=%27x%27")]
+    [InlineData("a=\\#b", "a=%23b")]
+    [InlineData("a=café", "a=caf%C3%A9")]
+    // "?" is not in the query set, so it survives (the pattern string escapes it again)
+    [InlineData("a=b\\?c", "a=b\\?c")]
+    public void Create_Search_IsPercentEncoded(string search, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Search = search });
+
+        Assert.Equal(expected, pattern.Search);
+    }
+
+    [Theory]
+    // The fragment percent-encode set, which covers "`" but not "#" or "?"
+    [InlineData("a b", "a%20b")]
+    [InlineData("a\\`b", "a%60b")]
+    [InlineData("a\"b", "a%22b")]
+    [InlineData("a\\?b", "a\\?b")]
+    [InlineData("café", "caf%C3%A9")]
+    public void Create_Hash_IsPercentEncoded(string hash, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Hash = hash });
+
+        Assert.Equal(expected, pattern.Hash);
+    }
+
+    [Fact]
+    public void IsMatch_SearchAndHashWrittenAsLiteralText_MatchTheEncodedUrl()
+    {
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Search = "a=b c" }).IsMatch("https://example.com/?a=b c"));
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Hash = "a b" }).IsMatch("https://example.com/#a b"));
+    }
+
+    [Theory]
+    // The userinfo percent-encode set, which adds "/ : ; = @ [ \ ] ^ |" to the path set
+    [InlineData("jo hn", "jo%20hn")]
+    [InlineData("a\\:b", "a%3Ab")]
+    [InlineData("a@b", "a%40b")]
+    [InlineData("a|b", "a%7Cb")]
+    [InlineData("café", "caf%C3%A9")]
+    public void Create_Username_IsPercentEncoded(string username, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Username = username });
+
+        Assert.Equal(expected, pattern.Username);
+    }
+
+    [Fact]
+    public void IsMatch_UsernameAndPasswordWrittenAsLiteralText_MatchTheEncodedUrl()
+    {
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Username = "jo hn" })
+            .IsMatch("https://jo%20hn@example.com/"));
+
+        Assert.True(UrlPattern.Create(new UrlPatternInit { Password = @"pa\:ss" })
+            .IsMatch("https://user:pa:ss@example.com/"));
+    }
+
+    [Theory]
+    // A hostname goes through "domain to ASCII", which lowercases it and applies IDNA label by label
+    [InlineData("EXAMPLE.com", "example.com")]
+    [InlineData("CAFÉ.example.com", "xn--caf-dma.example.com")]
+    [InlineData("%C3%A9.com", "xn--9ca.com")]
+    // Hostname state stops at whatever would start the next component
+    [InlineData("example.com/ignored", "example.com")]
+    [InlineData("example.com\\?ignored", "example.com")]
+    [InlineData("example.com\\#ignored", "example.com")]
+    public void Create_Hostname_IsCanonicalized(string hostname, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Hostname = hostname });
+
+        Assert.Equal(expected, pattern.Hostname);
+    }
+
+    [Fact]
+    public void IsMatch_HostnameWrittenInUnicode_MatchesTheUnicodeUrl()
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Hostname = "café.example.com" });
+
+        Assert.True(pattern.IsMatch("https://café.example.com/"));
+        Assert.True(pattern.IsMatch("https://xn--caf-dma.example.com/"));
+    }
+
+    [Fact]
+    public void Create_HostnameThatContainsAPort_Throws()
+    {
+        Assert.Throws<UrlPatternException>(() => UrlPattern.Create(new UrlPatternInit { Hostname = @"example.com\:80" }));
+    }
+
+    [Fact]
+    public void IsMatch_IPv6Hostname_IgnoresTheDottedFormOfUri()
+    {
+        // Uri writes the last two pieces of "[::ab:1]" as "[::0.171.0.1]", which the URL Standard never does
+        var pattern = UrlPattern.Create(new UrlPatternInit { Hostname = @"[\:\:ab\:1]" });
+
+        Assert.True(pattern.IsMatch("http://[::ab:1]/"));
+        Assert.False(pattern.IsMatch("http://[::ab:2]/"));
+    }
+
+    [Fact]
+    public void Create_IPv6HostnameWithAnInvalidCodePoint_Throws()
+    {
+        Assert.Throws<UrlPatternException>(() => UrlPattern.Create(new UrlPatternInit { Hostname = "[zz]" }));
+    }
+
+    [Theory]
+    [InlineData("HTTPS", "https")]
+    [InlineData("https:", "https")]
+    [InlineData("HTTPS:", "https")]
+    public void Create_Protocol_IsCanonicalized(string protocol, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Protocol = protocol });
+
+        Assert.Equal(expected, pattern.Protocol);
+    }
+
+    [Theory]
+    [InlineData("1http")]
+    [InlineData("ht tp")]
+    public void Create_ProtocolThatIsNotASchemeName_Throws(string protocol)
+    {
+        Assert.Throws<UrlPatternException>(() => UrlPattern.Create(new UrlPatternInit { Protocol = protocol }));
+    }
+
+    [Fact]
+    public void Create_PortThatIsOutOfRange_Throws()
+    {
+        Assert.Throws<UrlPatternException>(() => UrlPattern.Create(new UrlPatternInit { Port = "99999" }));
+    }
+
+    [Theory]
+    // Port state keeps the digits it read and stops at the first code point that is not one
+    [InlineData("80x", "80")]
+    [InlineData("08080", "8080")]
+    public void Create_Port_KeepsTheLeadingDigits(string port, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Port = port });
+
+        Assert.Equal(expected, pattern.Port);
+    }
+
+    [Fact]
+    public void Create_EmptyGroupBetweenTwoLiterals_IsCanonicalizedAsASingleValue()
+    {
+        // A "{foo}" grouping is buffered unencoded so that it joins the text around it, which is what lets
+        // the "/" of "{.com/}" end the hostname instead of surviving in the middle of it
+        var pattern = UrlPattern.Create(new UrlPatternInit { Hostname = "{sub.}?example{.com/}foo" });
+
+        Assert.Equal("{sub.}?example.com", pattern.Hostname);
+        Assert.True(pattern.IsMatch("https://example.com/foo"));
+        Assert.True(pattern.IsMatch("https://sub.example.com/foo"));
+    }
+
+    [Fact]
+    public void Create_LoneSurrogate_BecomesTheReplacementCharacter()
+    {
+        // A DOMString becomes a USVString before it is canonicalized
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/\ud83d" });
+
+        Assert.Equal("/%EF%BF%BD", pattern.Pathname);
+    }
+
+    [Theory]
+    // A name is an ECMAScript identifier, so it is not limited to ASCII: U+2118 is Other_ID_Start and
+    // U+10450 is a letter outside the basic multilingual plane
+    [InlineData("℘")]
+    [InlineData("\U00010450")]
+    public void Create_GroupNameOutsideAscii_IsAName(string name)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/:" + name });
+
+        var result = pattern.Match(new UrlPatternInit { Pathname = "/foo" });
+
+        Assert.NotNull(result);
+        Assert.Equal("foo", result.Pathname.Groups[name]);
+    }
+
+    [Theory]
+    [InlineData("8\t0", "80")]
+    [InlineData("80x", "80")]
+    public void IsMatch_InitInput_CanonicalizesThePort(string port, string patternPort)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Port = patternPort });
+
+        Assert.True(pattern.IsMatch(new UrlPatternInit { Port = port }));
+    }
+
+    [Fact]
+    public void IsMatch_InitInput_DropsAPortThatIsTheDefaultOfTheProtocol()
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Protocol = "https", Port = "" });
+
+        Assert.True(pattern.IsMatch(new UrlPatternInit { Protocol = "https", Port = "443" }));
+        Assert.False(pattern.IsMatch(new UrlPatternInit { Protocol = "https", Port = "8443" }));
+    }
+
+    [Fact]
+    public void IsMatch_InitInput_ThatCannotBeCanonicalized_DoesNotMatch()
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Port = "*" });
+
+        Assert.False(pattern.IsMatch(new UrlPatternInit { Port = "invalid80" }));
+    }
+
+    [Fact]
+    public void IsMatch_InitInput_CanonicalizesThePathname()
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/foo bar" });
+
+        Assert.True(pattern.IsMatch(new UrlPatternInit { Pathname = "/foo bar" }));
+        Assert.True(pattern.IsMatch(new UrlPatternInit { Pathname = "/foo%20bar" }));
+        Assert.True(pattern.IsMatch(new UrlPatternInit { Pathname = "/baz/../foo bar" }));
+    }
+
+    [Fact]
+    public void Create_WithAnEmptyBaseUrl_Throws()
+    {
+        Assert.Throws<UrlPatternException>(() => UrlPattern.Create(new UrlPatternInit { Pathname = "/foo", BaseUrl = "" }));
     }
 }

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -1750,12 +1750,19 @@ public sealed class UrlPatternTests
         Assert.Equal(expected, pattern.Hostname);
     }
 
-    [Fact]
-    public void IsMatch_HostnameWrittenInUnicode_MatchesTheUnicodeUrl()
+    [Theory]
+    [InlineData("café.example.com")]
+    // ToASCII maps a label to lower case before it encodes it, which IdnMapping only does when ICU is
+    // available, so an upper-case label is what tells the two modes apart
+    [InlineData("CAFÉ.example.com")]
+    [InlineData("xn--caf-dma.example.com")]
+    public void IsMatch_HostnameWrittenInUnicode_MatchesTheUnicodeUrl(string hostname)
     {
-        var pattern = UrlPattern.Create(new UrlPatternInit { Hostname = "café.example.com" });
+        var pattern = UrlPattern.Create(new UrlPatternInit { Hostname = hostname });
 
+        Assert.Equal("xn--caf-dma.example.com", pattern.Hostname);
         Assert.True(pattern.IsMatch("https://café.example.com/"));
+        Assert.True(pattern.IsMatch("https://CAFÉ.example.com/"));
         Assert.True(pattern.IsMatch("https://xn--caf-dma.example.com/"));
     }
 

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternWebPlatformTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternWebPlatformTests.cs
@@ -1,0 +1,373 @@
+using System.Collections.Frozen;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Meziantou.Framework.Tests;
+
+/// <summary>
+/// Runs the URL Pattern conformance corpus of the web-platform-tests project.
+/// See <c>files/urlpatterntestdata.LICENSE.md</c> for its source and its license.
+/// </summary>
+public sealed class UrlPatternWebPlatformTests
+{
+    /// <summary>The cases that are known not to pass, by their index in the corpus.</summary>
+    /// <remarks>
+    /// A case listed here is asserted to still fail, so that fixing one of them fails this test rather than
+    /// passing silently. None of these are canonicalization: they are the parts of the spec that either rely
+    /// on a JavaScript regular expression feature that .NET does not have, or on a URL parser of our own.
+    /// </remarks>
+    private static readonly FrozenDictionary<int, string> ExpectedFailures = new Dictionary<int, string>
+    {
+        // Uri resolves a relative URL against a base URL that has an opaque path, where the URL Standard fails
+        [254] = "\"foo\" against the base URL \"data:data-urls-cannot-be-base-urls\"",
+
+        // The constructor string parser does not read an escaped ":" as part of the username
+        [260] = @"https\:foo\:bar@example.com",
+
+        // A group that did not participate reports the empty string rather than being absent
+        [329] = "*{}**?",
+
+        // The "v" flag set operations of a JavaScript regular expression, which .NET cannot express
+        [352] = "/([[a-z]--a])",
+        [353] = @"/([\d&&[0-1]])",
+    }.ToFrozenDictionary();
+
+    public static TheoryData<int> TestCaseIndexes()
+    {
+        var data = new TheoryData<int>();
+        for (var i = 0; i < TestCases.Length; i++)
+        {
+            data.Add(i);
+        }
+
+        return data;
+    }
+
+    private static readonly JsonElement[] TestCases = LoadTestCases();
+
+    private static JsonElement[] LoadTestCases()
+    {
+        using var stream = typeof(UrlPatternWebPlatformTests).GetTypeInfo().Assembly.GetManifestResourceStream("urlpatterntestdata.json");
+        Assert.NotNull(stream);
+
+        using var document = JsonDocument.Parse(stream);
+
+        return [.. document.RootElement.EnumerateArray().Select(element => element.Clone())];
+    }
+
+    [Theory]
+    [MemberData(nameof(TestCaseIndexes))]
+    public void OfficialTestSuite(int index)
+    {
+        var testCase = TestCases[index];
+        var failure = Run(testCase);
+
+        if (ExpectedFailures.TryGetValue(index, out var reason))
+        {
+            if (failure is null)
+            {
+                Assert.Fail($"Case {index} ({reason}) is listed as an expected failure but it passes now. Remove it from {nameof(ExpectedFailures)}.");
+            }
+
+            return;
+        }
+
+        // The failure carries the case with it, so that the assertion says which one it was
+        Assert.Null(failure is null ? null : $"{testCase.GetProperty("pattern").GetRawText()}: {failure}");
+    }
+
+    /// <summary>Runs one case and returns what went wrong, or <see langword="null"/> when it passed.</summary>
+    private static string? Run(JsonElement testCase)
+    {
+        var patternArguments = testCase.GetProperty("pattern");
+        var expectedObject = testCase.TryGetProperty("expected_obj", out var obj) ? obj : (JsonElement?)null;
+        var expectsConstructorError = expectedObject?.ValueKind is JsonValueKind.String && ReadString(expectedObject.Value) is "error";
+
+        UrlPattern pattern;
+        try
+        {
+            pattern = CreatePattern(patternArguments);
+        }
+        catch (UrlPatternException ex)
+        {
+            return expectsConstructorError ? null : $"the constructor threw '{ex.Message}'";
+        }
+
+        if (expectsConstructorError)
+            return "the constructor was expected to throw";
+
+        var failures = new List<string>();
+
+        if (expectedObject?.ValueKind is JsonValueKind.Object)
+        {
+            foreach (var component in expectedObject.Value.EnumerateObject())
+            {
+                var actual = GetComponent(pattern, component.Name);
+                var expected = ReadString(component.Value);
+                if (actual is not null && actual != expected)
+                {
+                    failures.Add($"{component.Name} is '{actual}' instead of '{expected}'");
+                }
+            }
+        }
+
+        // A component listed in exactly_empty_components is the empty string rather than a wildcard
+        if (testCase.TryGetProperty("exactly_empty_components", out var emptyComponents))
+        {
+            foreach (var component in emptyComponents.EnumerateArray())
+            {
+                var name = ReadString(component);
+                var actual = GetComponent(pattern, name);
+                if (actual is not "")
+                {
+                    failures.Add($"{name} is '{actual}' instead of being empty");
+                }
+            }
+        }
+
+        failures.AddRange(RunInputs(testCase, pattern));
+
+        return failures.Count is 0 ? null : string.Join("; ", failures);
+    }
+
+    private static List<string> RunInputs(JsonElement testCase, UrlPattern pattern)
+    {
+        var failures = new List<string>();
+        if (!testCase.TryGetProperty("inputs", out var inputs) || inputs.GetArrayLength() is 0)
+            return failures;
+
+        var expectedMatch = testCase.TryGetProperty("expected_match", out var match) ? match : (JsonElement?)null;
+        var expectsMatchError = expectedMatch?.ValueKind is JsonValueKind.String && ReadString(expectedMatch.Value) is "error";
+        var expectsNoMatch = expectedMatch is null || expectedMatch.Value.ValueKind is JsonValueKind.Null;
+
+        UrlPatternResult? result;
+        try
+        {
+            result = Match(pattern, inputs);
+        }
+        catch (UrlPatternException ex)
+        {
+            if (!expectsMatchError)
+            {
+                failures.Add($"matching threw '{ex.Message}'");
+            }
+
+            return failures;
+        }
+
+        if (expectsMatchError)
+        {
+            failures.Add("matching was expected to throw");
+            return failures;
+        }
+
+        if (expectsNoMatch)
+        {
+            if (result is not null)
+            {
+                failures.Add("the input was expected not to match");
+            }
+
+            return failures;
+        }
+
+        if (result is null)
+        {
+            failures.Add("the input was expected to match");
+            return failures;
+        }
+
+        foreach (var component in expectedMatch!.Value.EnumerateObject())
+        {
+            if (component.Name is "inputs")
+                continue;
+
+            var actual = GetComponentResult(result, component.Name);
+            if (actual is null)
+                continue;
+
+            if (component.Value.TryGetProperty("input", out var expectedInput) && actual.Input != ReadString(expectedInput))
+            {
+                failures.Add($"{component.Name}.input is '{actual.Input}' instead of '{ReadString(expectedInput)}'");
+            }
+
+            if (!component.Value.TryGetProperty("groups", out var expectedGroups))
+                continue;
+
+            foreach (var group in expectedGroups.EnumerateObject())
+            {
+                var expected = group.Value.ValueKind is JsonValueKind.Null ? null : ReadString(group.Value);
+                actual.Groups.TryGetValue(group.Name, out var value);
+                if (value != expected)
+                {
+                    failures.Add($"{component.Name}.groups['{group.Name}'] is '{value ?? "<null>"}' instead of '{expected ?? "<null>"}'");
+                }
+            }
+        }
+
+        return failures;
+    }
+
+    private static UrlPattern CreatePattern(JsonElement arguments)
+    {
+        // The arguments are those of the URLPattern constructor: a pattern string or an init, optionally
+        // followed by a base URL, optionally followed by the options
+        if (arguments.GetArrayLength() is 0)
+            return UrlPattern.Create(new UrlPatternInit());
+
+        var first = arguments[0];
+        var options = ReadOptions(arguments);
+
+        if (first.ValueKind is JsonValueKind.String)
+        {
+            var baseUrl = arguments.GetArrayLength() > 1 && arguments[1].ValueKind is JsonValueKind.String
+                ? ReadString(arguments[1])
+                : null;
+
+            return UrlPattern.Create(ReadString(first), baseUrl, options);
+        }
+
+        ThrowIfBaseUrlAccompaniesAnInit(arguments);
+
+        return UrlPattern.Create(ReadInit(first), options);
+    }
+
+    private static UrlPatternOptions? ReadOptions(JsonElement arguments)
+    {
+        for (var i = 1; i < arguments.GetArrayLength(); i++)
+        {
+            if (arguments[i].ValueKind is JsonValueKind.Object && arguments[i].TryGetProperty("ignoreCase", out var ignoreCase))
+                return new UrlPatternOptions { IgnoreCase = ignoreCase.GetBoolean() };
+        }
+
+        return null;
+    }
+
+    private static UrlPatternResult? Match(UrlPattern pattern, JsonElement inputs)
+    {
+        var first = inputs[0];
+        if (first.ValueKind is not JsonValueKind.String)
+        {
+            ThrowIfBaseUrlAccompaniesAnInit(inputs);
+
+            return pattern.Match(ReadInit(first));
+        }
+
+        var baseUrl = inputs.GetArrayLength() > 1 ? ReadString(inputs[1]) : null;
+
+        return pattern.Match(ReadString(first), baseUrl);
+    }
+
+    /// <summary>Reports the error the spec requires when an init is given together with a base URL.</summary>
+    /// <remarks>
+    /// An init carries its own base URL, so supplying a second one is a TypeError. There is no C# overload
+    /// that takes both, which makes it a compile-time error rather than a run-time one, so the corpus cases
+    /// that check for it are answered here.
+    /// </remarks>
+    private static void ThrowIfBaseUrlAccompaniesAnInit(JsonElement arguments)
+    {
+        if (arguments.GetArrayLength() > 1 && arguments[1].ValueKind is JsonValueKind.String)
+            throw new UrlPatternException("A base URL cannot be given alongside a UrlPatternInit");
+    }
+
+    private static UrlPatternInit ReadInit(JsonElement element)
+    {
+        var init = new UrlPatternInit();
+        foreach (var property in element.EnumerateObject())
+        {
+            // An init is a dictionary, so a member that is not a component is ignored rather than rejected
+            var value = property.Value.ValueKind is JsonValueKind.Null ? null : ReadString(property.Value);
+            switch (property.Name)
+            {
+                case "protocol": init.Protocol = value; break;
+                case "username": init.Username = value; break;
+                case "password": init.Password = value; break;
+                case "hostname": init.Hostname = value; break;
+                case "port": init.Port = value; break;
+                case "pathname": init.Pathname = value; break;
+                case "search": init.Search = value; break;
+                case "hash": init.Hash = value; break;
+                case "baseURL": init.BaseUrl = value; break;
+            }
+        }
+
+        return init;
+    }
+
+    private static string? GetComponent(UrlPattern pattern, string name) => name switch
+    {
+        "protocol" => pattern.Protocol,
+        "username" => pattern.Username,
+        "password" => pattern.Password,
+        "hostname" => pattern.Hostname,
+        "port" => pattern.Port,
+        "pathname" => pattern.Pathname,
+        "search" => pattern.Search,
+        "hash" => pattern.Hash,
+        _ => null,
+    };
+
+    private static UrlPatternComponentResult? GetComponentResult(UrlPatternResult result, string name) => name switch
+    {
+        "protocol" => result.Protocol,
+        "username" => result.Username,
+        "password" => result.Password,
+        "hostname" => result.Hostname,
+        "port" => result.Port,
+        "pathname" => result.Pathname,
+        "search" => result.Search,
+        "hash" => result.Hash,
+        _ => null,
+    };
+
+    /// <summary>Reads a JSON string, including one that holds an unpaired surrogate.</summary>
+    /// <remarks>
+    /// A few cases check what happens to a lone surrogate, which <see cref="JsonElement.GetString"/> refuses
+    /// to return. The raw text of such a token is unescaped here instead, which is what a JavaScript engine
+    /// would hand to the URLPattern constructor.
+    /// </remarks>
+    private static string ReadString(JsonElement element)
+    {
+        try
+        {
+            return element.GetString()!;
+        }
+        catch (InvalidOperationException)
+        {
+            return UnescapeJsonString(element.GetRawText());
+        }
+    }
+
+    private static string UnescapeJsonString(string rawText)
+    {
+        // The raw text of a string token, quotes included
+        var value = rawText.AsSpan(1, rawText.Length - 2);
+        var builder = new StringBuilder(value.Length);
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] is not '\\')
+            {
+                builder.Append(value[i]);
+                continue;
+            }
+
+            i++;
+            switch (value[i])
+            {
+                case 'u':
+                    builder.Append((char)int.Parse(value.Slice(i + 1, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+                    i += 4;
+                    break;
+                case 'b': builder.Append('\b'); break;
+                case 'f': builder.Append('\f'); break;
+                case 'n': builder.Append('\n'); break;
+                case 'r': builder.Append('\r'); break;
+                case 't': builder.Append('\t'); break;
+                default: builder.Append(value[i]); break;
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/tests/Meziantou.Framework.Uri.Tests/files/urlpatterntestdata.LICENSE.md
+++ b/tests/Meziantou.Framework.Uri.Tests/files/urlpatterntestdata.LICENSE.md
@@ -1,0 +1,21 @@
+The file `urlpatterntestdata.json` in this directory is the URL Pattern conformance corpus of the
+web-platform-tests project, vendored unmodified from:
+
+  https://github.com/web-platform-tests/wpt/blob/23aac9278460a73394585ff5a15b6a04dfcd5ec8/urlpattern/resources/urlpatterntestdata.json
+
+To refresh it, download that path at a newer commit and update the URL above. It is covered by the
+following license, reproduced from https://github.com/web-platform-tests/wpt/blob/23aac9278460a73394585ff5a15b6a04dfcd5ec8/LICENSE.md
+
+---
+
+# The 3-Clause BSD License
+
+Copyright © web-platform-tests contributors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/Meziantou.Framework.Uri.Tests/files/urlpatterntestdata.json
+++ b/tests/Meziantou.Framework.Uri.Tests/files/urlpatterntestdata.json
@@ -1,0 +1,3181 @@
+[
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/ba" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?otherquery#otherhash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?otherquery#otherhash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?query#hash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "hash", "groups": { "0": "hash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "query", "groups": { "0": "query" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "http://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://other.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "http://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/([^\\/]+?)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/index.html" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/index.html", "groups": { "bar": "index.html" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "bar": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "username": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "password": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hash": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "protocol": ":café" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":café" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":café" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":café" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:café" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":café" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":café" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u2118" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u2118" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u2118" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u2118" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u2118" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u2118" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u2118" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u3400" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u3400" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u3400" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u3400" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u3400" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u3400" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u3400" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol" : "café" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol": "cafe" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "cafe", "groups": { "0": "cafe" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "foo-bar" }],
+    "inputs": [{ "protocol": "foo-bar" }],
+    "expected_match": {
+      "protocol": { "input": "foo-bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%C3%A9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "café" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_obj": {
+      "username": "caf%C3%A9"
+    },
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%c3%a9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "password": "caf%C3%A9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "café" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_obj": {
+      "password": "caf%C3%A9"
+    },
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "caf%c3%a9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "xn--caf-dma.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "café.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_obj": {
+      "hostname": "xn--caf-dma.com"
+    },
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D\uDEB2.com/"],
+    "inputs": ["http://\uD83D\uDEB2.com/"],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "xn--h78h.com",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}},
+      "hostname": { "input": "xn--h78h.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D \uDEB2"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"hostname":"\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":"\uD83D \uDEB2"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": "%EF%BF%BD%20%EF%BF%BD"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":":\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":":a\uDB40\uDD00b"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": ":a\uDB40\uDD00b"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":"test/:a\uD801\uDC50b"}],
+    "inputs": [{"pathname":"test/foo"}],
+    "expected_obj": {
+      "pathname": "test/:a\uD801\uDC50b"
+    },
+    "expected_match": {
+      "pathname": { "input": "test/foo", "groups": { "a\uD801\uDC50b": "foo" }}
+    }
+  },
+  {
+    "pattern": [{"pathname":":\uD83D\uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": { "0": "http" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80{20}?" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80 " }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_obj": {
+      "protocol": "http",
+      "port": "80"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "100000" }],
+    "inputs": [{ "protocol": "http", "port": "100000" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "8\t0" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80?x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80\\x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "(.*)" }],
+    "inputs": [{ "port": "invalid80" }],
+    "expected_obj": {
+      "port": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "443*" }],
+    "inputs": [{ "protocol": "https", "port": "4430" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "4430", "groups": { "0": "0" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "*443" }],
+    "inputs": [{ "protocol": "https", "port": "1443" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "1443", "groups": { "0": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/./bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/baz" }],
+    "inputs": [{ "pathname": "/foo/bar/../baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/baz", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%C3%A9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/café" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_obj": {
+      "pathname": "/caf%C3%A9"
+    },
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%c3%a9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/../bar" }],
+    "inputs": [{ "pathname": "/bar" }],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "/", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{/bar}", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "\\/bar", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "b", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./b", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/b"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/b", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name.html", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo.html"] ,
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/:name.html"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo.html", "groups": { "name": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%C3%A9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=café" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_obj": {
+      "search": "q=caf%C3%A9"
+    },
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%c3%a9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hash": "caf%C3%A9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "café" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_obj": {
+      "hash": "caf%C3%A9"
+    },
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "caf%c3%a9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "about", "pathname": "(blank|sourcedoc)" }],
+    "inputs": [ "about:blank" ],
+    "expected_match": {
+      "protocol": { "input": "about", "groups": {}},
+      "pathname": { "input": "blank", "groups": { "0": "blank" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "data", "pathname": ":number([0-9]+)" }],
+    "inputs": [ "data:8675309" ],
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {}},
+      "pathname": { "input": "8675309", "groups": { "number": "8675309" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/(\\m)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo!" }],
+    "inputs": [{ "pathname": "/foo!" }],
+    "expected_match": {
+      "pathname": { "input": "/foo!", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\:" }],
+    "inputs": [{ "pathname": "/foo:" }],
+    "expected_match": {
+      "pathname": { "input": "/foo:", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\{" }],
+    "inputs": [{ "pathname": "/foo{" }],
+    "expected_obj": {
+      "pathname": "/foo%7B"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo%7B", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\(" }],
+    "inputs": [{ "pathname": "/foo(" }],
+    "expected_match": {
+      "pathname": { "input": "/foo(", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "baseURL": "javascript:var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(data|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {"0": "javascript"}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(https|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": {
+      "pathname": { "input": "var%20x%20=%201;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "./foo/bar", "https://example.com" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ { "pathname": "/foo/bar" }, "https://example.com" ],
+    "expected_match": "error"
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "*",
+      "password": "*",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "http{s}?://{*.}?example.com/:product/:endpoint" ],
+    "inputs": [ "https://sub.example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "hostname": "{*.}?example.com",
+      "pathname": "/:product/:endpoint"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "sub.example.com", "groups": { "0": "sub" } },
+      "pathname": { "input": "/foo/bar", "groups": { "product": "foo",
+                                                     "endpoint": "bar" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080?foo" ],
+    "inputs": [ "https://example.com:8080/?foo" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080#foo" ],
+    "inputs": [ "https://example.com:8080/#foo" ],
+    "exactly_empty_components": [ "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/*?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/*\\?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/:name?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/:name\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "name": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/(bar)?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/(bar)\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "0": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/{bar}?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/{bar}?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/{bar}\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/bar",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/" ],
+    "inputs": [ "https://example.com:8080/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "",
+      "pathname": "/"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foobar"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foobar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "/foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example{.com/}foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" } }
+    }
+  },
+  {
+    "pattern": [ "{https://}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub.)?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://(sub.)?example(.com/)foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example(.com/)foo",
+      "pathname": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(https://)example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://{sub{.}}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub(?:.))?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub(?:.))?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "file:///foo/bar" ],
+    "inputs": [ "file:///foo/bar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "file",
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "file", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "data:" ],
+    "inputs": [ "data:" ],
+    "exactly_empty_components": [ "hostname", "port", "pathname" ],
+    "expected_obj": {
+      "protocol": "data"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "foo://bar" ],
+    "inputs": [ "foo://bad_url_browser_interop" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "foo",
+      "hostname": "bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(café)://foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://example.com/foo?bar#baz" ],
+    "inputs": [{ "protocol": "https:",
+                 "search": "?bar",
+                 "hash": "#baz",
+                 "baseURL": "http://example.com/foo" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?:",
+                  "search": "?bar",
+                  "hash": "#baz" }],
+    "inputs": [ "http://example.com/foo?bar#baz" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" }},
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar#baz", "https://example.com/foo" ],
+    "inputs": [ "?bar#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar", "https://example.com/foo#baz" ],
+    "inputs": [ "?bar", "https://example.com/foo#snafu" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo?bar" ],
+    "inputs": [ "#baz", "https://example.com/foo?bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo" ],
+    "inputs": [ "#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "data:data-urls-cannot-be-base-urls" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "not|a|valid|url" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://foo\\:bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://foo@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://\\:bar@example.com" ],
+    "inputs": [ "https://:bar@example.com" ],
+    "exactly_empty_components": [ "username", "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://:user::pass@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": ":user",
+      "password": ":pass",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": { "user": "foo" } },
+      "password": { "input": "bar", "groups": { "pass": "bar" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https\\:foo\\:bar@example.com" ],
+    "inputs": [ "https:foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "data\\:foo\\:bar@example.com" ],
+    "inputs": [ "data:foo:bar@example.com" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foo\\:bar@example.com"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foo:bar@example.com", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://foo{\\:}bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo%3Abar",
+      "hostname": "example.com"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data{\\:}channel.html", "https://example.com" ],
+    "inputs": [ "https://example.com/data:channel.html" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/data\\:channel.html",
+      "search": "*",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/data:channel.html", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]:8080/" ],
+    "inputs": [ "http://[::1]:8080/" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "port": "8080",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:a]/" ],
+    "inputs": [ "http://[::a]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:a]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::a]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[:address]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[:address]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": { "address": "::1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:AB\\::num]/" ],
+    "inputs": [ "http://[::ab:1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:ab\\::num]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:AB\\::num]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_obj": {
+      "hostname": "[\\:\\:ab\\::num]"
+    },
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:xY\\::num]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:ab\\::num]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:fé\\::num]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:1]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:fé]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "[*\\:1]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "0": "::ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "*\\:1]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{{@}}example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:text/javascript,let x = 100/:tens?5;" ],
+    "inputs": [ "data:text/javascript,let x = 100/5;" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "text/javascript,let x = 100/:tens?5;"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "text/javascript,let x = 100/5;", "groups": { "tens": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:id/:id" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo", "baseURL": "" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "/foo", "" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo" }, "https://example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": ":name*" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name+" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name*" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name+" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad#hostname" }],
+    "inputs": [{ "hostname":  "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad%hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad/hostname" }],
+    "inputs": [{ "hostname": "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\\:hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad<hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad>hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad?hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad@hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad[hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad]hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\\\hostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "bad^hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad|hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\nhostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\rhostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\thostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{}],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": [{}],
+    "expected_match": {}
+  },
+  {
+    "pattern": [],
+    "inputs": [],
+    "expected_match": { "inputs": [{}] }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{(foo)bar}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "(foo)?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(barbaz)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)bar}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{*bar}"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{bar(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{bar*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}:bar(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo:bar(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "bar": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\.bar}" }],
+    "inputs": [{ "pathname": "foo.bar" }],
+    "expected_obj": {
+      "pathname": "{:foo.bar}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo.bar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo(foo)bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo\\bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}(.*)" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "f", "0": "oobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}?bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*{}**?" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "*(.*)?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "0": "foobar", "1": null }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)(.*)" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz", "0": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)bar" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*\\/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_obj": {
+      "pathname": "*/{*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/{*}" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*//*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/:foo." }],
+    "inputs": [{ "pathname": "/bar." }],
+    "expected_match": {
+      "pathname": { "input": "/bar.", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo.." }],
+    "inputs": [{ "pathname": "/bar.." }],
+    "expected_match": {
+      "pathname": { "input": "/bar..", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo" }],
+    "inputs": [{ "pathname": "./foo" }],
+    "expected_match": {
+      "pathname": { "input": "./foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "../foo" }],
+    "inputs": [{ "pathname": "../foo" }],
+    "expected_match": {
+      "pathname": { "input": "../foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo./" }],
+    "inputs": [{ "pathname": "bar./" }],
+    "expected_match": {
+      "pathname": { "input": "bar./", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo../" }],
+    "inputs": [{ "pathname": "bar../" }],
+    "expected_match": {
+      "pathname": { "input": "bar../", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo\\bar" }],
+    "inputs": [{ "pathname": "/bazbar" }],
+    "expected_obj": {
+      "pathname": "{/:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }, { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": { "0": "/FOO/BAR" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", { "ignoreCase": true },
+                 "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "inputs": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/a/\\+/b"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/a/+/b", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "inputs": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#foo", "https://example.com/?q=*&v=?&hmm={}&umm=()" ],
+    "inputs": [ "https://example.com/?q=*&v=?&hmm={}&umm=()#foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/a" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/z" }],
+    "expected_match": {
+      "pathname": { "input": "/z", "groups": { "0": "z" } }
+    }
+  },
+    {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/0" }],
+    "expected_match": {
+      "pathname": { "input": "/0", "groups": { "0": "0" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/3" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com/ignoredpath" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com\\?ignoredsearch" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "search": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com#ignoredhash" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/x", "groups": { "0": "x" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/xyz"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/xyz", "groups": { "0": "xyz" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/example"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/example", "groups": { "0": "example" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/text"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/text", "groups": { "0": "text" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/path/with/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/path/with/x", "groups": { "0": "path/with/x" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":domain(.*)" }],
+    "inputs": [{ "hostname": "localhost" }],
+    "expected_obj": {
+      "hostname": ":domain(.*)"
+    },
+    "expected_match": {
+      "hostname": { "input": "localhost", "groups": { "domain" : "localhost"} }
+    }
+  },
+  {
+    "pattern": ["((?R)):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": ["(\\H):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [
+      {"pathname": "/:foo((?<x>a))"}
+    ],
+    "inputs": [
+      {"pathname": "/a"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/a",
+        "groups": {"foo": "a"}
+      }
+    }
+  },
+  {
+    "pattern": [
+      {"pathname": "/foo/(bar(?<x>baz))"}
+    ],
+    "inputs": [
+      {"pathname": "/foo/barbaz"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/foo/barbaz",
+        "groups": {"0": "barbaz"}
+      }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:𠀀" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "𠀀": "foo" } }
+    }
+  }
+]


### PR DESCRIPTION
## What

`UrlPattern` matched a pathname as written, while the values it was compared to came from a `Uri`, which percent-encodes them. A pattern containing a space, a non-ASCII code point, or any of `" < > ` + "`` ` ``" + ` { }` could never match:

```csharp
UrlPattern.Create(new UrlPatternInit { Pathname = "/foo bar" })
    .IsMatch("https://example.com/foo%20bar");   // was false
```

The search, hash, username and password had the same problem. The username and password were worse than uncanonicalized: the pattern side escaped with `Uri.EscapeDataString` while the input side unescaped with `Uri.UnescapeDataString`, so the two were transformed in opposite directions and a pattern with any special character could never match.

This implements the URL Standard primitives the spec's [encoding callbacks](https://urlpattern.spec.whatwg.org/#canon-encoding-callbacks) are defined in terms of, and wires all eight components to their callback:

- `PercentEncodeSet.cs` / `PercentEncoding.cs` — the six percent-encode sets, UTF-8 encode/decode, lone surrogate to U+FFFD
- `UrlCanonicalizer.cs` — the nine canonicalize algorithms, including the path state machine (dot segments, `\` as a separator) with the spec's `/-` prefix trick, and the opaque path state

The strip-`:`/`?`/`#` steps move out of the callbacks into a `ProcessUrlPatternInit` that follows the spec's `process-*-for-init` shape, so a match input is canonicalized the same way a pattern is. `GetUrlComponents` reads the components in their least-escaped form and canonicalizes them again, which is what lets both sides of a match line up.

## Adjacent conformance bugs fixed

- **`AddPart`** encoded a `{foo}` grouping on its own instead of buffering it unencoded, so `{sub.}?example{.com/}foo` produced the hostname `{sub.}?example.comfoo` instead of `{sub.}?example.com`.
- **The tokenizer** walked the pattern by UTF-16 code unit and accepted an ASCII-ish set of name code points. A name is an ECMAScript identifier, so it now walks code points and uses `ID_Start`/`ID_Continue` (`:℘` and `:𐑐` are valid group names).
- **`Match(UrlPatternInit)`** processed the init twice, leaving the reported `Inputs` holding the canonicalized values rather than what the caller supplied.

## Behaviour changes (6 existing tests updated)

Each was checked against the spec text or the WPT corpus before changing:

| Change | Evidence |
|---|---|
| A tab or newline is **removed** from every component the URL parser touches, so `{Pathname = "/admin\n"}` now matches `/admin` | WPT: `{port: "8\t0"}` → `80`, `{hostname: "bad\nhostname"}` → `badhostname` |
| `{Protocol = "https", Port = "0443"}` gives `.Port == "443"` and no longer matches `https://example.com/` | WPT: `{protocol: "http", port: "80 "}` → obj `80`, `expected_match: null` — same shape |
| `{Port = "99999"}` throws | Port state: not a 16-bit integer → failure |
| `https://john:pa:ss@…` gives the password `pa%3Ass` | URL authority state percent-encodes with the userinfo set |

A username/password is percent-encoded *without* being parsed, so a newline survives there as `%0A`. That asymmetry is spec'd and covered by a test.

## Deliberately not spec-exact

Two `System.Uri` divergences are load-bearing and documented in the code — do not fix one side alone:

- `Uri` decodes the escape of an unreserved code point, so `/%41` arrives as `/A` where the URL Standard keeps `/%41`.
- WHATWG IPv4 host shorthand (`0x7f.1` → `127.0.0.1`) is **not** applied, because `Uri` does not apply it either; normalizing only the pattern would break matching.

The IPv6 divergence *is* fixed: `Uri` renders `[::ab:1]` as `[::0.171.0.1]`, so there is now a WHATWG IPv6 serializer.

## Testing

The second commit vendors WPT's `urlpatterntestdata.json` (369 cases) as an embedded resource and runs it as a theory, one test per case. It is pinned to a WPT commit and sits next to `urlpatterntestdata.LICENSE.md`, which carries the 3-clause BSD license, the source URL and how to refresh it.

Conformance goes from **277/369 to 364/369**, with **no case regressing**. The five that do not pass are listed in `ExpectedFailures` with a reason each, and a listed case is asserted to *still* fail — so fixing one of them fails the test rather than passing silently:

| Case | Why |
|---|---|
| `/([[a-z]--a])`, `/([\d&&[0-1]])` | JavaScript `v`-flag regex set operations, which .NET regex cannot express |
| `*{}**?` | a group that did not participate reports `""` rather than being absent |
| `"foo"` against `data:data-urls-cannot-be-base-urls` | `Uri` resolves against an opaque-path base URL where the URL Standard fails |
| `https\:foo\:bar@example.com` | the constructor string parser does not read an escaped `:` as part of the username |

None of them are canonicalization.

Two further cases check that constructing or matching with an init *and* a base URL is a `TypeError`. There is no C# overload taking both, so that is a compile-time error here; the adapter reports it as the error the spec asks for rather than leaving those cases unrepresented.

~30 targeted tests were added to `UrlPatternTests.cs` covering each encode set, dot segments, the literal-after-a-group trap, IDN, IPv6, port and protocol validation, and the round-trip property.

790 tests pass on net10.0 and net11.0, in Debug and in Release with `IsOfficialBuild=true`, with `TreatWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` is clean and `ref/` is unchanged — everything new is `internal`.
