### PR TITLE
Skip the MongoDB tests on the failure itself, not on a kernel version

### DIFF
--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerTestHelper.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerTestHelper.cs
@@ -43,7 +43,8 @@ internal static class ContainerTestHelper
         return StartWithRetryAsync(definition.CreateContainer, cancellationToken);
     }
 
-    public static async Task<TContainer> StartWithRetryAsync<TContainer>(Func<TContainer> containerFactory, CancellationToken cancellationToken)
+    /// <param name="isPermanentFailure">Recognizes a failure that no retry can fix, so it is reported as-is instead of being attempted <see cref="MaxStartAttempts"/> times.</param>
+    public static async Task<TContainer> StartWithRetryAsync<TContainer>(Func<TContainer> containerFactory, CancellationToken cancellationToken, Func<Exception, bool>? isPermanentFailure = null)
         where TContainer : TemporaryContainer
     {
         var failures = new List<Exception>();
@@ -60,6 +61,10 @@ internal static class ContainerTestHelper
                 // The container may already exist when the failure happens (for instance when a wait strategy times out), so it must be removed before retrying.
                 await DisposeSafeAsync(container);
                 cancellationToken.ThrowIfCancellationRequested();
+
+                if (isPermanentFailure?.Invoke(ex) is true)
+                    throw;
+
                 failures.Add(ex);
 
                 if (attempt >= MaxStartAttempts)

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
@@ -13,12 +13,6 @@ public sealed class MongoDbContainerTests
     {
         if (!OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions())
             global::Xunit.Assert.Skip("Only runs on Linux.");
-
-        // mongod refuses to start on Linux 6.19 and newer (https://jira.mongodb.org/browse/SERVER-121912), and 8.3.8,
-        // the newest image there is, still carries the guard. A Linux container shares the host kernel, so the host
-        // version is the one that decides; elsewhere the container runs in a VM whose kernel is its own.
-        if (OperatingSystem.IsLinux() && Environment.OSVersion.Version >= new Version(6, 19))
-            global::Xunit.Assert.Skip("The MongoDB image cannot start on Linux kernel 6.19 or newer (SERVER-121912).");
     }
 
     [Fact]
@@ -101,8 +95,28 @@ public sealed class MongoDbContainerTests
         Assert.Equal(1, count);
     }
 
-    private static Task<MongoDbContainer> StartWithRetryAsync(MongoDbContainerDefinition definition)
+    private static async Task<MongoDbContainer> StartWithRetryAsync(MongoDbContainerDefinition definition)
     {
-        return ContainerTestHelper.StartWithRetryAsync(definition.CreateContainer, XunitCancellationToken);
+        try
+        {
+            return await ContainerTestHelper.StartWithRetryAsync(definition.CreateContainer, XunitCancellationToken, IsIncompatibleKernelFailure);
+        }
+        catch (Exception ex) when (IsIncompatibleKernelFailure(ex))
+        {
+            global::Xunit.Assert.Skip("The MongoDB image cannot start on this kernel (SERVER-121912): " + ex.Message);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Recognizes the fatal log line <c>mongod</c> writes before exiting on Linux 6.19 and newer
+    /// (https://jira.mongodb.org/browse/SERVER-121912), which the readiness wait reports in its failure message.
+    /// Matching the ticket rather than comparing kernel versions keeps the skip tied to the image actually refusing
+    /// to run: the container's kernel is the one that decides (the host's on Linux, the runtime VM's elsewhere), and
+    /// the tests start running again on their own once an image without the guard ships.
+    /// </summary>
+    private static bool IsIncompatibleKernelFailure(Exception exception)
+    {
+        return exception.ToString().Contains("SERVER-121912", StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
`mongod` refuses to start on Linux 6.19 and newer ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)), so `MongoDbContainerTests` gated its container-starting tests on `Environment.OSVersion.Version >= 6.19`.

That proxy is wrong in both directions:

- **False negative.** A Linux container's kernel is the host's, but everywhere else it is the runtime VM's. Docker Desktop on macOS now runs `7.0.12-linuxkit`, so those runs hit the failure unskipped while `Environment.OSVersion` reported a Darwin version.
- **No expiry.** Once MongoDB ships an image without the guard, the kernel comparison keeps skipping forever and nobody notices.

The readiness wait already reports the container's log tail in its failure message (added in #2915), and the fatal line is the last thing `mongod` writes before exiting, so the failure carries the ticket ID:

```
The log pattern 'Waiting\ for\ connections' matched 0 time(s) before the log stream ended (expected 2).
The container is Exited with exit code 1 (exited). Last 1 log line(s):
  {"s":"F","c":"CONTROL","id":12257600,...,"msg":"MongoDB cannot start: Linux kernel versions 6.19 and newer ... See https://jira.mongodb.org/browse/SERVER-121912 ..."}
```

## Changes

- `MongoDbContainerTests` drops the kernel comparison. `IsIncompatibleKernelFailure` matches `SERVER-121912` in the start failure, and the skip message carries the actual `mongod` output so the reason is visible in the test log.
- `ContainerTestHelper.StartWithRetryAsync` takes an optional `isPermanentFailure` predicate, so a failure no retry can fix is reported at once instead of being attempted 4 times with backoff. The parameter defaults to `null` and is inert for every existing caller.

## Notes for reviewers

- The detection depends on `LogMessageWaitStrategy` continuing to include the container's log tail in its failure message. If that reporting is ever trimmed, the skip silently becomes a failure again. There is no test pinning that coupling — worth a comment if you'd rather it be enforced.
- Trade-off: it now costs one real container start on affected machines rather than skipping instantly. Measured at ~1.9s for all three tests.

## Verification

Both directions were exercised on an arm64 Mac, which has one runtime on each side of the cutoff:

- Forced onto `ContainerRuntime.Docker` (kernel `7.0.12-linuxkit`) — `total: 7, succeeded: 4, skipped: 3` in 1.9s, each skip carrying the `mongod` message. The override was reverted before committing.
- Default Apple `container` runtime (kernel `6.18.15`) — all 14 MongoDB tests pass across both TFMs.
- Full project: `total: 266, succeeded: 220, failed: 4, skipped: 42`. The 4 failures are the pre-existing `SqlServerContainerTests` ones (`mcr.microsoft.com/mssql/server` has no arm64 variant) and are unrelated.
- Build clean with `/p:TreatsWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` produced no changes.

Also re-checked upstream while here: `mongo:8` is currently 8.3.8, the newest tag on both `library/mongo` and `mongodb/mongodb-community-server`, and the guard is a fatal assertion inside `mongod` itself with no override env var (`GLIBC_TUNABLES=glibc.pthread.rseq=0` does not help either). So the skip is still needed today.
