### PR TITLE
Fix request forwarding, typed client resolution and host isolation in HttpClientMock

### DIFF
--- a/ref/Meziantou.Framework.HttpClientMock.cs
+++ b/ref/Meziantou.Framework.HttpClientMock.cs
@@ -39,6 +39,7 @@ namespace Meziantou.Framework
         public Meziantou.Framework.HttpMockServiceBuilder AddHttpClientMock(Meziantou.Framework.HttpClientMock mock) => throw null;
         public Meziantou.Framework.HttpMockServiceBuilder AddHttpClientMock(string name, Meziantou.Framework.HttpClientMock mock) => throw null;
         public Meziantou.Framework.HttpMockServiceBuilder AddHttpClientMock<T>(Meziantou.Framework.HttpClientMock mock) => throw null;
+        public Meziantou.Framework.HttpMockServiceBuilder ThrowOnUnknownHttpClient() => throw null;
     }
 
     public sealed class RequestCounter

--- a/src/Meziantou.Framework.HttpClientMock/HttpClientMock.cs
+++ b/src/Meziantou.Framework.HttpClientMock/HttpClientMock.cs
@@ -11,10 +11,14 @@ using Microsoft.Extensions.Logging;
 namespace Meziantou.Framework;
 
 /// <summary>A mock HTTP server for testing HTTP clients. Use this to simulate HTTP endpoints without requiring a real server.</summary>
+/// <remarks>
+/// The single-argument constructors all accept a reference type, so a bare <c>null</c> is ambiguous. Use a named
+/// argument to select one, for instance <c>new HttpClientMock(configureLogging: null, configureServices: services => ...)</c>.
+/// </remarks>
 /// <example>
 /// Create a mock server with a simple endpoint:
 /// <code>
-/// using var mock = new HttpClientMock();
+/// await using var mock = new HttpClientMock();
 /// mock.MapGet("/api/users", () => Results.Ok(new { name = "John" }));
 /// using var httpClient = mock.CreateHttpClient();
 /// var response = await httpClient.GetAsync("/api/users");
@@ -22,7 +26,8 @@ namespace Meziantou.Framework;
 /// </example>
 public sealed partial class HttpClientMock : IAsyncDisposable
 {
-    private bool _running;
+    private readonly Lock _lock = new();
+    private Task? _runTask;
 
     /// <summary>Initializes a new instance of the <see cref="HttpClientMock"/> class.</summary>
     public HttpClientMock()
@@ -72,7 +77,17 @@ public sealed partial class HttpClientMock : IAsyncDisposable
     /// <param name="configureServices">An action to configure services.</param>
     public HttpClientMock(Action<ILoggingBuilder>? configureLogging, Action<IServiceCollection>? configureServices)
     {
-        var builder = WebApplication.CreateBuilder();
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            ContentRootPath = AppContext.BaseDirectory,
+            EnvironmentName = Environments.Production,
+        });
+
+        // The mock must not depend on ambient state, so the configuration of the host application
+        // ("appsettings.json", "ASPNETCORE_*"/"DOTNET_*" environment variables, command line) is discarded.
+        // Use configureServices to add the sources the mock actually needs.
+        builder.Configuration.Sources.Clear();
+
         builder.Services.Configure<ConsoleLifetimeOptions>(opts => opts.SuppressStatusMessages = true);
         builder.Services.AddHttpClient();
         builder.Services.AddSingleton<MatcherPolicy, SchemeMatcherPolicy>();
@@ -85,16 +100,18 @@ public sealed partial class HttpClientMock : IAsyncDisposable
 
         builder.WebHost.UseTestServer();
         Application = builder.Build();
-        Application.Use(async (context, next) =>
+        // WebApplication runs the routing middleware before any middleware added here, so the endpoint is already
+        // selected. Counting on the way in means a request is counted even when its handler throws, and that
+        // RequestCounter.Get() called from a handler includes the request being handled.
+        Application.Use((context, next) =>
         {
-            await next().ConfigureAwait(false);
             var counter = context.RequestServices.GetRequiredService<RequestCounter>();
             counter.IncrementTotal();
             counter.IncrementEndpoint(context);
+            return next();
         });
     }
 
-    /// <summary>Gets the underlying <see cref="WebApplication"/> instance.</summary>
     /// <summary>Gets the underlying <see cref="WebApplication"/> instance.</summary>
     public WebApplication Application { get; }
 
@@ -116,10 +133,17 @@ public sealed partial class HttpClientMock : IAsyncDisposable
 
     private void StartServer()
     {
-        if (!_running)
+        Task runTask;
+        lock (_lock)
         {
-            _running = true;
-            _ = Application.RunAsync();
+            runTask = _runTask ??= Application.RunAsync();
+        }
+
+        // The host disposes itself when startup fails. Observing the task reports the actual error instead of the
+        // ObjectDisposedException that using the disposed application would raise.
+        if (runTask.IsCompleted)
+        {
+            runTask.GetAwaiter().GetResult();
         }
     }
 
@@ -153,9 +177,6 @@ public sealed partial class HttpClientMock : IAsyncDisposable
     private static IEndpointConventionBuilder MapCore(string path, Func<string, IEndpointConventionBuilder> mapMethodFunc)
     {
         var (scheme, domain, pathOnly, query) = ParseUrl(path);
-        if (pathOnly is null)
-            throw new ArgumentException("path must be a URI with a path segment", nameof(path));
-
         var method = mapMethodFunc(pathOnly);
         var order = 0;
 
@@ -179,7 +200,7 @@ public sealed partial class HttpClientMock : IAsyncDisposable
         method.WithOrder(order);
         return method;
 
-        static (string? Scheme, string? Domain, string? Path, string? Query) ParseUrl(string path)
+        static (string? Scheme, string? Domain, string Path, string? Query) ParseUrl(string path)
         {
             if (path.Contains('#', StringComparison.Ordinal))
                 throw new ArgumentException("Fragment ('#') is not supported", nameof(path));

--- a/src/Meziantou.Framework.HttpClientMock/HttpMockServiceBuilder.cs
+++ b/src/Meziantou.Framework.HttpClientMock/HttpMockServiceBuilder.cs
@@ -35,4 +35,15 @@ public sealed class HttpMockServiceBuilder
         Builder.AddMock<T>(mock);
         return this;
     }
+
+    /// <summary>
+    /// Throws an <see cref="InvalidOperationException"/> when an <see cref="HttpClient"/> is created for which no
+    /// mock is registered, instead of letting it send real HTTP requests.
+    /// </summary>
+    /// <returns>The builder for chaining additional calls.</returns>
+    public HttpMockServiceBuilder ThrowOnUnknownHttpClient()
+    {
+        Builder.ThrowOnUnknownHttpClient = true;
+        return this;
+    }
 }

--- a/src/Meziantou.Framework.HttpClientMock/Internals/ForwardResult.cs
+++ b/src/Meziantou.Framework.HttpClientMock/Internals/ForwardResult.cs
@@ -1,10 +1,27 @@
+using System.Collections.Frozen;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
 
 namespace Meziantou.Framework.Internals;
 
 internal sealed class ForwardResult(HttpClient? httpClient) : IResult
 {
+    // Hop-by-hop headers are scoped to a single connection and must not be forwarded (RFC 9110 §7.6.1)
+    private static readonly FrozenSet<string> HopByHopHeaders = new[]
+    {
+        HeaderNames.Connection,
+        HeaderNames.KeepAlive,
+        HeaderNames.ProxyAuthenticate,
+        HeaderNames.ProxyAuthorization,
+        "Proxy-Connection",
+        HeaderNames.TE,
+        HeaderNames.Trailer,
+        HeaderNames.TransferEncoding,
+        HeaderNames.Upgrade,
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
     public Task ExecuteAsync(HttpContext context)
     {
         return ExecuteAsyncCore(context, httpClient);
@@ -18,23 +35,54 @@ internal sealed class ForwardResult(HttpClient? httpClient) : IResult
 
         var method = HttpMethod.Parse(context.Request.Method);
         var url = $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path}{request.QueryString}";
-        using var requestMessage = new HttpRequestMessage(method, url)
+        using var requestMessage = new HttpRequestMessage(method, url);
+        if (HasBody(request))
         {
-            Content = new StreamContent(context.Request.Body),
-        };
+            requestMessage.Content = new StreamContent(context.Request.Body);
+        }
 
         foreach (var header in request.Headers)
         {
-            requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.AsEnumerable());
+            if (HopByHopHeaders.Contains(header.Key))
+                continue;
+
+            var values = header.Value.AsEnumerable();
+
+            // Content headers ("Content-Type", "Content-Length", ...) are rejected by HttpRequestMessage.Headers,
+            // they must be set on the content instead
+            if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, values))
+            {
+                requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, values);
+            }
         }
 
         using var response = await localHttpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, context.RequestAborted).ConfigureAwait(false);
         context.Response.StatusCode = (int)response.StatusCode;
-        foreach (var header in response.Headers)
-        {
-            context.Response.Headers[header.Key] = header.Value.ToArray();
-        }
+        CopyResponseHeaders(response.Headers, context.Response);
+        CopyResponseHeaders(response.Content.Headers, context.Response);
 
         await response.Content.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
+
+        static bool HasBody(HttpRequest request)
+        {
+            return request.ContentLength > 0
+                || request.ContentType is not null
+                || request.Headers.ContainsKey(HeaderNames.TransferEncoding);
+        }
+
+        static void CopyResponseHeaders(HttpHeaders headers, HttpResponse response)
+        {
+            foreach (var header in headers)
+            {
+                if (HopByHopHeaders.Contains(header.Key))
+                    continue;
+
+                // The length is recomputed by the server for the body it actually writes
+                if (string.Equals(header.Key, HeaderNames.ContentLength, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                response.Headers[header.Key] = header.Value.ToArray();
+            }
+        }
     }
 }

--- a/src/Meziantou.Framework.HttpClientMock/Internals/QueryStringMatcherPolicy.cs
+++ b/src/Meziantou.Framework.HttpClientMock/Internals/QueryStringMatcherPolicy.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.Extensions.Primitives;
 
 namespace Meziantou.Framework.Internals;
 
@@ -34,7 +35,7 @@ internal sealed class QueryStringMatcherPolicy : MatcherPolicy, IEndpointSelecto
         for (var i = 0; i < candidates.Count; i++)
         {
             var metadata = candidates[i].Endpoint?.Metadata.GetMetadata<QueryStringMetadata>();
-            if (metadata == null || metadata.QueryString is null)
+            if (metadata?.QueryString is null)
                 continue;
 
             if (!candidates.IsValidCandidate(i))
@@ -65,13 +66,24 @@ internal sealed class QueryStringMatcherPolicy : MatcherPolicy, IEndpointSelecto
             if (values.Count != kvp.Value.Count)
                 return false;
 
-            foreach (var value in kvp.Value)
-            {
-                if (!values.Contains(value, StringComparer.Ordinal))
-                    return false;
-            }
+            if (!SameValues(kvp.Value, values))
+                return false;
         }
 
         return true;
+    }
+
+    // Values of a repeated key are compared without taking their order into account, but a value expected twice
+    // must also be present twice
+    private static bool SameValues(StringValues expected, StringValues actual)
+    {
+        if (expected.Count == 1)
+            return string.Equals(expected[0], actual[0], StringComparison.Ordinal);
+
+        var expectedValues = expected.ToArray();
+        var actualValues = actual.ToArray();
+        Array.Sort(expectedValues, StringComparer.Ordinal);
+        Array.Sort(actualValues, StringComparer.Ordinal);
+        return expectedValues.AsSpan().SequenceEqual(actualValues);
     }
 }

--- a/src/Meziantou.Framework.HttpClientMock/Internals/SchemeMatcherPolicy.cs
+++ b/src/Meziantou.Framework.HttpClientMock/Internals/SchemeMatcherPolicy.cs
@@ -34,14 +34,14 @@ internal sealed class SchemeMatcherPolicy : MatcherPolicy, IEndpointSelectorPoli
         for (var i = 0; i < candidates.Count; i++)
         {
             var metadata = candidates[i].Endpoint?.Metadata.GetMetadata<SchemeMetadata>();
-            if (metadata == null || metadata.Scheme is null)
+            if (metadata?.Scheme is null)
                 continue;
 
             if (!candidates.IsValidCandidate(i))
                 continue;
 
-            var httpMethod = httpContext.Request.Scheme;
-            if (!string.Equals(httpMethod, metadata.Scheme, StringComparison.OrdinalIgnoreCase))
+            var scheme = httpContext.Request.Scheme;
+            if (!string.Equals(scheme, metadata.Scheme, StringComparison.OrdinalIgnoreCase))
             {
                 candidates.SetValidity(i, false);
                 continue;

--- a/src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj
+++ b/src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj
@@ -3,10 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Allow to create mocks for HttpClient</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../common/TypeNameHelper.cs" Link="TypeNameHelper.cs" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />

--- a/src/Meziantou.Framework.HttpClientMock/MockHttpMessageHandlerBuilder.cs
+++ b/src/Meziantou.Framework.HttpClientMock/MockHttpMessageHandlerBuilder.cs
@@ -1,40 +1,70 @@
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework;
 
 internal sealed class MockHttpMessageHandlerBuilder : HttpMessageHandlerBuilder, IDisposable
 {
-    private readonly ConcurrentDictionary<string, HttpMessageHandler> _handlers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HttpMessageHandler> _handlers = new(StringComparer.Ordinal);
+    private HttpMessageHandler? _primaryHandler;
+    private HttpMessageHandler? _ownedPrimaryHandler;
+
+    public bool ThrowOnUnknownHttpClient { get; set; }
 
     public void AddMock(HttpClientMock mock)
     {
+        ArgumentNullException.ThrowIfNull(mock);
+
         _handlers[""] = mock.CreateHttpMessageHandler();
     }
 
     public void AddMock(string name, HttpClientMock mock)
     {
         ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(mock);
 
         _handlers[name] = mock.CreateHttpMessageHandler();
     }
 
     public void AddMock<T>(HttpClientMock mock)
     {
-        _handlers[typeof(T).Name] = mock.CreateHttpMessageHandler();
+        ArgumentNullException.ThrowIfNull(mock);
+
+        // Must match the name computed by AddHttpClient<T>(), which is not typeof(T).Name for generic types
+        _handlers[TypeNameHelper.GetTypeDisplayName(typeof(T), fullName: false)] = mock.CreateHttpMessageHandler();
     }
 
     public override string Name { get; set; } = "";
-    public override HttpMessageHandler PrimaryHandler { get; set; } = new HttpClientHandler();
+
+    public override HttpMessageHandler PrimaryHandler
+    {
+        // Only created when no mock matches, so the common case doesn't allocate a real handler
+        get => _primaryHandler ??= _ownedPrimaryHandler = new HttpClientHandler();
+        set => _primaryHandler = value;
+    }
+
     public override IList<DelegatingHandler> AdditionalHandlers { get; } = new List<DelegatingHandler>();
 
     public override HttpMessageHandler Build()
     {
-        if (Name is not null && _handlers.TryGetValue(Name, out var handler))
+        if (_handlers.TryGetValue(Name, out var handler))
             return CreateHandlerPipeline(handler, AdditionalHandlers);
+
+        if (ThrowOnUnknownHttpClient)
+            throw new InvalidOperationException($"No HttpClientMock is registered for the HttpClient '{FormatName(Name)}', so the request would be sent to the network. Register a mock for it using AddHttpClientMock, or stop calling ThrowOnUnknownHttpClient to allow real HTTP requests. Registered mocks: {FormatRegisteredNames()}");
 
         return CreateHandlerPipeline(PrimaryHandler, AdditionalHandlers);
     }
+
+    private string FormatRegisteredNames()
+    {
+        if (_handlers.Count == 0)
+            return "<none>";
+
+        return string.Join(", ", _handlers.Keys.Order(StringComparer.Ordinal).Select(FormatName));
+    }
+
+    private static string FormatName(string name) => name.Length == 0 ? "<default>" : name;
 
     public void Dispose()
     {
@@ -42,5 +72,7 @@ internal sealed class MockHttpMessageHandlerBuilder : HttpMessageHandlerBuilder,
         {
             handler.Dispose();
         }
+
+        _ownedPrimaryHandler?.Dispose();
     }
 }

--- a/src/Meziantou.Framework.HttpClientMock/RequestCounter.cs
+++ b/src/Meziantou.Framework.HttpClientMock/RequestCounter.cs
@@ -11,9 +11,11 @@ public sealed class RequestCounter(IHttpContextAccessor httpContextAccessor)
     private readonly ConcurrentDictionary<Key, long> _endpointCounter = [];
 
     /// <summary>Gets the total number of requests made to the mock server.</summary>
+    /// <remarks>A request is counted before its handler runs, so reading this from a handler includes the request being handled.</remarks>
     public long TotalCount => _totalCount;
 
     /// <summary>Gets the number of requests made to the current endpoint.</summary>
+    /// <remarks>A request is counted before its handler runs, so calling this from a handler includes the request being handled.</remarks>
     /// <returns>The number of requests made to the current endpoint.</returns>
     public long Get()
     {

--- a/src/Meziantou.Framework.HttpClientMock/ResultExtensions.cs
+++ b/src/Meziantou.Framework.HttpClientMock/ResultExtensions.cs
@@ -6,9 +6,6 @@ namespace Meziantou.Framework;
 /// <summary>
 /// Extension methods for creating <see cref="IResult"/> instances with various content types.
 /// </summary>
-/// <summary>
-/// Extension methods for creating <see cref="IResult"/> instances with various content types.
-/// </summary>
 public static class ResultExtensions
 {
     /// <summary>Creates a result that returns raw JSON content.</summary>

--- a/src/Meziantou.Framework.HttpClientMock/ServicesCollectionExtensions.cs
+++ b/src/Meziantou.Framework.HttpClientMock/ServicesCollectionExtensions.cs
@@ -6,9 +6,6 @@ namespace Meziantou.Framework;
 /// <summary>
 /// Extension methods for registering <see cref="HttpClientMock"/> instances with the service collection.
 /// </summary>
-/// <summary>
-/// Extension methods for registering <see cref="HttpClientMock"/> instances with the service collection.
-/// </summary>
 public static class ServicesCollectionExtensions
 {
     /// <summary>Registers HTTP client mocks in the service collection.</summary>
@@ -17,6 +14,8 @@ public static class ServicesCollectionExtensions
     /// <returns>The service collection for chaining additional calls.</returns>
     public static IServiceCollection AddHttpClientMock(this IServiceCollection services, Action<HttpMockServiceBuilder> builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         return AddHttpClientMock(services, (_, b) => builder(b));
     }
 
@@ -26,10 +25,13 @@ public static class ServicesCollectionExtensions
     /// <returns>The service collection for chaining additional calls.</returns>
     public static IServiceCollection AddHttpClientMock(this IServiceCollection services, Action<IServiceProvider, HttpMockServiceBuilder> builder)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
+
         services.AddTransient<HttpMessageHandlerBuilder>(serviceProvider =>
         {
             var instance = new HttpMockServiceBuilder();
-            builder?.Invoke(serviceProvider, instance);
+            builder.Invoke(serviceProvider, instance);
             return instance.Builder;
         });
 

--- a/src/Meziantou.Framework.HttpClientMock/readme.md
+++ b/src/Meziantou.Framework.HttpClientMock/readme.md
@@ -29,6 +29,7 @@ mock.ForwardUnknownRequestsToUpstream();
 ````
 
 The `RequestCounter` class allows you to count the number of requests per endpoint. You can use it to test if a specific endpoint has been called.
+A request is counted before its handler runs, so `Get()` includes the request being handled, and a request whose handler throws is still counted.
 
 ````c#
 mock.MapGet("/counter", (RequestCounter counter) => counter.Get());
@@ -67,6 +68,15 @@ There are multiple ways to use the mock depending on your needs:
         .ConfigurePrimaryHttpMessageHandler(() => mock.CreateHttpMessageHandler());
     ````
 
+    By default, an `HttpClient` for which no mock is registered sends real HTTP requests. Use `ThrowOnUnknownHttpClient`
+    to fail instead, so a client you forgot to mock cannot silently reach the network.
+
+    ````c#
+    services.AddHttpClientMock(builder => builder
+        .AddHttpClientMock(mock)
+        .ThrowOnUnknownHttpClient());
+    ````
+
 # Use resiliency policies when forwarding requests
 
 When forwarding requests to an upstream server, you can use resiliency policies to handle transient failures. You can use the `Microsoft.Extensions.Http.Resilience` package.
@@ -88,7 +98,9 @@ You can forward logs to the xUnit `ITestOutputHelper`. This can be useful to deb
    await using var mock = new HttpClientMock(loggerProvider);
    ````
 
-If you need more controls about logging, you can use the `configureLogging` parameter of the constructor.
+If you need more controls about logging, you can use the `configureLogging` parameter of the constructor. Note that a bare
+`null` is ambiguous between the constructor overloads, so use a named argument to select one
+(`new HttpClientMock(configureLogging: null, configureServices: ...)`).
 
 ````c#
 using var loggerProvider = new XUnitLoggerProvider(testOutputHelper);
@@ -96,5 +108,18 @@ await using var mock = new HttpClientMock(logs =>
 {
     logs.AddProvider(loggerProvider);
     logs.SetMinimumLevel(LogLevel.Trace);
+});
+````
+
+# Configuration
+
+The mock does not read the configuration of the host application: `appsettings.json`, the `ASPNETCORE_*`/`DOTNET_*`
+environment variables and the command line are ignored, so a mock behaves the same on any machine. Use the
+`configureServices` parameter to add the configuration sources you need.
+
+````c#
+await using var mock = new HttpClientMock(configureLogging: null, configureServices: services =>
+{
+    services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(...).Build());
 });
 ````

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/MockTests.cs
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/MockTests.cs
@@ -1,10 +1,13 @@
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 using Meziantou.Extensions.Logging.InMemory;
 using Meziantou.Extensions.Logging.Xunit.v3;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.Tests;
@@ -34,14 +37,15 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
     {
         await using var mock1 = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
         mock1.MapGet("https://example.com/", () => "test");
-        using var mock1Client = mock1.CreateHttpClient();
 
         await using var mock2 = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper), services =>
         {
-            services.AddSingleton<IHttpClientFactory>(new CustomHttpFactory(mock1));
+            // ForwardToUpstream() without an explicit client resolves IHttpClientFactory. Replacing the primary
+            // handler of every client it creates keeps the request inside mock1 instead of reaching the network.
+            services.ConfigureHttpClientDefaults(builder => builder.ConfigurePrimaryHttpMessageHandler(mock1.CreateHttpMessageHandler));
         });
 
-        mock2.MapGet("https://example.com/", () => Results.Extensions.ForwardToUpstream(mock1Client));
+        mock2.MapGet("https://example.com/", () => Results.Extensions.ForwardToUpstream());
 
         using var client = mock2.CreateHttpClient();
         var value = await client.GetStringAsync("https://example.com/", XunitCancellationToken);
@@ -87,10 +91,10 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
         mock.MapGet("/current", (RequestCounter counter) => counter.Get());
         mock.MapGet("/total", (RequestCounter counter) => counter.TotalCount);
 
-        await ExpectString(mock, "/current", "0");
         await ExpectString(mock, "/current", "1");
-        await ExpectString(mock, "/total", "2");
         await ExpectString(mock, "/current", "2");
+        await ExpectString(mock, "/total", "3");
+        await ExpectString(mock, "/current", "3");
     }
 
     [Fact]
@@ -239,6 +243,221 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
         Assert.NotEmpty(loggerProvider.Logs);
     }
 
+
+    [Fact]
+    public async Task RequestCounter_CountsRequestWhoseHandlerThrows()
+    {
+        await using var mock = new HttpClientMock();
+        mock.MapGet("/boom", void () => throw new InvalidOperationException("boom"));
+        mock.MapGet("/total", (RequestCounter counter) => counter.TotalCount);
+
+        using var client = mock.CreateHttpClient();
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync("/boom", XunitCancellationToken));
+
+        await ExpectString(mock, "/total", "2");
+    }
+
+    [Fact]
+    public async Task Forward_PreservesRequestContentHeaders()
+    {
+        await using var upstream = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        upstream.MapPost("https://example.com/echo", async (HttpContext context) =>
+        {
+            using var reader = new StreamReader(context.Request.Body);
+            var body = await reader.ReadToEndAsync(context.RequestAborted);
+            return Results.Text(context.Request.ContentType + "|" + body);
+        });
+        using var upstreamClient = upstream.CreateHttpClient();
+
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.ForwardUnknownRequestsToUpstream(upstreamClient);
+
+        using var client = mock.CreateHttpClient();
+        using var response = await client.PostAsJsonAsync("https://example.com/echo", new { id = 1 }, XunitCancellationToken);
+        var content = await response.Content.ReadAsStringAsync(XunitCancellationToken);
+        Assert.Equal("""application/json; charset=utf-8|{"id":1}""", content);
+    }
+
+    [Fact]
+    public async Task Forward_PreservesResponseContentHeaders()
+    {
+        await using var upstream = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        upstream.MapGet("https://example.com/json", () => Results.Extensions.RawJson("""{"id":1}"""));
+        using var upstreamClient = upstream.CreateHttpClient();
+
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.ForwardUnknownRequestsToUpstream(upstreamClient);
+
+        using var client = mock.CreateHttpClient();
+        using var response = await client.GetAsync("https://example.com/json", XunitCancellationToken);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var data = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>(XunitCancellationToken);
+        Assert.NotNull(data);
+        Assert.Contains("id", data);
+    }
+
+    [Fact]
+    public async Task Forward_GetRequest_HasNoBody()
+    {
+        await using var upstream = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        upstream.MapGet("https://example.com/probe", (HttpContext context) =>
+            (context.Request.ContentLength?.ToString(CultureInfo.InvariantCulture) ?? "<null>") + "|" + (context.Request.ContentType ?? "<null>"));
+        using var upstreamClient = upstream.CreateHttpClient();
+
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.ForwardUnknownRequestsToUpstream(upstreamClient);
+
+        await ExpectString(mock, "https://example.com/probe", "<null>|<null>");
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    [InlineData("DELETE")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public async Task Map_AllVerbs(string verb)
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.MapGet("/", () => "GET");
+        mock.MapPost("/", () => "POST");
+        mock.MapPut("/", () => "PUT");
+        mock.MapPatch("/", () => "PATCH");
+        mock.MapDelete("/", () => "DELETE");
+        mock.MapHead("/", () => "HEAD");
+        mock.MapOptions("/", () => "OPTIONS");
+
+        using var client = mock.CreateHttpClient();
+        using var request = new HttpRequestMessage(HttpMethod.Parse(verb), "/");
+        using var response = await client.SendAsync(request, XunitCancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        // TestServer does not strip the body of a HEAD response the way a real server does
+        var content = await response.Content.ReadAsStringAsync(XunitCancellationToken);
+        Assert.Equal(verb, content);
+    }
+
+    [Fact]
+    public async Task Map_RequestDelegate()
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.MapPost("/", context => context.Response.WriteAsync("delegate", context.RequestAborted));
+
+        using var client = mock.CreateHttpClient();
+        using var response = await client.PostAsync("/", content: null, XunitCancellationToken);
+        Assert.Equal("delegate", await response.Content.ReadAsStringAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task MapGet_RouteParameter()
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.MapGet("/todos/{id}", (int id) => id.ToString(CultureInfo.InvariantCulture));
+
+        await ExpectString(mock, "/todos/42", "42");
+    }
+
+    [Fact]
+    public async Task MapGet_QueryString_RepeatedValues()
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.MapGet("/", () => "fallback");
+        mock.MapGet("/?a=1&a=1", () => "match");
+
+        await ExpectString(mock, "/?a=1&a=1", "match");
+        await ExpectString(mock, "/?a=1&a=2", "fallback");
+    }
+
+    [Fact]
+    public async Task Extensions_RawXml()
+    {
+        await using var mock = new HttpClientMock();
+        mock.MapGet("/", () => Results.Extensions.RawXml("<root></root>"));
+
+        using var client = mock.CreateHttpClient();
+        using var response = await client.GetAsync("/", XunitCancellationToken);
+        Assert.Equal("text/xml", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("<root></root>", await response.Content.ReadAsStringAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task NamedHttpClientMock()
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.Application.MapGet("/", () => "named");
+
+        var services = new ServiceCollection();
+        services.AddHttpClient("api");
+        services.AddHttpClientMock(builder => builder.AddHttpClientMock("api", mock));
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        using var client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("api");
+        Assert.Equal("named", await client.GetStringAsync("https://example.com/", XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task GenericTypedHttpClientMock()
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.Application.MapGet("/", () => "generic");
+
+        var services = new ServiceCollection();
+        services.AddHttpClient<GenericClient<int>>();
+        services.AddHttpClientMock(builder => builder.AddHttpClientMock<GenericClient<int>>(mock));
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<GenericClient<int>>();
+        Assert.Equal("generic", await client.GetStringAsync("https://example.com/"));
+    }
+
+    [Fact]
+    public async Task ThrowOnUnknownHttpClient()
+    {
+        await using var mock = new HttpClientMock(XUnitLogger.CreateLogger(testOutputHelper));
+        mock.Application.MapGet("/", () => "mocked");
+
+        var services = new ServiceCollection().AddHttpClient();
+        services.AddHttpClient<SampleClient>();
+        services.AddHttpClientMock(builder => builder
+            .AddHttpClientMock(mock)
+            .ThrowOnUnknownHttpClient());
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        Assert.Equal("mocked", await serviceProvider.GetRequiredService<HttpClient>().GetStringAsync("https://example.com/", XunitCancellationToken));
+
+        var exception = Record.Exception(() => serviceProvider.GetRequiredService<SampleClient>());
+        Assert.NotNull(exception);
+        Assert.Contains(nameof(SampleClient), exception.ToString());
+    }
+
+    [Fact]
+    public async Task StartupFailure_ReportsActualError()
+    {
+        await using var mock = new HttpClientMock(configureLogging: null, configureServices: services => services.AddHostedService<ThrowingHostedService>());
+        mock.MapGet("/", () => "ok");
+
+        var exception = Record.Exception(() => mock.CreateHttpClient().Dispose());
+        Assert.NotNull(exception);
+        Assert.Equal("startup boom", exception.Message);
+    }
+
+    [Fact]
+    public async Task HostConfiguration_IsIsolatedFromTheAmbientEnvironment()
+    {
+        await using var mock = new HttpClientMock();
+
+        Assert.Equal(Environments.Production, mock.Application.Environment.EnvironmentName);
+        Assert.Equal(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar),
+            mock.Application.Environment.ContentRootPath.TrimEnd(Path.DirectorySeparatorChar));
+
+        var configuration = (IConfigurationRoot)mock.Application.Configuration;
+        Assert.Empty(configuration.Providers);
+    }
+
     private static async Task ExpectString(HttpClientMock mock, string url, string expectedValue)
     {
         using var client = mock.CreateHttpClient();
@@ -258,9 +477,15 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
         public Task<string> GetStringAsync(string url) => httpClient.GetStringAsync(url, TestContext.Current.CancellationToken);
     }
 
-    private sealed class CustomHttpFactory(HttpClientMock mock) : IHttpClientFactory
+    private sealed class GenericClient<T>(HttpClient httpClient)
     {
-        public HttpClient CreateClient(string name) => mock.CreateHttpClient();
+        public Task<string> GetStringAsync(string url) => httpClient.GetStringAsync(url, TestContext.Current.CancellationToken);
+    }
+
+    private sealed class ThrowingHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken) => throw new InvalidOperationException("startup boom");
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
 }


### PR DESCRIPTION
An audit of `Meziantou.Framework.HttpClientMock` surfaced several defects that share a failure mode: the mock quietly does the wrong thing, so a test passes (or reaches the network) while appearing to exercise something it doesn't. Every fix below has a regression test that fails without it.

## High

**Forwarding dropped every content header, in both directions** — `Internals/ForwardResult.cs`

`TryAddWithoutValidation` on `HttpRequestMessage.Headers` rejects content headers, so `Content-Type` never reached the upstream server; the response loop only read `HttpResponseMessage.Headers`, so the upstream's `Content-Type` never reached the caller. Reproduced: a forwarded POST arrives upstream with `ContentType == null` (a real upstream with a `[FromBody]` parameter answers 415), and a forwarded JSON response comes back with no content type, so `ReadFromJsonAsync` throws.

The `Content-Encoding` case was worse than a hard failure: the header was dropped while the gzip body was forwarded byte-for-byte, so the caller silently read compressed bytes as text.

Content headers now go on the content, response content headers are copied, hop-by-hop headers are filtered both ways (they were previously forwarded, which can corrupt response framing), and the server recomputes `Content-Length`. A forwarded GET no longer carries a body.

**Generic typed clients silently bypassed the mock and hit the real network** — `MockHttpMessageHandlerBuilder.cs`

`AddMock<T>` keyed handlers on `typeof(T).Name`, but `IHttpClientFactory` names typed clients with `TypeNameHelper.GetTypeDisplayName(fullName: false)`. These agree for ordinary and nested types but diverge for generics (``GenericClient`1`` vs `GenericClient<int>`), so the lookup missed and `Build()` fell back to a real `HttpClientHandler`. Reproduced as a genuine `Connection refused` on an outbound socket — the test believes it is mocked while making a real request, possibly authenticated, from a test run.

Now uses the shared `common/TypeNameHelper.cs`. Added `ThrowOnUnknownHttpClient()` (opt-in) so an unmatched client name fails loudly rather than reaching the network.

## Medium

- **Startup failures reported `ObjectDisposedException`** — `RunAsync`'s task was discarded; on failure the host disposes itself and the real exception stayed on the unobserved task. Reproduced: a hosted service throwing `"startup boom"` produced `Cannot access a disposed object.`, with the actual message nowhere. The task is now kept and its exception rethrown.
- **Test gaps** that lined up with the defects: the forwarding tests all asserted on plain-text bodies, the one shape the header bug didn't break; `Results_ForwardToUpstream_HttpClientFactory` registered an `IHttpClientFactory` it then bypassed by passing an explicit client, so that branch had no coverage; only `MapGet` of the fourteen generated `Map*` methods was exercised.

## Behavior changes

Two changes affect existing users, hence the minor bump to **2.1.0**:

- **Host configuration is isolated.** `appsettings.json`, `ASPNETCORE_*`/`DOTNET_*` and the command line are discarded, and the environment and content root are pinned, so a mock behaves the same on any machine. Previously a stray `Logging` section in an `appsettings.json` copied to the test output directory could override the mock's own logging config. Callers needing configuration add sources through `configureServices`.
- **`RequestCounter` counts on the way in.** `Get()` now includes the request being handled (first call returns `1`, not `0`), which also means a request whose handler throws is counted — previously `TotalCount` was `0` after a failing request, exactly when you'd be debugging. `MockTests.RequestCounter` updated accordingly.

## Also fixed

A query-string match where a route expecting `?a=1&a=1` matched a request for `?a=1&a=2`; a per-builder `HttpClientHandler` allocated eagerly and never disposed; duplicated `<summary>` blocks; an XML doc example that didn't compile (`using` on an `IAsyncDisposable`); an unreachable branch; and a few `== null` / missing-guard convention violations.

## Not fixed

`new HttpClientMock(null)` remains ambiguous (CS0121). Nullable annotations don't participate in overload resolution, so the three single-argument constructors all stay candidates. Adding an `Action<IServiceCollection>?` overload would make it worse — every existing `new HttpClientMock(builder => ...)` call would become ambiguous too — and removing constructors is breaking. Documented on the type and in the readme: use a named argument.

## Notes for the reviewer

- Public API change is additive: `HttpMockServiceBuilder.ThrowOnUnknownHttpClient()`. `ref/` regenerated.
- `Results_ForwardToUpstream_HttpClientFactory` now replaces the primary handler of the *real* `DefaultHttpClientFactory` instead of substituting the interface. This covers more (the genuine factory path in `ForwardResult`) and makes it structurally impossible for the test to reach the network, rather than relying on a DI registration-order subtlety.
- Verified: 66/66 tests pass on `net10.0` and `net11.0`; `Release` + `IsOfficialBuild` build clean with `TreatsWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` reports no pending changes.
