### PR TITLE
Pin the precedence between the two image snapshot backends

### DIFF
--- a/slnx/Meziantou.Framework.ProcessWrapper.slnx
+++ b/slnx/Meziantou.Framework.ProcessWrapper.slnx
@@ -15,6 +15,8 @@
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />

--- a/slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx
@@ -6,7 +6,15 @@
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
+    <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj" />
   </Folder>
 </Solution>

--- a/slnx/Meziantou.Framework.SnapshotTesting.SkiaSharp.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.SkiaSharp.slnx
@@ -6,7 +6,15 @@
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
+    <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj" />
   </Folder>
 </Solution>

--- a/slnx/Meziantou.Framework.SnapshotTesting.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.slnx
@@ -11,6 +11,8 @@
     <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -30,7 +30,9 @@
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Roslyn/Meziantou.Framework.SnapshotTesting.Roslyn.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Tool/Meziantou.Framework.SnapshotTesting.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.Templating.Tool/Meziantou.Framework.Templating.Tool.csproj" />

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageBackendRegistrationTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageBackendRegistrationTests.cs
@@ -1,0 +1,113 @@
+using System.Reflection;
+using Meziantou.Framework.SnapshotTesting.ImageSharp;
+using Meziantou.Framework.SnapshotTesting.SkiaSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SkiaSharp;
+using ImageSharpImage = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>;
+
+namespace Meziantou.Framework.SnapshotTesting.Tests;
+
+/// <summary>
+/// Pins the precedence between the two image backends when both are registered on the same settings.
+/// The tests only inspect the registrations, so they do not need the SkiaSharp native libraries.
+/// </summary>
+public sealed class ImageBackendRegistrationTests
+{
+    private static readonly Assembly ImageSharpBackend = typeof(SnapsthotSettingsImageSharpExtensions).Assembly;
+    private static readonly Assembly SkiaSharpBackend = typeof(SnapshotSettingsSkiaSharpExtensions).Assembly;
+
+    [Fact]
+    public void AddSkiaSharpAfterImageSharp_SkiaSharpSerializerIsTriedFirst()
+    {
+        var settings = new SnapshotSettings();
+        settings.AddImageSharp();
+        settings.AddSkiaSharp();
+
+        // Serialize walks the collection from the last serializer to the first, so being registered last wins
+        Assert.Equal<Assembly>([ImageSharpBackend, SkiaSharpBackend], GetBackendSerializers(settings));
+    }
+
+    [Fact]
+    public void AddImageSharpAfterSkiaSharp_ImageSharpSerializerIsTriedFirst()
+    {
+        var settings = new SnapshotSettings();
+        settings.AddSkiaSharp();
+        settings.AddImageSharp();
+
+        Assert.Equal<Assembly>([SkiaSharpBackend, ImageSharpBackend], GetBackendSerializers(settings));
+    }
+
+    [Fact]
+    public void AddSkiaSharpAfterImageSharp_SkiaSharpComparerWinsForTheSharedFormats()
+    {
+        var settings = new SnapshotSettings();
+        settings.AddImageSharp();
+        settings.AddSkiaSharp();
+
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Bmp)));
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Png)));
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Jpeg)));
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Webp)));
+
+        // Only SkiaSharp registers a comparer for these formats
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Gif)));
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Ico)));
+
+        // SKCodec cannot decode TIFF, so AddSkiaSharp does not register a comparer for it and the ImageSharp one is kept
+        Assert.Equal(ImageSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Tiff)));
+    }
+
+    [Fact]
+    public void AddImageSharpAfterSkiaSharp_ImageSharpComparerWinsForTheSharedFormats()
+    {
+        var settings = new SnapshotSettings();
+        settings.AddSkiaSharp();
+        settings.AddImageSharp();
+
+        Assert.Equal(ImageSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Bmp)));
+        Assert.Equal(ImageSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Png)));
+        Assert.Equal(ImageSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Jpeg)));
+        Assert.Equal(ImageSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Webp)));
+        Assert.Equal(ImageSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Tiff)));
+
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Gif)));
+        Assert.Equal(SkiaSharpBackend, GetBackend(settings.Comparers.Get(SnapshotType.Ico)));
+    }
+
+    [Fact]
+    public void AddSkiaSharpAfterImageSharp_ImageSharpValuesAreStillSerialized()
+    {
+        var settings = new SnapshotSettings();
+        settings.AddImageSharp();
+        settings.AddSkiaSharp();
+
+        // The SkiaSharp serializer does not claim ImageSharp values, so the ImageSharp one still handles them
+        using var image = new ImageSharpImage(2, 2);
+        var snapshot = settings.Serializers.Serialize(SnapshotType.Png, image);
+
+        var data = Assert.Single(snapshot.Data);
+        Assert.Equal(SnapshotType.Png.FileExtension, data.Extension);
+        Assert.Equal<byte>([0x89, (byte)'P', (byte)'N', (byte)'G'], data.Data.AsSpan(0, 4));
+    }
+
+    [Fact]
+    public void AddSkiaSharpAfterImageSharp_BothColorConvertersAreUsable()
+    {
+        var settings = new SnapshotSettings();
+        settings.AddImageSharp();
+        settings.AddSkiaSharp();
+
+        var value = new { ImageSharpColor = new Rgba32(0x01, 0x02, 0x03, 0x04), SkiaSharpColor = new SKColor(0x11, 0x22, 0x33, 0x44) };
+        var snapshot = settings.Serializers.Serialize(SnapshotType.Default, value);
+        var text = Encoding.UTF8.GetString(Assert.Single(snapshot.Data).Data);
+
+        // Converters resolve first-registered-wins, but the two backends convert different types so neither shadows the other
+        Assert.Contains("#01020304", text);
+        Assert.Contains("#11223344", text);
+    }
+
+    private static Assembly[] GetBackendSerializers(SnapshotSettings settings)
+        => [.. settings.Serializers.Select(GetBackend).Where(backend => backend == ImageSharpBackend || backend == SkiaSharpBackend)];
+
+    private static Assembly GetBackend(object instance) => instance.GetType().Assembly;
+}

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
     <Compile Include="../../common/TargetFrameworkHelper.cs" Link="TargetFrameworkHelper.cs" />
   </ItemGroup>


### PR DESCRIPTION
## What

Adds `ImageBackendRegistrationTests` to `Meziantou.Framework.SnapshotTesting.Tests`, covering what happens when both image backends are registered on the same `SnapshotSettings`:

- serializer order in both registration orders (`AddImageSharp()` then `AddSkiaSharp()`, and the reverse)
- comparer resolution per `SnapshotType`, including the two formats that are never shared
- an ImageSharp value still round-trips to a real PNG when SkiaSharp is registered after it
- the two human-readable colour converters (`Rgba32`, `SKColor`) do not shadow each other

The test project gains a `ProjectReference` to each backend. No production code changed.

## Why

`AddImageSharp()` followed by `AddSkiaSharp()` already gives SkiaSharp precedence, but nothing pinned it and it rests on two implementation details pointing in the same direction:

- `SnapshotSerializerCollection.Serialize` iterates `Count-1 → 0`, so the **last** registered serializer is tried first.
- `SnapshotComparerCollection.Set` overwrites the entry for a snapshot type, so the last registration wins there too.

Two formats are deliberately never shared, and the tests say so explicitly:

- **TIFF** stays with ImageSharp — `SKCodec` cannot decode it, so `AddSkiaSharp()` registers no TIFF comparer, whatever the order. Overriding it would turn every TIFF comparison into a mismatch.
- **GIF** and **ICO** stay with SkiaSharp — `AddImageSharp()` registers no comparer for them.

## Notes for the reviewer

The tests assert on the **backend assembly** (`typeof(SnapshotSettingsSkiaSharpExtensions).Assembly`) instead of the internal comparer/serializer types. That is not just a style choice: `SsimAccumulator` is `Compile Include`-linked into both backends under the same namespace, so granting `InternalsVisibleTo` to this test project from both of them makes that type ambiguous (`CS0433`) in the existing `ImageLoaderTests.cs`. Asserting on the assembly avoids the extra `InternalsVisibleTo` entirely, keeps `src/` untouched, and states the actual contract — which backend won — in a rename-proof way.

The tests only inspect registrations, so they need no SkiaSharp native libraries and behave identically on all four CI legs.

The `slnx/*.slnx` changes are generated by `dotnet run ./eng/update-all.cs`.

## Verification

- `Meziantou.Framework.SnapshotTesting.Tests`, Release with `IsOfficialBuild=true`: **382 passed, 0 failed** (191 × net10.0/net11.0) — 370 pre-existing plus the 6 new tests.
- Build is warning-free with `TreatWarningsAsErrors=true`; no `ref/` churn.
- `dotnet run ./eng/update-all.cs` is idempotent on a second run.