### PR TITLE
Add a DateTimeOffset overload of GetNextOccurrence

### DIFF
--- a/ref/Meziantou.Framework.Scheduling.cs
+++ b/ref/Meziantou.Framework.Scheduling.cs
@@ -101,6 +101,7 @@ namespace Meziantou.Framework.Scheduling
     public static class RecurrenceRuleExtensions
     {
         public static System.DateTime? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate) => throw null;
+        public static System.DateTimeOffset? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTimeOffset startDate) => throw null;
     }
 
     public static class RecurrenceRuleHumanizerExtensions

--- a/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
+++ b/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks);netstandard2.0</TargetFrameworks>
     <Description>RecurrenceRule (RFC 5545) and Cron expression parser and evaluator</Description>
-    <Version>4.0.4</Version>
+    <Version>4.0.5</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs
@@ -14,4 +14,18 @@ public static class RecurrenceRuleExtensions
 
         return null;
     }
+
+    /// <summary>Gets the next occurrence of the recurrence starting from the specified date.</summary>
+    /// <param name="startDate">The date to start searching for the next occurrence.</param>
+    /// <returns>The next occurrence date with the same offset as <paramref name="startDate"/>, or <see langword="null"/> if there are no more occurrences.</returns>
+    /// <remarks>The occurrences are computed using the local time of <paramref name="startDate"/>, and the offset of <paramref name="startDate"/> is applied to the result.</remarks>
+    public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        foreach (var occurrence in recurrenceRule.GetNextOccurrences(startDate.DateTime))
+            return new DateTimeOffset(DateTime.SpecifyKind(occurrence, DateTimeKind.Unspecified), startDate.Offset);
+
+        return null;
+    }
 }

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -85,6 +85,42 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
+    public void GetNextOccurrence_DateTimeOffset_ReturnsTheFirstOccurrenceWithTheSameOffset()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        var startDate = new DateTimeOffset(2024, 01, 01, 09, 00, 00, TimeSpan.FromHours(2));
+
+        var occurrence = rrule.GetNextOccurrence(startDate);
+
+        Assert.NotNull(occurrence);
+        Assert.Equal(startDate, occurrence);
+        Assert.Equal(TimeSpan.FromHours(2), occurrence.Value.Offset);
+        Assert.Equal(new DateTime(2024, 01, 01, 09, 00, 00), occurrence.Value.DateTime);
+    }
+
+    [Fact]
+    public void GetNextOccurrence_DateTimeOffset_UsesTheLocalTimeOfTheStartDate()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=10");
+        var startDate = new DateTimeOffset(2024, 01, 01, 09, 00, 00, TimeSpan.FromHours(-5));
+
+        var occurrence = rrule.GetNextOccurrence(startDate);
+
+        Assert.NotNull(occurrence);
+        Assert.Equal(new DateTimeOffset(2024, 01, 01, 10, 00, 00, TimeSpan.FromHours(-5)), occurrence);
+        Assert.Equal(TimeSpan.FromHours(-5), occurrence.Value.Offset);
+    }
+
+    [Fact]
+    public void GetNextOccurrence_DateTimeOffset_ReturnsNullWhenTheRuleIsExhausted()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=0");
+        var startDate = new DateTimeOffset(2024, 01, 01, 09, 00, 00, TimeSpan.FromHours(2));
+
+        Assert.Null(rrule.GetNextOccurrence(startDate));
+    }
+
+    [Fact]
     public void Weekly_Text01()
     {
         var rrule = RecurrenceRule.Parse("FREQ=WEEKLY;UNTIL=20000131T140000Z;BYMONTH=1;BYDAY=TU,WE");


### PR DESCRIPTION
Contributes to https://github.com/meziantou/Meziantou.Framework/issues/2952

## What

Adds a `DateTimeOffset` overload to `RecurrenceRuleExtensions.GetNextOccurrence`:

```csharp
public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate)
```

It applies to every `IRecurrenceRule`, so both `RecurrenceRule` (RFC 5545) and `CronExpression` get it.

## Why

Callers holding a `DateTimeOffset` previously had to unwrap it, call the `DateTime` overload, and rewrap the result themselves — deciding the offset semantics along the way, which is exactly the part that is easy to get wrong.

## Semantics

Occurrences are computed from the **wall-clock time** of `startDate` (`startDate.DateTime`), and the result carries the **same offset** as `startDate`.

This keeps RFC 5545 fields bound to local time, as the spec intends: `BYHOUR=10` means 10:00 in the caller's offset, not 10:00 UTC. Cron expressions are conventionally local too. A caller who wants UTC evaluation passes a zero offset (`startDate.ToOffset(TimeSpan.Zero)`), so the offset itself is the knob.

Computing on `startDate.UtcDateTime` instead and reapplying the original offset would shift the instant by that offset — the first occurrence of a daily rule would no longer equal the start date.

`DateTime.SpecifyKind(..., Unspecified)` guards the `DateTimeOffset(DateTime, TimeSpan)` constructor, which throws when a `Utc`-kind value is paired with a non-zero offset, in case a rule implementation returns a kinded value.

## Notes for reviewers

- Three tests in `RecurrenceRuleTests`. They assert `.Offset` explicitly rather than relying on `Assert.Equal`, since `DateTimeOffset.Equals` compares instants only and would pass even if the offset were dropped.
- `ref/Meziantou.Framework.Scheduling.cs` regenerated; the new API is present on all three TFMs, netstandard2.0 included.
- Package version bumped 4.0.4 → 4.0.5, matching the repo's patch-bump convention (the netstandard2.0 target addition was also a patch bump). Say the word if this additive API warrants 4.1.0 instead.

Verified: Release build with `TreatsWarningsAsErrors=true` clean, `dotnet run ./eng/update-all.cs` produces no further changes, and the full Scheduling suite passes 630/630 on net10.0 and net11.0.