### PR TITLE
Only quote YAML scalars that actually need quoting

### DIFF
--- a/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
+++ b/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <Description>A high-performance .NET YAML library providing parsing and serialization of object graphs, NativeAOT ready.</Description>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -1401,7 +1401,29 @@ public sealed class YamlWriter : YamlReaderWriterBase
             {
                 return false;
             }
-            if (c is ':' or '#' or '{' or '}' or '[' or ']' or ',' or '&' or '*' or '!' or '|' or '>' or '\'' or '"' or '%' or '@' or '`')
+
+            // A flow indicator closes the enclosing collection, but it is an ordinary character in a block context.
+            if (isFlow && c is '{' or '}' or '[' or ']' or ',')
+            {
+                return false;
+            }
+
+            // '#' only starts a comment when a space comes before it, so "C# 14" needs no quotes.
+            if (c is '#' && (i == 0 || char.IsWhiteSpace(value[i - 1])))
+            {
+                return false;
+            }
+
+            // ':' only separates a key from its value when a space (or the end of the scalar) comes after it,
+            // so "12:30" needs no quotes. Inside a flow collection the character closing the collection also
+            // ends the scalar, which puts the ':' at its end again.
+            if (c is ':' && (i == value.Length - 1 || char.IsWhiteSpace(value[i + 1]) || (isFlow && value[i + 1] is '{' or '}' or '[' or ']' or ',')))
+            {
+                return false;
+            }
+
+            // The remaining indicators only carry a meaning as the first character of a scalar.
+            if (i == 0 && c is '{' or '}' or '[' or ']' or ',' or '&' or '*' or '!' or '|' or '>' or '\'' or '"' or '%' or '@' or '`')
             {
                 return false;
             }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlConverterAttributeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlConverterAttributeTests.cs
@@ -124,7 +124,7 @@ public sealed class YamlConverterAttributeTests
     public void RoundTrip_UsesOpenGenericPropertyConverterWithMultipleTypeParameters()
     {
         var yaml = YamlSerializer.Serialize(new PairModel { Pair = new Pair<int, string> { First = 1, Second = "two" } });
-        Assert.Contains("Pair: \"1|two\"", yaml);
+        Assert.Contains("Pair: 1|two", yaml);
 
         var value = YamlSerializer.Deserialize<PairModel>(yaml)!;
         Assert.Equal(1, value.Pair!.First);
@@ -135,7 +135,7 @@ public sealed class YamlConverterAttributeTests
     public void RoundTrip_UsesNestedOpenGenericPropertyConverter()
     {
         var yaml = YamlSerializer.Serialize(new NestedConverterPairModel { Pair = new Pair<int, string> { First = 3, Second = "four" } });
-        Assert.Contains("Pair: \"3|four\"", yaml);
+        Assert.Contains("Pair: 3|four", yaml);
 
         var value = YamlSerializer.Deserialize<NestedConverterPairModel>(yaml)!;
         Assert.Equal(3, value.Pair!.First);

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -2179,7 +2179,7 @@ public class YamlSerializerSourceGenerationTests
             },
             typeInfo);
 
-        Assert.Contains("url_value: \"https://example.com\"", yaml);
+        Assert.Contains("url_value: https://example.com", yaml);
         Assert.Contains("display_name: Ada", yaml);
 
         var roundtripped = YamlSerializer.Deserialize(yaml, typeInfo);
@@ -3779,8 +3779,8 @@ extra_list:
         Assert.NotNull(value);
         Assert.Equal(id, value.Id);
         Assert.Equal(optionalId, value.OptionalId);
-        Assert.Contains("Id: \"ref:id\"", yaml);
-        Assert.Contains("OptionalId: \"ref:optional-id\"", yaml);
+        Assert.Contains("Id: ref:id", yaml);
+        Assert.Contains("OptionalId: ref:optional-id", yaml);
     }
 
     [Fact]
@@ -3806,7 +3806,7 @@ extra_list:
         Assert.Equal(1, createConverterCount);
         Assert.Equal(canConvertCount, factory.CanConvertCount);
         Assert.Equal(createConverterCount, factory.CreateConverterCount);
-        Assert.Contains("Id: \"ref:id\"", yaml);
+        Assert.Contains("Id: ref:id", yaml);
         Assert.NotNull(value);
         Assert.Equal(id, value.Id);
     }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -219,7 +219,7 @@ public sealed class YamlWellKnownScalarConverterTests
     {
         var yaml = YamlSerializer.Serialize(new Uri("https://example.com/a%20b", UriKind.Absolute));
 
-        Assert.Equal("\"https://example.com/a%20b\"\n", yaml, ignoreLineEndingDifferences: true);
+        Assert.Equal("https://example.com/a%20b\n", yaml, ignoreLineEndingDifferences: true);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
@@ -12,8 +12,13 @@ public sealed class YamlWriterTests
             ("", "''"),
             (" leading", "\" leading\""),
             ("trailing ", "\"trailing \""),
-            ("a:b", "\"a:b\""),
-            ("a#b", "\"a#b\""),
+            ("a:b", "a:b"),
+            ("a: b", "\"a: b\""),
+            ("a:", "\"a:\""),
+            ("a#b", "a#b"),
+            ("4 ways to enable the latest C# features", "4 ways to enable the latest C# features"),
+            ("a #b", "\"a #b\""),
+            ("#a", "\"#a\""),
             ("a\nb", "\"a\\nb\""),
             ("\u0001", "\"\\u0001\""),
         };
@@ -24,6 +29,51 @@ public sealed class YamlWriterTests
             writer.WriteScalar(@case.Value);
 
             Assert.Equal(@case.ExpectedYaml, buffer.ToString());
+        }
+    }
+
+    [Theory]
+    [InlineData(true, "4 ways to enable the latest C# features")]
+    [InlineData(true, "a#b")]
+    [InlineData(true, "12:30")]
+    [InlineData(true, "https://example.com/a%20b")]
+    [InlineData(true, "it's a plan")]
+    [InlineData(true, "1|two")]
+    [InlineData(true, "x@example.com")]
+    // A flow indicator ends a plain scalar inside a flow collection, but carries no meaning in a block context.
+    [InlineData(false, "a, b")]
+    [InlineData(false, "a[0]")]
+    public void Scalar_ThatNeedsNoQuotes_IsWrittenPlainAndRoundTrips(bool alsoInFlow, string value)
+    {
+        bool[] modes = alsoInFlow ? [true, false] : [true];
+        foreach (var writeIndented in modes)
+        {
+            var options = new YamlSerializerOptions { WriteIndented = writeIndented };
+            var yaml = YamlSerializer.Serialize(new TextContainer { Text = value }, options);
+
+            Assert.Contains(value, yaml);
+            Assert.DoesNotContain("\"", yaml);
+            Assert.Equal(value, YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
+        }
+    }
+
+    [Theory]
+    [InlineData("a #b")]
+    [InlineData("#a")]
+    [InlineData("a: b")]
+    [InlineData("a:")]
+    [InlineData("[a]")]
+    [InlineData("'a'")]
+    [InlineData("%a")]
+    public void Scalar_ThatNeedsQuotes_IsQuotedAndRoundTrips(string value)
+    {
+        foreach (var writeIndented in new[] { true, false })
+        {
+            var options = new YamlSerializerOptions { WriteIndented = writeIndented };
+            var yaml = YamlSerializer.Serialize(new TextContainer { Text = value }, options);
+
+            Assert.Contains("\"", yaml);
+            Assert.Equal(value, YamlSerializer.Deserialize<TextContainer>(yaml, options)?.Text);
         }
     }
 


### PR DESCRIPTION
## What

`YamlWriter.IsPlainSafe` rejected a fixed set of characters wherever they appeared in a scalar, so ordinary text was serialized double-quoted:

```yaml
value: "4 ways to enable the latest C# features"
```

Most of those characters are only meaningful in a specific position, per the YAML 1.2 plain-scalar rules. The check now follows them:

- `#` starts a comment only at the beginning of a scalar or after a space
- `:` separates a key from its value only when followed by whitespace or at the end of the scalar (or, inside a flow collection, before the character that closes it)
- `,`, `[`, `]`, `{`, `}` end a scalar only inside a flow collection — they are ordinary characters in a block context
- `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` `` are indicators only as the first character

So these are now emitted plain instead of quoted:

```yaml
Title: 4 ways to enable the latest C# features
Time: 12:30
Url: https://example.com/a%20b
Pair: 1|two
```

while `a #b`, `#a`, `a: b`, `a:`, `[a]`, `'a'` and `%a` stay quoted.

Tabs, line breaks, control characters, leading/trailing whitespace, and the existing leading `-`/`?` and flow `?` rules are unchanged.

## Why

Quoting text that needs no quotes makes the output noisy and diffs harder to read. `#` in particular only introduces a comment when preceded by whitespace, so `C#` never required quotes.

`Emitter` (the libyaml port used by the document API) already analyzed scalars this way — it tracked `preceeded_by_whitespace` — and `YamlishWriter` already special-cased `" #"`. Only the serializer's writer was wrong.

## Notes for reviewers

- This changes the emitted YAML for affected values. It is a formatting change only: every case is still valid YAML that round-trips to the same string, and parsing is untouched. Five existing test expectations asserting the old quoted output were updated; each of them already deserialized and asserted the value, so the round-trip was verified by the same tests.
- Two new theories in `YamlWriterTests` cover plain-safe and must-quote values, asserting both the quoting decision and the round-trip, in block and flow modes.
- `Meziantou.Framework.Yaml` bumped 1.0.7 → 1.0.8.
- No public API change, so `ref/` is untouched.

## Verification

- `Meziantou.Framework.Yaml.Tests`: 1990/1990 pass (net10.0 + net11.0)
- `Meziantou.Framework.Yamlish.Tests`: 385/385 pass
- `Meziantou.Framework.DependencyScanning.Tests`: 234/234 pass
- `dotnet run ./eng/update-all.cs` ran clean and produced no changes