### PR TITLE
Remove the Array.MaxLength limit from PooledMemoryStream

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -19,6 +19,12 @@ namespace Meziantou.Framework;
 /// returned by the <see cref="IBufferWriter{T}"/> members) are owned by the stream and are returned to the pool when
 /// the stream is disposed. Accessing them after the stream is disposed is undefined behavior.
 /// </para>
+/// <para>
+/// Because the storage is a chain of blocks rather than one array, the stream is not bounded by
+/// <see cref="Array.MaxLength"/>: it can hold as many bytes as memory allows. The members that have to materialize
+/// the contents as a single array (<see cref="ToArray"/>, <see cref="GetBuffer"/> and <see cref="TryGetBuffer"/>)
+/// are still bounded by it and throw an <see cref="InvalidOperationException"/> on a longer stream.
+/// </para>
 /// <para>This type is not thread-safe; the shared pool is.</para>
 /// </remarks>
 public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
@@ -104,7 +110,6 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         {
             EnsureOpen();
             ArgumentOutOfRangeException.ThrowIfNegative(value);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, Array.MaxLength);
 
             _position = value;
         }
@@ -117,8 +122,9 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         {
             EnsureOpen();
 
-            // _capacity is a long and can exceed int.MaxValue by up to one block on a stream near Array.MaxLength.
-            // Clamp rather than wrap to a negative value; a getter that throws would be worse.
+            // _capacity is a long and the stream is not bounded by Array.MaxLength, so the capacity can exceed the
+            // range of this int property. Clamp rather than wrap to a negative value; a getter that throws would be
+            // worse.
             return _capacity > int.MaxValue ? int.MaxValue : (int)_capacity;
         }
         set
@@ -152,20 +158,23 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     public override long Seek(long offset, SeekOrigin loc)
     {
         EnsureOpen();
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, Array.MaxLength);
 
-        var newPosition = loc switch
+        var origin = loc switch
         {
-            SeekOrigin.Begin => offset,
-            SeekOrigin.Current => _position + offset,
-            SeekOrigin.End => _length + offset,
+            SeekOrigin.Begin => 0L,
+            SeekOrigin.Current => _position,
+            SeekOrigin.End => _length,
             _ => throw new ArgumentException("Invalid seek origin.", nameof(loc)),
         };
 
+        // The position is not bounded by Array.MaxLength, so the only limit left is the range of Int64. The origin is
+        // never negative, so only a positive offset can overflow.
+        if (offset > 0 && origin > long.MaxValue - offset)
+            throw new ArgumentOutOfRangeException(nameof(offset), offset, "The resulting position would be greater than Int64.MaxValue.");
+
+        var newPosition = origin + offset;
         if (newPosition < 0)
             throw new IOException("An attempt was made to move the position before the beginning of the stream.");
-
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(newPosition, Array.MaxLength, nameof(offset));
 
         _position = newPosition;
         return newPosition;
@@ -176,7 +185,6 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     {
         EnsureOpen();
         ArgumentOutOfRangeException.ThrowIfNegative(value);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, Array.MaxLength);
 
         if (value > _length)
         {
@@ -257,7 +265,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         EnsureOpen();
         if (_position == _length)
         {
-            if (_length + 1 > Array.MaxLength)
+            if (_length == long.MaxValue)
                 throw new IOException("Stream was too long.");
 
             var index = EnsureAppendCapacity();
@@ -391,9 +399,11 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     }
 
     /// <summary>Returns a new array containing the contents of the stream.</summary>
+    /// <exception cref="InvalidOperationException">The stream is longer than <see cref="Array.MaxLength"/>.</exception>
     public override byte[] ToArray()
     {
         EnsureOpen();
+        ThrowIfLongerThanAnArray();
         var result = GC.AllocateUninitializedArray<byte>((int)_length);
         CopyAllTo(result);
         return result;
@@ -404,6 +414,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     /// larger than <see cref="Length"/>; only the first <see cref="Length"/> bytes are valid. The array is owned by
     /// the stream and is returned to the pool when the stream is disposed.
     /// </summary>
+    /// <exception cref="InvalidOperationException">The stream is longer than <see cref="Array.MaxLength"/>.</exception>
     public override byte[] GetBuffer()
     {
         EnsureOpen();
@@ -411,6 +422,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     }
 
     /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">The stream is longer than <see cref="Array.MaxLength"/>.</exception>
     public override bool TryGetBuffer(out ArraySegment<byte> buffer)
     {
         EnsureOpen();
@@ -430,7 +442,8 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         if (_segments.Count == 0 || count > _segments[^1].Array.Length - _segments[^1].Used)
             throw new InvalidOperationException("Cannot advance past the end of the reserved buffer.");
 
-        if (_length + count > Array.MaxLength)
+        // Subtract rather than add: _length + count can overflow long on a stream near Int64.MaxValue.
+        if (_length > long.MaxValue - count)
             throw new IOException("Stream was too long.");
 
         CollectionsMarshal.AsSpan(_segments)[_segments.Count - 1].Used += count;
@@ -509,7 +522,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
             return;
 
         // Subtract rather than add: _position + source.Length can overflow long for a far-out position.
-        if (_position > Array.MaxLength - source.Length)
+        if (_position > long.MaxValue - source.Length)
             throw new IOException("Stream was too long.");
 
         if (_position > _length)
@@ -670,6 +683,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
 
     private byte[] Consolidate()
     {
+        ThrowIfLongerThanAnArray();
         if (_length == 0)
             return Array.Empty<byte>();
 
@@ -758,6 +772,13 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     {
         _cursorIndex = 0;
         _cursorStart = 0;
+    }
+
+    // The stream itself is not bounded by Array.MaxLength, but the members handing back a single byte[] are.
+    private void ThrowIfLongerThanAnArray()
+    {
+        if (_length > Array.MaxLength)
+            throw new InvalidOperationException("The stream is longer than Array.MaxLength and cannot be represented as a single array.");
     }
 
     private void EnsureOpen()

--- a/src/Meziantou.Framework.PooledMemoryStream/readme.md
+++ b/src/Meziantou.Framework.PooledMemoryStream/readme.md
@@ -64,4 +64,5 @@ using var stream = new PooledMemoryStream(options);
 
 - The byte arrays (including the array returned by `GetBuffer()` / `TryGetBuffer()`, and the spans/memory returned by the `IBufferWriter<byte>` members) are owned by the stream and are returned to the shared pool on `Dispose`. **Do not use them after the stream is disposed.**
 - `GetBuffer()` returns the whole underlying array, not just the first `Length` bytes. Only `[0, Length)` is meaningful; the rest is zeroed before the array is handed out, so it never exposes data written by another stream. The spans returned by the `IBufferWriter<byte>` members are uninitialized, as usual for a buffer writer.
+- Because the storage is a chain of blocks rather than a single array, the stream is not bounded by `Array.MaxLength`: it can hold as many bytes as memory allows. The members that must produce a single array (`ToArray()`, `GetBuffer()`, `TryGetBuffer()`) are still bounded by it and throw an `InvalidOperationException` on a longer stream. `Capacity` is an `int` inherited from `MemoryStream`, so its getter is clamped to `int.MaxValue`.
 - The instance is not thread-safe (like `MemoryStream`); the shared pool is.

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -125,41 +125,65 @@ public sealed class PooledMemoryStreamTests
     }
 
     [Fact]
-    public void Position_AboveArrayMaxLength_Throws()
+    public void Position_AboveArrayMaxLength_IsAllowed()
     {
+        // The storage is a chain of blocks, so the stream is not bounded by the length of a single array.
         using var stream = new PooledMemoryStream();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = (long)Array.MaxLength + 1);
-        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = long.MaxValue);
-        Assert.Equal(0, stream.Position);
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = -1);
 
-        stream.Position = Array.MaxLength;
-        Assert.Equal(Array.MaxLength, stream.Position);
+        stream.Position = (long)Array.MaxLength + 1;
+        Assert.Equal((long)Array.MaxLength + 1, stream.Position);
+
+        stream.Position = long.MaxValue;
+        Assert.Equal(long.MaxValue, stream.Position);
     }
 
     [Fact]
-    public void Seek_AboveArrayMaxLength_Throws()
+    public void Seek_AboveArrayMaxLength_IsAllowed()
     {
         using var stream = new PooledMemoryStream();
         stream.Write(CreateData(100));
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(long.MaxValue, SeekOrigin.Begin));
-        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek((long)Array.MaxLength + 1, SeekOrigin.Begin));
-        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(Array.MaxLength, SeekOrigin.End));
+        Assert.Equal(long.MaxValue, stream.Seek(long.MaxValue, SeekOrigin.Begin));
+        Assert.Equal((long)Array.MaxLength + 1, stream.Seek((long)Array.MaxLength + 1, SeekOrigin.Begin));
+        Assert.Equal(Array.MaxLength + 100L, stream.Seek(Array.MaxLength, SeekOrigin.End));
+    }
+
+    [Fact]
+    public void Seek_PastInt64MaxValue_Throws()
+    {
+        using var stream = new PooledMemoryStream();
+        stream.Write(CreateData(100));
+
+        stream.Position = long.MaxValue - 10;
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(11, SeekOrigin.Current));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(long.MaxValue, SeekOrigin.End));
+        Assert.Equal(long.MaxValue - 10, stream.Position);
+    }
+
+    [Fact]
+    public void SetLength_AboveArrayMaxLength_IsNotRejected()
+    {
+        // The length is only validated against the range of Int64; the actual allocation is what bounds the stream.
+        using var stream = new PooledMemoryStream();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.SetLength(-1));
+        Assert.Equal(0, stream.Length);
     }
 
     [Fact]
     public void WriteAtFarPosition_Throws_InsteadOfAllocatingForever()
     {
-        // Regression: Position was unbounded and WriteCore guarded with "_position + count > Array.MaxLength",
-        // which overflows to a negative value near long.MaxValue. The guard passed and the write fell into an
-        // unbounded zero-fill loop that never returned.
+        // Regression: WriteCore guarded with "_position + count > limit", which overflows to a negative value near
+        // long.MaxValue. The guard passed and the write fell into an unbounded zero-fill loop that never returned.
         using var stream = new PooledMemoryStream();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = long.MaxValue);
-
-        stream.Position = Array.MaxLength;
+        stream.Position = long.MaxValue;
         Assert.Throws<IOException>(() => stream.WriteByte(1));
+        Assert.Throws<IOException>(() => stream.Write(CreateData(10)));
+
+        stream.Position = long.MaxValue - 5;
         Assert.Throws<IOException>(() => stream.Write(CreateData(10)));
     }
 


### PR DESCRIPTION
## What

`PooledMemoryStream` is no longer capped at `Array.MaxLength`. Its storage is already a chain of pooled blocks rather than a single array, so nothing in the design required that bound — it was only inherited from `MemoryStream`'s single-array layout.

- `Position`, `Seek` and `SetLength` now validate against the range of `Int64` only. `Seek` was rewritten to resolve the origin first and then guard the addition against `long` overflow; since the origin is never negative, only a positive offset can overflow.
- The overflow guards in `WriteCore`, `WriteByte` and `IBufferWriter.Advance` move from `Array.MaxLength` to `long.MaxValue`. They stay written as subtractions so the check itself cannot wrap.
- `ToArray()`, `GetBuffer()` and `TryGetBuffer()` must produce a single `byte[]`, so the limit is real for them. They previously would have cast `(int)_length` and silently corrupted; they now throw `InvalidOperationException` on a longer stream.

## Notes for reviewers

- **`Capacity` still clamps to `int.MaxValue`.** The property type is inherited from `MemoryStream` and cannot change, so the getter clamps rather than wrapping to a negative value. A getter that throws would be worse. The comment on it says so.
- **Writing at a far position now zero-fills without an upper bound.** That is the direct consequence of removing the cap: `SetLength` and a write past the end are bounded by available memory instead of by `Array.MaxLength`. The `Int64` guards still make the extreme cases throw `IOException` up front rather than falling into an unbounded loop.
- **The `InvalidOperationException` paths have no automated coverage.** Reaching them needs a stream larger than 2 GiB, and a test that allocates that much does not belong in the suite. I verified them with a throwaway program against a 2,147,484,591-byte stream: writing, reading across the `Array.MaxLength` boundary, `Seek` from `End`, and truncating back down all behaved, and the three single-array members threw as intended. That program is not part of this branch.

## Testing

- `dotnet test` on `Meziantou.Framework.PooledMemoryStream.Tests` passes in Debug and in Release with `IsOfficialBuild=true` (124 tests, 62 per TFM, 0 warnings, `TreatsWarningsAsErrors=true`).
- The three tests that asserted the old caps were rewritten to assert the new behavior, plus a new `Seek_PastInt64MaxValue_Throws` case. All of them are cheap — none allocate.
- `ref/Meziantou.Framework.PooledMemoryStream.cs` regenerated with no diff: no public API change.
- `dotnet run ./eng/update-all.cs` produced no changes.
