### PR TITLE
Align HTTP caching behavior with RFC 9111

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -184,9 +184,9 @@ internal sealed class CacheEntry
 
             if (request.Headers.TryGetValues(headerName, out var values))
             {
-                // Sort values to ensure consistent ordering for cache matching
-                // RFC 7234: Order of header values shouldn't affect cache matching
-                foreach (var value in values.Order(StringComparer.Ordinal))
+                // Values can only be reordered when their field specification says that ordering does not
+                // affect semantics. A generic Vary implementation must preserve the received order.
+                foreach (var value in values)
                 {
                     secondaryKey.Add(headerName, value);
                 }
@@ -400,8 +400,7 @@ internal sealed class CacheEntry
             Expires = newExpires;
         }
 
-        // RFC 7234 Section 4.3.4: Update stored response headers with headers from 304 response
-        // The cache MUST update the stored response with header fields provided in the 304 response
+        // RFC 9111 Section 4.3.4: Update stored response headers with headers from 304 response.
         await UpdateSerializedResponseHeaders(validationResponse, cancellationToken);
     }
 
@@ -410,17 +409,13 @@ internal sealed class CacheEntry
         // Deserialize the stored response
         var storedResponse = ResponseSerializer.Deserialize(SerializedResponse);
 
-        // Collect headers to update from the 304 response
-        // RFC 7234 Section 4.3.4: Update stored response headers, but exclude headers
-        // that are managed as metadata properties (Cache-Control, Date, ETag, Expires, Last-Modified)
+        // RFC 9111 Section 3.2: every response field supplied by the 304 replaces the stored value,
+        // except Content-Length. Age is regenerated when the cached response is returned.
         var headersToUpdate = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         foreach (var header in validationResponse.Headers)
         {
-            // Skip headers managed separately via properties
-            if (string.Equals(header.Key, "Cache-Control", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(header.Key, "Date", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(header.Key, "ETag", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(header.Key, "Expires", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(header.Key, "Content-Length", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(header.Key, "Age", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
@@ -430,8 +425,8 @@ internal sealed class CacheEntry
 
         foreach (var header in validationResponse.Content.Headers)
         {
-            // Skip headers managed separately via properties
-            if (string.Equals(header.Key, "Last-Modified", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(header.Key, "Content-Length", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(header.Key, "Age", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
@@ -486,4 +481,3 @@ internal sealed class CacheEntry
         storedResponse.Dispose();
     }
 }
-

--- a/src/Meziantou.Framework.Http.Caching/CacheEntrySecondaryKey.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntrySecondaryKey.cs
@@ -97,9 +97,9 @@ internal readonly struct CacheEntrySecondaryKey : IEquatable<CacheEntrySecondary
         {
             if (request.Headers.TryGetValues(headerName, out var values))
             {
-                // Sort values to ensure consistent ordering for cache matching
-                // RFC 7234: Order of header values shouldn't affect cache matching
-                foreach (var value in values.Order(StringComparer.Ordinal))
+                // Values can only be reordered when their field specification says that ordering does not
+                // affect semantics. A generic Vary implementation must preserve the received order.
+                foreach (var value in values)
                 {
                     requestKey.Add(headerName, value);
                 }

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -213,13 +213,14 @@ internal sealed class HttpCache
         // response is stored under the same rules as any other. It remains the caller's responsibility not
         // to share one HttpClient, and therefore one cache, between users.
 
-        // Check if response has explicit freshness information or is cacheable by default
-        var hasExplicitFreshness = responseCacheControl?.MaxAge is not null ||
-                                   responseCacheControl?.SharedMaxAge is not null ||
-                                   responseCacheControl?.Public is true;
+        // Check if the response is explicitly cacheable by this private cache or is cacheable by default.
+        // s-maxage only applies to shared caches, so it cannot make a response storable here.
+        var isExplicitlyCacheable = responseCacheControl?.MaxAge is not null ||
+                                    responseCacheControl?.Public is true ||
+                                    responseCacheControl?.Private is true;
 
         // Validate Expires header if present and no Cache-Control freshness
-        if (!hasExplicitFreshness && HasExpiresHeader(response))
+        if (!isExplicitlyCacheable && HasExpiresHeader(response))
         {
             var expires = CacheEntry.ParseExpiresHeader(response);
             var date = response.Headers.Date ?? DateTimeOffset.UtcNow;
@@ -227,12 +228,12 @@ internal sealed class HttpCache
             // If Expires is valid and in the future, it counts as explicit freshness
             if (expires.HasValue && expires.Value > date)
             {
-                hasExplicitFreshness = true;
+                isExplicitlyCacheable = true;
             }
             // If Expires is expired or invalid, don't cache unless status is cacheable by default
         }
 
-        if (!hasExplicitFreshness && !HasDefaultCacheableStatusCode(response.StatusCode))
+        if (!isExplicitlyCacheable && !HasDefaultCacheableStatusCode(response.StatusCode))
             return false;
 
         return true;

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -210,7 +210,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             // RFC 7234 Section 5.2.1.7: only-if-cached request directive
             if ((requestCacheControl?.OnlyIfCached) is true)
             {
-                if (isFresh || allowStale)
+                if (!requiresValidation && (isFresh || allowStale))
                 {
                     // RFC 7234 Section 5.5: Add Warning header for stale response
                     var warningHeader = !isFresh ? "110 - \"Response is Stale\"" : null;
@@ -266,6 +266,21 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                     // RFC 7234 Section 4.3.3: Handle 304 Not Modified
                     if (conditionalResponse.StatusCode is HttpStatusCode.NotModified)
                     {
+                        // RFC 9111 Section 4.3.4 only allows a 304 to update a stored response when its
+                        // validators identify that response. A mismatched validator means this 304 cannot
+                        // validate the representation whose body we selected.
+                        if (HasMismatchedValidator(cacheResult, conditionalResponse))
+                        {
+                            conditionalResponse.Dispose();
+
+                            var replacementRequestTime = _timeProvider.GetUtcNow();
+                            var replacementResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                            var replacementResponseTime = _timeProvider.GetUtcNow();
+                            await StoreAsync(request, replacementResponse, replacementRequestTime, replacementResponseTime, cancellationToken).ConfigureAwait(false);
+                            replacementResponse.RequestMessage ??= request;
+                            return replacementResponse;
+                        }
+
                         // Update cached entry with new headers from 304 response
                         await cacheResult.UpdateFromValidationResponse(conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
                         try
@@ -470,66 +485,6 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         // RFC 7234 Section 5.1: Set Age header
         response.Headers.Age = currentAge;
 
-        // Rebuild Cache-Control header from CacheEntry properties
-        // This ensures that updates from 304 responses are reflected
-        if (entry.MaxAge is not null || entry.SharedMaxAge is not null || entry.MustRevalidate || entry.ProxyRevalidate || entry.ResponseNoCache || entry.Public || entry.Private || entry.NoTransform || entry.Immutable || entry.StaleIfError is not null)
-        {
-            response.Headers.Remove("Cache-Control");
-            var cacheControl = new CacheControlHeaderValue();
-
-            if (entry.MaxAge is not null)
-            {
-                cacheControl.MaxAge = entry.MaxAge;
-            }
-
-            if (entry.SharedMaxAge is not null)
-            {
-                cacheControl.SharedMaxAge = entry.SharedMaxAge;
-            }
-
-            if (entry.MustRevalidate)
-            {
-                cacheControl.MustRevalidate = true;
-            }
-
-            if (entry.ProxyRevalidate)
-            {
-                cacheControl.ProxyRevalidate = true;
-            }
-
-            if (entry.ResponseNoCache)
-            {
-                cacheControl.NoCache = true;
-            }
-
-            if (entry.Public)
-            {
-                cacheControl.Public = true;
-            }
-
-            if (entry.Private)
-            {
-                cacheControl.Private = true;
-            }
-
-            if (entry.NoTransform)
-            {
-                cacheControl.NoTransform = true;
-            }
-
-            if (entry.Immutable)
-            {
-                cacheControl.Extensions.Add(new NameValueHeaderValue("immutable"));
-            }
-
-            if (entry.StaleIfError is not null)
-            {
-                cacheControl.Extensions.Add(new NameValueHeaderValue("stale-if-error", ((int)entry.StaleIfError.Value.TotalSeconds).ToString(CultureInfo.InvariantCulture)));
-            }
-
-            response.Headers.CacheControl = cacheControl;
-        }
-
         // Set RequestMessage on the response
         response.RequestMessage = request;
         return response;
@@ -566,7 +521,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
     {
         // RFC 5861: stale-if-error allows a stale response to be served for the given amount of time past
         // the point at which it became stale.
-        if (entry.StaleIfError is null)
+        if (entry.StaleIfError is null || entry.MustRevalidate || entry.ResponseNoCache)
             return false;
 
         var staleness = currentAge - freshnessLifetime;
@@ -600,5 +555,24 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                headers.IfModifiedSince is not null ||
                headers.IfUnmodifiedSince is not null ||
                headers.IfRange is not null;
+    }
+
+    private static bool HasMismatchedValidator(CacheEntry entry, HttpResponseMessage validationResponse)
+    {
+        var validator = validationResponse.Headers.ETag;
+        if (validator is not null)
+            return !string.Equals(entry.ETag, validator.ToString(), StringComparison.Ordinal);
+
+        var lastModified = validationResponse.Content.Headers.LastModified;
+        if (lastModified is null && validationResponse.Headers.TryGetValues("Last-Modified", out var values))
+        {
+            var value = values.FirstOrDefault();
+            if (value is not null && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, out var parsedDate))
+            {
+                lastModified = parsedDate;
+            }
+        }
+
+        return lastModified is not null && entry.LastModified != lastModified;
     }
 }

--- a/tests/Meziantou.Framework.Http.Caching.Tests/RequestValidationTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/RequestValidationTests.cs
@@ -203,6 +203,35 @@ public class RequestValidationTests
     }
 
     [Fact]
+    public async Task WhenOnlyIfCachedResponseRequiresValidationThen504()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=600, no-cache"), ("ETag", "\"v1\""));
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: no-cache, max-age=600
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: cached
+            """);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue { OnlyIfCached = true };
+        await context.SnapshotResponse(request, """
+            StatusCode: 504 (GatewayTimeout)
+            Content:
+              Headers:
+                Content-Length: 0
+              Value:
+            """);
+    }
+
+    [Fact]
     public async Task WhenOnlyIfCachedWithStaleAndMaxStaleThenServed()
     {
         await using var context = new HttpTestContext();

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Response304UpdateTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Response304UpdateTests.cs
@@ -5,11 +5,12 @@ namespace Meziantou.Framework.Http.Caching.Tests;
 public class Response304UpdateTests
 {
     [Fact]
-    public async Task When304ResponseHasNewETagThenCachedETagUpdated()
+    public async Task When304ResponseHasMismatchedETagThenFetchesFullResponse()
     {
         await using var context = new HttpTestContext();
         context.AddResponse(HttpStatusCode.OK, "content", ("Cache-Control", "max-age=0"), ("ETag", "\"v1\""));
         context.AddResponse(HttpStatusCode.NotModified, ("Cache-Control", "max-age=600"), ("ETag", "\"v2\""));
+        context.AddResponse(HttpStatusCode.OK, "replacement", ("Cache-Control", "max-age=600"), ("ETag", "\"v2\""));
 
         await context.SnapshotResponse("http://example.com/resource", """
             StatusCode: 200 (OK)
@@ -26,19 +27,18 @@ public class Response304UpdateTests
         await context.SnapshotResponse("http://example.com/resource", """
             StatusCode: 200 (OK)
             Headers:
-              Age: 0
               Cache-Control: max-age=600
-              ETag: "v1"
+              ETag: "v2"
             Content:
               Headers:
-                Content-Length: 7
+                Content-Length: 11
                 Content-Type: text/plain; charset=utf-8
-              Value: content
+              Value: replacement
             """);
     }
 
     [Fact]
-    public async Task When304ResponseHasNewLastModifiedThenCachedLastModifiedUpdated()
+    public async Task When304ResponseHasMismatchedLastModifiedThenFetchesFullResponse()
     {
         await using var context = new HttpTestContext();
         var oldLastModified = context.TimeProvider.GetUtcNow().AddDays(-2);
@@ -46,6 +46,7 @@ public class Response304UpdateTests
 
         context.AddResponse(HttpStatusCode.OK, "content", ("Cache-Control", "max-age=0"), ("Last-Modified", oldLastModified.ToString("R")));
         context.AddResponse(HttpStatusCode.NotModified, ("Cache-Control", "max-age=600"), ("Last-Modified", newLastModified.ToString("R")));
+        context.AddResponse(HttpStatusCode.OK, "replacement", ("Cache-Control", "max-age=600"), ("Last-Modified", newLastModified.ToString("R")));
 
         await context.SnapshotResponse("http://example.com/resource", """
             StatusCode: 200 (OK)
@@ -62,14 +63,13 @@ public class Response304UpdateTests
         await context.SnapshotResponse("http://example.com/resource", """
             StatusCode: 200 (OK)
             Headers:
-              Age: 0
               Cache-Control: max-age=600
             Content:
               Headers:
-                Content-Length: 7
+                Content-Length: 11
                 Content-Type: text/plain; charset=utf-8
-                Last-Modified: Thu, 30 Dec 1999 00:00:00 GMT
-              Value: content
+                Last-Modified: Fri, 31 Dec 1999 00:00:00 GMT
+              Value: replacement
             """);
     }
 
@@ -102,6 +102,41 @@ public class Response304UpdateTests
               Headers:
                 Expires: Sat, 01 Jan 2000 01:00:00 GMT
               Value:
+            """);
+    }
+
+    [Fact]
+    public async Task When304ResponseHasMatchingETagThenReplacesStoredHeaders()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content", ("Cache-Control", "max-age=0"), ("ETag", "\"v1\""), ("X-Version", "old"));
+        context.AddResponse(HttpStatusCode.NotModified, ("Cache-Control", "max-age=600"), ("ETag", "\"v1\""), ("X-Version", "new"));
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=0
+              ETag: "v1"
+              X-Version: old
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=600
+              ETag: "v1"
+              X-Version: new
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
             """);
     }
 

--- a/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
@@ -222,6 +222,57 @@ public class StaleResponseTests
     }
 
     [Fact]
+    public async Task WhenMustRevalidateThenStaleIfErrorDoesNotServeStaleResponse()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, must-revalidate, stale-if-error=60"), ("ETag", "\"v1\"")));
+        innerHandler.AddThrow(static () => new HttpRequestException("origin unreachable"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenResponseHasNoCacheThenStaleIfErrorDoesNotServeStaleResponse()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, no-cache, stale-if-error=60"), ("ETag", "\"v1\"")));
+        innerHandler.AddThrow(static () => new HttpRequestException("origin unreachable"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenPrivateCacheReceivesSMaxAgeOnlyThenDoesNotStoreTheResponse()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.InternalServerError, "error", ("Cache-Control", "s-maxage=60, stale-if-error=60")));
+        innerHandler.AddThrow(static () => new HttpRequestException("origin unreachable"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.InternalServerError, firstResponse.StatusCode);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
     public async Task WhenEntryHasNoValidatorAndRequestThrowsAndStaleIfErrorAllowsItThenStaleResponseServed()
     {
         using var innerHandler = new StubHandler();

--- a/tests/Meziantou.Framework.Http.Caching.Tests/VaryHeaderTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/VaryHeaderTests.cs
@@ -441,10 +441,13 @@ public sealed class VaryHeaderTests
     }
 
     [Fact]
-    public async Task WhenVaryHeaderValueOrderDiffersThenStillMatches()
+    public async Task WhenVaryHeaderValueOrderDiffersThenFetchesNewResponse()
     {
         await using var context = new HttpTestContext();
         context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept-Language"));
+        context.AddResponse(HttpStatusCode.OK, "different-content",
             ("Cache-Control", "max-age=3600"),
             ("Vary", "Accept-Language"));
 
@@ -467,14 +470,13 @@ public sealed class VaryHeaderTests
         await context.SnapshotResponse(request2, """
             StatusCode: 200 (OK)
             Headers:
-              Age: 0
               Cache-Control: max-age=3600
               Vary: Accept-Language
             Content:
               Headers:
-                Content-Length: 7
+                Content-Length: 17
                 Content-Type: text/plain; charset=utf-8
-              Value: content
+              Value: different-content
             """);
     }
 }


### PR DESCRIPTION
## Summary

- Preserve received header-value order when generating `Vary` cache keys.
- Correct private-cache storage rules for `s-maxage` and explicit cache directives.
- Enforce `only-if-cached`, validator matching for `304` responses, and stale-if-error restrictions.
- Update stored headers according to RFC 9111 and add regression coverage.

## Testing

- Added and updated HTTP caching tests covering `Vary`, `304` validation, request directives, and stale responses.
- Not run (not requested).