### PR TITLE
Make EnumLocalizationUtilities caches thread safe

### DIFF
--- a/src/Meziantou.Framework.WPF/EnumLocalizationUtilities.cs
+++ b/src/Meziantou.Framework.WPF/EnumLocalizationUtilities.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq.Expressions;
@@ -7,8 +8,8 @@ namespace Meziantou.Framework.WPF;
 
 internal static class EnumLocalizationUtilities
 {
-    private static readonly Dictionary<Type, LocalizedEnumValueCollection> EnumsCache = [];
-    private static readonly Dictionary<Expression, string?> PropertiesCache = [];
+    private static readonly ConcurrentDictionary<Type, LocalizedEnumValueCollection> EnumsCache = new();
+    private static readonly ConcurrentDictionary<Expression, string?> PropertiesCache = new();
 
     public static LocalizedEnumValueCollection GetEnumLocalization<T>()
         where T : struct
@@ -18,9 +19,11 @@ internal static class EnumLocalizationUtilities
 
     public static LocalizedEnumValueCollection GetEnumLocalization(Type type)
     {
-        if (EnumsCache.TryGetValue(type, out var value))
-            return value;
+        return EnumsCache.GetOrAdd(type, CreateEnumLocalization);
+    }
 
+    private static LocalizedEnumValueCollection CreateEnumLocalization(Type type)
+    {
         var result = new List<LocalizedEnumValue>();
         var enumValues = type.GetEnumValues();
 
@@ -42,23 +45,19 @@ internal static class EnumLocalizationUtilities
             }
         }
 
-        var localizedValueCollection = new LocalizedEnumValueCollection(result);
-        EnumsCache.Add(type, localizedValueCollection);
-        return localizedValueCollection;
+        return new LocalizedEnumValueCollection(result);
     }
 
     public static string? GetPropertyLocalization<T>(Expression<Func<T>> exp)
     {
-        if (!PropertiesCache.TryGetValue(exp, out var value))
-        {
-            var memberExpression = (MemberExpression)exp.Body;
-            var displayAttribute = memberExpression.Member.GetCustomAttribute<DisplayAttribute>();
-            value = displayAttribute?.GetName() ?? memberExpression.Member.Name;
+        return PropertiesCache.GetOrAdd(exp, CreatePropertyLocalization);
+    }
 
-            PropertiesCache.Add(exp, value);
-        }
-
-        return value;
+    private static string? CreatePropertyLocalization(Expression expression)
+    {
+        var memberExpression = (MemberExpression)((LambdaExpression)expression).Body;
+        var displayAttribute = memberExpression.Member.GetCustomAttribute<DisplayAttribute>();
+        return displayAttribute?.GetName() ?? memberExpression.Member.Name;
     }
 
     public static string GetEnumMemberLocalization(Enum value)


### PR DESCRIPTION
## What

`EnumLocalizationUtilities` kept its two static caches in `Dictionary<,>`, which is not safe for concurrent use. Both are now `ConcurrentDictionary<,>`, and the value-building logic moved into private factory methods passed to `GetOrAdd`:

- `EnumsCache` (`Type` -> `LocalizedEnumValueCollection`) -> `CreateEnumLocalization`
- `PropertiesCache` (`Expression` -> `string?`) -> `CreatePropertyLocalization`

## Why

The read-then-add pattern on a plain `Dictionary` is a data race: a concurrent read during a write can throw or corrupt the internal state. `EnumsCache` is reachable from the `LocalizedEnumValues` markup extension, and WPF applications can run more than one dispatcher/UI thread, so this is not purely theoretical.

Under contention `GetOrAdd` may invoke the factory more than once for the same key, but only one instance is ever published, so every caller observes a consistent value. The factories are pure reflection reads, so running one twice is harmless.

## Notes for reviewers

- No public API change: the class is `internal`, and `ref/Meziantou.Framework.WPF.cs` is unchanged.
- `dotnet build src/Meziantou.Framework.WPF` succeeds for `net10.0-windows` and `net11.0-windows`, 0 warnings / 0 errors with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no changes.
- The tests could not be executed locally (macOS has no `Microsoft.WindowsDesktop.App` runtime, so the test host fails to launch); the test project does compile, and neither existing WPF test touches this class. CI will run them.
- Unrelated pre-existing issue left alone: `PropertiesCache` is keyed on the `Expression` instance, so each call site builds a fresh tree, lookups never hit, and the dictionary grows without bound. `GetPropertyLocalization` currently has no callers — happy to delete it or re-key the cache on `MemberInfo` in a follow-up.