### PR TITLE
Add scanning for NuGet project.assets.json dependencies

### DIFF
--- a/ref/Meziantou.Framework.DependencyScanning.cs
+++ b/ref/Meziantou.Framework.DependencyScanning.cs
@@ -219,6 +219,13 @@ namespace Meziantou.Framework.DependencyScanning.Scanners
         public override System.Threading.Tasks.ValueTask ScanAsync(Meziantou.Framework.DependencyScanning.ScanFileContext context) => throw null;
     }
 
+    public sealed class ProjectAssetsDependencyScanner : Meziantou.Framework.DependencyScanning.DependencyScanner
+    {
+        protected internal override System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.DependencyScanning.DependencyType> SupportedDependencyTypes { get => throw null; }
+        protected override bool ShouldScanFileCore(Meziantou.Framework.DependencyScanning.CandidateFileContext context) => throw null;
+        public override System.Threading.Tasks.ValueTask ScanAsync(Meziantou.Framework.DependencyScanning.ScanFileContext context) => throw null;
+    }
+
     public sealed class ProjectJsonDependencyScanner : Meziantou.Framework.DependencyScanning.DependencyScanner
     {
         protected internal override System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.DependencyScanning.DependencyType> SupportedDependencyTypes { get => throw null; }

--- a/src/Meziantou.Framework.DependencyScanning/ScannerOptions.cs
+++ b/src/Meziantou.Framework.DependencyScanning/ScannerOptions.cs
@@ -33,6 +33,7 @@ public sealed class ScannerOptions
         new NpmPackageJsonDependencyScanner(),
         new NuSpecDependencyScanner(),
         new PackagesConfigDependencyScanner(),
+        new ProjectAssetsDependencyScanner(),
         new ProjectJsonDependencyScanner(),
         new PythonRequirementsDependencyScanner(),
         new RenovateExtendsDependencyScanner(),

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/ProjectAssetsDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/ProjectAssetsDependencyScanner.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Meziantou.Framework.DependencyScanning.Internals;
+using Meziantou.Framework.DependencyScanning.Locations;
+
+namespace Meziantou.Framework.DependencyScanning.Scanners;
+
+/// <summary>Scans NuGet project assets files (project.assets.json) for resolved package dependencies, including transitive dependencies.</summary>
+public sealed class ProjectAssetsDependencyScanner : DependencyScanner
+{
+    protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } = [DependencyType.NuGet];
+
+    protected override bool ShouldScanFileCore(CandidateFileContext context)
+    {
+        return context.HasFileName("project.assets.json", ignoreCase: false);
+    }
+
+    public override async ValueTask ScanAsync(ScanFileContext context)
+    {
+        try
+        {
+            var doc = await JsonNodeDocument.ParseAsync(context.Content, context.CancellationToken).ConfigureAwait(false);
+            if (doc.GetRootObject() is not JsonObject root || !JsonNodeDocument.TryGetObject(root, "libraries", out var libraries))
+                return;
+
+            foreach (var library in JsonNodeDocument.GetProperties(libraries))
+            {
+                if (library.Value is not JsonObject libraryValue ||
+                    !JsonNodeDocument.TryGetProperty(libraryValue, "type", out var typeValue) ||
+                    !JsonNodeDocument.TryGetString(typeValue, out var type) ||
+                    !string.Equals(type, "package", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var separatorIndex = library.Name.LastIndexOf('/', StringComparison.Ordinal);
+                if (separatorIndex <= 0 || separatorIndex == library.Name.Length - 1)
+                    continue;
+
+                var packageName = library.Name[..separatorIndex];
+                var packageVersion = library.Name[(separatorIndex + 1)..];
+                context.ReportDependency(this, packageName, packageVersion, DependencyType.NuGet,
+                    nameLocation: new NonUpdatableLocation(context),
+                    versionLocation: new NonUpdatableLocation(context));
+            }
+        }
+        catch (JsonException)
+        {
+        }
+    }
+}

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -563,6 +563,41 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
     }
 
     [Fact]
+    public async Task ProjectAssetsDependencies()
+    {
+        AddFile("obj/project.assets.json", /*lang=json,strict*/ """
+            {
+              "libraries": {
+                "DirectDependency/1.0.0": {
+                  "type": "package"
+                },
+                "TransitiveDependency/2.0.0": {
+                  "type": "package"
+                },
+                "ProjectReference/1.0.0": {
+                  "type": "project"
+                },
+                "Invalid": {
+                  "type": "package"
+                }
+              }
+            }
+            """);
+
+        var result = await GetDependencies<ProjectAssetsDependencyScanner>([new ProjectAssetsDependencyScanner()]);
+
+        AssertContainDependency(result,
+            (DependencyType.NuGet, "DirectDependency", "1.0.0", 0, 0),
+            (DependencyType.NuGet, "TransitiveDependency", "2.0.0", 0, 0));
+        Assert.HasCount(2, result);
+        Assert.All(result, dependency =>
+        {
+            Assert.False(dependency.NameLocation!.IsUpdatable);
+            Assert.False(dependency.VersionLocation!.IsUpdatable);
+        });
+    }
+
+    [Fact]
     public async Task PackagesConfigWithCsprojDependencies()
     {
         const string Original = """


### PR DESCRIPTION
Fix https://github.com/meziantou/Meziantou.Framework/issues/2940

## Summary

- Add a scanner for resolved NuGet packages in `project.assets.json`.
- Include transitive package dependencies while excluding project references and invalid entries.
- Register the scanner in the default dependency scanner options.
- Add coverage for package detection and non-updatable locations.

## Testing

- Added and ran unit coverage for `project.assets.json` dependency scanning.