### PR TITLE
Parse robots.txt lines with the shared SplitLines helper

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -652,6 +652,8 @@ namespace Meziantou.Framework
         public static string RemovePrefix(this string str, string prefix, System.StringComparison stringComparison) => throw null;
         public static LineSplitEnumerator SplitLines(this string str) => throw null;
         public static LineSplitEnumerator SplitLines(this string str, Meziantou.Framework.LineBreakMode lineBreakMode) => throw null;
+        public static LineSplitEnumerator SplitLines(this System.ReadOnlySpan<char> str) => throw null;
+        public static LineSplitEnumerator SplitLines(this System.ReadOnlySpan<char> str, Meziantou.Framework.LineBreakMode lineBreakMode) => throw null;
         public ref struct LineSplitEntry
         {
             public System.ReadOnlySpan<char> Line { get => throw null; }

--- a/src/Meziantou.Framework.RobotsTxt/Meziantou.Framework.RobotsTxt.csproj
+++ b/src/Meziantou.Framework.RobotsTxt/Meziantou.Framework.RobotsTxt.csproj
@@ -7,4 +7,8 @@
     <Description>robots.txt parser following RFC 9309 with Google path-wildcard extensions</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="../Meziantou.Framework/StringExtensions.SplitLines.cs" Link="Internals/StringExtensions.SplitLines.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
+++ b/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
@@ -278,27 +278,10 @@ public sealed class RobotsFile
 
         public void Feed(ReadOnlySpan<char> content)
         {
-            while (!content.IsEmpty)
+            // RFC 9309 ends a line at CR, LF or CRLF only, so the other Unicode line breaks stay
+            // part of the value they appear in.
+            foreach (ReadOnlySpan<char> line in content.SplitLines(LineBreakMode.Standard))
             {
-                var nl = content.IndexOfAny('\n', '\r');
-                ReadOnlySpan<char> line;
-                if (nl < 0)
-                {
-                    line = content;
-                    content = [];
-                }
-                else
-                {
-                    line = content[..nl];
-                    var isCarriageReturn = content[nl] == '\r';
-                    content = content[(nl + 1)..];
-                    // Skip the '\n' of a "\r\n" pair. Only a '\r' can be followed by a '\n'
-                    // belonging to the same line break; consuming it unconditionally would
-                    // swallow the empty line in "\n\n".
-                    if (isCarriageReturn && !content.IsEmpty && content[0] == '\n')
-                        content = content[1..];
-                }
-
                 FeedLine(line.ToString());
             }
         }

--- a/src/Meziantou.Framework/StringExtensions.SplitLines.cs
+++ b/src/Meziantou.Framework/StringExtensions.SplitLines.cs
@@ -14,6 +14,9 @@ static partial class StringExtensions
 
     public static LineSplitEnumerator SplitLines(this string str, LineBreakMode lineBreakMode) => new(str.AsSpan(), lineBreakMode);
 
+    public static LineSplitEnumerator SplitLines(this ReadOnlySpan<char> str) => new(str, LineBreakMode.Unicode);
+
+    public static LineSplitEnumerator SplitLines(this ReadOnlySpan<char> str, LineBreakMode lineBreakMode) => new(str, lineBreakMode);
 
     [StructLayout(LayoutKind.Auto)]
     [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "<Pending>")]

--- a/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
+++ b/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
@@ -246,6 +246,24 @@ public sealed class RobotsFileTests
         Assert.Equal(["B"], robots.Groups[1].UserAgents);
     }
 
+    [Theory]
+    [InlineData("\v")]
+    [InlineData("\f")]
+    [InlineData("\u0085")]
+    [InlineData("\u2028")]
+    [InlineData("\u2029")]
+    public void Parse_NonStandardLineSeparators_DoNotEndTheLine(string separator)
+    {
+        // RFC 9309 ends a line at CR, LF or CRLF only. Every other Unicode line break is an
+        // ordinary character that belongs to the value it appears in.
+        var robots = RobotsFile.Parse($"User-agent: *\nDisallow: /a{separator}b\n");
+
+        var group = Assert.Single(robots.Groups);
+        var rule = Assert.Single(group.Rules);
+        Assert.Equal($"/a{separator}b", rule.Value);
+        Assert.Empty(robots.ParseErrors);
+    }
+
     [Fact]
     public void Parse_LeadingByteOrderMark_IsIgnored()
     {

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -95,6 +95,32 @@ public class StringExtensionsTests
     }
 
     [Theory]
+    [MemberData(nameof(SplitLineData))]
+    public void SplitLineSpan_FromReadOnlySpan(string str, (string Line, string Separator)[] expected)
+    {
+        var actual = new List<(string, string)>();
+        foreach (var (line, separator) in str.AsSpan().SplitLines())
+        {
+            actual.Add((line.ToString(), separator.ToString()));
+        }
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(SplitLineWithLineBreakModeData))]
+    public void SplitLineSpan_FromReadOnlySpan_WithLineBreakMode(string str, LineBreakMode lineBreakMode, (string Line, string Separator)[] expected)
+    {
+        var actual = new List<(string, string)>();
+        foreach (var (line, separator) in str.AsSpan().SplitLines(lineBreakMode))
+        {
+            actual.Add((line.ToString(), separator.ToString()));
+        }
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
     [MemberData(nameof(SplitLineWithLineBreakModeData))]
     public void SplitLineSpan_WithLineBreakMode(string str, LineBreakMode lineBreakMode, (string Line, string Separator)[] expected)
     {


### PR DESCRIPTION
## What

`RobotsFile.Parser.Feed` hand-rolled its own line splitter, including the bookkeeping needed to keep the `\n` of a `"\r\n"` pair from swallowing the empty line in `"\n\n"`. `StringExtensions.SplitLines` already handles that, so this links the shared file into `Meziantou.Framework.RobotsTxt` (the same way `Meziantou.Framework.Globbing` does) and uses it:

```csharp
foreach (ReadOnlySpan<char> line in content.SplitLines(LineBreakMode.Standard))
```

`SplitLines` only had `string` overloads, so this also adds the `ReadOnlySpan<char>` ones. `LineSplitEnumerator` already had a span constructor, so they are one-liners:

```csharp
public static LineSplitEnumerator SplitLines(this ReadOnlySpan<char> str) => new(str, LineBreakMode.Unicode);
public static LineSplitEnumerator SplitLines(this ReadOnlySpan<char> str, LineBreakMode lineBreakMode) => new(str, lineBreakMode);
```

## Notes for reviewers

- `LineBreakMode.Standard` is deliberate: RFC 9309 ends a line at CR, LF or CRLF only, so a form feed, VT, NEL, LS or PS stays part of the value it appears in. This reproduces the previous behaviour exactly — the parser is unchanged from the outside. A new theory in `RobotsFileTests` locks that in.
- The two new public overloads changed the public surface, so `ref/Meziantou.Framework.cs` is regenerated (a two-line diff).
- `StringExtensionsTests` runs the existing `SplitLineData` / `SplitLineWithLineBreakModeData` corpora through the span overloads as well.

## Validation

- Builds of `Meziantou.Framework`, `Meziantou.Framework.RobotsTxt` and `Meziantou.Framework.Globbing` with `/p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet test` with the same flag: RobotsTxt 200/200 passed, Meziantou.Framework 2080 passed / 16 pre-existing skips, Globbing 904/904 passed.
- `dotnet run ./eng/update-all.cs`: no further file changes.