### PR TITLE
Fix security and correctness issues in the AspNetCore.Mvc TagHelpers

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -164,6 +164,7 @@
     <Project Path="tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj" />
     <Project Path="tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj" />
     <Project Path="tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj" />
+    <Project Path="tests/Meziantou.AspNetCore.Mvc.Tests/Meziantou.AspNetCore.Mvc.Tests.csproj" />
     <Project Path="tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj" Id="a1514aa2-f75e-4dcc-bf6b-1860a8c44fcb" />
     <Project Path="tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj" />
     <Project Path="tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj" />

--- a/ref/Meziantou.AspNetCore.Mvc.cs
+++ b/ref/Meziantou.AspNetCore.Mvc.cs
@@ -7,27 +7,27 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers
     public sealed class InlineImgTagHelper : Meziantou.AspNetCore.Mvc.TagHelpers.InlineTagHelper
     {
         public string? Src { get => throw null; set { } }
-        public InlineImgTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache) : base(default(Microsoft.AspNetCore.Hosting.IWebHostEnvironment), default(Microsoft.Extensions.Caching.Memory.IMemoryCache)) { }
+        public InlineImgTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache, Microsoft.Extensions.Logging.ILogger<Meziantou.AspNetCore.Mvc.TagHelpers.InlineImgTagHelper> logger) : base(default(Microsoft.AspNetCore.Hosting.IWebHostEnvironment), default(Microsoft.Extensions.Caching.Memory.IMemoryCache), default(Microsoft.Extensions.Logging.ILogger)) { }
         public override System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) => throw null;
     }
 
     public sealed class InlineScriptTagHelper : Meziantou.AspNetCore.Mvc.TagHelpers.InlineTagHelper
     {
         public string? Src { get => throw null; set { } }
-        public InlineScriptTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache) : base(default(Microsoft.AspNetCore.Hosting.IWebHostEnvironment), default(Microsoft.Extensions.Caching.Memory.IMemoryCache)) { }
+        public InlineScriptTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache, Microsoft.Extensions.Logging.ILogger<Meziantou.AspNetCore.Mvc.TagHelpers.InlineScriptTagHelper> logger) : base(default(Microsoft.AspNetCore.Hosting.IWebHostEnvironment), default(Microsoft.Extensions.Caching.Memory.IMemoryCache), default(Microsoft.Extensions.Logging.ILogger)) { }
         public override System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) => throw null;
     }
 
     public sealed class InlineStyleTagHelper : Meziantou.AspNetCore.Mvc.TagHelpers.InlineTagHelper
     {
         public string? Href { get => throw null; set { } }
-        public InlineStyleTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache) : base(default(Microsoft.AspNetCore.Hosting.IWebHostEnvironment), default(Microsoft.Extensions.Caching.Memory.IMemoryCache)) { }
+        public InlineStyleTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache, Microsoft.Extensions.Logging.ILogger<Meziantou.AspNetCore.Mvc.TagHelpers.InlineStyleTagHelper> logger) : base(default(Microsoft.AspNetCore.Hosting.IWebHostEnvironment), default(Microsoft.Extensions.Caching.Memory.IMemoryCache), default(Microsoft.Extensions.Logging.ILogger)) { }
         public override System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) => throw null;
     }
 
     public abstract class InlineTagHelper : Microsoft.AspNetCore.Razor.TagHelpers.TagHelper
     {
-        protected InlineTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache) { }
+        protected InlineTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment webHostEnvironment, Microsoft.Extensions.Caching.Memory.IMemoryCache cache, Microsoft.Extensions.Logging.ILogger logger) { }
         protected System.Threading.Tasks.Task<string?> GetFileContentAsync(string? path) => throw null;
         protected System.Threading.Tasks.Task<string?> GetFileContentBase64Async(string? path) => throw null;
     }

--- a/slnx/Meziantou.AspNetCore.Mvc.slnx
+++ b/slnx/Meziantou.AspNetCore.Mvc.slnx
@@ -1,5 +1,12 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.AspNetCore.Mvc.Tests/Meziantou.AspNetCore.Mvc.Tests.csproj" />
   </Folder>
 </Solution>

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="../src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj" />
     <Project Path="../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
     <Project Path="../src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
     <Project Path="../src/Meziantou.Framework.AtlassianDataFormat.Tool/Meziantou.Framework.AtlassianDataFormat.Tool.csproj" />
@@ -48,6 +49,7 @@
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.AspNetCore.Mvc.Tests/Meziantou.AspNetCore.Mvc.Tests.csproj" />
     <Project Path="../tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.AtlassianDataFormat.Tool.Tests/Meziantou.Framework.AtlassianDataFormat.Tool.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj" />

--- a/src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj
+++ b/src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>TagHelpers for Razor Pages</Description>
   </PropertyGroup>

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineImgTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineImgTagHelper.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 
@@ -10,7 +11,7 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 /// <code language="razor">
 /// &lt;!-- Input --&gt;
 /// &lt;inline-img src="logo.png" alt="Company Logo" /&gt;
-/// 
+///
 /// &lt;!-- Output --&gt;
 /// &lt;img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..." alt="Company Logo" /&gt;
 /// </code>
@@ -30,8 +31,9 @@ public sealed class InlineImgTagHelper : InlineTagHelper
     /// <summary>Initializes a new instance of the <see cref="InlineImgTagHelper"/> class.</summary>
     /// <param name="webHostEnvironment">The web host environment for accessing web root files.</param>
     /// <param name="cache">The memory cache for storing file contents.</param>
-    public InlineImgTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache)
-   : base(webHostEnvironment, cache)
+    /// <param name="logger">The logger used to report missing files.</param>
+    public InlineImgTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache, ILogger<InlineImgTagHelper> logger)
+        : base(webHostEnvironment, cache, logger)
     {
     }
 
@@ -59,7 +61,5 @@ public sealed class InlineImgTagHelper : InlineTagHelper
         output.Attributes.RemoveAll("src");
         output.Attributes.Add("src", srcAttribute);
         output.TagMode = TagMode.SelfClosing;
-        output.Content.AppendHtml(fileContent);
     }
 }
-

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineScriptTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineScriptTagHelper.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 
@@ -11,7 +12,7 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 /// <code language="razor">
 /// &lt;!-- Input --&gt;
 /// &lt;inline-script src="app.js" /&gt;
-/// 
+///
 /// &lt;!-- Output --&gt;
 /// &lt;script&gt;
 /// function init() {
@@ -35,8 +36,9 @@ public sealed class InlineScriptTagHelper : InlineTagHelper
     /// <summary>Initializes a new instance of the <see cref="InlineScriptTagHelper"/> class.</summary>
     /// <param name="webHostEnvironment">The web host environment for accessing web root files.</param>
     /// <param name="cache">The memory cache for storing file contents.</param>
-    public InlineScriptTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache)
-     : base(webHostEnvironment, cache)
+    /// <param name="logger">The logger used to report missing files.</param>
+    public InlineScriptTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache, ILogger<InlineScriptTagHelper> logger)
+        : base(webHostEnvironment, cache, logger)
     {
     }
 
@@ -55,7 +57,6 @@ public sealed class InlineScriptTagHelper : InlineTagHelper
         output.TagName = "script";
         output.Attributes.RemoveAll("src");
         output.TagMode = TagMode.StartTagAndEndTag;
-        output.Content.AppendHtml(fileContent);
+        output.Content.AppendHtml(EscapeClosingTag(fileContent, "script"));
     }
 }
-

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineStyleTagHelper.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 
@@ -11,7 +12,7 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 /// <code language="razor">
 /// &lt;!-- Input --&gt;
 /// &lt;inline-style href="site.css" /&gt;
-/// 
+///
 /// &lt;!-- Output --&gt;
 /// &lt;style&gt;
 /// body { margin: 0; padding: 0; }
@@ -33,8 +34,9 @@ public sealed class InlineStyleTagHelper : InlineTagHelper
     /// <summary>Initializes a new instance of the <see cref="InlineStyleTagHelper"/> class.</summary>
     /// <param name="webHostEnvironment">The web host environment for accessing web root files.</param>
     /// <param name="cache">The memory cache for storing file contents.</param>
-    public InlineStyleTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache)
-        : base(webHostEnvironment, cache)
+    /// <param name="logger">The logger used to report missing files.</param>
+    public InlineStyleTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache, ILogger<InlineStyleTagHelper> logger)
+        : base(webHostEnvironment, cache, logger)
     {
     }
 
@@ -53,7 +55,6 @@ public sealed class InlineStyleTagHelper : InlineTagHelper
         output.TagName = "style";
         output.Attributes.RemoveAll("href");
         output.TagMode = TagMode.StartTagAndEndTag;
-        output.Content.AppendHtml(fileContent);
+        output.Content.AppendHtml(EscapeClosingTag(fileContent, "style"));
     }
 }
-

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/InlineTagHelper.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 
@@ -11,36 +12,48 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 /// and automatically invalidate the cache when files change. It supports reading files as both text
 /// and Base64-encoded strings.
 /// </remarks>
-public abstract class InlineTagHelper : TagHelper
+public abstract partial class InlineTagHelper : TagHelper
 {
-    private const string CacheKeyPrefix = "InlineTagHelper-";
+    // The text and Base64 representations of a file must not share a cache entry, otherwise a file inlined
+    // both ways (<inline-img> and <inline-style> for instance) serves whichever encoding was computed first.
+    private const string TextCacheKeyPrefix = "InlineTagHelper-text-";
+    private const string Base64CacheKeyPrefix = "InlineTagHelper-base64-";
 
     private readonly IWebHostEnvironment _webHostEnvironment;
     private readonly IMemoryCache _cache;
+    private readonly ILogger _logger;
 
     /// <summary>Initializes a new instance of the <see cref="InlineTagHelper"/> class.</summary>
     /// <param name="webHostEnvironment">The web host environment for accessing web root files.</param>
     /// <param name="cache">The memory cache for storing file contents.</param>
-    protected InlineTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache)
+    /// <param name="logger">The logger used to report missing files.</param>
+    protected InlineTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache cache, ILogger logger)
     {
         _webHostEnvironment = webHostEnvironment;
         _cache = cache;
+        _logger = logger;
     }
 
-    private async Task<T?> GetContentAsync<T>(ICacheEntry entry, string path, Func<IFileInfo, Task<T>> getContent)
-        where T : class
+    private async Task<string?> GetContentAsync(ICacheEntry entry, string path, Func<IFileInfo, Task<string>> getContent)
     {
         var fileProvider = _webHostEnvironment.WebRootFileProvider;
-        var changeToken = fileProvider.Watch(path);
 
-        entry.SetPriority(CacheItemPriority.NeverRemove);
-        entry.AddExpirationToken(changeToken);
+        // Watch the path even when the file is missing, so the entry is invalidated if the file is created later
+        entry.AddExpirationToken(fileProvider.Watch(path));
 
         var file = fileProvider.GetFileInfo(path);
-        if (file is null || !file.Exists)
-            return default;
+        if (!file.Exists)
+        {
+            LogFileNotFound(path);
 
-        return await getContent(file);
+            // A size must be set on every entry when the application configures MemoryCacheOptions.SizeLimit
+            entry.SetSize(1);
+            return null;
+        }
+
+        var content = await getContent(file);
+        entry.SetSize(content.Length);
+        return content;
     }
 
     /// <summary>Gets the file content as a string with caching support.</summary>
@@ -51,7 +64,7 @@ public abstract class InlineTagHelper : TagHelper
         if (path is null)
             return Task.FromResult<string?>(null);
 
-        return _cache.GetOrCreateAsync(CacheKeyPrefix + path, entry =>
+        return _cache.GetOrCreateAsync(TextCacheKeyPrefix + path, entry =>
         {
             return GetContentAsync(entry, path, ReadFileContentAsStringAsync);
         });
@@ -65,10 +78,18 @@ public abstract class InlineTagHelper : TagHelper
         if (path is null)
             return Task.FromResult<string?>(null);
 
-        return _cache.GetOrCreateAsync(CacheKeyPrefix + path, entry =>
+        return _cache.GetOrCreateAsync(Base64CacheKeyPrefix + path, entry =>
         {
             return GetContentAsync(entry, path, ReadFileContentAsBase64Async);
         });
+    }
+
+    // The content of <script> and <style> is raw text: the element ends at the first matching close sequence,
+    // whatever the JavaScript or CSS syntax around it. "<\/tag" is equivalent inside strings and regexes,
+    // and "</tag" cannot legally appear anywhere else.
+    internal static string EscapeClosingTag(string content, string tagName)
+    {
+        return content.Replace("</" + tagName, "<\\/" + tagName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<string> ReadFileContentAsStringAsync(IFileInfo file)
@@ -88,4 +109,7 @@ public abstract class InlineTagHelper : TagHelper
         writer.Seek(0, SeekOrigin.Begin);
         return Convert.ToBase64String(writer.ToArray());
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot inline '{Path}': the file does not exist in the web root")]
+    private partial void LogFileNotFound(string path);
 }

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/RenderOnPageLoadTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/RenderOnPageLoadTagHelper.cs
@@ -9,7 +9,7 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 /// &lt;render-on-page-load&gt;
 ///     &lt;link rel="stylesheet" href="/css/non-critical.css" /&gt;
 /// &lt;/render-on-page-load&gt;
-/// 
+///
 /// &lt;!-- Defer loading with custom ID --&gt;
 /// &lt;render-on-page-load id="analytics-scripts"&gt;
 ///     &lt;script src="/js/analytics.js"&gt;&lt;/script&gt;
@@ -25,7 +25,13 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 [HtmlTargetElement("render-on-page-load")]
 public sealed class RenderOnPageLoadTagHelper : TagHelper
 {
-    /// <summary>Gets or sets the unique identifier for the noscript element. Defaults to "render-onload" if not specified.</summary>
+    // The script locates its own element through document.currentScript instead of an id, so no value is
+    // ever interpolated into it. Interpolating the id allowed script injection when it came from user data.
+    // The work is scheduled on the load event rather than requestAnimationFrame: rAF callbacks do not run
+    // while the document is hidden, so a page opened in a background tab never rendered its deferred content.
+    private const string Script = "<script>(function(){var e=document.currentScript.previousElementSibling;function r(){var n=document.createElement('div');n.innerHTML=e.textContent;document.body.appendChild(n);e.parentElement.removeChild(e);}if(document.readyState==='complete'){r();}else{window.addEventListener('load',r);}})();</script>";
+
+    /// <summary>Gets or sets an optional identifier for the noscript element. No identifier is emitted when not specified.</summary>
     [HtmlAttributeName("id")]
     public string? Id { get; set; }
 
@@ -36,8 +42,11 @@ public sealed class RenderOnPageLoadTagHelper : TagHelper
     {
         output.TagName = "noscript";
 
-        var id = string.IsNullOrEmpty(Id) ? "render-onload" : Id;
-        output.Attributes.Add("id", id);
-        output.PostElement.AppendHtml("<script>var renderOnLoad=function(){var e=document.getElementById('" + id + "'),n=document.createElement('div');n.innerHTML=e.textContent,document.body.appendChild(n),e.parentElement.removeChild(e)},r=window.requestAnimationFrame;r?r(function(){window.setTimeout(renderOnLoad,0)}):window.addEventListener('load',renderOnLoad);</script>");
+        if (!string.IsNullOrEmpty(Id))
+        {
+            output.Attributes.SetAttribute("id", Id);
+        }
+
+        output.PostElement.AppendHtml(Script);
     }
 }

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/ShowIfTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/ShowIfTagHelper.cs
@@ -9,7 +9,7 @@ namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 /// &lt;div show-if="@User.Identity.IsAuthenticated"&gt;
 ///   Welcome back, @User.Identity.Name!
 /// &lt;/div&gt;
-/// 
+///
 /// @* Show error message conditionally *@
 /// &lt;div class="alert alert-danger" show-if="@Model.HasErrors"&gt;
 ///     Please correct the errors below.

--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/TimeTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/TimeTagHelper.cs
@@ -2,25 +2,35 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Meziantou.AspNetCore.Mvc.TagHelpers;
 
-/// <summary>Converts a <see cref="DateTimeOffset"/> value to a properly formatted datetime attribute for HTML time elements.</summary>
+/// <summary>Converts a <see cref="DateTimeOffset"/> value to a properly formatted <c>datetime</c> attribute for HTML elements.</summary>
 /// <example>
 /// <code language="razor">
-/// &lt;time datetime="@DateTime.Now"&gt;Just now&lt;/time&gt;
-/// &lt;!-- Outputs: &lt;time datetime="2024-01-15T10:30:45.123"&gt;Just now&lt;/time&gt; --&gt;
+/// &lt;time datetime-value="@DateTimeOffset.Now"&gt;Just now&lt;/time&gt;
+/// &lt;!-- Outputs: &lt;time datetime="2024-01-15T10:30:45.123Z"&gt;Just now&lt;/time&gt; --&gt;
 /// </code>
 /// </example>
-[HtmlTargetElement(Attributes = "datetime")]
+/// <remarks>
+/// The value is normalized to UTC and always written with the <c>Z</c> designator. A <c>datetime</c> attribute
+/// without a time zone designator is interpreted as local time by the reader, which would shift the value by
+/// the reader's UTC offset.
+/// </remarks>
+[HtmlTargetElement("time", Attributes = DatetimeValueAttributeName)]
+[HtmlTargetElement("del", Attributes = DatetimeValueAttributeName)]
+[HtmlTargetElement("ins", Attributes = DatetimeValueAttributeName)]
 public sealed class TimeTagHelper : TagHelper
 {
-    /// <summary>Gets or sets the date and time to format for the datetime attribute.</summary>
+    private const string DatetimeValueAttributeName = "datetime-value";
+
+    /// <summary>Gets or sets the date and time to format for the <c>datetime</c> attribute.</summary>
+    [HtmlAttributeName(DatetimeValueAttributeName)]
     public DateTimeOffset? Datetime { get; set; }
 
-    /// <summary>Processes the tag helper and sets the datetime attribute in ISO 8601 format.</summary>
+    /// <summary>Processes the tag helper and sets the <c>datetime</c> attribute in ISO 8601 format.</summary>
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         if (Datetime.HasValue)
         {
-            output.Attributes.SetAttribute("datetime", Datetime?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture));
+            output.Attributes.SetAttribute("datetime", Datetime.Value.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff'Z'", CultureInfo.InvariantCulture));
         }
         else
         {

--- a/src/Meziantou.AspNetCore.Mvc/readme.md
+++ b/src/Meziantou.AspNetCore.Mvc/readme.md
@@ -54,20 +54,29 @@ Inlines an image from `wwwroot` as a base64 data URI.
 
 ### `render-on-page-load`
 
-Defers rendering of non-critical content until the page loads.
+Defers rendering of non-critical content until the page loads. The `id` attribute is optional and only used
+if you need to reference the `<noscript>` element yourself.
 
 ```razor
-<render-on-page-load id="deferred-content">
+<render-on-page-load>
     <link rel="stylesheet" href="/css/non-critical.css" />
 </render-on-page-load>
 ```
 
-### `datetime`
+### `datetime-value`
 
-Formats a `DateTimeOffset` value into an ISO 8601 `datetime` attribute.
+Formats a `DateTimeOffset` value into an ISO 8601 `datetime` attribute on `<time>`, `<del>` or `<ins>`.
+The value is normalized to UTC and written with the `Z` designator.
 
 ```razor
-<time datetime="@Model.PublishedAt">Published</time>
+<time datetime-value="@Model.PublishedAt">Published</time>
+<!-- Outputs: <time datetime="2024-01-15T10:30:45.123Z">Published</time> -->
+```
+
+Literal `datetime` attributes are left untouched, so existing markup keeps working:
+
+```razor
+<time datetime="2024-01-01">Jan 1</time>
 ```
 
 ## Additional resources

--- a/tests/Meziantou.AspNetCore.Mvc.Tests/Meziantou.AspNetCore.Mvc.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Mvc.Tests/Meziantou.AspNetCore.Mvc.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Meziantou.NET.Sdk.Test">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Mvc\Meziantou.AspNetCore.Mvc.csproj" />
+    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Meziantou.AspNetCore.Mvc.Tests/TagHelpersTests.cs
+++ b/tests/Meziantou.AspNetCore.Mvc.Tests/TagHelpersTests.cs
@@ -1,0 +1,307 @@
+using System.Text.Encodings.Web;
+using Meziantou.AspNetCore.Mvc.TagHelpers;
+using Meziantou.Framework;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+
+namespace Meziantou.AspNetCore.Mvc.Tests;
+
+public sealed class TagHelpersTests
+{
+    [Fact]
+    public void ShowIf_True_RendersTheElementWithoutTheAttribute()
+    {
+        var helper = new ShowIfTagHelper { Value = true };
+        var output = CreateOutput("div", [new TagHelperAttribute("show-if", "true"), new TagHelperAttribute("class", "alert")]);
+
+        helper.Process(CreateContext(), output);
+
+        Assert.Equal("<div class=\"alert\"></div>", Render(output));
+    }
+
+    [Fact]
+    public void ShowIf_False_SuppressesTheElement()
+    {
+        var helper = new ShowIfTagHelper { Value = false };
+        var output = CreateOutput("div", [new TagHelperAttribute("show-if", "false")]);
+
+        helper.Process(CreateContext(), output);
+
+        Assert.Empty(Render(output));
+    }
+
+    [Fact]
+    public void Datetime_IsNormalizedToUtcAndKeepsTheZDesignator()
+    {
+        var helper = new TimeTagHelper { Datetime = new DateTimeOffset(2024, 1, 15, 10, 30, 45, 123, TimeSpan.FromHours(5)) };
+        var output = CreateOutput("time");
+
+        helper.Process(CreateContext(), output);
+
+        // Without the Z designator the value is read as local time and shifted by the reader's UTC offset
+        Assert.Equal("<time datetime=\"2024-01-15T05:30:45.123Z\"></time>", Render(output));
+    }
+
+    [Fact]
+    public void Datetime_Null_RemovesTheAttribute()
+    {
+        var helper = new TimeTagHelper { Datetime = null };
+        var output = CreateOutput("time", [new TagHelperAttribute("datetime", "2024-01-01")]);
+
+        helper.Process(CreateContext(), output);
+
+        Assert.Equal("<time></time>", Render(output));
+    }
+
+    [Fact]
+    public void RenderOnPageLoad_MaliciousId_IsNotInjectedIntoTheScript()
+    {
+        var helper = new RenderOnPageLoadTagHelper { Id = "');alert('xss');//" };
+        var output = CreateOutput("render-on-page-load");
+
+        helper.Process(CreateContext(), output);
+
+        var html = Render(output);
+        var script = html[html.IndexOf("<script>", StringComparison.Ordinal)..];
+        Assert.DoesNotContain("alert", script);
+        Assert.Contains("id=\"&#x27;);alert(&#x27;xss&#x27;);//\"", html);
+    }
+
+    [Fact]
+    public void RenderOnPageLoad_WithoutId_DoesNotEmitAnIdAttribute()
+    {
+        var helper = new RenderOnPageLoadTagHelper();
+        var output = CreateOutput("render-on-page-load");
+
+        helper.Process(CreateContext(), output);
+
+        Assert.StartsWith("<noscript></noscript>", Render(output));
+    }
+
+    [Fact]
+    public void RenderOnPageLoad_SchedulesOnLoadInsteadOfRequestAnimationFrame()
+    {
+        var helper = new RenderOnPageLoadTagHelper();
+        var output = CreateOutput("render-on-page-load");
+
+        helper.Process(CreateContext(), output);
+
+        var html = Render(output);
+
+        // requestAnimationFrame never fires while the document is hidden, so the content was never rendered
+        // when the page was opened in a background tab
+        Assert.DoesNotContain("requestAnimationFrame", html);
+        Assert.Contains("addEventListener('load'", html);
+    }
+
+    [Fact]
+    public async Task InlineScript_EscapesTheClosingScriptTag()
+    {
+        using var host = new TestHost();
+        host.Directory.CreateTextFile("app.js", """var s = "</script>";""");
+
+        var helper = host.CreateScriptTagHelper();
+        helper.Src = "app.js";
+        var output = CreateOutput("inline-script");
+
+        await helper.ProcessAsync(CreateContext(), output);
+
+        var html = Render(output);
+
+        // An unescaped sequence ends the <script> element early, whatever the JavaScript syntax around it
+        Assert.Contains("""<\/script>""", html);
+        Assert.Equal(1, CountOccurrences(html, "</script>"));
+    }
+
+    [Fact]
+    public async Task InlineStyle_EscapesTheClosingStyleTag()
+    {
+        using var host = new TestHost();
+        host.Directory.CreateTextFile("site.css", """a::after { content: "</style>"; }""");
+
+        var helper = host.CreateStyleTagHelper();
+        helper.Href = "site.css";
+        var output = CreateOutput("inline-style");
+
+        await helper.ProcessAsync(CreateContext(), output);
+
+        var html = Render(output);
+        Assert.Contains("""<\/style>""", html);
+        Assert.Equal(1, CountOccurrences(html, "</style>"));
+    }
+
+    [Fact]
+    public async Task InlineImg_RendersTheContentOnceAsADataUri()
+    {
+        using var host = new TestHost();
+        host.Directory.CreateTextFile("logo.png", "fake-png-bytes");
+        var expected = Convert.ToBase64String(File.ReadAllBytes(host.Directory / "logo.png"));
+
+        var helper = host.CreateImgTagHelper();
+        helper.Src = "logo.png";
+        var output = CreateOutput("inline-img");
+
+        await helper.ProcessAsync(CreateContext(), output);
+
+        Assert.Equal($"<img src=\"data:image/png;base64,{expected}\" />", Render(output));
+    }
+
+    [Fact]
+    public async Task SamePathInlinedAsTextAndAsBase64_DoNotShareACacheEntry()
+    {
+        using var host = new TestHost();
+        host.Directory.CreateTextFile("shared.css", "body{color:red}");
+
+        var img = host.CreateImgTagHelper();
+        img.Src = "shared.css";
+        var imgOutput = CreateOutput("inline-img");
+        await img.ProcessAsync(CreateContext(), imgOutput);
+
+        var style = host.CreateStyleTagHelper();
+        style.Href = "shared.css";
+        var styleOutput = CreateOutput("inline-style");
+        await style.ProcessAsync(CreateContext(), styleOutput);
+
+        // A shared key made the second helper serve whichever encoding was computed first
+        Assert.Contains("data:text/css;base64,", Render(imgOutput));
+        Assert.Contains("body{color:red}", Render(styleOutput));
+    }
+
+    [Fact]
+    public async Task InlineFile_IsCachedWhenTheApplicationConfiguresASizeLimit()
+    {
+        using var host = new TestHost(new MemoryCacheOptions { SizeLimit = 1024 });
+        host.Directory.CreateTextFile("app.js", "console.log(1)");
+
+        var helper = host.CreateScriptTagHelper();
+        helper.Src = "app.js";
+        var output = CreateOutput("inline-script");
+
+        await helper.ProcessAsync(CreateContext(), output);
+
+        Assert.Contains("console.log(1)", Render(output));
+    }
+
+    [Fact]
+    public async Task CachedContent_CanBeEvictedUnderMemoryPressure()
+    {
+        using var host = new TestHost();
+        host.Directory.CreateTextFile("app.js", "console.log(1)");
+
+        var helper = host.CreateScriptTagHelper();
+        helper.Src = "app.js";
+        await helper.ProcessAsync(CreateContext(), CreateOutput("inline-script"));
+
+        Assert.NotEqual(0, host.Cache.Count);
+
+        // Compact never removes CacheItemPriority.NeverRemove entries
+        host.Cache.Compact(1.0);
+        Assert.Equal(0, host.Cache.Count);
+    }
+
+    [Fact]
+    public async Task MissingFile_SuppressesTheOutputAndLogsAWarning()
+    {
+        using var host = new TestHost();
+
+        var helper = host.CreateScriptTagHelper();
+        helper.Src = "does-not-exist.js";
+        var output = CreateOutput("inline-script");
+
+        await helper.ProcessAsync(CreateContext(), output);
+
+        Assert.Empty(Render(output));
+        var message = Assert.Single(host.ScriptLogger.Messages);
+        Assert.Contains("does-not-exist.js", message);
+    }
+
+    private static int CountOccurrences(string value, string substring)
+    {
+        return value.Split(substring).Length - 1;
+    }
+
+    private static string Render(TagHelperOutput output)
+    {
+        using var writer = new StringWriter();
+        output.WriteTo(writer, HtmlEncoder.Default);
+        return writer.ToString();
+    }
+
+    private static TagHelperContext CreateContext()
+    {
+        return new TagHelperContext([], new Dictionary<object, object>(), "test");
+    }
+
+    private static TagHelperOutput CreateOutput(string tagName, TagHelperAttributeList? attributes = null)
+    {
+        return new TagHelperOutput(tagName, attributes ?? [], (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+    }
+
+    private sealed class TestHost : IDisposable
+    {
+        private readonly PhysicalFileProvider _fileProvider;
+        private readonly IWebHostEnvironment _environment;
+
+        public TestHost(MemoryCacheOptions? options = null)
+        {
+            Directory = TemporaryDirectory.Create();
+            Cache = new MemoryCache(options ?? new MemoryCacheOptions());
+            _fileProvider = new PhysicalFileProvider(Directory.FullPath);
+            _environment = new TestWebHostEnvironment(Directory.FullPath, _fileProvider);
+        }
+
+        public TemporaryDirectory Directory { get; }
+
+        public MemoryCache Cache { get; }
+
+        public CollectingLogger<InlineScriptTagHelper> ScriptLogger { get; } = new();
+
+        public InlineScriptTagHelper CreateScriptTagHelper() => new(_environment, Cache, ScriptLogger);
+
+        public InlineStyleTagHelper CreateStyleTagHelper() => new(_environment, Cache, new CollectingLogger<InlineStyleTagHelper>());
+
+        public InlineImgTagHelper CreateImgTagHelper() => new(_environment, Cache, new CollectingLogger<InlineImgTagHelper>());
+
+        public void Dispose()
+        {
+            _fileProvider.Dispose();
+            Cache.Dispose();
+            Directory.Dispose();
+        }
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public TestWebHostEnvironment(FullPath root, IFileProvider fileProvider)
+        {
+            WebRootPath = root;
+            ContentRootPath = root;
+            WebRootFileProvider = fileProvider;
+            ContentRootFileProvider = fileProvider;
+        }
+
+        public string ApplicationName { get; set; } = "Tests";
+        public string EnvironmentName { get; set; } = "Test";
+        public string WebRootPath { get; set; }
+        public IFileProvider WebRootFileProvider { get; set; }
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; }
+    }
+
+    private sealed class CollectingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
A review of `Meziantou.AspNetCore.Mvc` surfaced one script injection vulnerability and several output-correctness bugs. This fixes all of them and adds a test project (14 tests, one per finding).

## Security

**`RenderOnPageLoadTagHelper` interpolated the `id` attribute into a JavaScript string literal** and wrote it with `AppendHtml`, so an id coming from user data executed arbitrary script. The `id` *attribute* was correctly HTML-encoded, which is what made this easy to miss on inspection — the script body was not:

```html
<noscript id="&#x27;);alert(1);//">...</noscript>
<script>var renderOnLoad=function(){var e=document.getElementById('');alert(1);//'), ...
```

The emitted script is now a constant that locates its own element through `document.currentScript.previousElementSibling`, so nothing is interpolated into it at all.

## Correctness

- **`render-on-page-load` never rendered in a hidden tab.** Scheduling used `requestAnimationFrame`, which does not fire while the document is hidden — so a page opened in a background tab (middle-click, session restore, prerender) never loaded its deferred stylesheet or analytics. It now uses the `load` event, which also removes the previously-unreachable fallback branch.
- **Inline helpers threw a 500 when the app set `MemoryCacheOptions.SizeLimit`.** No size was set on the cache entry, so `MemoryCache` threw `InvalidOperationException` at render time on every page using an inline helper.
- **Text and Base64 shared one cache key.** A file inlined both ways served whichever encoding was computed first, so base64 could be rendered inside a `<style>` element. Order-dependent, so it presented as an unreproducible bug.
- **`</script>` / `</style>` inside an inlined file ended the element early**, truncating the script and leaking the rest of the file into the document as text. The sequence is now escaped to `<\/script>` / `<\/style>`.
- **Cache entries used `CacheItemPriority.NeverRemove`** on the application's shared cache, opting them out of eviction under memory pressure. Now default priority; the change token still guarantees freshness.
- **A missing file was silently ignored.** Now logged as a warning naming the path.

## Breaking changes (version bumped to 3.0.0)

- **`TimeTagHelper`: `datetime` renamed to `datetime-value`, restricted to `<time>`/`<del>`/`<ins>`.** It previously bound to *any* element with a `datetime` attribute, so adding this package to an app failed the build of every view containing literal `datetime` markup, with errors that pointed at nonsense (`The name 'Z' does not exist in the current context`). Literal `datetime` attributes now pass through untouched.
- **`datetime` values are written with the `Z` designator.** Without it the value is read as local time and shifted by the reader's UTC offset — silently wrong on every use, affecting structured data, feeds and any JS reading the attribute.
- **`render-on-page-load` no longer emits a default `id`** of `render-onload` (it produced duplicate ids with multiple instances and is no longer needed by the script).
- **The inline helpers' constructors take an additional `ILogger`.** This only affects code instantiating the tag helpers directly; DI handles it automatically.

## Notes for the reviewer

- The interesting diff is `RenderOnPageLoadTagHelper.cs` — it is the security fix and the one place where the emitted JavaScript changed shape.
- Two deliberate choices worth a second opinion:
  - The change-token watcher is still registered for missing files. Skipping it would cache the miss permanently, so a file created after first render would never appear; dropping `NeverRemove` already addresses the growth risk.
  - `TimeTagHelper` normalizes to UTC rather than preserving the original offset — adding only the missing designator keeps the instant semantics identical.

## Verification

- Builds clean for `net10.0`/`net11.0` under `Release` + `IsOfficialBuild` + `TreatsWarningsAsErrors=true` (0 warnings).
- 28/28 tests pass (14 tests x 2 TFMs). `ref/` regenerated; `dotnet run ./eng/update-all.cs` clean.
- Beyond unit tests, the helpers were rendered through a real Razor Pages app (Razor attribute binding is not reachable from unit tests) and checked in a browser: in a hidden tab the deferred stylesheet now loads and applies, both `noscript` blocks are processed, the payload does not execute, and literal `<time datetime="2024-01-01">` / `<del datetime="...">` compile and render untouched.