### PR TITLE
Fix dispatcher deadlock in DelegateCommand and related WPF issues

### DIFF
--- a/src/Meziantou.Framework.WPF/AsyncDelegateCommand.cs
+++ b/src/Meziantou.Framework.WPF/AsyncDelegateCommand.cs
@@ -6,7 +6,7 @@ internal sealed class AsyncDelegateCommand : IDelegateCommand
 {
     private readonly Func<object?, Task> _execute;
     private readonly Func<object?, bool> _canExecute;
-    private readonly Dispatcher _dispatcher;
+    private readonly Dispatcher? _dispatcher;
     private bool _isExecuting;
 
     public event EventHandler? CanExecuteChanged;
@@ -15,7 +15,7 @@ internal sealed class AsyncDelegateCommand : IDelegateCommand
     {
         _execute = execute;
         _canExecute = canExecute;
-        _dispatcher = Dispatcher.CurrentDispatcher;
+        _dispatcher = DelegateCommandDispatcher.GetCurrentThreadDispatcher();
     }
 
     public bool CanExecute(object? parameter)
@@ -44,17 +44,6 @@ internal sealed class AsyncDelegateCommand : IDelegateCommand
 
     public void RaiseCanExecuteChanged()
     {
-        var canExecuteChanged = CanExecuteChanged;
-        if (canExecuteChanged is not null)
-        {
-            if (_dispatcher is not null)
-            {
-                _dispatcher.Invoke(() => canExecuteChanged.Invoke(this, EventArgs.Empty));
-            }
-            else
-            {
-                canExecuteChanged.Invoke(this, EventArgs.Empty);
-            }
-        }
+        DelegateCommandDispatcher.RaiseCanExecuteChanged(_dispatcher, this, CanExecuteChanged);
     }
 }

--- a/src/Meziantou.Framework.WPF/BooleanToValueConverter.cs
+++ b/src/Meziantou.Framework.WPF/BooleanToValueConverter.cs
@@ -19,7 +19,7 @@ public sealed class BooleanToValueConverter : IValueConverter
     /// <summary>Gets or sets the value to return when the input is <see langword="false"/>.</summary>
     public object? FalseValue { get; set; }
 
-    /// <summary>Gets or sets the value to return when the input is <see langword="null"/>. If not set, <see cref="FalseValue"/> is used instead.</summary>
+    /// <summary>Gets or sets the value to return when the input is <see langword="null"/> or cannot be converted to a boolean. If not set, <see cref="FalseValue"/> is used instead.</summary>
     public object? NullValue { get; set; }
 
     private object? GetValue(bool value)
@@ -50,7 +50,7 @@ public sealed class BooleanToValueConverter : IValueConverter
             }
         }
 
-        return NullValue;
+        return NullValue ?? FalseValue;
     }
 
     /// <summary>This method is not supported and always throws <see cref="NotSupportedException"/>.</summary>

--- a/src/Meziantou.Framework.WPF/DelegateCommand.cs
+++ b/src/Meziantou.Framework.WPF/DelegateCommand.cs
@@ -63,6 +63,12 @@ public static class DelegateCommand
     /// <summary>Creates an asynchronous command that executes the specified task.</summary>
     /// <param name="execute">The task to execute when the command is invoked.</param>
     /// <returns>A new <see cref="IDelegateCommand"/> instance.</returns>
+    /// <remarks>
+    /// Execution is fire-and-forget: if the task faults, the exception is rethrown on the dispatcher and cannot be
+    /// caught by the caller. Handle it inside <paramref name="execute"/>, or subscribe to
+    /// <see cref="System.Windows.Application.DispatcherUnhandledException"/>. The command reports
+    /// <see cref="System.Windows.Input.ICommand.CanExecute(object)"/> as <see langword="false"/> while the task runs.
+    /// </remarks>
     public static IDelegateCommand Create(Func<Task>? execute)
     {
         return new AsyncDelegateCommand(WrapAction(execute), CanExecuteTrue);
@@ -71,6 +77,12 @@ public static class DelegateCommand
     /// <summary>Creates an asynchronous command that executes the specified task with a parameter.</summary>
     /// <param name="execute">The task to execute when the command is invoked.</param>
     /// <returns>A new <see cref="IDelegateCommand"/> instance.</returns>
+    /// <remarks>
+    /// Execution is fire-and-forget: if the task faults, the exception is rethrown on the dispatcher and cannot be
+    /// caught by the caller. Handle it inside <paramref name="execute"/>, or subscribe to
+    /// <see cref="System.Windows.Application.DispatcherUnhandledException"/>. The command reports
+    /// <see cref="System.Windows.Input.ICommand.CanExecute(object)"/> as <see langword="false"/> while the task runs.
+    /// </remarks>
     public static IDelegateCommand Create(Func<object?, Task>? execute)
     {
         return new AsyncDelegateCommand(execute ?? DefaultExecuteAsync, CanExecuteTrue);
@@ -80,6 +92,13 @@ public static class DelegateCommand
     /// <param name="execute">The task to execute when the command is invoked.</param>
     /// <param name="canExecute">The function that determines if the command can execute.</param>
     /// <returns>A new <see cref="IDelegateCommand"/> instance.</returns>
+    /// <remarks>
+    /// Execution is fire-and-forget: if the task faults, the exception is rethrown on the dispatcher and cannot be
+    /// caught by the caller. Handle it inside <paramref name="execute"/>, or subscribe to
+    /// <see cref="System.Windows.Application.DispatcherUnhandledException"/>. The command reports
+    /// <see cref="System.Windows.Input.ICommand.CanExecute(object)"/> as <see langword="false"/> while the task runs,
+    /// regardless of <paramref name="canExecute"/>.
+    /// </remarks>
     public static IDelegateCommand Create(Func<Task>? execute, Func<bool>? canExecute)
     {
         return new AsyncDelegateCommand(WrapAction(execute), WrapAction(canExecute));
@@ -89,6 +108,13 @@ public static class DelegateCommand
     /// <param name="execute">The task to execute when the command is invoked.</param>
     /// <param name="canExecute">The function that determines if the command can execute.</param>
     /// <returns>A new <see cref="IDelegateCommand"/> instance.</returns>
+    /// <remarks>
+    /// Execution is fire-and-forget: if the task faults, the exception is rethrown on the dispatcher and cannot be
+    /// caught by the caller. Handle it inside <paramref name="execute"/>, or subscribe to
+    /// <see cref="System.Windows.Application.DispatcherUnhandledException"/>. The command reports
+    /// <see cref="System.Windows.Input.ICommand.CanExecute(object)"/> as <see langword="false"/> while the task runs,
+    /// regardless of <paramref name="canExecute"/>.
+    /// </remarks>
     public static IDelegateCommand Create(Func<object?, Task>? execute, Func<object?, bool>? canExecute)
     {
         return new AsyncDelegateCommand(execute ?? DefaultExecuteAsync, canExecute ?? CanExecuteTrue);

--- a/src/Meziantou.Framework.WPF/DelegateCommandDispatcher.cs
+++ b/src/Meziantou.Framework.WPF/DelegateCommandDispatcher.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Meziantou.Framework.WPF;
+
+/// <summary>Shared dispatcher handling for the <see cref="IDelegateCommand"/> implementations.</summary>
+internal static class DelegateCommandDispatcher
+{
+    /// <summary>Gets the dispatcher of the calling thread, or <see langword="null"/> when that thread has none.</summary>
+    /// <remarks>
+    /// <see cref="Dispatcher.CurrentDispatcher"/> must not be used here: it creates a dispatcher for the calling thread
+    /// when there is none. A command created on a thread pool thread would then be bound to a dispatcher whose thread
+    /// never runs a message pump, and every notification sent to it would be queued and never dispatched.
+    /// </remarks>
+    public static Dispatcher? GetCurrentThreadDispatcher()
+    {
+        return Dispatcher.FromThread(Thread.CurrentThread);
+    }
+
+    /// <summary>Raises <paramref name="handler"/> on the UI thread.</summary>
+    /// <param name="dispatcher">The dispatcher captured when the command was created, or <see langword="null"/> when it was not created on a dispatcher thread.</param>
+    /// <param name="sender">The command raising the event.</param>
+    /// <param name="handler">The handlers to invoke, or <see langword="null"/> when nobody subscribed.</param>
+    /// <remarks>
+    /// The event is raised synchronously when the caller is already on the target thread, so the common case keeps the
+    /// ordering callers expect. Otherwise it is posted with <see cref="Dispatcher.BeginInvoke(Delegate, object?[])"/>
+    /// rather than <see cref="Dispatcher.Invoke(Action)"/>: a command bound to a dispatcher that is not pumping
+    /// messages then loses the notification instead of blocking the caller forever.
+    /// </remarks>
+    public static void RaiseCanExecuteChanged(Dispatcher? dispatcher, IDelegateCommand sender, EventHandler? handler)
+    {
+        if (handler is null)
+            return;
+
+        dispatcher ??= Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            handler(sender, EventArgs.Empty);
+        }
+        else
+        {
+            _ = dispatcher.BeginInvoke(() => handler(sender, EventArgs.Empty));
+        }
+    }
+}

--- a/src/Meziantou.Framework.WPF/DispatcherExtensions.cs
+++ b/src/Meziantou.Framework.WPF/DispatcherExtensions.cs
@@ -18,10 +18,16 @@ public static class DispatcherExtensions
     }
 
     /// <summary>An awaitable that switches execution to the UI thread.</summary>
+    /// <remarks>
+    /// Instances must be obtained from <see cref="SwitchToDispatcherThread(Dispatcher)"/>. A default-initialized value
+    /// has no dispatcher to switch to and throws <see cref="InvalidOperationException"/> when awaited.
+    /// </remarks>
     [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "<Pending>")]
     public readonly struct SwitchToUiAwaitable : INotifyCompletion
     {
-        private readonly Dispatcher _dispatcher;
+        // Nullable even though the constructor never receives null: the type is a public struct, so
+        // default(SwitchToUiAwaitable) is reachable from user code and leaves this field null.
+        private readonly Dispatcher? _dispatcher;
 
         internal SwitchToUiAwaitable(Dispatcher dispatcher)
         {
@@ -41,13 +47,52 @@ public static class DispatcherExtensions
         }
 
         /// <summary>Gets a value indicating whether the awaiter has completed.</summary>
-        public bool IsCompleted => _dispatcher.CheckAccess();
+        /// <exception cref="InvalidOperationException">The instance was default-initialized instead of being obtained from <see cref="SwitchToDispatcherThread(Dispatcher)"/>.</exception>
+        public bool IsCompleted => GetDispatcher().CheckAccess();
 
         /// <summary>Schedules the continuation action to run on the dispatcher thread.</summary>
         /// <param name="continuation">The continuation action.</param>
+        /// <exception cref="InvalidOperationException">The instance was default-initialized instead of being obtained from <see cref="SwitchToDispatcherThread(Dispatcher)"/>, or the dispatcher has already shut down.</exception>
         public void OnCompleted(Action continuation)
         {
-            _ = _dispatcher.BeginInvoke(continuation);
+            // The operation is aborted when the dispatcher shuts down before it gets a chance to run. Resuming the
+            // continuation in that case lets the caller observe the shutdown; leaving it unscheduled would make the
+            // awaiting task hang forever with nothing to diagnose.
+            var resumption = new Resumption(continuation);
+            var operation = GetDispatcher().BeginInvoke(resumption.Resume);
+            operation.Aborted += resumption.OnAborted;
+
+            // The operation may have been aborted before the handler above was attached.
+            if (operation.Status is DispatcherOperationStatus.Aborted)
+            {
+                resumption.Resume();
+            }
+        }
+
+        private Dispatcher GetDispatcher()
+        {
+            return _dispatcher ?? throw new InvalidOperationException($"This '{nameof(SwitchToUiAwaitable)}' has no dispatcher. Use '{nameof(SwitchToDispatcherThread)}' to create one.");
+        }
+
+        /// <summary>Ensures the continuation runs at most once, whether the operation completes or is aborted.</summary>
+        private sealed class Resumption
+        {
+            private Action? _continuation;
+
+            public Resumption(Action continuation)
+            {
+                _continuation = continuation;
+            }
+
+            public void Resume()
+            {
+                Interlocked.Exchange(ref _continuation, value: null)?.Invoke();
+            }
+
+            public void OnAborted(object? sender, EventArgs e)
+            {
+                Resume();
+            }
         }
     }
 }

--- a/src/Meziantou.Framework.WPF/EnumLocalizationUtilities.cs
+++ b/src/Meziantou.Framework.WPF/EnumLocalizationUtilities.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
-using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Meziantou.Framework.WPF;
@@ -9,13 +8,6 @@ namespace Meziantou.Framework.WPF;
 internal static class EnumLocalizationUtilities
 {
     private static readonly ConcurrentDictionary<Type, LocalizedEnumValueCollection> EnumsCache = new();
-    private static readonly ConcurrentDictionary<Expression, string?> PropertiesCache = new();
-
-    public static LocalizedEnumValueCollection GetEnumLocalization<T>()
-        where T : struct
-    {
-        return GetEnumLocalization(typeof(T));
-    }
 
     public static LocalizedEnumValueCollection GetEnumLocalization(Type type)
     {
@@ -46,23 +38,5 @@ internal static class EnumLocalizationUtilities
         }
 
         return new LocalizedEnumValueCollection(result);
-    }
-
-    public static string? GetPropertyLocalization<T>(Expression<Func<T>> exp)
-    {
-        return PropertiesCache.GetOrAdd(exp, CreatePropertyLocalization);
-    }
-
-    private static string? CreatePropertyLocalization(Expression expression)
-    {
-        var memberExpression = (MemberExpression)((LambdaExpression)expression).Body;
-        var displayAttribute = memberExpression.Member.GetCustomAttribute<DisplayAttribute>();
-        return displayAttribute?.GetName() ?? memberExpression.Member.Name;
-    }
-
-    public static string GetEnumMemberLocalization(Enum value)
-    {
-        var localizedValueCollection = GetEnumLocalization(value.GetType());
-        return localizedValueCollection[value].Name;
     }
 }

--- a/src/Meziantou.Framework.WPF/EnumValuesExtension.cs
+++ b/src/Meziantou.Framework.WPF/EnumValuesExtension.cs
@@ -30,8 +30,11 @@ public sealed class EnumValuesExtension : MarkupExtension
     /// <summary>Returns the enum values.</summary>
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        if (EnumType == null)
+        if (EnumType is null)
             throw new InvalidOperationException("The enum type is not set");
+
+        if (!EnumType.IsEnum)
+            throw new InvalidOperationException($"'{EnumType}' is not an enum type");
 
         return Enum.GetValues(EnumType);
     }

--- a/src/Meziantou.Framework.WPF/IDelegateCommand.cs
+++ b/src/Meziantou.Framework.WPF/IDelegateCommand.cs
@@ -6,6 +6,10 @@ namespace Meziantou.Framework.WPF;
 public interface IDelegateCommand : ICommand
 {
     /// <summary>Raises the CanExecuteChanged event to notify that the command's execution state has changed.</summary>
+    /// <remarks>
+    /// The event is raised on the UI thread. When the caller is already on that thread the handlers run synchronously;
+    /// otherwise the notification is posted to the dispatcher and this method returns immediately.
+    /// </remarks>
     [SuppressMessage("Design", "CA1030:Use events where appropriate", Justification = "This method raise an existing event")]
     void RaiseCanExecuteChanged();
 }

--- a/src/Meziantou.Framework.WPF/LocalizedEnumValueCollection.cs
+++ b/src/Meziantou.Framework.WPF/LocalizedEnumValueCollection.cs
@@ -8,6 +8,4 @@ internal sealed class LocalizedEnumValueCollection : ReadOnlyCollection<Localize
         : base(list)
     {
     }
-
-    public LocalizedEnumValue this[object value] => this.First(_ => _.Value.Equals(value));
 }

--- a/src/Meziantou.Framework.WPF/LocalizedEnumValuesExtension.cs
+++ b/src/Meziantou.Framework.WPF/LocalizedEnumValuesExtension.cs
@@ -32,8 +32,11 @@ public sealed class LocalizedEnumValuesExtension : MarkupExtension
     /// <summary>Returns the localized enum values.</summary>
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        if (EnumType == null)
+        if (EnumType is null)
             throw new InvalidOperationException("The enum type is not set");
+
+        if (!EnumType.IsEnum)
+            throw new InvalidOperationException($"'{EnumType}' is not an enum type");
 
         return EnumLocalizationUtilities.GetEnumLocalization(EnumType);
     }

--- a/src/Meziantou.Framework.WPF/SyncDelegateCommand.cs
+++ b/src/Meziantou.Framework.WPF/SyncDelegateCommand.cs
@@ -6,7 +6,7 @@ internal sealed class SyncDelegateCommand : IDelegateCommand
 {
     private readonly Action<object?> _execute;
     private readonly Func<object?, bool> _canExecute;
-    private readonly Dispatcher _dispatcher;
+    private readonly Dispatcher? _dispatcher;
 
     public event EventHandler? CanExecuteChanged;
 
@@ -14,7 +14,7 @@ internal sealed class SyncDelegateCommand : IDelegateCommand
     {
         _execute = execute;
         _canExecute = canExecute;
-        _dispatcher = Dispatcher.CurrentDispatcher;
+        _dispatcher = DelegateCommandDispatcher.GetCurrentThreadDispatcher();
     }
 
     public bool CanExecute(object? parameter)
@@ -29,13 +29,6 @@ internal sealed class SyncDelegateCommand : IDelegateCommand
 
     public void RaiseCanExecuteChanged()
     {
-        if (_dispatcher is not null)
-        {
-            _dispatcher.Invoke(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
-        }
-        else
-        {
-            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-        }
+        DelegateCommandDispatcher.RaiseCanExecuteChanged(_dispatcher, this, CanExecuteChanged);
     }
 }

--- a/src/Meziantou.Framework.WPF/WindowUtilities.CloseOnEscapeKeyDown.cs
+++ b/src/Meziantou.Framework.WPF/WindowUtilities.CloseOnEscapeKeyDown.cs
@@ -53,12 +53,12 @@ public static partial class WindowUtilities
 
     private static void CloseOnEscapeKeyDown_PreviewKeyDown(object sender, KeyEventArgs e)
     {
-        if (sender is Window target)
+        if (sender is Window target && e.Key is Key.Escape)
         {
-            if (e.Key == Key.Escape)
-            {
-                target.Close();
-            }
+            // Mark the event as handled before closing, so a Cancel button or a KeyDown handler on a child element
+            // does not also react to the key press on a window that is already closing.
+            e.Handled = true;
+            target.Close();
         }
     }
 }

--- a/tests/Meziantou.Framework.WPF.Tests/BooleanToValueConverterTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/BooleanToValueConverterTests.cs
@@ -43,4 +43,31 @@ public sealed class BooleanToValueConverterTests
         _converter.NullValue = null;
         Assert.Equal(_converter.FalseValue, Convert(null));
     }
+
+    [Fact]
+    public void FallbackToFalseValueWhenTheStringCannotBeParsed()
+    {
+        _converter.NullValue = null;
+        Assert.Equal(_converter.FalseValue, Convert("abc"));
+    }
+
+    [Fact]
+    public void FallbackToFalseValueWhenTheValueCannotBeCast()
+    {
+        _converter.NullValue = null;
+        Assert.Equal(_converter.FalseValue, Convert(DateTime.UnixEpoch));
+    }
+
+    [Fact]
+    public void FallbackToFalseValueWhenTheValueIsNotConvertible()
+    {
+        _converter.NullValue = null;
+        Assert.Equal(_converter.FalseValue, Convert(new object()));
+    }
+
+    [Fact]
+    public void ConvertBackIsNotSupported()
+    {
+        Assert.Throws<NotSupportedException>(() => _converter.ConvertBack(value: true, typeof(object), parameter: null, culture: null));
+    }
 }

--- a/tests/Meziantou.Framework.WPF.Tests/DelegateCommandTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/DelegateCommandTests.cs
@@ -1,0 +1,331 @@
+using System.Windows.Threading;
+
+namespace Meziantou.Framework.WPF.Tests;
+
+public sealed class DelegateCommandTests
+{
+    [Fact]
+    public void ExecuteAction()
+    {
+        var count = 0;
+        var command = DelegateCommand.Create(() => count++);
+
+        Assert.True(command.CanExecute(parameter: null));
+        command.Execute(parameter: null);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void ExecuteActionWithParameter()
+    {
+        object? received = null;
+        var command = DelegateCommand.Create(parameter => received = parameter);
+
+        command.Execute("value");
+
+        Assert.Equal("value", received);
+    }
+
+    [Fact]
+    public void CanExecuteIsUsed()
+    {
+        var canExecute = false;
+        var command = DelegateCommand.Create(() => { }, () => canExecute);
+
+        Assert.False(command.CanExecute(parameter: null));
+
+        canExecute = true;
+        Assert.True(command.CanExecute(parameter: null));
+    }
+
+    [Fact]
+    public void CanExecuteReceivesParameter()
+    {
+        object? received = null;
+        var command = DelegateCommand.Create(_ => { }, parameter =>
+        {
+            received = parameter;
+            return true;
+        });
+
+        Assert.True(command.CanExecute("value"));
+        Assert.Equal("value", received);
+    }
+
+    [Fact]
+    public void NullExecuteIsANoOp()
+    {
+        var command = DelegateCommand.Create((Action?)null);
+
+        Assert.True(command.CanExecute(parameter: null));
+        command.Execute(parameter: null);
+    }
+
+    [Fact]
+    public void NullCanExecuteReturnsTrue()
+    {
+        var command = DelegateCommand.Create(() => { }, canExecute: null);
+
+        Assert.True(command.CanExecute(parameter: null));
+    }
+
+    [Fact]
+    public void NullAsyncExecuteIsANoOp()
+    {
+        var command = DelegateCommand.Create((Func<Task>?)null);
+
+        Assert.True(command.CanExecute(parameter: null));
+        command.Execute(parameter: null);
+        Assert.True(command.CanExecute(parameter: null));
+    }
+
+    [Fact]
+    public void AsyncCommandCannotExecuteWhileRunning()
+    {
+        var tcs = new TaskCompletionSource();
+        var executions = 0;
+        var command = DelegateCommand.Create(() =>
+        {
+            executions++;
+            return tcs.Task;
+        });
+
+        using var finished = WatchForCompletion(command);
+
+        Assert.True(command.CanExecute(parameter: null));
+        command.Execute(parameter: null);
+
+        Assert.False(command.CanExecute(parameter: null));
+
+        // The re-entrant call must be ignored
+        command.Execute(parameter: null);
+        Assert.Equal(1, executions);
+
+        tcs.SetResult();
+        Assert.True(finished.Wait(TimeSpan.FromSeconds(30)), "The command did not complete");
+        Assert.True(command.CanExecute(parameter: null));
+    }
+
+    [Fact]
+    public void AsyncCommandResetsStateWhenTheTaskFails()
+    {
+        var previousContext = SynchronizationContext.Current;
+        var context = new CapturingSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(context);
+        try
+        {
+            var tcs = new TaskCompletionSource();
+            var command = DelegateCommand.Create(() => tcs.Task);
+
+            using var finished = WatchForCompletion(command);
+
+            command.Execute(parameter: null);
+            Assert.False(command.CanExecute(parameter: null));
+
+            tcs.SetException(new InvalidOperationException("boom"));
+            Assert.True(finished.Wait(TimeSpan.FromSeconds(30)), "The command did not complete");
+            Assert.True(command.CanExecute(parameter: null));
+
+            // Execute is `async void`: the failure is rethrown on the synchronization context and cannot be observed
+            // by the caller. This is the documented behavior of the asynchronous DelegateCommand.Create overloads.
+            var exception = Assert.Single(context.Exceptions);
+            Assert.Equal("boom", exception.Message);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+    }
+
+    [Fact]
+    public void AsyncCommandOverridesCanExecuteWhileRunning()
+    {
+        var tcs = new TaskCompletionSource();
+        var command = DelegateCommand.Create(() => tcs.Task, () => true);
+
+        using var finished = WatchForCompletion(command);
+
+        command.Execute(parameter: null);
+        Assert.False(command.CanExecute(parameter: null));
+
+        tcs.SetResult();
+        Assert.True(finished.Wait(TimeSpan.FromSeconds(30)), "The command did not complete");
+        Assert.True(command.CanExecute(parameter: null));
+    }
+
+    [Fact]
+    public void CanExecuteChangedIsRaisedSynchronouslyWithoutDispatcher()
+    {
+        var command = DelegateCommand.Create(() => { });
+        var raised = false;
+        command.CanExecuteChanged += (_, _) => raised = true;
+
+        command.RaiseCanExecuteChanged();
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void CanExecuteChangedWithoutHandlerDoesNotThrow()
+    {
+        var command = DelegateCommand.Create(() => { });
+
+        command.RaiseCanExecuteChanged();
+    }
+
+    // Regression test: the commands used to capture Dispatcher.CurrentDispatcher, which *creates* a dispatcher for the
+    // calling thread. A command created on a thread pool thread was therefore bound to a dispatcher that never pumps
+    // messages, and RaiseCanExecuteChanged blocked forever on Dispatcher.Invoke.
+    [Fact(Timeout = 95000)]
+    public async Task CanExecuteChangedDoesNotBlockWhenTheCommandIsCreatedOnTheThreadPool()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var command = await Task.Run(() => DelegateCommand.Create(() => { }), cancellationToken);
+
+        var raised = false;
+        command.CanExecuteChanged += (_, _) => raised = true;
+
+        using var done = new ManualResetEventSlim();
+        var thread = new Thread(() =>
+        {
+            command.RaiseCanExecuteChanged();
+            done.Set();
+        })
+        {
+            IsBackground = true,
+        };
+        thread.Start();
+
+        Assert.True(done.Wait(TimeSpan.FromSeconds(30), cancellationToken), "RaiseCanExecuteChanged blocked");
+        Assert.True(raised);
+    }
+
+    [Fact(Timeout = 95000)]
+    public async Task CanExecuteChangedIsRaisedOnTheDispatcherThread()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var dispatcher = await StartDispatcherThreadAsync(cancellationToken);
+        try
+        {
+            var command = dispatcher.Invoke(() => DelegateCommand.Create(() => { }));
+
+            var raisedOnThreadId = 0;
+            using var raised = new ManualResetEventSlim();
+            command.CanExecuteChanged += (_, _) =>
+            {
+                raisedOnThreadId = Environment.CurrentManagedThreadId;
+                raised.Set();
+            };
+
+            Assert.NotEqual(dispatcher.Thread.ManagedThreadId, Environment.CurrentManagedThreadId);
+            command.RaiseCanExecuteChanged();
+
+            Assert.True(raised.Wait(TimeSpan.FromSeconds(30), cancellationToken), "The event was not raised");
+            Assert.Equal(dispatcher.Thread.ManagedThreadId, raisedOnThreadId);
+        }
+        finally
+        {
+            dispatcher.InvokeShutdown();
+        }
+    }
+
+    [Fact(Timeout = 95000)]
+    public async Task CanExecuteChangedIsRaisedSynchronouslyOnTheDispatcherThread()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var dispatcher = await StartDispatcherThreadAsync(cancellationToken);
+        try
+        {
+            var raised = dispatcher.Invoke(() =>
+            {
+                var command = DelegateCommand.Create(() => { });
+                var handled = false;
+                command.CanExecuteChanged += (_, _) => handled = true;
+
+                command.RaiseCanExecuteChanged();
+                return handled;
+            });
+
+            Assert.True(raised, "The event was not raised synchronously");
+        }
+        finally
+        {
+            dispatcher.InvokeShutdown();
+        }
+    }
+
+    /// <summary>Signals once the async command has raised CanExecuteChanged both before and after running its task.</summary>
+    private static ManualResetEventSlim WatchForCompletion(IDelegateCommand command)
+    {
+        var completed = new ManualResetEventSlim();
+        var count = 0;
+        command.CanExecuteChanged += (_, _) =>
+        {
+            if (Interlocked.Increment(ref count) == 2)
+            {
+                completed.Set();
+            }
+        };
+
+        return completed;
+    }
+
+    /// <summary>Captures the exceptions an <c>async void</c> method rethrows instead of letting them crash the process.</summary>
+    private sealed class CapturingSynchronizationContext : SynchronizationContext
+    {
+        private readonly List<Exception> _exceptions = [];
+
+        public IReadOnlyList<Exception> Exceptions
+        {
+            get
+            {
+                lock (_exceptions)
+                {
+                    return [.. _exceptions];
+                }
+            }
+        }
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            try
+            {
+                d(state);
+            }
+            catch (Exception ex)
+            {
+                lock (_exceptions)
+                {
+                    _exceptions.Add(ex);
+                }
+            }
+        }
+
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            Post(d, state);
+        }
+    }
+
+    private static async Task<Dispatcher> StartDispatcherThreadAsync(CancellationToken cancellationToken)
+    {
+        Dispatcher? dispatcher = null;
+        var thread = new Thread(() =>
+        {
+            Volatile.Write(ref dispatcher, Dispatcher.CurrentDispatcher);
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true,
+        };
+        thread.Start();
+
+        while (Volatile.Read(ref dispatcher) is null)
+        {
+            await Task.Delay(1, cancellationToken);
+        }
+
+        return Volatile.Read(ref dispatcher)!;
+    }
+}

--- a/tests/Meziantou.Framework.WPF.Tests/DispatcherExtensionsTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/DispatcherExtensionsTests.cs
@@ -32,4 +32,49 @@ public sealed class DispatcherExtensionsTests
 
         currentDispatcher.BeginInvokeShutdown(DispatcherPriority.Background);
     }
+
+    [Fact]
+    public void DefaultAwaitableThrows()
+    {
+        var awaitable = default(DispatcherExtensions.SwitchToUiAwaitable);
+
+        Assert.Throws<InvalidOperationException>(() => awaitable.IsCompleted);
+        Assert.Throws<InvalidOperationException>(() => awaitable.OnCompleted(() => { }));
+    }
+
+    [Fact(Timeout = 95000)]
+    public async Task SwitchToUIThreadAfterShutdownDoesNotHang()
+    {
+        Dispatcher? dispatcher = null;
+        var t = new Thread(() =>
+        {
+            Volatile.Write(ref dispatcher, Dispatcher.CurrentDispatcher);
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true,
+        };
+        t.Start();
+
+        while (Volatile.Read(ref dispatcher) is null)
+        {
+            await Task.Delay(1, TestContext.Current.CancellationToken);
+        }
+
+        var currentDispatcher = Volatile.Read(ref dispatcher)!;
+        currentDispatcher.InvokeShutdown();
+
+        while (!currentDispatcher.HasShutdownFinished)
+        {
+            await Task.Delay(1, TestContext.Current.CancellationToken);
+        }
+
+        // The dispatcher aborts the operation instead of running it. The await must still resume: leaving the
+        // continuation unscheduled would make this task hang forever.
+        var switchTask = Task.Run(async () => await currentDispatcher.SwitchToDispatcherThread(), TestContext.Current.CancellationToken);
+
+        var completed = await Task.WhenAny(switchTask, Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
+        Assert.Same(switchTask, completed);
+        await switchTask;
+    }
 }

--- a/tests/Meziantou.Framework.WPF.Tests/EnumMarkupExtensionsTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/EnumMarkupExtensionsTests.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Meziantou.Framework.WPF.Tests;
+
+public sealed class EnumMarkupExtensionsTests
+{
+    private enum SampleEnum
+    {
+        [Display(Name = "First value")]
+        First,
+
+        Second,
+
+        [Display(Description = "No name set")]
+        Third,
+    }
+
+    [Fact]
+    public void EnumValues_ReturnsEveryValue()
+    {
+        var extension = new EnumValuesExtension(typeof(SampleEnum));
+
+        var values = Assert.IsType<SampleEnum[]>(extension.ProvideValue(serviceProvider: null!));
+
+        Assert.Equal([SampleEnum.First, SampleEnum.Second, SampleEnum.Third], values);
+    }
+
+    [Fact]
+    public void EnumValues_WithoutType_Throws()
+    {
+        var extension = new EnumValuesExtension();
+
+        Assert.Throws<InvalidOperationException>(() => extension.ProvideValue(serviceProvider: null!));
+    }
+
+    [Fact]
+    public void EnumValues_WithNonEnumType_Throws()
+    {
+        var extension = new EnumValuesExtension(typeof(string));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => extension.ProvideValue(serviceProvider: null!));
+        Assert.Contains(nameof(String), exception.Message);
+    }
+
+    [Fact]
+    public void LocalizedEnumValues_UsesDisplayNameThenMemberName()
+    {
+        var extension = new LocalizedEnumValuesExtension(typeof(SampleEnum));
+
+        var values = Assert.IsAssignableTo<IReadOnlyList<LocalizedEnumValue>>(extension.ProvideValue(serviceProvider: null!));
+
+        Assert.HasCount(3, values);
+        Assert.Equal("First value", values[0].Name);
+        Assert.Equal(SampleEnum.First, values[0].Value);
+
+        Assert.Equal(nameof(SampleEnum.Second), values[1].Name);
+
+        // The DisplayAttribute has no Name, so the member name is used
+        Assert.Equal(nameof(SampleEnum.Third), values[2].Name);
+    }
+
+    [Fact]
+    public void LocalizedEnumValues_IsCached()
+    {
+        var first = new LocalizedEnumValuesExtension(typeof(SampleEnum)).ProvideValue(serviceProvider: null!);
+        var second = new LocalizedEnumValuesExtension(typeof(SampleEnum)).ProvideValue(serviceProvider: null!);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void LocalizedEnumValues_WithoutType_Throws()
+    {
+        var extension = new LocalizedEnumValuesExtension();
+
+        Assert.Throws<InvalidOperationException>(() => extension.ProvideValue(serviceProvider: null!));
+    }
+
+    [Fact]
+    public void LocalizedEnumValues_WithNonEnumType_Throws()
+    {
+        var extension = new LocalizedEnumValuesExtension(typeof(string));
+
+        Assert.Throws<InvalidOperationException>(() => extension.ProvideValue(serviceProvider: null!));
+    }
+
+    [Fact]
+    public void LocalizedEnumValue_ToStringReturnsName()
+    {
+        var value = new LocalizedEnumValue(SampleEnum.Second);
+
+        Assert.Equal(nameof(SampleEnum.Second), value.ToString());
+        Assert.Equal(nameof(SampleEnum.Second), value.Name);
+    }
+}


### PR DESCRIPTION
## What

Fixes a deadlock in the `DelegateCommand` implementations plus several smaller defects found while reviewing `Meziantou.Framework.WPF`. Test count goes from 13 to 42.

### The deadlock

`SyncDelegateCommand` and `AsyncDelegateCommand` captured `Dispatcher.CurrentDispatcher` in their constructor. That property does not return "the UI dispatcher" — it returns the *calling thread's* dispatcher, **creating one if the thread has none**. A command built off the UI thread (`await Task.Run(() => new MyViewModel())`, or a DI container resolving on a pool thread) was bound to a dispatcher whose thread never runs a message pump, and `RaiseCanExecuteChanged` then blocked forever on `Dispatcher.Invoke`, which has no timeout.

The symptom is a frozen UI with no exception and no log entry. It is invisible in the common case — a view model built on the UI thread — so it ships and then reproduces only where startup happens to run on a background thread.

Dispatcher handling moved into a shared internal `DelegateCommandDispatcher` so the two implementations cannot drift apart:

- `Dispatcher.FromThread(Thread.CurrentThread)` replaces `CurrentDispatcher`, so nothing is captured on a thread that has no dispatcher.
- When nothing was captured, the raise falls back to `Application.Current?.Dispatcher`, so a view model built on a background thread still notifies the real UI thread. With no `Application` (unit tests, XAML islands) the event is raised inline.
- `BeginInvoke` replaces `Invoke`, with a `CheckAccess()` fast path so the common same-thread case stays synchronous. A command bound to a non-pumping dispatcher now loses a notification instead of hanging the caller.

The `if (_dispatcher is not null)` branches were dead code before (`CurrentDispatcher` never returns null) and made the case look handled; the field is now genuinely nullable.

### Other fixes

- **`BooleanToValueConverter`** returned `NullValue` raw when a value could not be converted, skipping the `FalseValue` fallback that the null path already applied and that the `NullValue` doc comment promises. With `NullValue` unset, a `Visibility` binding received `null`, WPF fell back to the property default, and an element meant to be hidden appeared.
- **`SwitchToUiAwaitable`** discarded the `DispatcherOperation`, so an operation aborted by dispatcher shutdown left the continuation unscheduled and the awaiting task never completed — a silent hang. It now resumes on abort, guarded by `Interlocked.Exchange` so the continuation runs at most once (the operation can be aborted between `BeginInvoke` returning and the handler being attached). Being a public struct, `default(SwitchToUiAwaitable)` is reachable from user code and threw `NullReferenceException`; it now throws a named `InvalidOperationException`.
- **`CloseOnEscapeKeyDown`** did not set `e.Handled`, so a dialog pairing it with an `IsCancel="True"` button ran both paths against a window already closing.
- **Markup extensions** used `== null` (the only violations of the `AGENTS.md` `is null` rule in this project) and did not validate that `EnumType` is an enum, so a wrong type surfaced as an `ArgumentException` from inside `Enum.GetValues`, wrapped in a `XamlParseException` naming neither the type nor the extension.
- **Dead code deleted**: `GetPropertyLocalization`, `GetEnumMemberLocalization`, `GetEnumLocalization<T>` and the `LocalizedEnumValueCollection` indexer had no callers anywhere in the repo. `PropertiesCache` was keyed on `Expression`, which uses reference equality against a freshly allocated tree every call — it never hit and grew without bound (measured: 100 identical calls produced 100 entries, each pinning the lambda closure). This is the follow-up explicitly left open by #2955.
- **Documentation**: the four asynchronous `Create` overloads now state that execution is fire-and-forget and that a faulting task is rethrown on the dispatcher and cannot be caught by the caller; `IDelegateCommand.RaiseCanExecuteChanged` documents its threading contract.

## Notes for reviewers

- **No public API change** — `ref/Meziantou.Framework.WPF.cs` is unchanged. `DelegateCommandDispatcher` is `internal`, and every deleted member was `internal`.
- The deadlock regression test (`CanExecuteChangedDoesNotBlockWhenTheCommandIsCreatedOnTheThreadPool`) was run against a temporarily reverted implementation and **failed** with "RaiseCanExecuteChanged blocked" after 30s, then passed against the fix.
- `RaiseCanExecuteChanged` from a non-UI thread is now asynchronous where it used to block until the handler ran. This is the intended behaviour change; the same-thread path stays synchronous, and WPF's `CanExecuteChanged` consumers do not depend on the ordering.
- `AsyncDelegateCommand.Execute` remains `async void`, so a faulting task still terminates the app unless a global handler is installed — writing the test for it initially crashed the test host. This PR documents that behaviour rather than changing it; adding an opt-in `onError` overload would be a public API decision, happy to do it in a follow-up.
- `dotnet build … /p:TreatWarningsAsErrors=true` succeeds for `net10.0-windows` and `net11.0-windows` with 0 warnings / 0 errors, and all 42 tests pass on both. `dotnet run ./eng/update-all.cs` produces no changes to this project (it rewrites some unrelated `src/*.Tool/readme.md` files, which is pre-existing and leaves the tree clean).
- `WindowUtilities` is still untested — it needs an STA `Window` — so the `e.Handled` fix is verified by reading, not by a test.

## Known issues left alone

Three review findings are deliberately not addressed here because each is a public-API or policy decision rather than a defect:

1. `WindowUtilities.CloseOnEscapeProperty` does not follow the `<RegisteredName>Property` convention (would be `CloseOnEscapeKeyDownProperty`). Renaming is breaking; an `[Obsolete]` alias emits warnings in consumer builds.
2. `LocalizedEnumValue.Value` is typed `object` although all constructors take an `Enum`. Narrowing the getter is binary-breaking.
3. `tests/Trimmable.Wpf` validates nothing: it declares no `TrimmerRootAssembly`, so publishing it drops `Meziantou.Framework.WPF.dll` from the output entirely. Adding the root makes the publish fail with `NETSDK1144` on ~14 IL2xxx errors, all from `System.Windows.*`/`MS.Internal.*` and none from this library — WPF is not trim-compatible, so no configuration makes that project useful.