### PR TITLE
Unload the assembly a template is compiled into

### DIFF
--- a/ref/Meziantou.Framework.Templating.cs
+++ b/ref/Meziantou.Framework.Templating.cs
@@ -160,7 +160,7 @@ namespace Meziantou.Framework.Templating
         public virtual void Write(string format, params object?[] args) { }
     }
 
-    public class Template
+    public class Template : System.IDisposable
     {
         public string? OutputParameterName { get => throw null; set { } }
         public System.Type? OutputType { get => throw null; set { } }
@@ -192,6 +192,7 @@ namespace Meziantou.Framework.Templating
         protected virtual Microsoft.CodeAnalysis.CSharp.CSharpCompilation CreateCompilation(Microsoft.CodeAnalysis.SyntaxTree syntaxTree) => throw null;
         protected virtual Microsoft.CodeAnalysis.Emit.EmitOptions CreateEmitOptions() => throw null;
         protected virtual void Compile(string source, System.Threading.CancellationToken cancellationToken) { }
+        protected virtual System.Runtime.Loader.AssemblyLoadContext CreateAssemblyLoadContext() => throw null;
         protected virtual System.Reflection.Assembly LoadAssembly(System.IO.MemoryStream peStream, System.IO.MemoryStream pdbStream) => throw null;
         protected virtual System.Reflection.MethodInfo FindMethod(System.Reflection.Assembly assembly) => throw null;
         protected virtual System.IO.StringWriter CreateStringWriter() => throw null;
@@ -203,6 +204,8 @@ namespace Meziantou.Framework.Templating
         public virtual void Run(System.IO.TextWriter writer, System.Collections.Generic.IReadOnlyDictionary<string, object?> parameters) { }
         protected virtual object?[] CreateMethodParameters(System.IO.TextWriter writer, System.Collections.Generic.IReadOnlyDictionary<string, object?> parameters) => throw null;
         protected virtual void InvokeRunMethod(object?[] p) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
     }
 
     public class TemplateArgument

--- a/src/Meziantou.Framework.Templating.Html/HtmlEmailTemplate.cs
+++ b/src/Meziantou.Framework.Templating.Html/HtmlEmailTemplate.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+
 namespace Meziantou.Framework.Templating;
 
 /// <summary>Provides a templating engine specialized for generating HTML email content with automatic encoding and metadata extraction.</summary>
@@ -50,7 +52,12 @@ public class HtmlEmailTemplate : Template
         ArgumentNullException.ThrowIfNull(parameters);
 
         using var writer = CreateStringWriter();
-        Run(writer, out metadata, parameters);
+
+        // Wrapped, not passed as-is: IDictionary<,> does not derive from IReadOnlyDictionary<,>, so
+        // the call would bind to the params overload and pass the whole dictionary as the first
+        // positional argument instead of matching the parameters by name. The wrapper keeps the
+        // comparer of the original dictionary, which a copy would not.
+        Run(writer, out metadata, new ReadOnlyDictionary<string, object?>(parameters));
         return writer.ToString();
     }
 

--- a/src/Meziantou.Framework.Templating.Html/readme.md
+++ b/src/Meziantou.Framework.Templating.Html/readme.md
@@ -148,3 +148,14 @@ var result = template.Run(out var metadata, "John", 30);
 // No parameters
 var result = template.Run(out var metadata);
 ```
+
+### Memory Usage
+
+Building a template compiles it into an assembly, which is loaded in a collectible `AssemblyLoadContext` owned by the template. Dispose the template to unload that assembly; otherwise it is unloaded once the template becomes unreachable and the garbage collector runs.
+
+```csharp
+using var template = new HtmlEmailTemplate { OutputType = typeof(HtmlEmailOutput) };
+```
+
+> [!IMPORTANT]
+> `HtmlEmailTemplate` compiles to `dynamic` code unless `OutputType` is set, and a template that uses `dynamic` is **never** unloaded, even when disposed. See [Memory Usage](../Meziantou.Framework.Templating/readme.md#memory-usage) for the details. A server that keeps compiling templates — one per tenant, per file, or on every file change — should set `OutputType` to `typeof(HtmlEmailOutput)` and give every argument a type.

--- a/src/Meziantou.Framework.Templating.Tool/Program.cs
+++ b/src/Meziantou.Framework.Templating.Tool/Program.cs
@@ -131,7 +131,7 @@ internal static partial class Program
             return 1;
         }
 
-        var template = new Template
+        using var template = new Template
         {
             StartCodeBlockDelimiter = resolvedStartCodeBlockDelimiter,
             EndCodeBlockDelimiter = resolvedEndCodeBlockDelimiter,

--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
@@ -7,16 +8,22 @@ using Microsoft.CodeAnalysis.Text;
 namespace Meziantou.Framework.Templating;
 
 /// <summary>Represents a text template with embedded code blocks that can be dynamically compiled and executed.</summary>
+/// <remarks>
+/// Building a template compiles it into an assembly that is loaded in a dedicated collectible
+/// <see cref="AssemblyLoadContext"/>. Dispose the template to unload that assembly as soon as the
+/// template is no longer needed; otherwise it is unloaded once the template becomes unreachable and
+/// the garbage collector runs.
+/// </remarks>
 /// <example>
 /// <code><![CDATA[
-/// var template = new Template();
+/// using var template = new Template();
 /// template.Load("Hello <%=Name%>!");
 /// template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
 /// var result = template.Run("Meziantou");
 /// // result: "Hello Meziantou!"
 /// ]]></code>
 /// </example>
-public class Template
+public class Template : IDisposable
 {
     private const string DefaultClassName = "Template";
     private const string DefaultRunMethodName = "Run";
@@ -25,6 +32,8 @@ public class Template
     private readonly Lock _buildLock = new();
 
     private MethodInfo? _runMethodInfo;
+    private AssemblyLoadContext? _assemblyLoadContext;
+    private bool _disposed;
 
     [NotNull]
     private string? ClassName
@@ -437,13 +446,18 @@ public class Template
 
     /// <summary>Compiles the template into executable code.</summary>
     /// <param name="cancellationToken">A cancellation token to observe.</param>
+    /// <exception cref="ObjectDisposedException">The template is disposed.</exception>
     public void Build(CancellationToken cancellationToken)
     {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed), this);
+
         if (IsBuilt)
             return;
 
         lock (_buildLock)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             if (IsBuilt)
                 return;
 
@@ -824,13 +838,32 @@ public class Template
         Volatile.Write(ref _runMethodInfo, runMethodInfo);
     }
 
+    /// <summary>Creates the load context the compiled template is loaded into.</summary>
+    /// <returns>A new load context. It should be collectible, otherwise the compiled template can never be unloaded.</returns>
+    protected virtual AssemblyLoadContext CreateAssemblyLoadContext()
+    {
+        return new AssemblyLoadContext(GetAssemblyLoadContextName(), isCollectible: true);
+    }
+
+    private string GetAssemblyLoadContextName()
+    {
+        var name = "Meziantou.Framework.Templating." + ClassName;
+        return SourceFileName is null ? name : name + " (" + SourceFileName + ")";
+    }
+
     /// <summary>Loads an assembly from memory streams.</summary>
     /// <param name="peStream">The stream containing the assembly.</param>
     /// <param name="pdbStream">The stream containing debug symbols.</param>
     /// <returns>The loaded assembly.</returns>
+    /// <remarks>
+    /// The assembly is loaded in the load context created by <see cref="CreateAssemblyLoadContext"/>, so that
+    /// <see cref="Dispose()"/> can unload it. Loading it in the default context instead, for instance with
+    /// <see cref="Assembly.Load(byte[], byte[])"/>, keeps it in memory for the lifetime of the process.
+    /// </remarks>
     protected virtual Assembly LoadAssembly(MemoryStream peStream, MemoryStream pdbStream)
     {
-        return Assembly.Load(peStream.ToArray(), pdbStream.ToArray());
+        var loadContext = _assemblyLoadContext ??= CreateAssemblyLoadContext();
+        return loadContext.LoadFromStream(peStream, pdbStream);
     }
 
     /// <summary>Finds the Run method in the compiled assembly.</summary>
@@ -982,5 +1015,41 @@ public class Template
         }
 
         Volatile.Read(ref _runMethodInfo)!.Invoke(null, p);
+    }
+
+    /// <summary>Unloads the assembly the template was compiled into.</summary>
+    /// <remarks>
+    /// The assembly is unloaded once nothing references it anymore, which includes any object the
+    /// template created. A disposed template cannot be built or run again.
+    /// </remarks>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Releases the resources used by the template.</summary>
+    /// <param name="disposing"><see langword="true"/> when called from <see cref="Dispose()"/>.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
+        // Take the build lock so the assembly is not unloaded while a concurrent build is loading it.
+        lock (_buildLock)
+        {
+            if (_disposed)
+                return;
+
+            Volatile.Write(ref _runMethodInfo, null);
+            Volatile.Write(ref _disposed, true);
+
+            var loadContext = _assemblyLoadContext;
+            _assemblyLoadContext = null;
+            if (loadContext?.IsCollectible is true)
+            {
+                loadContext.Unload();
+            }
+        }
     }
 }

--- a/src/Meziantou.Framework.Templating/readme.md
+++ b/src/Meziantou.Framework.Templating/readme.md
@@ -12,6 +12,7 @@ A powerful and flexible .NET template engine that allows you to create text temp
 - **Using directives** - Import namespaces and types for use in templates
 - **Class member blocks** - Add methods, fields, and properties to the generated template class
 - **Debug support** - Generate debug symbols for template debugging
+- **Unloadable** - Dispose a template to unload the assembly it was compiled into
 
 ## Usage
 
@@ -203,7 +204,7 @@ var result = template.Run();
 
 ### Dynamic Parameters
 
-Use dynamic parameters when types are not known at compile time:
+Use dynamic parameters when types are not known at compile time. Note that a template using `dynamic` can never be unloaded, see [Memory Usage](#memory-usage):
 
 ```csharp
 var template = new Template();
@@ -268,6 +269,32 @@ The default template syntax uses `<%` and `%>` delimiters:
 | `<% statement %>` | Executes a C# statement | `<% var x = 10; %>` |
 | `<%+ member %>` | Declares a class member in the generated template class | `<%+private static int Get() => 42; %>` |
 | Text | Any text outside code blocks is written as-is | `Hello World` |
+
+## Memory Usage
+
+Building a template compiles it into an assembly, which is loaded in a collectible `AssemblyLoadContext` owned by the template. Dispose the template to unload that assembly; otherwise it is unloaded once the template becomes unreachable and the garbage collector runs. A disposed template cannot be built or run again.
+
+```csharp
+using var template = new Template { OutputType = typeof(Output) };
+template.Load("Hello <%=Name%>!");
+template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
+var result = template.Run("Meziantou");
+```
+
+This matters for processes that compile many templates, such as a server that compiles one template per tenant, per file, or on every file change. A one-shot process does not need to dispose anything.
+
+> [!IMPORTANT]
+> A template that uses `dynamic` is **never** unloaded, even when disposed. Executing a dynamic call site registers the type that contains it in a process-wide cache held by the C# runtime binder, and that cache keeps the generated assembly alive for the lifetime of the process.
+>
+> A template uses `dynamic` when `OutputType` is `null` (the default), when a `TemplateArgument` is declared without a type, or when its code blocks use `dynamic` themselves. Set `OutputType` and give every argument a type to get an unloadable template:
+>
+> ```csharp
+> using var template = new Template { OutputType = typeof(Output) };
+> template.Load("Hello <%=Name%>!");
+> template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
+> ```
+>
+> Declaring the types is worth it on its own: the template binds its calls at compile time, so it runs faster and reports errors when it is built instead of when it is run.
 
 ## Error Handling
 

--- a/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
@@ -195,6 +195,43 @@ public class EmailTemplateTest
         Assert.Equal("ABC", metadata.Title);
     }
     [Fact]
+    public void EmailTemplate_RunWithNamedParameters_MatchesArgumentsByName()
+    {
+        using var template = new HtmlEmailTemplate();
+        template.Load("{{@begin_section title}}Welcome{{@end_section}}: {{#html FirstName}} {{#html LastName}}");
+        template.Arguments.Add(new TemplateArgument("FirstName", typeof(string)));
+        template.Arguments.Add(new TemplateArgument("LastName", typeof(string)));
+
+        // Declared in the opposite order of the arguments, so a positional binding would swap them
+        var result = template.Run(out var metadata, new Dictionary<string, object?>
+        {
+            ["LastName"] = "Barr<e>",
+            ["FirstName"] = "G&rald",
+        });
+
+        Assert.Equal("Welcome: G&amp;rald Barr&lt;e&gt;", result);
+        Assert.NotNull(metadata);
+        Assert.Equal("Welcome", metadata.Title);
+    }
+
+    [Fact]
+    public void EmailTemplate_RunWithNamedParameters_KeepsTheComparerOfTheDictionary()
+    {
+        using var template = new HtmlEmailTemplate();
+        template.Load("{{#html FirstName}} {{#html LastName}}");
+        template.Arguments.Add(new TemplateArgument("FirstName", typeof(string)));
+        template.Arguments.Add(new TemplateArgument("LastName", typeof(string)));
+
+        var parameters = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["firstname"] = "Gerald",
+            ["lastname"] = "Barre",
+        };
+
+        Assert.Equal("Gerald Barre", template.Run(out _, parameters));
+    }
+
+    [Fact]
     public void EmailTemplate_SettingTheOutputType_CompilesEveryBlockWithoutDynamic()
     {
         using var template = new HtmlEmailTemplate { OutputType = typeof(HtmlEmailOutput) };

--- a/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
@@ -1,3 +1,7 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+
 namespace Meziantou.Framework.Templating.Tests;
 
 public class EmailTemplateTest
@@ -6,7 +10,7 @@ public class EmailTemplateTest
     public void EmailTemplate_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{# \"Meziantou\" }}!");
 
         // Act 
@@ -20,7 +24,7 @@ public class EmailTemplateTest
     public void EmailTemplate_Section_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{@begin_section title}}{{# \"Meziantou\" }}{{@end_section}}!");
 
         // Act 
@@ -34,7 +38,7 @@ public class EmailTemplateTest
     public void EmailTemplate_HtmlEncode_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{#html \"<Meziantou>\" }}!");
 
         // Act 
@@ -46,7 +50,7 @@ public class EmailTemplateTest
     public void EmailTemplate_UrlEncode_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello <a href=\"http://www.localhost.com/{{#url \"Sample&Url\" }}\">Meziantou</a>!");
 
         // Act 
@@ -58,7 +62,7 @@ public class EmailTemplateTest
     public void EmailTemplate_HtmlAttributeEncode_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello <a href=\"{{#attr \"Sample&Sample\"}}\">Meziantou</a>!");
 
         // Act 
@@ -70,7 +74,7 @@ public class EmailTemplateTest
     public void EmailTemplate_HtmlCode_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("{{html for(int i = 0; i &lt; 3; i++) { }}{{#i}} {{ } }}");
 
         // Act 
@@ -82,7 +86,7 @@ public class EmailTemplateTest
     public void EmailTemplate_Cid_01()
     {
         // Arrange
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("<img src=\"{{cid test1.png}}\" /><img src=\"{{cid test2.png}}\" />");
 
         // Act 
@@ -97,7 +101,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_Section_CapturesPlainText()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{@begin_section title}}Plain text{{@end_section}}!");
 
         var result = template.Run(out var metadata);
@@ -109,7 +113,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_Section_CapturesExpressionValue()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{@begin_section title}}{{= 42 }}{{@end_section}}!");
 
         var result = template.Run(out var metadata);
@@ -121,7 +125,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_ExpressionBlock_WritesArrayValueWithoutTreatingItAsFormatArguments()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("{{# new object[] { 1, 2 } }}");
 
         Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run(out _));
@@ -130,7 +134,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_ExpressionBlock_WritesEmptyArrayValueWithoutThrowing()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("{{# System.Array.Empty<object>() }}");
 
         Assert.Equal(System.Array.Empty<object>().ToString(), template.Run(out _));
@@ -139,7 +143,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_HtmlEncode_EncodesArrayValueWithoutTreatingItAsFormatArguments()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("{{#html new object[] { 1, 2 } }}");
 
         Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run(out _));
@@ -148,7 +152,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_UnclosedSection_Throws()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{@begin_section title}}Subject");
 
         var exception = Assert.Throws<TemplateException>(() => template.Run(out _));
@@ -160,7 +164,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_SeveralUnclosedSections_AreAllReported()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("{{@begin_section title}}a{{@begin_section footer}}b");
 
         var exception = Assert.Throws<TemplateException>(() => template.Run(out _));
@@ -172,7 +176,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_UnclosedSection_ThrowsFromInheritedRunOverloadsToo()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("Hello {{@begin_section title}}Subject");
 
         Assert.Throws<TemplateException>(() => ((Template)template).Run());
@@ -181,7 +185,7 @@ public class EmailTemplateTest
     [Fact]
     public void EmailTemplate_NestedSectionsWithTheSameName_KeepTheOutermostContent()
     {
-        var template = new HtmlEmailTemplate();
+        using var template = new HtmlEmailTemplate();
         template.Load("{{@begin_section title}}A{{@begin_section title}}B{{@end_section}}C{{@end_section}}");
 
         var result = template.Run(out var metadata);
@@ -189,5 +193,74 @@ public class EmailTemplateTest
         Assert.Equal("ABC", result);
         Assert.NotNull(metadata);
         Assert.Equal("ABC", metadata.Title);
+    }
+    [Fact]
+    public void EmailTemplate_SettingTheOutputType_CompilesEveryBlockWithoutDynamic()
+    {
+        using var template = new HtmlEmailTemplate { OutputType = typeof(HtmlEmailOutput) };
+        template.Load("""
+            {{@begin_section title}}Welcome{{@end_section}}
+            <img src="{{cid logo.png}}" alt="{{#attr AltText}}">
+            <a href="{{#url Url}}">{{#html Name}}</a>
+            {{# 40 + 2 }}
+            """);
+        template.Arguments.Add(new TemplateArgument("AltText", typeof(string)));
+        template.Arguments.Add(new TemplateArgument("Url", typeof(string)));
+        template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
+
+        var result = template.Run(out var metadata, "Logo & co", "https://example.com/", "<Meziantou>");
+
+        Assert.DoesNotContain("dynamic", template.SourceCode);
+        Assert.Contains("""<img src="cid:logo.png" alt="Logo &amp; co">""", result);
+        Assert.Contains("""&lt;Meziantou&gt;</a>""", result);
+        Assert.Contains("42", result);
+        Assert.NotNull(metadata);
+        Assert.Equal("Welcome", metadata.Title);
+        Assert.Equal(["logo.png"], metadata.ContentIdentifiers);
+    }
+
+    [Fact]
+    public void EmailTemplate_Dispose_UnloadsTheCompiledAssembly_WhenTheOutputTypeIsSet()
+    {
+        var loadContext = BuildAndReleaseTemplate();
+
+        // Unloading is not synchronous: it completes on a later collection, once the runtime has
+        // finished walking everything that referenced the assembly.
+        for (var i = 0; i < 20 && loadContext.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(loadContext.IsAlive, "The compiled assembly was not unloaded");
+    }
+
+    // The template must not be reachable from the caller frame when the collection runs, so keep it
+    // in a non-inlined method and only return a weak reference to the load context it created.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference BuildAndReleaseTemplate()
+    {
+        using var template = new TemplateTrackingItsLoadContext { OutputType = typeof(HtmlEmailOutput) };
+        template.Load("Hello {{#html Name}}!");
+        template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
+
+        Assert.Equal("Hello &lt;Meziantou&gt;!", template.Run(out _, "<Meziantou>"));
+
+        var loadContext = template.LoadContext!;
+        Assert.True(loadContext.IsAlive, "The template was not loaded in its own load context");
+
+        return loadContext;
+    }
+
+    private sealed class TemplateTrackingItsLoadContext : HtmlEmailTemplate
+    {
+        public WeakReference? LoadContext { get; private set; }
+
+        protected override Assembly LoadAssembly(MemoryStream peStream, MemoryStream pdbStream)
+        {
+            var assembly = base.LoadAssembly(peStream, pdbStream);
+            LoadContext = new WeakReference(AssemblyLoadContext.GetLoadContext(assembly));
+            return assembly;
+        }
     }
 }

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -1,3 +1,7 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+
 namespace Meziantou.Framework.Templating.Tests;
 
 public class TemplateTest
@@ -6,7 +10,7 @@ public class TemplateTest
     public void Template_TextOnly()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Load("Sample");
         template.OutputType = typeof(Output);
 
@@ -19,7 +23,7 @@ public class TemplateTest
     public void Template_CodeOnly()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Load("<% " + template.OutputParameterName + ".Write(\"Sample\"); %>");
 
         // Act
@@ -31,7 +35,7 @@ public class TemplateTest
     public void Template_CodeEval()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%= \"Sample\" %>");
 
         // Act
@@ -42,7 +46,7 @@ public class TemplateTest
     [Fact]
     public void Template_CodeEval_VerbatimString()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%= @\"Sample\" %>");
 
         var result = template.Run();
@@ -54,7 +58,7 @@ public class TemplateTest
     public void Template_CodeEvalParameter01()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Load("Hello <%=Name%>!");
         template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
 
@@ -67,7 +71,7 @@ public class TemplateTest
     public void Template_CodeEvalParameter02()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Load("Hello <%=Name%>!");
         var arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
         {
@@ -87,7 +91,7 @@ public class TemplateTest
     public void Template_Loop01()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Load("Hello <% for(int i = 1; i <= 5; i++ ) { %><%= i %><% } %>!");
 
         // Act
@@ -98,7 +102,7 @@ public class TemplateTest
     [Fact]
     public void Template_ClassMemberBlock_IsParsed()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%+ private static string Sample() => \"Sample\"; %>");
 
         var block = Assert.Single(template.Blocks.OfType<ClassMemberBlock>());
@@ -108,7 +112,7 @@ public class TemplateTest
     [Fact]
     public void Template_CodeEvalBlock_IsParsedWithoutPrefix()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%= 1 %>");
 
         var block = Assert.Single(template.Blocks.OfType<CodeBlock>(), codeBlock => codeBlock.IsExpression);
@@ -118,7 +122,7 @@ public class TemplateTest
     [Fact]
     public void Template_DirectiveBlock_IsParsedWithoutPrefix()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%@ outputextension .cs %>");
 
         var block = Assert.Single(template.Blocks.OfType<DirectiveBlock>());
@@ -128,7 +132,7 @@ public class TemplateTest
     [Fact]
     public void Template_ClassMemberBlock_CanBeInvokedFromTemplate()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("""
             <%+ private static string Sample() => "Sample"; %>
             <%= Sample() %>
@@ -142,7 +146,7 @@ public class TemplateTest
     [Fact]
     public void Template_ClassMemberBlock_StrictSyntaxOnly()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<% + private static string Sample() => \"Sample\"; %>");
 
         Assert.Empty(template.Blocks.OfType<ClassMemberBlock>());
@@ -152,7 +156,7 @@ public class TemplateTest
     [Fact]
     public void Template_ClassMemberBlock_IsGeneratedAtClassScope()
     {
-        var template = new TemplateWithoutCompilation();
+        using var template = new TemplateWithoutCompilation();
         template.Load("""
             <%+private static string Sample() => "Sample"; %>
             <%= Sample() %>
@@ -167,7 +171,7 @@ public class TemplateTest
     [Fact]
     public void Template_OverlappingStartDelimiter_ExpressionBlockIsParsed()
     {
-        var template = new Template
+        using var template = new Template
         {
             StartCodeBlockDelimiter = "<#",
             EndCodeBlockDelimiter = "#>",
@@ -182,7 +186,7 @@ public class TemplateTest
     [Fact]
     public void Template_LineOnlyCodeBlock_DoesNotCreateTrailingTextNewLineBlock()
     {
-        var template = new Template
+        using var template = new Template
         {
             StartCodeBlockDelimiter = "<#",
             EndCodeBlockDelimiter = "#>",
@@ -200,7 +204,7 @@ public class TemplateTest
     [Fact]
     public void Template_LineOnlyDirective_DoesNotCreateTrailingTextNewLineBlock()
     {
-        var template = new Template
+        using var template = new Template
         {
             StartCodeBlockDelimiter = "<#",
             EndCodeBlockDelimiter = "#>",
@@ -219,7 +223,7 @@ public class TemplateTest
     public void Template_UntypedArgument()
     {
         // Arrange
-        var template = new Template();
+        using var template = new Template();
         template.Arguments.Add(new TemplateArgument("Name", type: null));
         template.Load("Hello <%= Name %>!");
 
@@ -232,7 +236,7 @@ public class TemplateTest
     public void Template_Debug()
     {
         // Arrange
-        var template = new Template
+        using var template = new Template
         {
             Debug = true,
         };
@@ -255,7 +259,7 @@ public class TemplateTest
     public void Template_Release()
     {
         // Arrange
-        var template = new Template
+        using var template = new Template
         {
             Debug = false,
         };
@@ -277,7 +281,7 @@ public class TemplateTest
     [Fact]
     public void Template_Directives_AreParsed_AndWellKnownDirectivesAreApplied()
     {
-        var template = new TemplateWithoutCompilation();
+        using var template = new TemplateWithoutCompilation();
         template.Load("""
             <%@ USING System.Linq %>
             <%@ InHeRiTs CustomBase %>
@@ -349,7 +353,7 @@ public class TemplateTest
 
         try
         {
-            var template = new Template();
+            using var template = new Template();
             template.Load($"""
                 <%@ include {sourceFilePath} %>
                 <%= IncludedHelper.GetValue() %>
@@ -373,7 +377,7 @@ public class TemplateTest
             <%@ outputextension .cs %>
             line3
             """;
-        var template = new Template();
+        using var template = new Template();
         template.Load(Source);
 
         var directive = Assert.Single(template.Blocks!.OfType<DirectiveBlock>());
@@ -389,7 +393,7 @@ public class TemplateTest
     [Fact]
     public void Template_UnknownDirective_DoesNotEmitCode()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("Hello <%@ outputextension .cs %> World");
 
         var result = template.Run();
@@ -402,7 +406,7 @@ public class TemplateTest
     public void Template_Blocks_HaveSpanMatchingOriginalText()
     {
         const string Source = "A<%= 1 %>B";
-        var template = new Template();
+        using var template = new Template();
         template.Load(Source);
 
         foreach (var block in template.Blocks!)
@@ -416,7 +420,7 @@ public class TemplateTest
     public void Template_Blocks_HaveCorrectSpanWithCRLF()
     {
         const string Source = "line1\r\n<%= 1 %>\r\nline3";
-        var template = new Template();
+        using var template = new Template();
         template.Load(Source);
 
         var codeBlock = Assert.Single(template.Blocks!.OfType<CodeBlock>(), codeBlock => codeBlock.IsExpression);
@@ -429,7 +433,7 @@ public class TemplateTest
     [Fact]
     public void Template_CodeBlocks_EmitLineDirectivesWithoutFileName()
     {
-        var template = new TemplateWithoutCompilation();
+        using var template = new TemplateWithoutCompilation();
         template.Load("<% var value = 0; %>");
 
         template.Build(CancellationToken.None);
@@ -441,7 +445,7 @@ public class TemplateTest
     [Fact]
     public void Template_ExpressionAndClassMemberBlocks_EmitLineDirectivesWithFileName()
     {
-        var template = new TemplateWithoutCompilation
+        using var template = new TemplateWithoutCompilation
         {
             SourceFileName = "template.cs",
         };
@@ -461,7 +465,7 @@ public class TemplateTest
     public void Template_LineDirectives_MapCompilerDiagnosticToTemplate(string source)
     {
         const string SourceFileName = "template.cs";
-        var template = new Template
+        using var template = new Template
         {
             SourceFileName = SourceFileName,
         };
@@ -514,7 +518,7 @@ public class TemplateTest
     [Fact]
     public void Template_Collections_CanBeModifiedBeforeBuild()
     {
-        var template = new Template();
+        using var template = new Template();
         var argument = new TemplateArgument("Value", typeof(int));
         template.Arguments.Add(argument);
         template.Usings.Add("System");
@@ -562,7 +566,7 @@ public class TemplateTest
     [Fact]
     public void Template_Load_ThrowsOnceBuilt()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("text");
         template.Build(CancellationToken.None);
 
@@ -572,7 +576,7 @@ public class TemplateTest
     [Fact]
     public void Template_Collections_ValidateNullAndEmptyItems()
     {
-        var template = new Template();
+        using var template = new Template();
 
         Assert.Throws<ArgumentNullException>(() => template.Arguments.Add(null!));
         Assert.Throws<ArgumentNullException>(() => template.Usings.Add(null!));
@@ -592,7 +596,7 @@ public class TemplateTest
     [Fact]
     public void Template_Collections_AreFrozenAfterBuild()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Arguments.Add(new TemplateArgument("Name", typeof(string)));
         template.Load("Hello <%= Name %>!");
 
@@ -616,7 +620,7 @@ public class TemplateTest
     [Fact]
     public void Template_ManualInterfaces_AreNotClearedByDirectiveApplication()
     {
-        var template = new TemplateWithoutCompilation();
+        using var template = new TemplateWithoutCompilation();
         template.ImplementedInterfaces.Add("IManual");
         template.Load("<%@implements IDirective %>");
 
@@ -628,7 +632,7 @@ public class TemplateTest
     [Fact]
     public void Template_ImplementsDirective_IsAddedToClassSignature()
     {
-        var template = new TemplateWithoutCompilation
+        using var template = new TemplateWithoutCompilation
         {
             BaseClassFullTypeName = "BaseClass",
         };
@@ -645,29 +649,39 @@ public class TemplateTest
         const int TemplateCount = 8;
 
         var templates = new Template[TemplateCount];
-        for (var i = 0; i < templates.Length; i++)
+        try
         {
-            var template = new Template();
-            template.Load($"value: <%= {i} %>");
-            templates[i] = template;
+            for (var i = 0; i < templates.Length; i++)
+            {
+                var template = new Template();
+                template.Load($"value: <%= {i} %>");
+                templates[i] = template;
+            }
+
+            var results = await Task.WhenAll(templates.Select(template => Task.Run(() =>
+            {
+                template.Build(CancellationToken.None);
+                return template.Run();
+            })));
+
+            for (var i = 0; i < results.Length; i++)
+            {
+                Assert.Equal($"value: {i}", results[i]);
+            }
         }
-
-        var results = await Task.WhenAll(templates.Select(template => Task.Run(() =>
+        finally
         {
-            template.Build(CancellationToken.None);
-            return template.Run();
-        })));
-
-        for (var i = 0; i < results.Length; i++)
-        {
-            Assert.Equal($"value: {i}", results[i]);
+            foreach (var template in templates)
+            {
+                template?.Dispose();
+            }
         }
     }
 
     [Fact]
     public async Task Template_SameInstance_BuiltOnceWhenRunConcurrently()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("Hello <%= 1 + 1 %>");
 
         var results = await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() => template.Run())));
@@ -681,10 +695,10 @@ public class TemplateTest
     {
         const string Source = "line1\r\n  <% var a = 0; %>  \r\ntext <%= a %>\ntail";
 
-        var fromString = new Template();
+        using var fromString = new Template();
         fromString.Load(Source);
 
-        var fromReader = new Template();
+        using var fromReader = new Template();
         using (var reader = new StringReader(Source))
         {
             fromReader.Load(reader);
@@ -706,7 +720,7 @@ public class TemplateTest
     [InlineData("a\n<%+ private int _f; %>\nb", "a\nb")]
     public void Template_LineOnlyCodeBlock_SwallowsRestOfItsLine(string source, string expected)
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load(source);
 
         Assert.Equal(expected, template.Run());
@@ -715,7 +729,7 @@ public class TemplateTest
     [Fact]
     public void Template_LineOnlyCodeBlock_KeepsWhitespaceWhenTextFollowsOnTheSameLine()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a\n  <% var x = 0; %>  b\n");
 
         Assert.Equal("a\n    b\n", template.Run());
@@ -724,7 +738,7 @@ public class TemplateTest
     [Fact]
     public void Template_ExpressionBlockAloneOnLine_DoesNotSwallowItsLine()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a\n  <%= 1 %>  \nb");
 
         Assert.Equal("a\n  1  \nb", template.Run());
@@ -733,7 +747,7 @@ public class TemplateTest
     [Fact]
     public void Template_UnterminatedCodeBlock_IsParsedAsTextKeepingTheStartDelimiter()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a<% var x = 0;");
 
         Assert.Collection(
@@ -747,7 +761,7 @@ public class TemplateTest
     [Fact]
     public void Template_UnterminatedCodeBlockAfterATerminatedOne_KeepsTheStartDelimiter()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a<%= 1 %>b<% var x = 0;");
 
         Assert.Equal("a1b<% var x = 0;", template.Run());
@@ -756,7 +770,7 @@ public class TemplateTest
     [Fact]
     public void Template_UnterminatedCodeBlock_ReportsThePositionOfTheStartDelimiter()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a\n<% var x = 0;");
 
         var block = Assert.IsType<TextBlock>(template.Blocks[^1]);
@@ -766,7 +780,7 @@ public class TemplateTest
     [Fact]
     public void Template_SelfOverlappingDelimiter_IsMatched()
     {
-        var template = new Template
+        using var template = new Template
         {
             StartCodeBlockDelimiter = "aab",
             EndCodeBlockDelimiter = "zzy",
@@ -789,7 +803,7 @@ public class TemplateTest
     [Fact]
     public void Template_ExpressionBlock_WritesNullAsEmptyString()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a<%= null %>b");
 
         Assert.Equal("ab", template.Run());
@@ -798,7 +812,7 @@ public class TemplateTest
     [Fact]
     public void Template_ExpressionBlock_FormatsFormattableValueUsingWriterFormatProvider()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%= 1.5 %>|<%= 42 %>|<%= new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc) %>");
 
         var expected = string.Create(CultureInfo.CurrentCulture, $"{1.5}|{42}|{new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc)}");
@@ -808,7 +822,7 @@ public class TemplateTest
     [Fact]
     public void Template_ExpressionBlock_WritesArrayValueWithoutTreatingItAsFormatArguments()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%= new object[] { 1, 2 } %>");
 
         Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run());
@@ -817,7 +831,7 @@ public class TemplateTest
     [Fact]
     public void Template_FailedBuild_ProducesTheSameDiagnosticsWhenRetried()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%@ implements System.IDisposable %><%= Missing %>");
 
         var first = Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
@@ -830,7 +844,7 @@ public class TemplateTest
     [Fact]
     public void Template_FailedBuild_RollsBackTheDirectivesItApplied()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%@ using System.Globalization %><%@ implements System.IDisposable %><%= Missing %>");
 
         Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
@@ -842,7 +856,7 @@ public class TemplateTest
     [Fact]
     public void Template_LoadAfterFailedBuild_AppliesOnlyTheNewDirectives()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%@ implements System.IDisposable %><%= Missing %>");
         Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
 
@@ -855,7 +869,7 @@ public class TemplateTest
     [Fact]
     public void Template_ClassMemberBlockDeclaringARunOverload_DoesNotBreakTheMethodLookup()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%+ public static void Run(int value) { } %>hi");
 
         Assert.Equal("hi", template.Run());
@@ -864,7 +878,7 @@ public class TemplateTest
     [Fact]
     public void Template_ClassMemberBlockDeclaringARunOverload_StillInvokesTheGeneratedMethod()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Arguments.Add(new TemplateArgument("value", typeof(int)));
         template.Load("<%+ public static void Run(int value) { } %><%= value %>");
 
@@ -876,7 +890,7 @@ public class TemplateTest
     [Fact]
     public void Template_ExpressionBlockMatchingTheGeneratedPrefix_EmitsTheColumnOfTheExpression()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("<%=__output__%>");
         template.Build(CancellationToken.None);
 
@@ -891,7 +905,7 @@ public class TemplateTest
     [Fact]
     public void Template_RunWithPositionalParameters_UsesCreateStringWriter()
     {
-        var template = new TemplateWithCountingStringWriter();
+        using var template = new TemplateWithCountingStringWriter();
         template.Load("a");
 
         Assert.Equal("a", template.Run());
@@ -901,7 +915,7 @@ public class TemplateTest
     [Fact]
     public void Template_RunWithNamedParameters_UsesCreateStringWriter()
     {
-        var template = new TemplateWithCountingStringWriter();
+        using var template = new TemplateWithCountingStringWriter();
         template.Load("a");
 
         Assert.Equal("a", template.Run(new Dictionary<string, object?>()));
@@ -911,7 +925,7 @@ public class TemplateTest
     [Fact]
     public void Template_RunWithPositionalParameters_ThrowsOnNullWriterWithoutBuilding()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a");
 
         Assert.Throws<ArgumentNullException>(() => template.Run(writer: null!));
@@ -921,11 +935,122 @@ public class TemplateTest
     [Fact]
     public void Template_RunWithNamedParameters_ThrowsOnNullWriterWithoutBuilding()
     {
-        var template = new Template();
+        using var template = new Template();
         template.Load("a");
 
         Assert.Throws<ArgumentNullException>(() => template.Run(writer: null!, new Dictionary<string, object?>()));
         Assert.False(template.IsBuilt);
+    }
+
+    [Fact]
+    public void Template_Dispose_UnloadsTheCompiledAssembly()
+    {
+        var loadContext = BuildAndDisposeTemplate(typeof(Output));
+        AssertUnloaded(loadContext);
+    }
+
+    [Fact]
+    public void Template_UnloadsTheCompiledAssembly_WhenNotDisposed()
+    {
+        var loadContext = BuildAndAbandonTemplate(typeof(Output));
+        AssertUnloaded(loadContext);
+    }
+
+    [Fact]
+    public void Template_DynamicTemplate_IsNeverUnloaded()
+    {
+        // Known limitation, documented in the readme: executing a dynamic call site registers the
+        // type that contains it in a process-wide cache held by the C# runtime binder, which roots
+        // the generated assembly for good. A template only unloads when it declares its types.
+        // If this test starts failing, the runtime has fixed the leak and the readme is stale.
+        var loadContext = BuildAndDisposeTemplate(outputType: null);
+
+        for (var i = 0; i < 20; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.True(loadContext.IsAlive, "A dynamic template is now unloadable");
+    }
+
+    [Fact]
+    public void Template_Build_ThrowsWhenDisposed()
+    {
+        var template = new Template();
+        template.Load("a");
+        template.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => template.Build(CancellationToken.None));
+        Assert.Throws<ObjectDisposedException>(() => template.Run());
+        Assert.Throws<ObjectDisposedException>(() => template.Run(new Dictionary<string, object?>()));
+    }
+
+    [Fact]
+    public void Template_Dispose_IsIdempotent()
+    {
+        var template = new Template();
+        template.Load("a");
+        Assert.Equal("a", template.Run());
+
+        template.Dispose();
+        template.Dispose();
+
+        Assert.False(template.IsBuilt);
+    }
+
+    // The template must not be reachable from the caller frame when the collection runs, so keep it
+    // in a non-inlined method and only return a weak reference to the load context it created.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference BuildAndDisposeTemplate(Type? outputType)
+    {
+        using var template = new TemplateTrackingItsLoadContext { OutputType = outputType };
+        return RunAndGetLoadContext(template);
+    }
+
+    // The template is deliberately left undisposed: unloading must also happen once it becomes unreachable.
+#pragma warning disable CA2000
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference BuildAndAbandonTemplate(Type? outputType)
+    {
+        var template = new TemplateTrackingItsLoadContext { OutputType = outputType };
+        return RunAndGetLoadContext(template);
+    }
+#pragma warning restore CA2000
+
+    private static WeakReference RunAndGetLoadContext(TemplateTrackingItsLoadContext template)
+    {
+        template.Load("Hello <%= 40 + 2 %>");
+        Assert.Equal("Hello 42", template.Run());
+
+        var loadContext = template.LoadContext!;
+        Assert.True(loadContext.IsAlive, "The template was not loaded in its own load context");
+        return loadContext;
+    }
+
+    private static void AssertUnloaded(WeakReference loadContext)
+    {
+        // Unloading is not synchronous: it completes on a later collection, once the runtime has
+        // finished walking everything that referenced the assembly.
+        for (var i = 0; i < 20 && loadContext.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(loadContext.IsAlive, "The compiled assembly was not unloaded");
+    }
+
+    private sealed class TemplateTrackingItsLoadContext : Template
+    {
+        public WeakReference? LoadContext { get; private set; }
+
+        protected override Assembly LoadAssembly(MemoryStream peStream, MemoryStream pdbStream)
+        {
+            var assembly = base.LoadAssembly(peStream, pdbStream);
+            LoadContext = new WeakReference(AssemblyLoadContext.GetLoadContext(assembly));
+            return assembly;
+        }
     }
 
     private sealed class TemplateWithCountingStringWriter : Template


### PR DESCRIPTION
Fixes #2702, plus a bug found while writing the tests for it.

## Every `Template.Build` leaked an assembly into the default load context

`Template.LoadAssembly` used `Assembly.Load(byte[], byte[])`, which loads into the default `AssemblyLoadContext`. That context is never collectible, so every build leaked roughly 320 KB of assembly, metadata and JIT'd native code for the lifetime of the process — building 30 trivial templates in a loop grew the managed heap from 2.7 MB to 12.3 MB with a forced full GC on either side. Any host that compiles templates per tenant, per file, or on file-change reload grew without bound until it restarted, which is exactly the long-running-server scenario `Meziantou.Framework.Templating.Html` advertises.

Each template now owns a collectible `AssemblyLoadContext`, created by a new `protected virtual CreateAssemblyLoadContext()`, and `Template` implements `IDisposable` to unload it.

**Disposing is not required for the leak to be fixed.** A collectible context also unloads once the template becomes unreachable and the garbage collector runs; `Dispose()` only makes it deterministic. Both paths have a test. A disposed template throws `ObjectDisposedException` rather than running stale code.

### `dynamic` templates are still never unloaded

The issue asked whether a collectible context actually unloads with the default `OutputType`, which compiles to `dynamic`. It does not. Measured:

| scenario | unloads? |
|---|---|
| typed `OutputType`, run | yes |
| `dynamic`, built but never run | yes |
| `dynamic`, run | **no** |
| `dynamic` dispatched from a helper in a non-collectible assembly | yes |

The root is the dynamic call site living *inside* the generated assembly: executing it registers the containing type in the C# runtime binder's process-wide cache, which pins the assembly for good. Moving the dispatch out of the generated assembly would fix the calls this library emits, but any `<% __output__.Foo() %>` in a user code block would still pin it, and it would change every `BuildCode()` output — not a trade worth making here.

Setting `OutputType` and giving every argument a type produces an unloadable template, so both readmes document that, and `Template_DynamicTemplate_IsNeverUnloaded` pins the limitation: if a future runtime fixes the leak, the test fails and the documentation gets flagged.

**Left for a follow-up decision:** `HtmlEmailTemplate` still defaults to `dynamic`, so a server has to opt in with `OutputType = typeof(HtmlEmailOutput)`. Defaulting it would fix that out of the box but breaks subclasses that override `CreateOutput` with extra members, so I left the API policy call alone. There is a test showing every HTML block — `#html`, `#attr`, `#url`, `cid`, sections — compiles without `dynamic` and unloads once `OutputType` is set.

## `HtmlEmailTemplate.Run(out metadata, dictionary)` ignored the parameter names

Found while writing the above tests, fixed in the second commit.

`Run(out metadata, IDictionary<string, object?>)` passed the dictionary straight to `Run(TextWriter, out metadata, ...)`. `IDictionary<,>` does not derive from `IReadOnlyDictionary<,>`, so the call bound to the `params object?[]` overload and handed the whole dictionary over as one positional argument: with a single template argument that argument silently received the dictionary itself, and with any other argument count the run threw `TargetParameterCountException`. This is the call documented in the readme and in the `<example>` on the class, and nothing covered it.

The dictionary is now wrapped in a `ReadOnlyDictionary` before the inner call. The public parameter type is deliberately left as `IDictionary<,>` — changing it to `IReadOnlyDictionary<,>` would relocate the same mis-binding into callers holding an `IDictionary<,>`-typed variable, where the `params` overload would swallow it again with no compiler error. Wrapping rather than copying keeps the comparer of the original dictionary, which the argument lookup relies on; both properties have a test, and both fail against the old code.

## Notes for review

- `ref/Meziantou.Framework.Templating.cs` is regenerated: `IDisposable`, `CreateAssemblyLoadContext`, and the two `Dispose` members. `ref/Meziantou.Framework.Templating.Html.cs` is unchanged — the second fix does not touch the public surface.
- Adding `IDisposable` makes CA2000 fire on every construction site, which is most of the churn in the test files. Downstream consumers will see the same warning; that is the "breaking-ish" part called out in the issue.
- `dotnet run ./eng/update-all.cs` reports no changes. Release + `IsOfficialBuild` builds of all three source projects are clean, and all templating tests pass on net10.0 and net11.0 (74 / 20 / 18).
