### PR TITLE
Fix crashes, XSS vector and correctness bugs in LogViewer

### DIFF
--- a/ref/Meziantou.AspNetCore.Components.LogViewer.cs
+++ b/ref/Meziantou.AspNetCore.Components.LogViewer.cs
@@ -29,7 +29,9 @@ namespace Meziantou.AspNetCore.Components
         public object? Data { get => throw null; set { } }
         public Meziantou.AspNetCore.Components.LogDetailsDisplayFormat Format { get => throw null; set { } }
         public bool CanChangeDisplayFormat { get => throw null; set { } }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder? __builder) { }
+        public int MaxDepth { get => throw null; set { } }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) { }
+        protected override void OnParametersSet() { }
     }
 
     public class LogHighlighterResult : System.IEquatable<Meziantou.AspNetCore.Components.LogHighlighterResult>

--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogEntryDetails.razor
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogEntryDetails.razor
@@ -1,134 +1,223 @@
-﻿@if (Data != null)
+﻿@if (Data is not null)
 {
-	if (CanChangeDisplayFormat)
-	{
-		<div class="format-selector-group">
-			<a class="format-selector @(Format == LogDetailsDisplayFormat.Table ? "selected" : "")" href="#" @onclick="() => Format = LogDetailsDisplayFormat.Table" @onclick:preventDefault="true">table</a> |
-			<a class="format-selector @(Format == LogDetailsDisplayFormat.Json ? "selected" : "")" href="#" @onclick="() => Format = LogDetailsDisplayFormat.Json" @onclick:preventDefault="true">json</a>
-		</div>
-	}
-	if (Format == LogDetailsDisplayFormat.Json)
-	{
-		<pre>@FormatDataAsJson(Data)</pre>
-	}
-	else if (Format == LogDetailsDisplayFormat.Table)
-	{
-		<table>
-			@foreach (var (propertyName, propertyValue, isSimpleType) in GetValues(Data))
-			{
-				<tr>
-					<th>@propertyName:</th>
-					<td>
-						@if (propertyValue == null)
-						{
-							<i>null</i>
-						}
-						else if (isSimpleType)
-						{
-							@propertyValue
-						}
-						else
-						{
-							<LogEntryDetails Data="propertyValue" Format="Format" CanChangeDisplayFormat="false" />
-						}
-					</td>
-				</tr>
-			}
-		</table>
-	}
+    if (MaxDepth <= 0)
+    {
+        <i>&#8230;</i>
+    }
+    else if (IsSimpleType(Data))
+    {
+        @Data
+    }
+    else
+    {
+        if (CanChangeDisplayFormat)
+        {
+            <div class="format-selector-group">
+                <a class="format-selector @(_format == LogDetailsDisplayFormat.Table ? "selected" : "")" href="#" @onclick="() => _format = LogDetailsDisplayFormat.Table" @onclick:preventDefault="true">table</a> |
+                <a class="format-selector @(_format == LogDetailsDisplayFormat.Json ? "selected" : "")" href="#" @onclick="() => _format = LogDetailsDisplayFormat.Json" @onclick:preventDefault="true">json</a>
+            </div>
+        }
+        if (_format == LogDetailsDisplayFormat.Json)
+        {
+            <pre>@FormatDataAsJson(Data)</pre>
+        }
+        else if (_format == LogDetailsDisplayFormat.Table)
+        {
+            <table>
+                @foreach (var (propertyName, propertyValue, isSimpleType) in GetValues(Data))
+                {
+                    <tr>
+                        <th>@propertyName:</th>
+                        <td>
+                            @if (propertyValue is null)
+                            {
+                                <i>null</i>
+                            }
+                            else if (propertyValue is PropertyError error)
+                            {
+                                <i class="value-error">@error.Message</i>
+                            }
+                            else if (isSimpleType)
+                            {
+                                @propertyValue
+                            }
+                            else
+                            {
+                                <LogEntryDetails Data="propertyValue" Format="_format" CanChangeDisplayFormat="false" MaxDepth="MaxDepth - 1" />
+                            }
+                        </td>
+                    </tr>
+                }
+            </table>
+        }
+    }
 }
 
-@code{
-	private static System.Text.Json.JsonSerializerOptions s_options = new System.Text.Json.JsonSerializerOptions()
-	{
-		WriteIndented = true,
-		Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
-	};
+@code {
+    private static readonly System.Text.Json.JsonSerializerOptions s_options = new()
+    {
+        WriteIndented = true,
+        // Logged objects are arbitrary graphs and may contain cycles; without this the serializer throws.
+        ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
 
-	/// <summary>
-	/// Gets or sets the data object to display. This can be any object that will be rendered as a table or JSON.
-	/// </summary>
-	[Parameter]
-	public object? Data { get; set; }
+    private LogDetailsDisplayFormat _format;
+    private LogDetailsDisplayFormat _lastFormatParameter;
 
-	/// <summary>
-	/// Gets or sets the format for displaying log entry details.
-	/// </summary>
-	[Parameter]
-	public LogDetailsDisplayFormat Format { get; set; }
+    /// <summary>
+    /// Gets or sets the data object to display. This can be any object that will be rendered as a table or JSON.
+    /// </summary>
+    /// <remarks>
+    /// The object graph is walked using reflection, so this component is not compatible with trimming or Native AOT.
+    /// </remarks>
+    [Parameter]
+    public object? Data { get; set; }
 
-	/// <summary>
-	/// Gets or sets a value indicating whether the user can change the display format. Default is <c>true</c>.
-	/// </summary>
-	[Parameter]
-	public bool CanChangeDisplayFormat { get; set; } = true;
+    /// <summary>
+    /// Gets or sets the format for displaying log entry details. The value is used as the initial format; the user can
+    /// change it when <see cref="CanChangeDisplayFormat"/> is <c>true</c>, and their choice is kept until this parameter changes.
+    /// </summary>
+    [Parameter]
+    public LogDetailsDisplayFormat Format { get; set; }
 
-	private static IEnumerable<(string PropertyName, object? Value, bool IsSimpleType)> GetValues(object data)
-	{
-		if (data is System.Collections.Generic.IEnumerable<KeyValuePair<string, object>> dict)
-		{
-			foreach (var item in dict)
-			{
-				yield return (item.Key, item.Value, IsSimpleType(item.Value));
-			}
-		}
-		else if (data is System.Collections.IEnumerable enumerable)
-		{
-			var index = 0;
-			foreach (var item in enumerable)
-			{
-				yield return ($"[{index}]", item, IsSimpleType(item));
-				index++;
-			}
-		}
-		else
-		{
-			foreach (var prop in data.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.FlattenHierarchy))
-			{
-				if (prop.GetMethod == null)
-					continue;
+    /// <summary>
+    /// Gets or sets a value indicating whether the user can change the display format. Default is <c>true</c>.
+    /// </summary>
+    [Parameter]
+    public bool CanChangeDisplayFormat { get; set; } = true;
 
-				var value = prop.GetValue(data);
-				yield return (prop.Name, value, IsSimpleType(value));
-			}
-		}
+    /// <summary>
+    /// Gets or sets how many levels of nested objects are rendered. Deeper values are elided, which also bounds
+    /// cyclic object graphs. Default is <c>32</c>.
+    /// </summary>
+    [Parameter]
+    public int MaxDepth { get; set; } = 32;
 
-		static bool IsSimpleType(object? data)
-		{
-			if (data == null)
-				return true;
+    protected override void OnParametersSet()
+    {
+        // Only reset the format when the parameter itself changes, so a parent re-render does not
+        // discard the format the user selected.
+        if (_lastFormatParameter != Format)
+        {
+            _lastFormatParameter = Format;
+            _format = Format;
+        }
+    }
 
-			var type = data.GetType();
-			return
-				type == typeof(char) ||
-				type == typeof(string) ||
-				type == typeof(bool) ||
-				type == typeof(byte) ||
-				type == typeof(sbyte) ||
-				type == typeof(short) ||
-				type == typeof(ushort) ||
-				type == typeof(int) ||
-				type == typeof(uint) ||
-				type == typeof(long) ||
-				type == typeof(ulong) ||
-				type == typeof(Half) ||
-				type == typeof(float) ||
-				type == typeof(double) ||
-				type == typeof(decimal) ||
-				type == typeof(Guid) ||
-				type == typeof(TimeSpan) ||
-				type == typeof(DateTime) ||
-				type == typeof(DateTimeOffset) ||
-				type == typeof(Uri) ||
-				type == typeof(TimeZoneInfo) ||
-				type == typeof(Type) ||
-				type == typeof(Version) ||
-				type.IsEnum;
-		}
-	}
+    // Signals that a property getter threw. Rendered inline so the failure is visible without taking down the render.
+    private sealed record PropertyError(string Message);
 
-	private static string FormatDataAsJson(object data)
-	{
-		return System.Text.Json.JsonSerializer.Serialize(data, data.GetType(), s_options);
-	}
+    private static IEnumerable<(string PropertyName, object? Value, bool IsSimpleType)> GetValues(object data)
+    {
+        if (data is IEnumerable<KeyValuePair<string, object>> dict)
+        {
+            foreach (var item in dict)
+            {
+                yield return (item.Key, item.Value, IsSimpleType(item.Value));
+            }
+        }
+        else if (data is System.Collections.IDictionary dictionary)
+        {
+            // Covers dictionaries whose value type is not object, such as Dictionary<string, string>, which is
+            // not an IEnumerable<KeyValuePair<string, object>> because KeyValuePair is a struct.
+            foreach (System.Collections.DictionaryEntry item in dictionary)
+            {
+                var key = System.Convert.ToString(item.Key, System.Globalization.CultureInfo.InvariantCulture) ?? "";
+                yield return (key, item.Value, IsSimpleType(item.Value));
+            }
+        }
+        else if (data is System.Collections.IEnumerable enumerable)
+        {
+            var index = 0;
+            foreach (var item in enumerable)
+            {
+                yield return ($"[{index}]", item, IsSimpleType(item));
+                index++;
+            }
+        }
+        else
+        {
+            foreach (var prop in data.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.FlattenHierarchy))
+            {
+                if (prop.GetMethod is null)
+                    continue;
+
+                // Indexers cannot be read without arguments; GetValue would throw TargetParameterCountException.
+                if (prop.GetIndexParameters().Length > 0)
+                    continue;
+
+                var value = GetPropertyValue(prop, data);
+                yield return (prop.Name, value, IsSimpleType(value));
+            }
+        }
+    }
+
+    private static object? GetPropertyValue(System.Reflection.PropertyInfo property, object data)
+    {
+        // A property getter can throw for any reason. Rendering the failure is better than tearing down the circuit.
+        try
+        {
+            return property.GetValue(data);
+        }
+        catch (System.Reflection.TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            return new PropertyError(ex.InnerException.Message);
+        }
+        catch (Exception ex)
+        {
+            return new PropertyError(ex.Message);
+        }
+    }
+
+    private static bool IsSimpleType(object? data)
+    {
+        if (data is null)
+            return true;
+
+        if (data is Type or Uri or TimeZoneInfo)
+            return true;
+
+        var type = data.GetType();
+        return
+            type == typeof(char) ||
+            type == typeof(string) ||
+            type == typeof(bool) ||
+            type == typeof(byte) ||
+            type == typeof(sbyte) ||
+            type == typeof(short) ||
+            type == typeof(ushort) ||
+            type == typeof(int) ||
+            type == typeof(uint) ||
+            type == typeof(long) ||
+            type == typeof(ulong) ||
+            type == typeof(Int128) ||
+            type == typeof(UInt128) ||
+            type == typeof(nint) ||
+            type == typeof(nuint) ||
+            type == typeof(Half) ||
+            type == typeof(float) ||
+            type == typeof(double) ||
+            type == typeof(decimal) ||
+            type == typeof(Guid) ||
+            type == typeof(TimeSpan) ||
+            type == typeof(DateTime) ||
+            type == typeof(DateTimeOffset) ||
+            type == typeof(DateOnly) ||
+            type == typeof(TimeOnly) ||
+            type == typeof(Version) ||
+            type.IsEnum;
+    }
+
+    private static string FormatDataAsJson(object data)
+    {
+        try
+        {
+            return System.Text.Json.JsonSerializer.Serialize(data, data.GetType(), s_options);
+        }
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or NotSupportedException)
+        {
+            return ex.Message;
+        }
+    }
 }

--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogEntryDetails.razor.css
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogEntryDetails.razor.css
@@ -30,3 +30,7 @@ th {
     padding-right: 15px;
     vertical-align: top;
 }
+
+.value-error {
+    color: var(--color-log-error);
+}

--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/LogHighlighter.cs
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/LogHighlighter.cs
@@ -5,7 +5,7 @@ namespace Meziantou.AspNetCore.Components;
 
 internal static class LogHighlighter
 {
-    public static MarkupString Highlight(string? text, IEnumerable<ILogHighlighter> highlighters, string? attributeName)
+    public static MarkupString Highlight(string? text, IEnumerable<ILogHighlighter>? highlighters, string? attributeName)
     {
         if (text is null)
             return new MarkupString();
@@ -14,94 +14,115 @@ internal static class LogHighlighter
         var visibleText = parsedText.Text;
         var ansiRuns = parsedText.Runs;
 
-        if (highlighters is not null)
+        var sb = new StringBuilder();
+        var lastIndex = 0;
+        foreach (var match in SelectMatches(visibleText, highlighters))
         {
-            var allMatches = highlighters
-                .SelectMany(highlighter => highlighter.Process(visibleText))
-                .OrderBy(result => result.Index)
-                .ToArray();
+            AppendStyledText(sb, visibleText, ansiRuns, lastIndex, match.Index, attributeName);
+            AppendMatch(sb, visibleText, ansiRuns, match, attributeName);
+            lastIndex = match.Index + match.Length;
+        }
 
-            if (allMatches.Length > 0)
+        AppendStyledText(sb, visibleText, ansiRuns, lastIndex, visibleText.Length, attributeName);
+        return new MarkupString(sb.ToString());
+    }
+
+    // Selects the non-overlapping set of highlights to render. A higher-priority match always wins
+    // over every match it overlaps, even when the lower-priority one starts earlier. Ties are broken
+    // on the lowest index, then on the longest match. Results that fall outside the text are dropped.
+    private static List<LogHighlighterResult> SelectMatches(string text, IEnumerable<ILogHighlighter>? highlighters)
+    {
+        var selected = new List<LogHighlighterResult>();
+        if (highlighters is null)
+            return selected;
+
+        var candidates = highlighters
+            .SelectMany(highlighter => highlighter.Process(text))
+            .Where(result => result.Length > 0 && result.Index >= 0 && result.Index <= text.Length - result.Length)
+            .OrderByDescending(result => result.Priority)
+            .ThenBy(result => result.Index)
+            .ThenByDescending(result => result.Length);
+
+        foreach (var candidate in candidates)
+        {
+            var insertionIndex = FindInsertionIndex(selected, candidate.Index);
+
+            var previous = insertionIndex > 0 ? selected[insertionIndex - 1] : null;
+            if (previous is not null && previous.Index + previous.Length > candidate.Index)
+                continue;
+
+            var next = insertionIndex < selected.Count ? selected[insertionIndex] : null;
+            if (next is not null && candidate.Index + candidate.Length > next.Index)
+                continue;
+
+            selected.Insert(insertionIndex, candidate);
+        }
+
+        return selected;
+    }
+
+    // Returns the position of the first selected match whose index is greater than or equal to <paramref name="index"/>.
+    private static int FindInsertionIndex(List<LogHighlighterResult> selected, int index)
+    {
+        var low = 0;
+        var high = selected.Count;
+        while (low < high)
+        {
+            var middle = low + ((high - low) / 2);
+            if (selected[middle].Index < index)
             {
-                // highlights
-                var lastIndex = 0;
-                var sb = new StringBuilder();
-
-                for (var i = 0; i < allMatches.Length; i++)
-                {
-                    var match = allMatches[i];
-                    if (match.Index < lastIndex)
-                        continue; // overlap
-
-                    // Find the best match in case of overlaps (highest priority and lowest index)
-                    var matchEnd = match.Index + match.Length;
-                    for (var j = i + 1; j < allMatches.Length; j++)
-                    {
-                        var potentialMatch = allMatches[j];
-                        if (potentialMatch.Index > matchEnd)
-                            break; // allMatches is sorted by index
-
-                        if (potentialMatch.Priority < match.Priority)
-                            continue; // only consider higher priority match
-
-                        if (potentialMatch.Index > match.Index)
-                            continue; // only consider lowest index
-
-                        match = allMatches[j];
-                    }
-
-                    // Highlights
-                    AppendStyledText(sb, visibleText, ansiRuns, lastIndex, match.Index, attributeName);
-
-                    lastIndex = match.Index + match.Length;
-
-                    if (match.Link is not null)
-                    {
-                        sb.Append("<a ").Append(attributeName).Append(" class='log-message-match-link' target='_blank' href='");
-                        sb.Append(HtmlEncoder.Default.Encode(match.Link));
-                        sb.Append('\'');
-                    }
-                    else
-                    {
-                        sb.Append("<span ").Append(attributeName).Append(" class='log-message-match'");
-                    }
-
-                    if (match.Title is not null)
-                    {
-                        sb.Append(" title='")
-                          .Append(HtmlEncoder.Default.Encode(match.Title))
-                          .Append('\'');
-                    }
-
-                    sb.Append('>');
-
-                    if (match.ReplacementText is not null)
-                    {
-                        sb.Append(HtmlEncoder.Default.Encode(match.ReplacementText));
-                    }
-                    else
-                    {
-                        AppendStyledText(sb, visibleText, ansiRuns, match.Index, lastIndex, attributeName);
-                    }
-
-                    if (match.Link is not null)
-                    {
-                        sb.Append("</a>");
-                    }
-                    else
-                    {
-                        sb.Append("</span>");
-                    }
-                }
-
-                AppendStyledText(sb, visibleText, ansiRuns, lastIndex, visibleText.Length, attributeName);
-                return new MarkupString(sb.ToString());
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle;
             }
         }
 
-        var result = new StringBuilder();
-        AppendStyledText(result, visibleText, ansiRuns, 0, visibleText.Length, attributeName);
-        return new MarkupString(result.ToString());
+        return low;
+    }
+
+    private static void AppendMatch(StringBuilder sb, string text, IReadOnlyList<Meziantou.Framework.AnsiTextProcessor.AnsiTextRun> ansiRuns, LogHighlighterResult match, string? attributeName)
+    {
+        // A highlighter can produce any string as a link, including "javascript:". Only http(s) links are
+        // rendered as anchors; anything else falls back to a plain highlight so the text is still visible.
+        var link = match.Link is not null && IsSafeLink(match.Link) ? match.Link : null;
+        if (link is not null)
+        {
+            sb.Append("<a ").Append(attributeName).Append(" class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='");
+            sb.Append(HtmlEncoder.Default.Encode(link));
+            sb.Append('\'');
+        }
+        else
+        {
+            sb.Append("<span ").Append(attributeName).Append(" class='log-message-match'");
+        }
+
+        if (match.Title is not null)
+        {
+            sb.Append(" title='")
+              .Append(HtmlEncoder.Default.Encode(match.Title))
+              .Append('\'');
+        }
+
+        sb.Append('>');
+
+        if (match.ReplacementText is not null)
+        {
+            sb.Append(HtmlEncoder.Default.Encode(match.ReplacementText));
+        }
+        else
+        {
+            AppendStyledText(sb, text, ansiRuns, match.Index, match.Index + match.Length, attributeName);
+        }
+
+        sb.Append(link is not null ? "</a>" : "</span>");
+    }
+
+    private static bool IsSafeLink(string link)
+    {
+        return Uri.TryCreate(link, UriKind.Absolute, out var uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
     }
 
     private static void AppendStyledText(StringBuilder sb, string text, IReadOnlyList<Meziantou.Framework.AnsiTextProcessor.AnsiTextRun> ansiRuns, int start, int end, string? attributeName)

--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/LogHighlighterResult.cs
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/LogHighlighterResult.cs
@@ -3,7 +3,7 @@ namespace Meziantou.AspNetCore.Components;
 /// <summary>Represents a highlighted portion of text in a log message.</summary>
 /// <param name="Index">The zero-based starting index of the highlighted text.</param>
 /// <param name="Length">The length of the highlighted text.</param>
-/// <param name="Priority">The priority of this highlight. Higher priority highlights take precedence when overlapping.</param>
+/// <param name="Priority">The priority of this highlight. When two highlights overlap, the one with the higher priority is rendered and the other is dropped, even when the dropped one starts earlier. Ties are broken on the lowest <paramref name="Index"/>, then on the longest <paramref name="Length"/>.</param>
 public record LogHighlighterResult(int Index, int Length, int Priority)
 {
     /// <summary>Gets or initializes the URL to link to when the highlighted text is clicked.</summary>

--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogViewer.razor
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogViewer.razor
@@ -1,15 +1,15 @@
 @using System.Globalization
+@using System.Runtime.CompilerServices
 @if (Entries is not null)
 {
-    Prepare();
     <div class="log-viewer">
-        @if (_firstEntry is not null && TimestampDisplayFormat is TimestampDisplayFormat.DateTimeThenRelativeTime)
+        @if (_entries.Count > 0 && TimestampDisplayFormat is TimestampDisplayFormat.DateTimeThenRelativeTime)
         {
             <div class="log-entry">
                 <span class="log-timestamp">@FormatDateTime(_startTime)</span>
             </div>
         }
-        @foreach (var entry in Entries)
+        @foreach (var entry in _entries)
         {
             @RenderEntry(entry)
         }
@@ -19,41 +19,30 @@
 @code {
     private RenderFragment<LogEntry> RenderEntry => context =>
     @<text>
-        <div class="log-entry @(IsSelected(context) ? "selected" : "")">
+        <div class="log-entry @(IsSelected(context) ? "selected" : "")" @key="context">
             @if (ShowLineNumbers)
             {
-                <a class="log-linenumber" @onclick="(e) => SelectLine(context, e.CtrlKey)" @onclick:preventDefault="true">@GetLineNumber(context)</a>
+                <button type="button" class="log-linenumber" @onclick="(e) => SelectLine(context, e.CtrlKey || e.MetaKey)">@GetLineNumber(context)</button>
             }
 
             @if (TimestampDisplayFormat is TimestampDisplayFormat.FullDateTime)
             {
                 <span class="log-timestamp">@FormatDateTime(context.Timestamp)</span>
             }
-            else if (TimestampDisplayFormat is TimestampDisplayFormat.DateTimeThenRelativeTime)
+            else if (TimestampDisplayFormat is TimestampDisplayFormat.DateTimeThenRelativeTime or TimestampDisplayFormat.RelativeTimeStartingAtZero)
             {
                 <span class="log-timestamp">@FormatTimeSpan(context.Timestamp - _startTime)</span>
-            }
-            else if (TimestampDisplayFormat is TimestampDisplayFormat.RelativeTimeStartingAtZero)
-            {
-                if (ReferenceEquals(context, _firstEntry))
-                {
-                    <span class="log-timestamp">@TimeSpan.Zero</span>
-                }
-                else
-                {
-                    <span class="log-timestamp">@FormatTimeSpan(context.Timestamp - _startTime)</span>
-                }
             }
 
             <span class="log-content">
                 @if (IsExpandable(context))
                 {
-                    <span class="log-toggle-details @(IsOpened(context) ? "opened" : "")" @onclick="() => ToggleDetails(context)">▶</span>
+                    <button type="button" class="log-toggle-details @(IsOpened(context) ? "opened" : "")" aria-expanded="@(IsOpened(context) ? "true" : "false")" aria-label="Toggle child entries" @onclick="() => ToggleDetails(context)">&#9654;</button>
                 }
 
                 @if (context.Message is string text)
                 {
-                    <span class="log-message log-@GetLogLevelClassName(context.LogLevel)">@LogHighlighter.Highlight(text, LogHighlighters, "mez-logviewer")</span>
+                    <span class="log-message log-@GetLogLevelClassName(context.LogLevel)">@GetMessageMarkup(context, text)</span>
                 }
                 else if (context.Message is not null)
                 {
@@ -75,16 +64,27 @@
         }
     </text>;
 
-    private readonly HashSet<LogEntry> _openedEntries = new HashSet<LogEntry>();
-    private readonly HashSet<LogEntry> _selectedEntries = new HashSet<LogEntry>();
+    // Entries the user explicitly expanded or collapsed. Entries that are absent fall back to LogEntry.Expanded,
+    // so entries appended to an existing collection keep honoring their own default.
+    private readonly Dictionary<LogEntry, bool> _explicitOpenState = new Dictionary<LogEntry, bool>(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<LogEntry> _selectedEntries = new HashSet<LogEntry>(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<LogEntry, int> _lineNumbers = new Dictionary<LogEntry, int>(ReferenceEqualityComparer.Instance);
+    // Weak keys, so cached markup is collected together with the entry it belongs to.
+    private readonly ConditionalWeakTable<LogEntry, CachedHighlight> _highlightCache = new ConditionalWeakTable<LogEntry, CachedHighlight>();
+    private IReadOnlyList<LogEntry> _entries = [];
     private IEnumerable<LogEntry>? _lastEntries;
-    private LogEntry? _firstEntry;
     private DateTimeOffset _startTime;
 
     /// <summary>
     /// Gets or sets the collection of log entries to display.
     /// </summary>
+    /// <remarks>
+    /// The sequence is snapshotted on each parameter change. Entries are tracked by reference, so a sequence that
+    /// creates new <see cref="LogEntry"/> instances every time it is enumerated is supported, but per-entry state
+    /// such as the expanded flag will not survive across renders.
+    /// The same <see cref="LogEntry"/> instance must not appear more than once in the tree: line numbers, selection
+    /// and expanded state are all keyed on the instance.
+    /// </remarks>
     [Parameter]
     public IEnumerable<LogEntry>? Entries { get; set; }
 
@@ -96,12 +96,14 @@
 
     /// <summary>
     /// Gets or sets the format string for displaying time spans. If not specified, uses the default format "G".
+    /// Values are formatted using <see cref="CultureInfo.InvariantCulture"/>.
     /// </summary>
     [Parameter]
     public string? TimeSpanStringFormat { get; set; }
 
     /// <summary>
     /// Gets or sets the format string for displaying date and time values. If not specified, uses the default format "R".
+    /// Values are formatted using <see cref="CultureInfo.InvariantCulture"/>.
     /// </summary>
     [Parameter]
     public string? DateTimeStringFormat { get; set; }
@@ -123,49 +125,37 @@
         if (!ReferenceEquals(_lastEntries, Entries))
         {
             _lastEntries = Entries;
-            _openedEntries.Clear();
-            if (Entries is not null)
-            {
-                SeedExpanded(Entries);
-            }
+            _explicitOpenState.Clear();
+            _selectedEntries.Clear();
+        }
+
+        // Snapshot the sequence. It is walked once to assign line numbers and again while rendering, and a computed
+        // IEnumerable would yield different LogEntry instances on each enumeration, breaking every per-entry lookup.
+        _entries = Entries is null ? [] : Entries as IReadOnlyList<LogEntry> ?? Entries.ToList();
+
+        _lineNumbers.Clear();
+        _startTime = DateTimeOffset.MaxValue;
+        var nextLineNumber = 1;
+        AssignLineNumbers(_entries, ref nextLineNumber);
+        if (_lineNumbers.Count is 0)
+        {
+            _startTime = DateTimeOffset.UtcNow;
         }
     }
 
-    // Computes the line-number map and the relative-time baseline before each render.
-    private void Prepare()
-    {
-        _lineNumbers.Clear();
-        _firstEntry = null;
-        var nextLineNumber = 1;
-        AssignLineNumbers(Entries!, ref nextLineNumber);
-        _startTime = _firstEntry?.Timestamp ?? DateTimeOffset.UtcNow;
-    }
-
-    private void AssignLineNumbers(IEnumerable<LogEntry> entries, ref int nextLineNumber)
+    private void AssignLineNumbers(IReadOnlyList<LogEntry> entries, ref int nextLineNumber)
     {
         foreach (var entry in entries)
         {
-            _firstEntry ??= entry;
             _lineNumbers[entry] = nextLineNumber++;
+            if (entry.Timestamp < _startTime)
+            {
+                _startTime = entry.Timestamp;
+            }
+
             if (entry.Children is { Count: > 0 } children)
             {
                 AssignLineNumbers(children, ref nextLineNumber);
-            }
-        }
-    }
-
-    private void SeedExpanded(IEnumerable<LogEntry> entries)
-    {
-        foreach (var entry in entries)
-        {
-            if (entry.Expanded)
-            {
-                _openedEntries.Add(entry);
-            }
-
-            if (entry.Children is { Count: > 0 } children)
-            {
-                SeedExpanded(children);
             }
         }
     }
@@ -174,35 +164,43 @@
 
     private static bool IsExpandable(LogEntry entry) => entry.Children is { Count: > 0 };
 
+    private MarkupString GetMessageMarkup(LogEntry entry, string text)
+    {
+        if (_highlightCache.TryGetValue(entry, out var cached) && cached.Matches(entry.Message, LogHighlighters))
+            return cached.Markup;
+
+        var markup = LogHighlighter.Highlight(text, LogHighlighters, "mez-logviewer");
+        _highlightCache.AddOrUpdate(entry, new CachedHighlight(entry.Message, LogHighlighters, markup));
+        return markup;
+    }
+
     private void SelectLine(LogEntry entry, bool append)
     {
         if (!append)
         {
             _selectedEntries.Clear();
         }
+        else if (_selectedEntries.Remove(entry))
+        {
+            return; // toggle the entry off
+        }
 
         _selectedEntries.Add(entry);
     }
 
-    private void ToggleDetails(LogEntry entry)
-    {
-        if (!_openedEntries.Remove(entry))
-        {
-            _openedEntries.Add(entry);
-        }
-    }
+    private void ToggleDetails(LogEntry entry) => _explicitOpenState[entry] = !IsOpened(entry);
 
     private bool IsSelected(LogEntry logEntry) => _selectedEntries.Contains(logEntry);
-    private bool IsOpened(LogEntry logEntry) => _openedEntries.Contains(logEntry);
+    private bool IsOpened(LogEntry logEntry) => _explicitOpenState.TryGetValue(logEntry, out var opened) ? opened : logEntry.Expanded;
 
     private string FormatTimeSpan(TimeSpan value)
     {
-        return value.ToString(TimeSpanStringFormat ?? "G");
+        return value.ToString(TimeSpanStringFormat ?? "G", CultureInfo.InvariantCulture);
     }
 
     private string FormatDateTime(DateTimeOffset value)
     {
-        return value.ToString(DateTimeStringFormat ?? "R");
+        return value.ToString(DateTimeStringFormat ?? "R", CultureInfo.InvariantCulture);
     }
 
     private static string GetLogLevelClassName(LogLevel logLevel)
@@ -217,5 +215,13 @@
             LogLevel.Critical => "critical",
             _ => "information",
         };
+    }
+
+    private sealed class CachedHighlight(object? message, IEnumerable<ILogHighlighter> highlighters, MarkupString markup)
+    {
+        public MarkupString Markup { get; } = markup;
+
+        public bool Matches(object? currentMessage, IEnumerable<ILogHighlighter> currentHighlighters)
+            => ReferenceEquals(message, currentMessage) && ReferenceEquals(highlighters, currentHighlighters);
     }
 }

--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogViewer.razor.css
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogViewer.razor.css
@@ -33,6 +33,11 @@
     }
 
 .log-linenumber {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
     color: var(--color-linenumber);
     white-space: nowrap;
     overflow: hidden;
@@ -56,6 +61,11 @@
 }
 
 .log-toggle-details {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
     cursor: pointer;
     user-select: none;
     color: var(--color-log-information);

--- a/src/Meziantou.AspNetCore.Components.LogViewer/readme.md
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/readme.md
@@ -1,6 +1,6 @@
 # Meziantou.AspNetCore.Components.LogViewer
 
-A Blazor component for displaying and analyzing log entries with support for filtering, highlighting, and interactive exploration.
+A Blazor component for displaying and analyzing log entries with support for highlighting and interactive exploration.
 
 ## Features
 
@@ -115,6 +115,16 @@ A Blazor component for displaying and analyzing log entries with support for fil
 
 When `Message` is a string, it is displayed as highlighted text. For non-string `Message` values, the structured payload is rendered inline and can be viewed as either a table or JSON.
 
+The table view walks the object with reflection: dictionaries are rendered as key/value rows, other sequences as
+indexed rows, and anything else by its public instance properties. Indexers are skipped, a property getter that
+throws is rendered as an error instead of failing the render, and nesting is capped by `MaxDepth` (default `32`),
+which also bounds cyclic object graphs.
+
+> **Trimming and Native AOT:** the table and JSON views use reflection over arbitrary objects, so `LogEntryDetails`
+> is not compatible with trimming or Native AOT. In a trimmed Blazor WebAssembly app, properties of logged types may
+> be removed and silently omitted from the output. Keep the types you log rooted, or pass a `Dictionary<string, object>`
+> instead of an arbitrary object.
+
 ### ANSI-formatted Messages
 
 `LogViewer` parses ANSI SGR escape sequences embedded in string messages and renders the corresponding foreground/background colors and text styles.
@@ -127,6 +137,17 @@ new LogEntry
     Message = "\u001b[1;33mwarning\u001b[0m \u001b[38;2;100;200;50mcustom color\u001b[0m",
 }
 ```
+
+### Highlighters
+
+`LogHighlighters` receives an ordered collection of `ILogHighlighter`. Each highlighter returns
+`LogHighlighterResult` values describing a range of the message to mark up. When two results overlap, the one with
+the higher `Priority` wins — even when the other one starts earlier; ties are broken on the lowest index, then on
+the longest match.
+
+A result can carry a `Link`, which turns the range into an anchor. Only `http` and `https` links are rendered as
+anchors; any other scheme falls back to a plain highlight, so a highlighter cannot inject a `javascript:` URL into
+the page from untrusted log text.
 
 ### Hierarchical / Nested Logs
 

--- a/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/LogHighlighterTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/LogHighlighterTests.cs
@@ -1,4 +1,4 @@
-namespace Meziantou.AspNetCore.Components.LogViewer.Tests;
+namespace Meziantou.AspNetCore.Components.Tests;
 
 public class LogHighlighterTests
 {
@@ -11,42 +11,42 @@ public class LogHighlighterTests
     public void SingleMatchInMiddle()
     {
         var result = Highlight("a http://test.com b", new UrlLogHighlighter());
-        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a> b", result);
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://test.com'>http://test.com</a> b", result);
     }
 
     [Fact]
     public void SingleMatchAtEnd()
     {
         var result = Highlight("a http://test.com", new UrlLogHighlighter());
-        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a>", result);
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://test.com'>http://test.com</a>", result);
     }
 
     [Fact]
     public void SingleMatchAtStart()
     {
         var result = Highlight("http://test.com b", new UrlLogHighlighter());
-        Assert.Equal("<a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a> b", result);
+        Assert.Equal("<a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://test.com'>http://test.com</a> b", result);
     }
 
     [Fact]
     public void MultipleMatches()
     {
         var result = Highlight("a http://test.com 'sample' b", new UrlLogHighlighter(), new QuoteLogHighlighter());
-        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a> &#x27;<span scope class='log-message-match'>sample</span>&#x27; b", result);
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://test.com'>http://test.com</a> &#x27;<span scope class='log-message-match'>sample</span>&#x27; b", result);
     }
 
     [Fact]
     public void MatchLocalhostUrl()
     {
         var result = Highlight("a http://localhost:5000/path b", new UrlLogHighlighter());
-        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://localhost:5000/path'>http://localhost:5000/path</a> b", result);
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://localhost:5000/path'>http://localhost:5000/path</a> b", result);
     }
 
     [Fact]
     public void MatchUrlWithTrailingPunctuation()
     {
         var result = Highlight("a http://test.com, b", new UrlLogHighlighter());
-        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a>, b", result);
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://test.com'>http://test.com</a>, b", result);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class LogHighlighterTests
     public void MatchUrlAcrossAnsiColorBoundary()
     {
         var result = Highlight($"a http://te\u001b[31mst.com/path\u001b[0m b", new UrlLogHighlighter());
-        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com/path'>http://te<span scope class='log-ansi' style='color: rgb(205, 49, 49);'>st.com/path</span></a> b", result);
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='http://test.com/path'>http://te<span scope class='log-ansi' style='color: rgb(205, 49, 49);'>st.com/path</span></a> b", result);
     }
 
     [Fact]
@@ -101,5 +101,92 @@ public class LogHighlighterTests
 
         Assert.Null(exception);
         Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void HigherPriorityWinsOverEarlierOverlappingMatch()
+    {
+        var result = Highlight("abcdefghij", new FakeLogHighlighter(
+            new LogHighlighterResult(0, 6, Priority: 0) { Title = "low" },
+            new LogHighlighterResult(2, 3, Priority: 100) { Title = "high" }));
+
+        Assert.Equal("ab<span scope class='log-message-match' title='high'>cde</span>fghij", result);
+    }
+
+    [Fact]
+    public void LowerPriorityNonOverlappingMatchIsKept()
+    {
+        var result = Highlight("abcdefghij", new FakeLogHighlighter(
+            new LogHighlighterResult(0, 2, Priority: 0) { Title = "low" },
+            new LogHighlighterResult(5, 3, Priority: 100) { Title = "high" }));
+
+        Assert.Equal("<span scope class='log-message-match' title='low'>ab</span>cde<span scope class='log-message-match' title='high'>fgh</span>ij", result);
+    }
+
+    [Fact]
+    public void EqualPriorityOverlapKeepsTheLongestMatchAtTheLowestIndex()
+    {
+        var result = Highlight("abcdefghij", new FakeLogHighlighter(
+            new LogHighlighterResult(1, 2, Priority: 0) { Title = "short" },
+            new LogHighlighterResult(0, 6, Priority: 0) { Title = "long" }));
+
+        Assert.Equal("<span scope class='log-message-match' title='long'>abcdef</span>ghij", result);
+    }
+
+    [Fact]
+    public void NonHttpLinkIsNotRenderedAsAnchor()
+    {
+        var result = Highlight("click me", new FakeLogHighlighter(
+            new LogHighlighterResult(0, 5, Priority: 0) { Link = "javascript:alert(document.cookie)" }));
+
+        Assert.Equal("<span scope class='log-message-match'>click</span> me", result);
+    }
+
+    [Theory]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com")]
+    [InlineData("HTTPS://example.com")]
+    public void HttpLinkIsRenderedAsAnchor(string link)
+    {
+        var result = Highlight("click me", new FakeLogHighlighter(
+            new LogHighlighterResult(0, 5, Priority: 0) { Link = link }));
+
+        Assert.Equal($"<a scope class='log-message-match-link' target='_blank' rel='noopener noreferrer' href='{link}'>click</a> me", result);
+    }
+
+    [Theory]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("not a url")]
+    public void NonHttpSchemesFallBackToPlainHighlight(string link)
+    {
+        var result = Highlight("click me", new FakeLogHighlighter(
+            new LogHighlighterResult(0, 5, Priority: 0) { Link = link }));
+
+        Assert.Equal("<span scope class='log-message-match'>click</span> me", result);
+    }
+
+    [Theory]
+    [InlineData(-3, 2)]
+    [InlineData(3, 100)]
+    [InlineData(0, 0)]
+    [InlineData(0, -1)]
+    [InlineData(int.MaxValue, 1)]
+    public void OutOfRangeMatchesAreIgnored(int index, int length)
+    {
+        var result = Highlight("short", new FakeLogHighlighter(new LogHighlighterResult(index, length, Priority: 0)));
+        Assert.Equal("short", result);
+    }
+
+    [Fact]
+    public void NullHighlightersRendersPlainText()
+    {
+        Assert.Equal("a &lt;b&gt; c", LogHighlighter.Highlight("a <b> c", highlighters: null, "scope").Value);
+    }
+
+    private sealed class FakeLogHighlighter(params LogHighlighterResult[] results) : ILogHighlighter
+    {
+        public IEnumerable<LogHighlighterResult> Process(string text) => results;
     }
 }

--- a/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/LogViewerComponentTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/LogViewerComponentTests.cs
@@ -1,0 +1,287 @@
+using System.Globalization;
+using Meziantou.Xunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meziantou.AspNetCore.Components.Tests;
+
+public class LogViewerComponentTests
+{
+    private static async Task<string> RenderAsync<TComponent>(object parameters)
+        where TComponent : IComponent
+    {
+        await using var renderer = new HtmlRenderer(EmptyServiceProvider.Instance, NullLoggerFactory.Instance);
+
+        return await renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var output = await renderer.RenderComponentAsync<TComponent>(ParameterView.FromDictionary(ToDictionary(parameters)));
+            return output.ToHtmlString();
+        });
+    }
+
+    private static Dictionary<string, object?> ToDictionary(object parameters)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var property in parameters.GetType().GetProperties())
+        {
+            result[property.Name] = property.GetValue(parameters);
+        }
+
+        return result;
+    }
+
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static EmptyServiceProvider Instance { get; } = new EmptyServiceProvider();
+
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static Task<string> RenderViewerAsync(object parameters) => RenderAsync<LogViewer>(parameters);
+
+    private static Task<string> RenderDetailsAsync(object data, LogDetailsDisplayFormat format = LogDetailsDisplayFormat.Table)
+        => RenderAsync<LogEntryDetails>(new { Data = data, Format = format });
+
+    private static LogEntry Entry(string message, int offsetSeconds = 0) => new()
+    {
+        Timestamp = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(offsetSeconds),
+        LogLevel = LogLevel.Information,
+        Message = message,
+    };
+
+    [Fact]
+    public async Task LineNumbersAreAssignedWhenEntriesIsAComputedSequence()
+    {
+        // A projecting sequence yields new LogEntry instances on every enumeration. The component must
+        // snapshot it, otherwise every per-entry lookup misses and line numbers render as 0.
+        var source = new[] { "first", "second", "third" };
+        var entries = source.Select(text => Entry(text));
+
+        var html = await RenderViewerAsync(new { Entries = entries });
+
+        Assert.Contains(">1</button>", html);
+        Assert.Contains(">2</button>", html);
+        Assert.Contains(">3</button>", html);
+        Assert.DoesNotContain(">0</button>", html);
+    }
+
+    [Fact]
+    public async Task LineNumbersCountCollapsedChildren()
+    {
+        var entries = new List<LogEntry>
+        {
+            new() { Message = "parent", Children = [Entry("child-a"), Entry("child-b")] },
+            Entry("sibling"),
+        };
+
+        var html = await RenderViewerAsync(new { Entries = entries });
+
+        // The collapsed children still consume line numbers 2 and 3, so the sibling is 4.
+        Assert.Contains(">1</button>", html);
+        Assert.Contains(">4</button>", html);
+        Assert.DoesNotContain("child-a", html);
+    }
+
+    [Fact]
+    public async Task ExpandedEntryRendersItsChildren()
+    {
+        var entries = new List<LogEntry>
+        {
+            new() { Message = "parent", Expanded = true, Children = [Entry("child-a")] },
+        };
+
+        var html = await RenderViewerAsync(new { Entries = entries });
+
+        Assert.Contains("child-a", html);
+        Assert.Contains("aria-expanded=\"true\"", html);
+    }
+
+    [Fact]
+    public async Task ToggleAndLineNumberAreFocusableControls()
+    {
+        var entries = new List<LogEntry> { new() { Message = "parent", Children = [Entry("child")] } };
+
+        var html = await RenderViewerAsync(new { Entries = entries });
+
+        Assert.Contains("<button type=\"button\" class=\"log-linenumber\"", html);
+        Assert.Contains("aria-expanded=\"false\"", html);
+        Assert.Contains("aria-label=\"Toggle child entries\"", html);
+    }
+
+    [Fact]
+    [RunIf(TestGlobalizationMode.NotInvariant)]
+    public async Task TimestampsDoNotDependOnTheCurrentCulture()
+    {
+        var entries = new List<LogEntry> { Entry("a"), Entry("b", offsetSeconds: 1) };
+
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var html = await RenderViewerAsync(new
+            {
+                Entries = entries,
+                TimestampDisplayFormat = TimestampDisplayFormat.RelativeTimeStartingAtZero,
+            });
+
+            // "G" is culture-sensitive: fr-FR would use a comma as the decimal separator.
+            Assert.Contains("0:00:00:01.0000000", html);
+            Assert.DoesNotContain("0:00:00:01,0000000", html);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public async Task RelativeTimeUsesTheConfiguredFormatForEveryRowIncludingTheFirst()
+    {
+        var entries = new List<LogEntry> { Entry("a"), Entry("b", offsetSeconds: 90) };
+
+        var html = await RenderViewerAsync(new
+        {
+            Entries = entries,
+            TimestampDisplayFormat = TimestampDisplayFormat.RelativeTimeStartingAtZero,
+            TimeSpanStringFormat = @"mm\:ss",
+        });
+
+        Assert.Contains("00:00", html);
+        Assert.Contains("01:30", html);
+        // The first row used to bypass TimeSpanStringFormat and render TimeSpan.Zero as "00:00:00".
+        Assert.DoesNotContain("00:00:00", html);
+    }
+
+    [Fact]
+    public async Task RelativeTimeIsBasedOnTheEarliestTimestamp()
+    {
+        var entries = new List<LogEntry> { Entry("newest", offsetSeconds: 60), Entry("oldest") };
+
+        var html = await RenderViewerAsync(new
+        {
+            Entries = entries,
+            TimestampDisplayFormat = TimestampDisplayFormat.RelativeTimeStartingAtZero,
+        });
+
+        // "G" includes the sign, so a baseline taken from the first entry rather than the earliest would show up here.
+        Assert.DoesNotContain("-0:00:01:00", html);
+        Assert.Contains("0:00:01:00.0000000", html);
+    }
+
+    [Fact]
+    public async Task MessageIsHtmlEncoded()
+    {
+        var entries = new List<LogEntry> { Entry("<script>alert(1)</script>") };
+
+        var html = await RenderViewerAsync(new { Entries = entries });
+
+        Assert.DoesNotContain("<script>", html);
+        Assert.Contains("&lt;script&gt;", html);
+    }
+
+    [Fact]
+    public async Task ObjectWithAnIndexerDoesNotThrow()
+    {
+        var html = await RenderDetailsAsync(new WithIndexer());
+
+        Assert.Contains("Name", html);
+        Assert.Contains("value", html);
+    }
+
+    [Fact]
+    public async Task ThrowingPropertyGetterIsRenderedAsAnError()
+    {
+        var html = await RenderDetailsAsync(new WithThrowingGetter());
+
+        Assert.Contains("Ok", html);
+        Assert.Contains("boom", html);
+        Assert.Contains("value-error", html);
+    }
+
+    [Fact]
+    public async Task CyclicGraphIsBoundedInTableFormat()
+    {
+        var a = new Node("a");
+        var b = new Node("b") { Next = a };
+        a.Next = b;
+
+        var html = await RenderDetailsAsync(a);
+
+        Assert.Contains("&#8230;", html);
+    }
+
+    [Fact]
+    public async Task CyclicGraphDoesNotThrowInJsonFormat()
+    {
+        var a = new Node("a");
+        var b = new Node("b") { Next = a };
+        a.Next = b;
+
+        var html = await RenderDetailsAsync(a, LogDetailsDisplayFormat.Json);
+
+        // The JSON is HTML-encoded by the renderer. IgnoreCycles terminates the graph instead of throwing.
+        Assert.Contains("&quot;Name&quot;", html);
+        Assert.Contains("&quot;Next&quot;: null", html);
+        Assert.DoesNotContain("object cycle", html);
+    }
+
+    [Fact]
+    public async Task DictionaryWithNonObjectValuesRendersKeyValueRows()
+    {
+        var data = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["User-Agent"] = "Mozilla/5.0",
+        };
+
+        var html = await RenderDetailsAsync(data);
+
+        Assert.Contains("User-Agent", html);
+        Assert.Contains("Mozilla/5.0", html);
+        // Not rendered as an indexed list of KeyValuePair objects.
+        Assert.DoesNotContain("[0]", html);
+    }
+
+    [Fact]
+    public async Task DateOnlyAndTimeOnlyRenderAsSingleValues()
+    {
+        var html = await RenderDetailsAsync(new { Date = new DateOnly(2024, 1, 2), Time = new TimeOnly(3, 4, 5) });
+
+        Assert.DoesNotContain("DayOfYear", html);
+        Assert.DoesNotContain("Millisecond", html);
+    }
+
+    [Fact]
+    public async Task StringDataIsNotRenderedCharacterByCharacter()
+    {
+        var html = await RenderDetailsAsync("hello");
+
+        Assert.Contains("hello", html);
+        Assert.DoesNotContain("[0]", html);
+    }
+
+    private sealed class WithIndexer
+    {
+        public string Name { get; } = "value";
+
+        public string this[int index] => "indexed";
+    }
+
+    private sealed class WithThrowingGetter
+    {
+        // These must be instance properties: the component only reflects over public instance members.
+#pragma warning disable CA1822 // Mark members as static
+        public int Ok => 1;
+
+        public string Bad => throw new InvalidOperationException("boom");
+#pragma warning restore CA1822
+    }
+
+    private sealed class Node(string name)
+    {
+        public string Name { get; } = name;
+
+        public Node? Next { get; set; }
+    }
+}


### PR DESCRIPTION
An audit of `Meziantou.AspNetCore.Components.LogViewer` surfaced a set of defects concentrated in the two areas that had no test coverage. This fixes them and adds component-level tests.

## Crashes in `LogEntryDetails`

The table view reflected over arbitrary objects with no guardrails, and an exception thrown during `BuildRenderTree` is unrecoverable — on Blazor Server it tears down the circuit. Three verified failure modes:

- **an indexer property** threw `TargetParameterCountException`, because `GetValue` was called with no index arguments. Indexers are now skipped.
- **a throwing property getter** propagated out of the render. The failure is now rendered inline instead.
- **a reference cycle** recursed without bound in table mode and threw `JsonException` in JSON mode. Recursion is now capped by a new `MaxDepth` parameter (default 32), and the serializer uses `ReferenceHandler.IgnoreCycles`.

None of these need adversarial input — `LogEntry.Message` is typed `object?` and the readme encourages passing arbitrary structured payloads, so an ordinary domain object with an indexer was enough.

## `javascript:` links in highlighted text

`LogHighlighterResult.Link` was HTML-encoded (so attribute breakout was prevented) but its **scheme was never checked**, so a custom `ILogHighlighter` deriving a link from untrusted log text could inject a `javascript:` URL into an `href`. The built-in `UrlLogHighlighter` was safe; the gap was in the component doing the `MarkupString` rendering. Only `http` and `https` now render as anchors, and anything else falls back to a plain highlight. Anchors also carry `rel='noopener noreferrer'`.

## `Entries` required stable instance identity but did not guarantee it

`Entries` was enumerated twice per render — once for line numbers, once to render — while per-entry state was keyed by reference. A projecting `IEnumerable` (`_records.Select(r => new LogEntry { … })`) yielded different instances on each pass, so every lookup missed: line numbers rendered as `0` and the expand toggle did nothing, with no error. The sequence is now snapshotted once in `OnParametersSet`, which also moves the O(n) line-number pass out of the render body.

## `Priority` did not decide overlaps

`LogHighlighterResult.Priority` is documented as winning on overlap, but the resolution loop only ever considered candidates at an *identical* index, so a higher-priority match starting later was silently discarded — i.e. the feature did nothing in the case it exists for. Rewritten as priority-ordered interval selection with documented tie-breaks.

## Other fixes

- expanded state falls back to `LogEntry.Expanded` instead of a one-shot seeding pass, so entries appended to an existing list honour the flag
- `LogEntryDetails` no longer writes to its own `Format` parameter; `@key` added so per-entry component state follows the entry rather than the row position
- highlighted markup is cached per entry in a `ConditionalWeakTable`
- the expand toggle and line number are `<button>`s with `aria-expanded`/`aria-label` instead of click handlers on non-focusable elements
- dictionaries whose value type is not `object` (`Dictionary<string, string>`, as used in the readme's own example) render as key/value rows — `KeyValuePair` is a struct, so they never matched `IEnumerable<KeyValuePair<string, object>>`
- timestamps use `InvariantCulture`; the first relative-time row no longer bypasses `TimeSpanStringFormat`; the baseline is the earliest timestamp rather than the first in enumeration order
- `DateOnly`, `TimeOnly`, `Int128`, `UInt128`, `nint` and `nuint` render as single values. `Type`, `Uri` and `TimeZoneInfo` now match too — comparing `GetType()` to `typeof(Type)` never matched, since the runtime type is `RuntimeType`
- a `string` passed directly to `LogEntryDetails` is no longer rendered character by character
- selection is cleared when `Entries` changes, ctrl/⌘-click toggles, and `MetaKey` is accepted so multi-select works on macOS
- readme no longer advertises filtering, which the component does not implement; the trimming/Native AOT limitation of the reflection-based views is documented

## Tests

32 new tests covering the above, using the first-party `HtmlRenderer` from `Microsoft.AspNetCore.Components.Web` rather than adding a third-party component-testing dependency. `LogHighlighterTests` moves to the `Meziantou.AspNetCore.Components.Tests` namespace (the csproj `RootNamespace`): the previous namespace shadowed the `LogViewer` type name, which is the mechanical reason the component could not be referenced from a test at all.

`dotnet build` and `dotnet test` with `/p:TreatsWarningsAsErrors=true` are clean on net10.0 and net11.0 — **88 passing, 0 failing**, up from 24. `dotnet run ./eng/update-all.cs` produces no further changes, and the Blazor WebAssembly sample still builds.

## Notes for reviewers

- **Public API additions:** `LogEntryDetails.MaxDepth` and `OnParametersSet`; `ref/` regenerated.
- **`@key` requires unique sibling keys**, so the same `LogEntry` instance appearing twice among siblings will now throw on re-render instead of rendering twice. This was already unsupported in practice — line numbers, selection and expanded state all key on the instance — and is now documented on `Entries`.
- **Markup changed:** line numbers and toggles are `<button>` elements, and links carry a `rel` attribute. External CSS targeting `a.log-linenumber` or `span.log-toggle-details` needs re-checking; the scoped stylesheet resets the default button chrome, but an external override may not.
- **Deliberately not done**, as each is a design change rather than a repair: trim/AOT analyzer attributes (`[RequiresUnreferencedCode]` cannot propagate out of the generated `BuildRenderTree` override — documented instead), virtualization (`<Virtualize>` does not compose with the recursive tree rendering), and a `SelectedEntriesChanged` callback (new public API on a published package).
- **Not covered by tests:** `HtmlRenderer` renders statically, so it cannot dispatch clicks or re-render an existing component instance. The expanded-state fallback across a mutation of the same list, and `Format` surviving a parent re-render, rest on code inspection. Both would need bUnit.
- `<Version>` left at `2.0.4` — `bump-versions.yml` owns that.
