### PR TITLE
Fix middleware pipeline diagnostics and NoCacheMiddleware defects

### DIFF
--- a/ref/Meziantou.AspNetCore.cs
+++ b/ref/Meziantou.AspNetCore.cs
@@ -4,6 +4,11 @@
 
 namespace Meziantou.AspNetCore
 {
+    public static class NoCacheApplicationBuilderExtensions
+    {
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseNoCache(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) => throw null;
+    }
+
     public sealed class NoCacheMiddleware
     {
         public NoCacheMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -12,21 +17,15 @@ namespace Meziantou.AspNetCore
 }
 namespace Meziantou.AspNetCore.Diagnostics
 {
-    public sealed class MiddlewarePipelineDebugEndpoint : System.IEquatable<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint>
+    public sealed class MiddlewarePipelineDebugEndpoint
     {
         [System.Text.Json.Serialization.JsonIgnore]
-        public Microsoft.AspNetCore.Http.Endpoint Endpoint { get => throw null; init { } }
+        public Microsoft.AspNetCore.Http.Endpoint? Endpoint { get => throw null; init { } }
         public string? DisplayName { get => throw null; init { } }
         public required string EndpointType { get => throw null; init { } }
         public string? RoutePattern { get => throw null; init { } }
         public int? Order { get => throw null; init { } }
         public required System.Collections.Generic.IReadOnlyList<string> HttpMethods { get => throw null; init { } }
-        public override string ToString() => throw null;
-        public static bool operator !=(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint? right) => throw null;
-        public static bool operator ==(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint? right) => throw null;
-        public override int GetHashCode() => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public bool Equals(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint? other) => throw null;
     }
 
     public sealed class MiddlewarePipelineDebugInfoProvider
@@ -35,41 +34,25 @@ namespace Meziantou.AspNetCore.Diagnostics
         public Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot GetSnapshot() => throw null;
     }
 
-    public sealed class MiddlewarePipelineDebugMiddleware : System.IEquatable<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware>
+    public sealed class MiddlewarePipelineDebugMiddleware
     {
         public required string Name { get => throw null; init { } }
-        public required string DelegateType { get => throw null; init { } }
-        public required string DelegateMethod { get => throw null; init { } }
+        public string? DelegateType { get => throw null; init { } }
+        public string? DelegateMethod { get => throw null; init { } }
         public required System.Collections.Generic.IReadOnlyList<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline> Branches { get => throw null; init { } }
-        public override string ToString() => throw null;
-        public static bool operator !=(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware? right) => throw null;
-        public static bool operator ==(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware? right) => throw null;
-        public override int GetHashCode() => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public bool Equals(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware? other) => throw null;
     }
 
-    public sealed class MiddlewarePipelineDebugPipeline : System.IEquatable<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline>
+    public sealed class MiddlewarePipelineDebugPipeline
     {
         public required System.Collections.Generic.IReadOnlyList<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugMiddleware> Middlewares { get => throw null; init { } }
-        public override string ToString() => throw null;
-        public static bool operator !=(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline? right) => throw null;
-        public static bool operator ==(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline? right) => throw null;
-        public override int GetHashCode() => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public bool Equals(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline? other) => throw null;
     }
 
-    public sealed class MiddlewarePipelineDebugSnapshot : System.IEquatable<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot>
+    public sealed class MiddlewarePipelineDebugSnapshot
     {
         public required Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugPipeline Pipeline { get => throw null; init { } }
+        public required bool IsPipelineCaptured { get => throw null; init { } }
         public required System.Collections.Generic.IReadOnlyList<Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugEndpoint> Endpoints { get => throw null; init { } }
         public override string ToString() => throw null;
-        public static bool operator !=(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot? right) => throw null;
-        public static bool operator ==(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot? left, Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot? right) => throw null;
-        public override int GetHashCode() => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public bool Equals(Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot? other) => throw null;
     }
 
     public static class MiddlewarePipelineDebuggingServiceCollectionExtensions
@@ -81,6 +64,7 @@ namespace Meziantou.AspNetCore.Diagnostics
     {
         public static Meziantou.AspNetCore.Diagnostics.MiddlewarePipelineDebugSnapshot GetMiddlewarePipelineDebugSnapshot(this Microsoft.AspNetCore.Builder.WebApplication app) => throw null;
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method maps a delegate endpoint, which may use reflection and is not trim-safe.")]
-        public static Microsoft.AspNetCore.Builder.RouteHandlerBuilder? MapMiddlewarePipelineDebugEndpoint(this Microsoft.AspNetCore.Builder.WebApplication app, string pattern = "/_debug/pipeline", bool developmentOnly = true) => throw null;
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("This method maps a delegate endpoint that serializes the snapshot with reflection-based JSON serialization.")]
+        public static Microsoft.AspNetCore.Builder.RouteHandlerBuilder MapMiddlewarePipelineDebugEndpoint(this Microsoft.AspNetCore.Builder.WebApplication app, string pattern = "/_debug/pipeline", bool developmentOnly = true) => throw null;
     }
 }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewareDescriptor.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewareDescriptor.cs
@@ -4,9 +4,11 @@ internal sealed class MiddlewareDescriptor
 {
     public required string Name { get; init; }
 
-    public required string DelegateType { get; init; }
+    /// <summary>Null for synthetic entries that do not correspond to a registered delegate.</summary>
+    public string? DelegateType { get; init; }
 
-    public required string DelegateMethod { get; init; }
+    /// <summary>Null for synthetic entries that do not correspond to a registered delegate.</summary>
+    public string? DelegateMethod { get; init; }
 
     public List<MiddlewarePipelineDescriptor> Branches { get; } = [];
 }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureApplicationBuilder.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureApplicationBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
 using System.Collections;
 using System.Reflection;
 
@@ -13,6 +14,8 @@ internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplication
     private readonly IApplicationBuilder _innerBuilder;
     private readonly MiddlewarePipelineDescriptor _pipeline;
     private readonly Queue<MiddlewarePipelineDescriptor> _pendingBranches = new();
+    private readonly List<MiddlewarePipelineCaptureApplicationBuilder> _branchBuilders = [];
+    private bool _recording = true;
 
     public MiddlewarePipelineCaptureApplicationBuilder(IApplicationBuilder innerBuilder, MiddlewarePipelineDescriptor pipeline)
     {
@@ -32,22 +35,74 @@ internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplication
 
     public RequestDelegate Build() => _innerBuilder.Build();
 
+    /// <summary>
+    /// Stops recording, so registrations made while the pipeline is being built are not reported as middleware the
+    /// application registered.
+    /// </summary>
+    /// <remarks>
+    /// Several framework helpers call <see cref="Use"/> or <see cref="New"/> from inside the
+    /// <see cref="Func{RequestDelegate, RequestDelegate}"/> they registered, which runs during <see cref="Build"/>
+    /// rather than during configuration: <c>UseWhen</c> rejoins its branch with <c>branchBuilder.Run(main)</c>, and
+    /// <c>UseExceptionHandler</c>, <c>UsePathBase</c> and <c>UseStatusCodePagesWithReExecute</c> reach
+    /// <c>RerouteHelper.Reroute</c>, which calls <c>New()</c>. Recording those would add middleware the application
+    /// never registered and would append again on every additional <see cref="Build"/> call.
+    /// </remarks>
+    public void CloseRecording()
+    {
+        if (!_recording)
+            return;
+
+        _recording = false;
+
+        // A branch created without a following Use() has no middleware to attach to. Report it rather than dropping it.
+        if (_pendingBranches.Count > 0)
+        {
+            var descriptor = new MiddlewareDescriptor { Name = "(unattached branch)" };
+            while (_pendingBranches.TryDequeue(out var branch))
+            {
+                descriptor.Branches.Add(branch);
+            }
+
+            _pipeline.Middlewares.Add(descriptor);
+        }
+
+        foreach (var branchBuilder in _branchBuilders)
+        {
+            branchBuilder.CloseRecording();
+        }
+    }
+
     public IApplicationBuilder New()
     {
+        if (!_recording)
+            return _innerBuilder.New();
+
         var branch = new MiddlewarePipelineDescriptor();
         _pendingBranches.Enqueue(branch);
 
-        return new MiddlewarePipelineCaptureApplicationBuilder(_innerBuilder.New(), branch);
+        var branchBuilder = new MiddlewarePipelineCaptureApplicationBuilder(_innerBuilder.New(), branch);
+        _branchBuilders.Add(branchBuilder);
+
+        return branchBuilder;
     }
 
     public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
     {
         ArgumentNullException.ThrowIfNull(middleware);
 
+        if (!_recording)
+        {
+            _innerBuilder.Use(middleware);
+            return this;
+        }
+
+        var properties = Properties;
+        var hasExplicitName = properties.TryGetValue(NextMiddlewareNamePropertyName, out var explicitName);
+
         var descriptor = new MiddlewareDescriptor
         {
-            Name = GetMiddlewareName(Properties, middleware),
-            DelegateType = middleware.GetType().FullName ?? middleware.GetType().Name,
+            Name = GetMiddlewareName(hasExplicitName ? explicitName?.ToString() : null, middleware),
+            DelegateType = middleware.Method.DeclaringType?.FullName ?? middleware.GetType().Name,
             DelegateMethod = middleware.Method.Name,
         };
 
@@ -57,28 +112,27 @@ internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplication
         }
 
         _pipeline.Middlewares.Add(descriptor);
+
+        // Delegate before clearing the property so another builder decorating this one still observes it, then clear
+        // it so the name is not reused for the next middleware. The framework always sets it immediately before its
+        // own Use call, so nothing expects it to outlive this registration.
         _innerBuilder.Use(middleware);
+
+        if (hasExplicitName)
+        {
+            properties.Remove(NextMiddlewareNamePropertyName);
+        }
 
         return this;
     }
 
-    private static string GetMiddlewareName(IDictionary<string, object?> properties, Func<RequestDelegate, RequestDelegate> middleware)
+    private static string GetMiddlewareName(string? explicitName, Func<RequestDelegate, RequestDelegate> middleware)
     {
-        if (properties.TryGetValue(NextMiddlewareNamePropertyName, out var middlewareName))
-        {
-            properties.Remove(NextMiddlewareNamePropertyName);
-
-            var middlewareNameString = middlewareName?.ToString();
-            if (!string.IsNullOrWhiteSpace(middlewareNameString))
-            {
-                return middlewareNameString;
-            }
-        }
+        if (!string.IsNullOrWhiteSpace(explicitName))
+            return explicitName;
 
         if (TryGetMiddlewareTypeName(middleware.Target, out var middlewareTypeName))
-        {
             return middlewareTypeName;
-        }
 
         var declaringType = middleware.Method.DeclaringType?.FullName;
         if (declaringType is null)
@@ -89,99 +143,154 @@ internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplication
 
     private static bool TryGetMiddlewareTypeName(object? middlewareTarget, [NotNullWhen(true)] out string? middlewareTypeName)
     {
-        if (middlewareTarget is null)
+        if (middlewareTarget is not null)
         {
-            middlewareTypeName = null;
-            return false;
-        }
-
-        if (TryGetMiddlewareType(middlewareTarget, new HashSet<object>(ReferenceEqualityComparer.Instance), maxDepth: 6, out var middlewareType))
-        {
-            middlewareTypeName = middlewareType.FullName ?? middlewareType.Name;
-            return true;
+            // Best-effort discovery over framework internals: never let it prevent the application from starting.
+            try
+            {
+                if (new MiddlewareTypeProbe().TryResolve(middlewareTarget, depth: 0, out var middlewareType))
+                {
+                    middlewareTypeName = middlewareType.FullName ?? middlewareType.Name;
+                    return true;
+                }
+            }
+            catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+            {
+            }
         }
 
         middlewareTypeName = null;
         return false;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Middleware diagnostics uses reflective best-effort discovery over ASP.NET internals.")]
-    private static bool TryGetMiddlewareType(object value, HashSet<object> visited, int maxDepth, [NotNullWhen(true)] out Type? middlewareType)
+    /// <summary>
+    /// Walks a middleware registration delegate's captured state looking for the middleware type, with hard bounds so
+    /// that a hostile or merely unusual object graph cannot make application startup fail, hang or allocate without end.
+    /// </summary>
+    private sealed class MiddlewareTypeProbe
     {
-        if (maxDepth < 0)
+        private const int MaxDepth = 6;
+        private const int MaxNodes = 512;
+        private const int MaxItemsPerCollection = 32;
+
+        private readonly HashSet<object> _path = new(ReferenceEqualityComparer.Instance);
+        private int _remainingNodes = MaxNodes;
+
+        [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Middleware diagnostics uses reflective best-effort discovery over ASP.NET internals; an unresolved name degrades to the declaring type name.")]
+        public bool TryResolve(object value, int depth, [NotNullWhen(true)] out Type? middlewareType)
         {
             middlewareType = null;
-            return false;
-        }
 
-        if (!visited.Add(value))
-        {
-            middlewareType = null;
-            return false;
-        }
+            if (depth > MaxDepth || _remainingNodes <= 0)
+                return false;
 
-        if (value is Delegate { Target: not null } delegateValue && TryGetMiddlewareType(delegateValue.Target, visited, maxDepth - 1, out middlewareType))
-            return true;
+            // Tracked per path rather than globally: a node reached first by a long path must not be excluded from a
+            // later, shallower path that still has depth budget left to find the type below it.
+            if (!_path.Add(value))
+                return false;
 
-        var valueType = value.GetType();
-        if (value is IEnumerable enumerable and not string)
-        {
-            foreach (var item in enumerable)
+            _remainingNodes--;
+
+            try
             {
-                if (item is { } and not string && !item.GetType().IsValueType && TryGetMiddlewareType(item, visited, maxDepth - 1, out middlewareType))
+                if (value is Delegate { Target: not null } delegateValue && TryResolve(delegateValue.Target, depth + 1, out middlewareType))
                     return true;
+
+                var valueType = value.GetType();
+                if (IsTraversalBoundary(value))
+                    return false;
+
+                // Only indexable collections, and only a bounded prefix: enumerating an arbitrary IEnumerable can run
+                // application code, block, throw, or never end. The framework hops that matter (ApplicationBuilder's
+                // component list, endpoint data source lists, delegate factory arrays) are all ILists.
+                if (value is IList list)
+                {
+                    var count = Math.Min(list.Count, MaxItemsPerCollection);
+                    for (var i = 0; i < count; i++)
+                    {
+                        if (list[i] is { } item && item is not string && !item.GetType().IsValueType && TryResolve(item, depth + 1, out middlewareType))
+                            return true;
+                    }
+                }
+
+                if (!ShouldInspectObject(valueType))
+                    return false;
+
+                var middlewareField = valueType.GetField("_middleware", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                if (middlewareField?.FieldType == typeof(Type) && middlewareField.GetValue(value) is Type explicitMiddlewareType && IsMiddlewareType(explicitMiddlewareType))
+                {
+                    middlewareType = explicitMiddlewareType;
+                    return true;
+                }
+
+                foreach (var field in valueType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+                {
+                    if (field.GetValue(value) is not { } fieldValue)
+                        continue;
+
+                    if (fieldValue is Type fieldTypeValue)
+                    {
+                        if (IsMiddlewareType(fieldTypeValue))
+                        {
+                            middlewareType = fieldTypeValue;
+                            return true;
+                        }
+
+                        continue;
+                    }
+
+                    if (fieldValue is not string && !fieldValue.GetType().IsValueType && TryResolve(fieldValue, depth + 1, out middlewareType))
+                        return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                _path.Remove(value);
             }
         }
+    }
 
-        if (!ShouldInspectObject(valueType))
-        {
-            middlewareType = null;
+    /// <summary>
+    /// Objects that lead away from the middleware being registered and into the rest of the application.
+    /// </summary>
+    /// <remarks>
+    /// Following them produces names that belong to something else. A registration delegate capturing an
+    /// <see cref="IApplicationBuilder"/> reaches its component list and resolves an unrelated middleware: that is how
+    /// <c>UseWhen</c> ends up named after a middleware inside its own branch, and how the single component that carries
+    /// a whole <c>WebApplication</c> pipeline ends up named after the first middleware registered on it.
+    /// </remarks>
+    private static bool IsTraversalBoundary(object value)
+        => value is IApplicationBuilder or IServiceProvider or IEndpointRouteBuilder or IDictionary
+                 or EndpointDataSource or MiddlewarePipelineDescriptor or MiddlewareDescriptor;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Middleware diagnostics inspects middleware invoke methods by reflection; an unresolved name degrades to the declaring type name.")]
+    private static bool IsMiddlewareType(Type type)
+    {
+        // Every delegate declares Invoke, so the shape test below would accept any Type-valued field holding one.
+        if (type == typeof(RequestDelegate) || typeof(Delegate).IsAssignableFrom(type))
             return false;
-        }
 
-        var middlewareField = valueType.GetField("_middleware", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-        if (middlewareField?.FieldType == typeof(Type) && middlewareField.GetValue(value) is Type explicitMiddlewareType && IsMiddlewareType(explicitMiddlewareType))
-        {
-            middlewareType = explicitMiddlewareType;
+        if (typeof(IMiddleware).IsAssignableFrom(type))
             return true;
-        }
 
-        foreach (var field in valueType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+        foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            if (field.GetValue(value) is not { } fieldValue)
+            if (method.Name is not ("Invoke" or "InvokeAsync"))
                 continue;
 
-            if (fieldValue is Type fieldTypeValue && IsMiddlewareType(fieldTypeValue))
-            {
-                middlewareType = fieldTypeValue;
-                return true;
-            }
+            if (!typeof(Task).IsAssignableFrom(method.ReturnType))
+                continue;
 
-            if (fieldValue is not string && !fieldValue.GetType().IsValueType && TryGetMiddlewareType(fieldValue, visited, maxDepth - 1, out middlewareType))
+            var parameters = method.GetParameters();
+            if (parameters.Length > 0 && parameters[0].ParameterType == typeof(HttpContext))
                 return true;
         }
 
-        middlewareType = null;
         return false;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Middleware diagnostics inspects middleware invoke methods by reflection.")]
-    private static bool IsMiddlewareType(Type type)
-    {
-        if (type == typeof(RequestDelegate))
-            return false;
-
-        return type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null ||
-               type.GetMethod("InvokeAsync", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null;
-    }
-
     private static bool ShouldInspectObject(Type type)
-    {
-        var @namespace = type.Namespace;
-        if (@namespace is null)
-            return false;
-
-        return @namespace.StartsWith("Microsoft.AspNetCore", StringComparison.Ordinal) ||
-               @namespace.StartsWith("Meziantou", StringComparison.Ordinal);
-    }
+        => type.Namespace?.StartsWith("Microsoft.AspNetCore", StringComparison.Ordinal) is true;
 }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureStartupFilter.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureStartupFilter.cs
@@ -14,7 +14,14 @@ internal sealed class MiddlewarePipelineCaptureStartupFilter(MiddlewarePipelineC
         return app =>
         {
             _captureState.Reset();
-            next(new MiddlewarePipelineCaptureApplicationBuilder(app, _captureState.Root));
+
+            var captureBuilder = new MiddlewarePipelineCaptureApplicationBuilder(app, _captureState.Root);
+            next(captureBuilder);
+
+            // Everything the application registers has been observed. Stop recording before the pipeline is built, so
+            // build-time registrations are not reported, then publish an immutable tree for readers.
+            captureBuilder.CloseRecording();
+            _captureState.Publish();
         };
     }
 }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureState.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureState.cs
@@ -5,16 +5,28 @@ namespace Meziantou.AspNetCore.Diagnostics;
 
 internal sealed class MiddlewarePipelineCaptureState
 {
+    private static readonly MiddlewarePipelineDebugPipeline EmptyPipeline = new() { Middlewares = [] };
+
+    // Written once by the startup filter when configuration completes, read by any thread afterwards. Readers never
+    // touch Root, so appends during configuration cannot tear a read or throw "Collection was modified".
+    private volatile MiddlewarePipelineDebugPipeline? _publishedPipeline;
+
     public MiddlewarePipelineDescriptor Root { get; } = new();
 
     public void Reset()
     {
+        _publishedPipeline = null;
         Root.Middlewares.Clear();
     }
+
+    /// <summary>Projects the recorded pipeline into an immutable tree and publishes it to readers.</summary>
+    public void Publish() => _publishedPipeline = CreatePipeline(Root);
 
     public MiddlewarePipelineDebugSnapshot CreateSnapshot(IEnumerable<EndpointDataSource> endpointDataSources)
     {
         ArgumentNullException.ThrowIfNull(endpointDataSources);
+
+        var pipeline = _publishedPipeline;
 
         var endpoints = endpointDataSources
             .SelectMany(static dataSource => dataSource.Endpoints)
@@ -25,7 +37,8 @@ internal sealed class MiddlewarePipelineCaptureState
 
         return new MiddlewarePipelineDebugSnapshot
         {
-            Pipeline = CreatePipeline(Root),
+            Pipeline = pipeline ?? EmptyPipeline,
+            IsPipelineCaptured = pipeline is not null,
             Endpoints = endpoints,
         };
     }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugEndpoint.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugEndpoint.cs
@@ -4,11 +4,17 @@ using Microsoft.AspNetCore.Http;
 namespace Meziantou.AspNetCore.Diagnostics;
 
 /// <summary>Represents one endpoint in the endpoint data source collection.</summary>
-public sealed record MiddlewarePipelineDebugEndpoint
+public sealed class MiddlewarePipelineDebugEndpoint
 {
-    /// <summary>Gets the underlying endpoint instance.</summary>
+    /// <summary>
+    /// Gets the underlying endpoint instance, or <see langword="null"/> when the snapshot was deserialized.
+    /// </summary>
+    /// <remarks>
+    /// This property is excluded from serialization, so a snapshot obtained from the debug endpoint's JSON always has
+    /// it set to <see langword="null"/>. It is only populated on a snapshot created in the same process.
+    /// </remarks>
     [JsonIgnore]
-    public Endpoint Endpoint { get; init; } = default!;
+    public Endpoint? Endpoint { get; init; }
 
     /// <summary>Gets the endpoint display name.</summary>
     public string? DisplayName { get; init; }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugMiddleware.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugMiddleware.cs
@@ -1,17 +1,30 @@
 namespace Meziantou.AspNetCore.Diagnostics;
 
 /// <summary>Represents one middleware registration and its child branches.</summary>
-public sealed record MiddlewarePipelineDebugMiddleware
+public sealed class MiddlewarePipelineDebugMiddleware
 {
     /// <summary>Gets the middleware name.</summary>
     public required string Name { get; init; }
 
-    /// <summary>Gets the delegate type used to register the middleware.</summary>
-    public required string DelegateType { get; init; }
+    /// <summary>
+    /// Gets the type declaring the delegate used to register the middleware, or <see langword="null"/> for a synthetic
+    /// entry that does not correspond to a registered delegate.
+    /// </summary>
+    public string? DelegateType { get; init; }
 
-    /// <summary>Gets the delegate method used to register the middleware.</summary>
-    public required string DelegateMethod { get; init; }
+    /// <summary>
+    /// Gets the delegate method used to register the middleware, or <see langword="null"/> for a synthetic entry that
+    /// does not correspond to a registered delegate.
+    /// </summary>
+    public string? DelegateMethod { get; init; }
 
     /// <summary>Gets the branch pipelines associated with this middleware.</summary>
+    /// <remarks>
+    /// <see cref="Microsoft.AspNetCore.Builder.IApplicationBuilder.New"/> gives no indication of which later
+    /// registration owns the branch it creates, so branches are attributed to the next middleware registered. That is
+    /// correct for <c>Map</c>, <c>MapWhen</c> and <c>UseWhen</c>, which register immediately after creating a branch.
+    /// A branch created by hand and followed by an unrelated registration is attributed to that registration; one with
+    /// no following registration is reported under a synthetic <c>(unattached branch)</c> entry.
+    /// </remarks>
     public required IReadOnlyList<MiddlewarePipelineDebugPipeline> Branches { get; init; }
 }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugPipeline.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugPipeline.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.AspNetCore.Diagnostics;
 
 /// <summary>Represents a middleware pipeline.</summary>
-public sealed record MiddlewarePipelineDebugPipeline
+public sealed class MiddlewarePipelineDebugPipeline
 {
     /// <summary>Gets the middlewares registered in this pipeline.</summary>
     public required IReadOnlyList<MiddlewarePipelineDebugMiddleware> Middlewares { get; init; }

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugSnapshot.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugSnapshot.cs
@@ -1,10 +1,21 @@
 namespace Meziantou.AspNetCore.Diagnostics;
 
 /// <summary>Represents a snapshot of the ASP.NET Core middleware pipeline and endpoint list.</summary>
-public sealed record MiddlewarePipelineDebugSnapshot
+public sealed class MiddlewarePipelineDebugSnapshot
 {
     /// <summary>Gets the middleware pipeline tree.</summary>
     public required MiddlewarePipelineDebugPipeline Pipeline { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the pipeline has been captured yet.
+    /// </summary>
+    /// <remarks>
+    /// The pipeline is captured while the host builds it. A snapshot taken before that — from an
+    /// <c>IHostedService</c> that starts before the web host, or before <c>StartAsync</c> — reports
+    /// <see langword="false"/> and an empty <see cref="Pipeline"/>. This distinguishes "not captured yet" from
+    /// "captured, and empty".
+    /// </remarks>
+    public required bool IsPipelineCaptured { get; init; }
 
     /// <summary>Gets the list of endpoints registered in the application.</summary>
     public required IReadOnlyList<MiddlewarePipelineDebugEndpoint> Endpoints { get; init; }
@@ -15,7 +26,16 @@ public sealed record MiddlewarePipelineDebugSnapshot
     {
         var sb = new StringBuilder();
         sb.AppendLine("Pipeline:");
-        AppendPipeline(sb, Pipeline, indentationLevel: 1);
+        if (IsPipelineCaptured)
+        {
+            AppendPipeline(sb, Pipeline, indentationLevel: 1);
+        }
+        else
+        {
+            AppendIndentation(sb, indentationLevel: 1);
+            sb.AppendLine("(not captured yet: the pipeline is captured when the host builds it)");
+        }
+
         sb.AppendLine();
         sb.AppendLine("Endpoints:");
         AppendEndpoints(sb, Endpoints);
@@ -36,11 +56,16 @@ public sealed record MiddlewarePipelineDebugSnapshot
             AppendIndentation(sb, indentationLevel);
             sb.Append("- ");
             sb.Append(middleware.Name);
-            sb.Append(" [");
-            sb.Append(middleware.DelegateType);
-            sb.Append("::");
-            sb.Append(middleware.DelegateMethod);
-            sb.AppendLine("]");
+            if (middleware.DelegateType is not null || middleware.DelegateMethod is not null)
+            {
+                sb.Append(" [");
+                sb.Append(middleware.DelegateType);
+                sb.Append("::");
+                sb.Append(middleware.DelegateMethod);
+                sb.Append(']');
+            }
+
+            sb.AppendLine();
 
             for (var branchIndex = 0; branchIndex < middleware.Branches.Count; branchIndex++)
             {

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingServiceCollectionExtensions.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingServiceCollectionExtensions.cs
@@ -8,6 +8,20 @@ namespace Meziantou.AspNetCore.Diagnostics;
 public static class MiddlewarePipelineDebuggingServiceCollectionExtensions
 {
     /// <summary>Adds services required to capture and expose the middleware pipeline tree.</summary>
+    /// <remarks>
+    /// <para>
+    /// Capture happens through an <see cref="Microsoft.AspNetCore.Hosting.IStartupFilter"/>, which observes the host
+    /// pipeline. Middleware registered directly on a <see cref="Microsoft.AspNetCore.Builder.WebApplication"/> is
+    /// <b>not</b> captured individually: <c>WebApplication</c> hands the host a single component standing for its whole
+    /// pipeline, which appears as one entry named after that component. Middleware registered from an
+    /// <see cref="Microsoft.AspNetCore.Hosting.IStartupFilter"/> or a classic <c>Configure</c> method is captured
+    /// individually, including its branches.
+    /// </para>
+    /// <para>
+    /// Middleware names are resolved on a best-effort basis by inspecting the registration delegate. A name that cannot
+    /// be resolved degrades to the declaring type and method of the delegate; it is never guessed from unrelated state.
+    /// </para>
+    /// </remarks>
     public static IServiceCollection AddMiddlewarePipelineDebugging(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingWebApplicationExtensions.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingWebApplicationExtensions.cs
@@ -9,6 +9,11 @@ namespace Meziantou.AspNetCore.Diagnostics;
 public static class MiddlewarePipelineDebuggingWebApplicationExtensions
 {
     /// <summary>Gets a middleware pipeline snapshot from code without using the debug route.</summary>
+    /// <remarks>
+    /// The pipeline is captured while the host builds it, so call this after the host has started. Before then,
+    /// <see cref="MiddlewarePipelineDebugSnapshot.IsPipelineCaptured"/> is <see langword="false"/> and the pipeline is
+    /// empty — notably inside an <c>IHostedService</c> registered before the web host.
+    /// </remarks>
     /// <param name="app">The web application.</param>
     /// <returns>The middleware pipeline snapshot.</returns>
     public static MiddlewarePipelineDebugSnapshot GetMiddlewarePipelineDebugSnapshot(this WebApplication app)
@@ -20,26 +25,39 @@ public static class MiddlewarePipelineDebuggingWebApplicationExtensions
 
     /// <summary>
     /// Maps a JSON endpoint that returns the middleware tree and endpoint list.
-    /// By default, the endpoint is only mapped in Development.
+    /// By default, the endpoint responds only in Development and returns 404 elsewhere.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The endpoint is <b>not authenticated</b>. It discloses every registered route, the middleware order, and
+    /// implementation type names. When mapping it outside Development, gate it — the returned builder allows
+    /// <c>.RequireAuthorization()</c>.
+    /// </para>
+    /// <para>
+    /// The route is always registered so the return value can be chained; when
+    /// <paramref name="developmentOnly"/> is <see langword="true"/> and the environment is not Development, the handler
+    /// responds 404 instead of returning the snapshot.
+    /// </para>
+    /// </remarks>
     /// <param name="app">The web application.</param>
     /// <param name="pattern">The route pattern used for the debug endpoint.</param>
-    /// <param name="developmentOnly">Indicates whether the endpoint should only be mapped in Development.</param>
-    /// <returns>The mapped route builder, or <see langword="null"/> if not mapped because of environment filtering.</returns>
+    /// <param name="developmentOnly">Indicates whether the endpoint should respond only in Development.</param>
+    /// <returns>The mapped route builder.</returns>
     [RequiresUnreferencedCode("This method maps a delegate endpoint, which may use reflection and is not trim-safe.")]
-    public static RouteHandlerBuilder? MapMiddlewarePipelineDebugEndpoint(this WebApplication app, string pattern = "/_debug/pipeline", bool developmentOnly = true)
+    [RequiresDynamicCode("This method maps a delegate endpoint that serializes the snapshot with reflection-based JSON serialization.")]
+    public static RouteHandlerBuilder MapMiddlewarePipelineDebugEndpoint(this WebApplication app, string pattern = "/_debug/pipeline", bool developmentOnly = true)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(pattern);
 
-        if (developmentOnly && !app.Environment.IsDevelopment())
-            return null;
-
+        // Checked regardless of environment, so a missing AddMiddlewarePipelineDebugging() fails the same way everywhere.
         _ = GetDebugInfoProvider(app.Services);
 
-        return app.MapGet(pattern, static (MiddlewarePipelineDebugInfoProvider debugInfoProvider) =>
+        var blocked = developmentOnly && !app.Environment.IsDevelopment();
+
+        return app.MapGet(pattern, (MiddlewarePipelineDebugInfoProvider debugInfoProvider) =>
         {
-            return TypedResults.Ok(debugInfoProvider.GetSnapshot());
+            return blocked ? Results.NotFound() : Results.Ok(debugInfoProvider.GetSnapshot());
         });
     }
 

--- a/src/Meziantou.AspNetCore/NoCacheApplicationBuilderExtensions.cs
+++ b/src/Meziantou.AspNetCore/NoCacheApplicationBuilderExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Meziantou.AspNetCore;
+
+/// <summary>Extension methods to register <see cref="NoCacheMiddleware"/>.</summary>
+public static class NoCacheApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds a middleware that sets a default non-cacheable <c>Cache-Control</c> response header when the response
+    /// does not define one.
+    /// </summary>
+    /// <remarks>
+    /// Register this after any component that serves cacheable content, such as <c>UseStaticFiles</c>. See
+    /// <see cref="NoCacheMiddleware"/> for the caching implications of the default value.
+    /// </remarks>
+    /// <param name="app">The application builder.</param>
+    /// <returns>The application builder, to allow chaining.</returns>
+    public static IApplicationBuilder UseNoCache(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        return app.UseMiddleware<NoCacheMiddleware>();
+    }
+}

--- a/src/Meziantou.AspNetCore/NoCacheMiddleware.cs
+++ b/src/Meziantou.AspNetCore/NoCacheMiddleware.cs
@@ -1,13 +1,39 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace Meziantou.AspNetCore;
 
 /// <summary>
 /// Ensures responses are marked as non-cacheable when no Cache-Control header is already set.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Register this middleware <em>after</em> any component that serves cacheable content, such as
+/// <c>UseStaticFiles</c>: the static file middleware sets <c>ETag</c> and <c>Last-Modified</c> but no
+/// <c>Cache-Control</c>, so an earlier registration marks every static asset as non-cacheable.
+/// </para>
+/// <para>
+/// Because the default includes <c>no-store</c>, responses defaulted by this middleware are not stored by
+/// <c>UseResponseCaching</c>, <c>UseOutputCache</c> or a CDN. Responses that set their own
+/// <c>Cache-Control</c> are never modified.
+/// </para>
+/// </remarks>
 /// <param name="next">The next middleware in the pipeline.</param>
 public sealed class NoCacheMiddleware(RequestDelegate next)
 {
+    private const string NoCacheValue = "no-cache,no-store,must-revalidate";
+
+    private static readonly Func<object, Task> OnStartingCallback = static state =>
+    {
+        var response = ((HttpContext)state).Response;
+        if (StringValues.IsNullOrEmpty(response.Headers.CacheControl))
+        {
+            response.Headers.CacheControl = NoCacheValue;
+        }
+
+        return Task.CompletedTask;
+    };
+
     /// <summary>
     /// Processes the request and adds a default non-cacheable Cache-Control header to the response when none is set.
     /// </summary>
@@ -15,15 +41,14 @@ public sealed class NoCacheMiddleware(RequestDelegate next)
     /// <returns>A task that completes when the middleware has finished processing.</returns>
     public async Task InvokeAsync(HttpContext context)
     {
-        context.Response.OnStarting(() =>
-        {
-            if (context.Response.Headers.CacheControl.Count is 0)
-            {
-                context.Response.Headers.CacheControl = "no-cache,no-store,must-revalidate";
-            }
+        ArgumentNullException.ThrowIfNull(context);
 
-            return Task.CompletedTask;
-        });
+        // OnStarting throws once the response has started. An upstream middleware may already have written and
+        // flushed, in which case the header can no longer be defaulted and the request must not be failed for it.
+        if (!context.Response.HasStarted)
+        {
+            context.Response.OnStarting(OnStartingCallback, context);
+        }
 
         await next(context);
     }

--- a/src/Meziantou.AspNetCore/readme.md
+++ b/src/Meziantou.AspNetCore/readme.md
@@ -17,14 +17,14 @@ Helpers for ASP.NET Core middleware diagnostics and response cache-control behav
 using Meziantou.AspNetCore.Diagnostics;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddMiddlewarePipelineDebugging();
+builder.Services.AddMiddlewarePipelineDebugging(); // must run before builder.Build()
 
 var app = builder.Build();
 
 app.UseRouting();
 app.MapGet("/hello", static () => "hello");
 
-// Mapped by default only in Development
+// Maps GET /_debug/pipeline. By default it responds only in Development and returns 404 elsewhere.
 app.MapMiddlewarePipelineDebugEndpoint();
 
 app.MapGet("/pipeline.txt", () =>
@@ -36,6 +36,41 @@ app.MapGet("/pipeline.txt", () =>
 app.Run();
 ```
 
+The default route is `/_debug/pipeline`; pass a different `pattern` to change it.
+
+#### What is captured
+
+Capture works through an `IStartupFilter`, which observes the **host** pipeline. This matters:
+
+- Middleware registered from an `IStartupFilter` or a classic `Configure` method is captured individually,
+  including `Map` / `MapWhen` / `UseWhen` branches.
+- Middleware registered **directly on `WebApplication`** is *not* captured individually. `WebApplication` hands the
+  host a single component representing its entire pipeline, so it appears as one entry named after that component
+  (`...WebApplicationBuilder+WireSourcePipeline.CreateMiddleware`). Its branches are not visible either.
+
+Names are resolved on a best-effort basis from the registration delegate. When a name cannot be resolved it degrades
+to the delegate's declaring type and method — it is never inferred from unrelated state, so a name you see belongs to
+the middleware it is listed against.
+
+#### Snapshot timing
+
+The pipeline is captured while the host builds it. A snapshot taken earlier reports
+`IsPipelineCaptured == false` and an empty pipeline — including inside an `IHostedService`, which starts *before* the
+web host. Read the snapshot after the host has started.
+
+#### Securing the debug endpoint
+
+The endpoint is **not authenticated**. It discloses every registered route, the middleware order and implementation
+type names. The default (`developmentOnly: true`) responds only in Development. To expose it elsewhere, gate it:
+
+```csharp
+app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: false)
+   .RequireAuthorization("DiagnosticsPolicy");
+```
+
+Note that `MiddlewarePipelineDebugEndpoint.Endpoint` is excluded from serialization, so it is `null` on a snapshot
+deserialized from the endpoint's JSON. It is only populated on a snapshot created in-process.
+
 ### Default no-cache response header
 
 ```csharp
@@ -44,11 +79,21 @@ using Meziantou.AspNetCore;
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-app.UseMiddleware<NoCacheMiddleware>();
+app.UseNoCache();
 
 app.MapGet("/", static () => "Hello World!");
 
 app.Run();
 ```
 
-`NoCacheMiddleware` sets `Cache-Control: no-cache,no-store,must-revalidate` only when the response does not already define `Cache-Control`.
+`UseNoCache` sets `Cache-Control: no-cache,no-store,must-revalidate` only when the response does not already define
+`Cache-Control` (an empty value counts as not defined). Responses that set their own `Cache-Control` are never
+modified, and if the response has already started the header is left alone rather than failing the request.
+
+Two consequences worth knowing before adding it:
+
+- Register it **after** anything serving cacheable content, such as `UseStaticFiles`. The static file middleware sets
+  `ETag` and `Last-Modified` but no `Cache-Control`, so an earlier registration marks every static asset
+  non-cacheable.
+- Because the default includes `no-store`, responses it defaults are not stored by `UseResponseCaching`,
+  `UseOutputCache` or a CDN.

--- a/tests/Meziantou.AspNetCore.Tests/MiddlewarePipelineDebuggingTests.cs
+++ b/tests/Meziantou.AspNetCore.Tests/MiddlewarePipelineDebuggingTests.cs
@@ -1,56 +1,67 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.RegularExpressions;
+using System.Text.Json;
 using Meziantou.AspNetCore.Diagnostics;
-using Meziantou.Framework.InlineSnapshotTesting;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Meziantou.Framework.InlineSnapshotTesting;
 
 namespace Meziantou.AspNetCore.Tests;
 
-public sealed partial class MiddlewarePipelineDebuggingTests
+public sealed class MiddlewarePipelineDebuggingTests
 {
+    private static WebApplicationBuilder CreateBuilder(string environment)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = environment });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+        return builder;
+    }
+
+    private static void AddHostPipeline(WebApplicationBuilder builder, Action<IApplicationBuilder> configure)
+        => builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter>(new DelegateStartupFilter(configure, configureAfter: null)));
+
+    private static void AddHostPipelineAfter(WebApplicationBuilder builder, Action<IApplicationBuilder> configure)
+        => builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter>(new DelegateStartupFilter(configure: null, configureAfter: configure)));
+
     [Fact]
     public async Task MapMiddlewarePipelineDebugEndpoint_Development_ReturnsPipelineAndEndpoints()
     {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
+        var builder = CreateBuilder(Environments.Development);
 
         await using var app = builder.Build();
         app.UseRouting();
-        app.Use(static (context, next) => next(context));
         app.MapGet("/hello", static () => "hello");
-
-        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: true);
-        Assert.NotNull(debugEndpointBuilder);
+        _ = app.MapMiddlewarePipelineDebugEndpoint();
 
         await app.StartAsync(XunitCancellationToken);
         using var client = app.GetTestClient();
-        var payload = await client.GetFromJsonAsync<MiddlewarePipelineDebugSnapshot>("/_debug/pipeline", cancellationToken: XunitCancellationToken);
-        var snapshot = Assert.IsType<MiddlewarePipelineDebugSnapshot>(payload);
+        var snapshot = await client.GetFromJsonAsync<MiddlewarePipelineDebugSnapshot>("/_debug/pipeline", cancellationToken: XunitCancellationToken);
 
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsPipelineCaptured);
         Assert.NotEmpty(snapshot.Pipeline.Middlewares);
         Assert.Contains(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/hello", StringComparison.Ordinal));
         Assert.Contains(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/_debug/pipeline", StringComparison.Ordinal));
     }
 
     [Fact]
-    public async Task MapMiddlewarePipelineDebugEndpoint_NonDevelopment_DoesNotMapByDefault()
+    public async Task MapMiddlewarePipelineDebugEndpoint_NonDevelopment_RespondsNotFoundByDefault()
     {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
+        var builder = CreateBuilder(Environments.Production);
 
         await using var app = builder.Build();
         app.UseRouting();
-        app.Use(static (context, next) => next(context));
         app.MapGet("/hello", static () => "hello");
 
-        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: true);
-        Assert.Null(debugEndpointBuilder);
+        // The route is always registered so the result can be chained; the handler is what refuses outside Development.
+        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint();
+        Assert.NotNull(debugEndpointBuilder);
 
         await app.StartAsync(XunitCancellationToken);
         using var client = app.GetTestClient();
@@ -59,118 +70,14 @@ public sealed partial class MiddlewarePipelineDebuggingTests
     }
 
     [Fact]
-    public async Task GetMiddlewarePipelineDebugSnapshot_NonDevelopment_WithoutRoute_ReturnsSnapshot()
-    {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
-
-        await using var app = builder.Build();
-        app.UseRouting();
-        app.Use(static (context, next) => next(context));
-        app.MapGet("/hello", static () => "hello");
-
-        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: true);
-        Assert.Null(debugEndpointBuilder);
-
-        await app.StartAsync(XunitCancellationToken);
-        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
-        Assert.NotEmpty(snapshot.Pipeline.Middlewares);
-        Assert.Contains(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/hello", StringComparison.Ordinal));
-        Assert.DoesNotContain(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/_debug/pipeline", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task GetMiddlewarePipelineDebugSnapshot_EndpointEntriesExposeRawEndpoint()
-    {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
-
-        await using var app = builder.Build();
-        app.UseRouting();
-        app.Use(static (context, next) => next(context));
-        app.MapGet("/hello", static () => "hello");
-
-        await app.StartAsync(XunitCancellationToken);
-        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
-        var endpoint = Assert.Single(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/hello", StringComparison.Ordinal));
-
-        _ = Assert.IsType<RouteEndpoint>(endpoint.Endpoint);
-    }
-
-    [Fact]
-    public async Task GetMiddlewarePipelineDebugSnapshot_ToString_ContainsPipelineAndEndpoints()
-    {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
-
-        await using var app = builder.Build();
-        app.UseRouting();
-        app.Use(static (context, next) => next(context));
-        app.MapGet("/hello", static () => "hello");
-
-        await app.StartAsync(XunitCancellationToken);
-        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
-        var text = snapshot.ToString();
-
-        Assert.Contains("Pipeline:", text);
-        Assert.Contains("Endpoints:", text);
-        Assert.Contains("/hello", text);
-        Assert.Contains("::", text);
-    }
-
-    [Fact]
-    public async Task MiddlewarePipelineDebugSnapshot_ToString_ReturnsExpectedFullOutput()
-    {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
-
-        await using var app = builder.Build();
-        app.UseMiddleware<NoCacheMiddleware>();
-        app.MapGet("/hello", static () => "hello");
-
-        await app.StartAsync(XunitCancellationToken);
-        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
-        var text = snapshot.ToString();
-        InlineSnapshot.WithSettings(static settings =>
-        {
-            settings.ScrubLinesWithReplace(static line =>
-            {
-                var scrubbed = AssemblyVersionRegex().Replace(line, "Version=*");
-                scrubbed = PublicKeyTokenRegex().Replace(scrubbed, "PublicKeyToken=*");
-                return scrubbed;
-            });
-        }).Validate(text,
-            """
-            Pipeline:
-              - Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware [System.Func`2[[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*],[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*]]::CreateMiddleware]
-              - Meziantou.AspNetCore.NoCacheMiddleware [System.Func`2[[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*],[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*]]::CreateMiddleware]
-              - Microsoft.AspNetCore.Routing.EndpointMiddleware [System.Func`2[[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*],[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*]]::CreateMiddleware]
-
-            Endpoints:
-              - [GET] /hello (Order: 0) HTTP: GET /hello [Microsoft.AspNetCore.Routing.RouteEndpoint]
-
-            """
-            );
-    }
-
-    [Fact]
     public async Task MapMiddlewarePipelineDebugEndpoint_NonDevelopment_CanBeMappedExplicitly()
     {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
-        builder.WebHost.UseTestServer();
-        builder.Services.AddMiddlewarePipelineDebugging();
+        var builder = CreateBuilder(Environments.Production);
 
         await using var app = builder.Build();
         app.UseRouting();
-        app.Use(static (context, next) => next(context));
         app.MapGet("/hello", static () => "hello");
-
-        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: false);
-        Assert.NotNull(debugEndpointBuilder);
+        _ = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: false);
 
         await app.StartAsync(XunitCancellationToken);
         using var client = app.GetTestClient();
@@ -179,20 +86,353 @@ public sealed partial class MiddlewarePipelineDebuggingTests
     }
 
     [Fact]
+    public async Task MapMiddlewarePipelineDebugEndpoint_ReturnedBuilderIsChainable()
+    {
+        var builder = CreateBuilder(Environments.Production);
+
+        await using var app = builder.Build();
+        app.MapGet("/hello", static () => "hello");
+
+        // The whole point of the non-nullable return: hardening the endpoint must not depend on the environment.
+        _ = app.MapMiddlewarePipelineDebugEndpoint().WithMetadata(new TestMarkerMetadata());
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        var debugEndpoint = Assert.Single(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/_debug/pipeline", StringComparison.Ordinal));
+        Assert.NotNull(debugEndpoint.Endpoint);
+        Assert.NotNull(debugEndpoint.Endpoint.Metadata.GetMetadata<TestMarkerMetadata>());
+    }
+
+    [Fact]
     public async Task MapMiddlewarePipelineDebugEndpoint_WithoutServiceRegistration_Throws()
     {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
         builder.WebHost.UseTestServer();
 
         await using var app = builder.Build();
 
-        var exception = Assert.Throws<InvalidOperationException>(() => app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: false));
+        // Not environment-dependent: a missing registration must fail the same way in every environment.
+        var exception = Assert.Throws<InvalidOperationException>(() => app.MapMiddlewarePipelineDebugEndpoint());
         Assert.Contains(nameof(MiddlewarePipelineDebuggingServiceCollectionExtensions.AddMiddlewarePipelineDebugging), exception.Message);
     }
 
-    [GeneratedRegex(@"Version=\d+\.\d+\.\d+\.\d+", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
-    private static partial Regex AssemblyVersionRegex();
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_HostPipeline_CapturesEachRegisteredMiddleware()
+    {
+        var builder = CreateBuilder(Environments.Production);
+        AddHostPipeline(builder, static app =>
+        {
+            app.UseMiddleware<AlphaMiddleware>();
+            app.UseMiddleware<BravoMiddleware>();
+        });
 
-    [GeneratedRegex(@"PublicKeyToken=[0-9a-f]{16}", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
-    private static partial Regex PublicKeyTokenRegex();
+        await using var app = builder.Build();
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        var names = snapshot.Pipeline.Middlewares.Select(static middleware => middleware.Name).ToArray();
+
+        Assert.Contains(typeof(AlphaMiddleware).FullName!, names, StringComparer.Ordinal);
+        Assert.Contains(typeof(BravoMiddleware).FullName!, names, StringComparer.Ordinal);
+        Assert.True(
+            Array.IndexOf(names, typeof(AlphaMiddleware).FullName!) < Array.IndexOf(names, typeof(BravoMiddleware).FullName!),
+            $"Middleware must be reported in registration order. Actual: {string.Join(", ", names)}");
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_HostPipeline_ResolvesFrameworkMiddlewareNames()
+    {
+        var builder = CreateBuilder(Environments.Production);
+        builder.Services.AddCors();
+        builder.Services.AddResponseCompression();
+        builder.Services.AddAuthentication();
+        AddHostPipeline(builder, static app =>
+        {
+            app.UseExceptionHandler("/error");
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+            app.UseResponseCompression();
+            app.UseRouting();
+            app.UseCors();
+            app.UseAuthentication();
+        });
+
+        await using var app = builder.Build();
+        app.MapGet("/error", static () => "error");
+
+        await app.StartAsync(XunitCancellationToken);
+        var names = app.GetMiddlewarePipelineDebugSnapshot().Pipeline.Middlewares.Select(static middleware => middleware.Name).ToArray();
+
+        // Framework middleware is what name resolution has to get right, and these types are all internal to ASP.NET:
+        // they can only be found by inspecting the registration delegate, so this covers the reflective walk against
+        // real middleware rather than only the test's own. ExceptionHandlerMiddleware is the one exception -- it is one
+        // of only three places in the shared framework that publish "analysis.NextMiddlewareName" -- so it also covers
+        // that branch, which nothing else exercises.
+        // A name that failed to resolve would show up as a compiler-generated "...Extensions+<>c__DisplayClass..."
+        // fallback, so asserting the exact type names is what makes this test meaningful.
+        string[] expected =
+        [
+            "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware",
+            "Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionMiddleware",
+            "Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware",
+            "Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware",
+            "Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware",
+            "Microsoft.AspNetCore.Cors.Infrastructure.CorsMiddleware",
+            "Microsoft.AspNetCore.Authentication.AuthenticationMiddleware",
+            "Microsoft.AspNetCore.Routing.EndpointMiddleware",
+        ];
+
+        var unresolved = expected.Except(names, StringComparer.Ordinal).ToArray();
+        Assert.Empty(unresolved, $"Framework middleware whose name did not resolve: {string.Join(", ", unresolved)}.{Environment.NewLine}Captured: {string.Join(", ", names)}");
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_HostPipeline_CapturesBranches()
+    {
+        var builder = CreateBuilder(Environments.Production);
+        AddHostPipeline(builder, static app =>
+        {
+            app.Map("/mapped", static branch => branch.UseMiddleware<AlphaMiddleware>());
+            app.UseWhen(static context => context.Request.Path == "/when", static branch => branch.UseMiddleware<BravoMiddleware>());
+        });
+
+        await using var app = builder.Build();
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+
+        var branches = snapshot.Pipeline.Middlewares.Where(static middleware => middleware.Branches.Count > 0).ToArray();
+        Assert.HasCount(2, branches);
+
+        // Each branch holds exactly the middleware registered in it, and no build-time rejoin delegate.
+        Assert.Collection(
+            branches.SelectMany(static middleware => middleware.Branches).Select(static branch => Assert.Single(branch.Middlewares).Name),
+            name => Assert.Equal(typeof(AlphaMiddleware).FullName!, name, StringComparer.Ordinal),
+            name => Assert.Equal(typeof(BravoMiddleware).FullName!, name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_BranchWithoutOwningMiddleware_IsReportedAsUnattached()
+    {
+        var builder = CreateBuilder(Environments.Production);
+
+        // Registered after the rest of the pipeline: a branch built by hand with no following Use() on the same
+        // builder has no middleware to attach to. (A branch followed by an unrelated Use() is attributed to it —
+        // positional attribution is all IApplicationBuilder.New() offers.)
+        AddHostPipelineAfter(builder, static app =>
+        {
+            var orphan = app.New();
+            orphan.UseMiddleware<BravoMiddleware>();
+            _ = orphan.Build();
+        });
+
+        await using var app = builder.Build();
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+
+        var unattached = Assert.Single(snapshot.Pipeline.Middlewares, static middleware => middleware.Name == "(unattached branch)");
+        Assert.Null(unattached.DelegateType);
+        Assert.Null(unattached.DelegateMethod);
+        var branch = Assert.Single(unattached.Branches);
+        Assert.Equal(typeof(BravoMiddleware).FullName!, Assert.Single(branch.Middlewares).Name, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_MinimalApiPipeline_IsReportedAsTheBridgeNotAsUserMiddleware()
+    {
+        // WebApplication hands the host pipeline one component standing for every middleware registered on it, so those
+        // middlewares cannot be captured. The entry must say so rather than borrow the name of one of them.
+        var builder = CreateBuilder(Environments.Production);
+
+        await using var app = builder.Build();
+        app.UseMiddleware<AlphaMiddleware>();
+        app.UseMiddleware<BravoMiddleware>();
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        var names = snapshot.Pipeline.Middlewares.Select(static middleware => middleware.Name).ToArray();
+
+        Assert.DoesNotContain(typeof(AlphaMiddleware).FullName!, names, StringComparer.Ordinal);
+        Assert.DoesNotContain(typeof(BravoMiddleware).FullName!, names, StringComparer.Ordinal);
+        Assert.Contains(names, static name => name.Contains("WireSourcePipeline", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_BeforeStart_ReportsNotCaptured()
+    {
+        var builder = CreateBuilder(Environments.Production);
+
+        await using var app = builder.Build();
+        app.MapGet("/hello", static () => "hello");
+
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        Assert.False(snapshot.IsPipelineCaptured);
+        Assert.Empty(snapshot.Pipeline.Middlewares);
+        Assert.Contains("not captured yet", snapshot.ToString());
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_MiddlewareHoldingAThrowingCollection_DoesNotFailStartup()
+    {
+        var builder = CreateBuilder(Environments.Production);
+        AddHostPipeline(builder, static app => app.UseThrowingCollectionMiddleware());
+
+        await using var app = builder.Build();
+
+        // Name resolution is best effort; a hostile object graph must degrade to a fallback name, not abort startup.
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+
+        Assert.True(snapshot.IsPipelineCaptured);
+        Assert.Contains(snapshot.Pipeline.Middlewares, static middleware => middleware.Name.Contains("ThrowingCollection", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Snapshot_JsonRoundTrip_LeavesEndpointNull()
+    {
+        var builder = CreateBuilder(Environments.Production);
+
+        await using var app = builder.Build();
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        Assert.NotNull(Assert.Single(snapshot.Endpoints).Endpoint);
+
+        var roundTripped = JsonSerializer.Deserialize<MiddlewarePipelineDebugSnapshot>(JsonSerializer.Serialize(snapshot));
+
+        // Endpoint is [JsonIgnore]d, so it is null after a round trip. The property type says so.
+        Assert.NotNull(roundTripped);
+        Assert.Null(Assert.Single(roundTripped.Endpoints).Endpoint);
+    }
+
+    [Fact]
+    public void ToString_RendersPipelineTreeAndEndpoints()
+    {
+        // Rendered from a hand-built snapshot so the expected text does not depend on ASP.NET internals.
+        var snapshot = new MiddlewarePipelineDebugSnapshot
+        {
+            IsPipelineCaptured = true,
+            Pipeline = new MiddlewarePipelineDebugPipeline
+            {
+                Middlewares =
+                [
+                    new MiddlewarePipelineDebugMiddleware
+                    {
+                        Name = "Contoso.FirstMiddleware",
+                        DelegateType = "Contoso.Registration",
+                        DelegateMethod = "CreateMiddleware",
+                        Branches = [],
+                    },
+                    new MiddlewarePipelineDebugMiddleware
+                    {
+                        Name = "Contoso.BranchingMiddleware",
+                        DelegateType = "Contoso.Registration",
+                        DelegateMethod = "CreateMiddleware",
+                        Branches =
+                        [
+                            new MiddlewarePipelineDebugPipeline
+                            {
+                                Middlewares =
+                                [
+                                    new MiddlewarePipelineDebugMiddleware
+                                    {
+                                        Name = "Contoso.InnerMiddleware",
+                                        DelegateType = "Contoso.Registration",
+                                        DelegateMethod = "CreateMiddleware",
+                                        Branches = [],
+                                    },
+                                ],
+                            },
+                            new MiddlewarePipelineDebugPipeline { Middlewares = [] },
+                        ],
+                    },
+                    new MiddlewarePipelineDebugMiddleware
+                    {
+                        Name = "(unattached branch)",
+                        Branches = [new MiddlewarePipelineDebugPipeline { Middlewares = [] }],
+                    },
+                ],
+            },
+            Endpoints =
+            [
+                new MiddlewarePipelineDebugEndpoint
+                {
+                    EndpointType = "Microsoft.AspNetCore.Routing.RouteEndpoint",
+                    DisplayName = "HTTP: GET /hello",
+                    RoutePattern = "/hello",
+                    Order = 0,
+                    HttpMethods = ["GET"],
+                },
+                new MiddlewarePipelineDebugEndpoint
+                {
+                    EndpointType = "Microsoft.AspNetCore.Routing.RouteEndpoint",
+                    HttpMethods = [],
+                },
+            ],
+        };
+
+        InlineSnapshot.Validate(snapshot.ToString(), """
+            Pipeline:
+              - Contoso.FirstMiddleware [Contoso.Registration::CreateMiddleware]
+              - Contoso.BranchingMiddleware [Contoso.Registration::CreateMiddleware]
+                Branch 1:
+                  - Contoso.InnerMiddleware [Contoso.Registration::CreateMiddleware]
+                Branch 2:
+                  (none)
+              - (unattached branch)
+                Branch 1:
+                  (none)
+
+            Endpoints:
+              - [GET] /hello (Order: 0) HTTP: GET /hello [Microsoft.AspNetCore.Routing.RouteEndpoint]
+              - [*] (no route pattern) (Order: -) (no display name) [Microsoft.AspNetCore.Routing.RouteEndpoint]
+
+            """);
+    }
+
+    [Fact]
+    public void ToString_NotCaptured_SaysSo()
+    {
+        var snapshot = new MiddlewarePipelineDebugSnapshot
+        {
+            IsPipelineCaptured = false,
+            Pipeline = new MiddlewarePipelineDebugPipeline { Middlewares = [] },
+            Endpoints = [],
+        };
+
+        InlineSnapshot.Validate(snapshot.ToString(), """
+            Pipeline:
+              (not captured yet: the pipeline is captured when the host builds it)
+
+            Endpoints:
+              (none)
+
+            """);
+    }
+
+    private sealed class TestMarkerMetadata;
+
+    private sealed class DelegateStartupFilter(Action<IApplicationBuilder>? configure, Action<IApplicationBuilder>? configureAfter) : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+        {
+            configure?.Invoke(app);
+            next(app);
+            configureAfter?.Invoke(app);
+        };
+    }
+
+    internal sealed class AlphaMiddleware(RequestDelegate next)
+    {
+        public Task InvokeAsync(HttpContext context) => next(context);
+    }
+
+    internal sealed class BravoMiddleware(RequestDelegate next)
+    {
+        public Task InvokeAsync(HttpContext context) => next(context);
+    }
 }

--- a/tests/Meziantou.AspNetCore.Tests/NoCacheMiddlewareTests.cs
+++ b/tests/Meziantou.AspNetCore.Tests/NoCacheMiddlewareTests.cs
@@ -6,11 +6,23 @@ namespace Meziantou.AspNetCore.Tests;
 
 public sealed class NoCacheMiddlewareTests
 {
-    [Fact]
-    public async Task ResponseWithoutCacheControl_AddsNoCacheHeader()
+    private static WebApplicationBuilder CreateBuilder()
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
+        return builder;
+    }
+
+    private static string[] Directives(HttpResponseMessage response)
+    {
+        var value = Assert.Single(response.Headers.GetValues("Cache-Control"));
+        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    [Fact]
+    public async Task ResponseWithoutCacheControl_AddsNoCacheHeader()
+    {
+        var builder = CreateBuilder();
 
         await using var app = builder.Build();
         app.UseMiddleware<NoCacheMiddleware>();
@@ -20,18 +32,32 @@ public sealed class NoCacheMiddlewareTests
         using var client = app.GetTestClient();
         using var response = await client.GetAsync("/no-cache", XunitCancellationToken);
 
-        var cacheControl = Assert.Single(response.Headers.GetValues("Cache-Control"));
-        var directives = cacheControl.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var directives = Directives(response);
         Assert.Contains("no-cache", directives, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("no-store", directives, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("must-revalidate", directives, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]
+    public async Task UseNoCache_AddsNoCacheHeader()
+    {
+        var builder = CreateBuilder();
+
+        await using var app = builder.Build();
+        app.UseNoCache();
+        app.MapGet("/no-cache", static () => "ok");
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/no-cache", XunitCancellationToken);
+
+        Assert.Contains("no-store", Directives(response), StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ResponseWithCacheControl_DoesNotOverrideHeader()
     {
-        var builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
+        var builder = CreateBuilder();
 
         await using var app = builder.Build();
         app.UseMiddleware<NoCacheMiddleware>();
@@ -47,5 +73,86 @@ public sealed class NoCacheMiddlewareTests
 
         var cacheControl = Assert.Single(response.Headers.GetValues("Cache-Control"));
         Assert.Equal("public,max-age=60", cacheControl.Replace(" ", string.Empty, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CacheControlSetFromDownstreamOnStarting_IsPreserved()
+    {
+        var builder = CreateBuilder();
+
+        await using var app = builder.Build();
+        app.UseMiddleware<NoCacheMiddleware>();
+
+        // OnStarting callbacks run in reverse registration order, so this inner one runs BEFORE the middleware's.
+        // The middleware must observe the header this sets and leave it alone. Response caching and static files
+        // set headers this way, so the ordering assumption is worth pinning.
+        app.Use(async (context, next) =>
+        {
+            context.Response.OnStarting(() =>
+            {
+                context.Response.Headers.CacheControl = "public,max-age=99";
+                return Task.CompletedTask;
+            });
+
+            await next(context);
+        });
+
+        app.MapGet("/late", static () => "ok");
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/late", XunitCancellationToken);
+
+        var cacheControl = Assert.Single(response.Headers.GetValues("Cache-Control"));
+        Assert.Equal("public,max-age=99", cacheControl.Replace(" ", string.Empty, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task EmptyCacheControl_IsTreatedAsUnset()
+    {
+        var builder = CreateBuilder();
+
+        await using var app = builder.Build();
+        app.UseMiddleware<NoCacheMiddleware>();
+
+        // Assigning "" leaves a StringValues with Count 1, so a Count-based emptiness test would ship an empty header.
+        app.MapGet("/empty", static (HttpContext context) =>
+        {
+            context.Response.Headers.CacheControl = "";
+            return "ok";
+        });
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/empty", XunitCancellationToken);
+
+        Assert.Contains("no-store", Directives(response), StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ResponseAlreadyStarted_DoesNotFailTheRequest()
+    {
+        var builder = CreateBuilder();
+
+        await using var app = builder.Build();
+
+        // Flush upstream so the response has started before the middleware runs. Registering an OnStarting callback
+        // then throws InvalidOperationException, which must not be allowed to abort the response.
+        app.Use(async (context, next) =>
+        {
+            await context.Response.WriteAsync("partial-", context.RequestAborted);
+            await context.Response.Body.FlushAsync(context.RequestAborted);
+            await next(context);
+        });
+
+        app.UseMiddleware<NoCacheMiddleware>();
+        app.Run(context => context.Response.WriteAsync("tail", context.RequestAborted));
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/anything", XunitCancellationToken);
+
+        Assert.Equal("partial-tail", await response.Content.ReadAsStringAsync(XunitCancellationToken));
+        Assert.False(response.Headers.Contains("Cache-Control"));
     }
 }

--- a/tests/Meziantou.AspNetCore.Tests/ThrowingCollection.cs
+++ b/tests/Meziantou.AspNetCore.Tests/ThrowingCollection.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+
+namespace Meziantou.AspNetCore.Tests;
+
+/// <summary>A collection that throws when read, held by a middleware registration in an inspected namespace.</summary>
+internal sealed class ThrowingCollection : IList
+{
+    public object? this[int index] { get => throw new InvalidOperationException("must not be read"); set => throw new InvalidOperationException(); }
+
+    public int Count => 1;
+
+    public bool IsFixedSize => true;
+
+    public bool IsReadOnly => true;
+
+    public bool IsSynchronized => false;
+
+    public object SyncRoot => this;
+
+    public int Add(object? value) => throw new NotSupportedException();
+
+    public void Clear() => throw new NotSupportedException();
+
+    public bool Contains(object? value) => false;
+
+    public void CopyTo(Array array, int index) => throw new NotSupportedException();
+
+    public IEnumerator GetEnumerator() => throw new InvalidOperationException("must not be enumerated");
+
+    public int IndexOf(object? value) => -1;
+
+    public void Insert(int index, object? value) => throw new NotSupportedException();
+
+    public void Remove(object? value) => throw new NotSupportedException();
+
+    public void RemoveAt(int index) => throw new NotSupportedException();
+}

--- a/tests/Meziantou.AspNetCore.Tests/ThrowingCollectionMiddlewareExtensions.cs
+++ b/tests/Meziantou.AspNetCore.Tests/ThrowingCollectionMiddlewareExtensions.cs
@@ -1,0 +1,21 @@
+using Meziantou.AspNetCore.Tests;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Declared in <c>Microsoft.AspNetCore.Builder</c> on purpose: that is the convention third-party <c>UseXxx</c>
+/// helpers follow, and it is the namespace the middleware name walk is allowed to inspect. The captured
+/// <see cref="ThrowingCollection"/> is therefore reachable by the walk.
+/// </summary>
+internal static class ThrowingCollectionMiddlewareExtensions
+{
+    public static IApplicationBuilder UseThrowingCollectionMiddleware(this IApplicationBuilder app)
+    {
+        var hostile = new ThrowingCollection();
+        return app.Use(next => context =>
+        {
+            _ = hostile;
+            return next(context);
+        });
+    }
+}


### PR DESCRIPTION
Fixes from a whole-project audit of `Meziantou.AspNetCore`. Two features, two independent sets of problems.

## Middleware pipeline diagnostics

**Names could belong to other middleware.** The reflective walk followed any field of an inspected object, including fields pointing back at an `IApplicationBuilder`, from where it reached that builder's component list and resolved an unrelated middleware. `UseWhen` was named after a middleware inside its own branch, and the single component carrying a whole `WebApplication` pipeline was named after the first middleware registered on it — so a snapshot looked authoritative while describing a pipeline that does not exist. Traversal now stops at `IApplicationBuilder`, `IServiceProvider`, `IEndpointRouteBuilder`, `IDictionary`, `EndpointDataSource` and the capture descriptors; an unresolved name degrades to the delegate's declaring type instead of borrowing another middleware's identity.

**A known limitation, now reported honestly.** `WebApplicationBuilder.ConfigureApplication` hands the host one `WireSourcePipeline` component standing for the entire user pipeline, so middleware registered directly on a `WebApplication` cannot be captured individually. Recovering it means reflecting into `WireSourcePipeline._builtApplication`; that was deliberately not done, to avoid a version-fragile internals dependency. The entry now names the bridge instead of a user middleware, and the limitation is documented on `AddMiddlewarePipelineDebugging` and in the readme, pinned by a test.

**The walk could fail or hang startup.** It enumerated arbitrary `IEnumerable` values *before* applying its namespace gate, with no item cap and no exception handling, inside `IApplicationBuilder.Use`. A sequence throwing on enumeration aborted startup; a lazy infinite one never returned. Enumeration is now restricted to indexable `IList`s with a per-collection cap, bounded by a global node budget, and the whole walk falls back on any exception. Note the gate was *not* simply moved above the enumeration branch: every productive hop goes through ungated `List<>`/arrays, so gating first would break resolution outright. Cycle tracking is now per-path, and `IsMiddlewareType` no longer accepts delegate types, which were reported as middleware because every delegate declares `Invoke`.

**State is published immutably.** Capture state was a mutable list written during startup and read afterwards. Readers now see an immutable tree published once configuration completes. Recording also stops before the pipeline is built, removing the phantom entry `UseWhen`'s build-time rejoin produced and making the tree idempotent across repeated builds. Branches with no owning middleware are reported under a synthetic entry instead of dropped, and `analysis.NextMiddlewareName` is cleared only after delegating, so another decorating builder still observes it.

## NoCacheMiddleware

- **Truncated responses.** `Response.OnStarting` was registered unconditionally; with an upstream middleware that had already flushed, it threw and the in-flight response was truncated, failing the request. It now checks `HasStarted`.
- **Empty header shipped.** An explicitly emptied `Cache-Control` was treated as already set, because assigning `""` leaves a `StringValues` with `Count == 1`. Now uses `StringValues.IsNullOrEmpty`.
- `UseNoCache()` added as the documented entry point; the per-request closure is replaced by a cached callback with state.

## Breaking API changes

All correct contracts that did not hold. `ref/Meziantou.AspNetCore.cs` is regenerated.

- The four snapshot types become `sealed class` instead of `record`. As records they advertised value equality that never worked — members are lists compared by reference, so two snapshots of one unchanged app compared unequal and hashed differently. `==`, `!=`, `Equals(T)`, `IEquatable<T>` and the generated `GetHashCode`/`ToString` are gone.
- `MiddlewarePipelineDebugEndpoint.Endpoint` is now `Endpoint?`. It is `[JsonIgnore]`d, so it was always null on a deserialized snapshot despite being non-nullable.
- `DelegateType`/`DelegateMethod` are now `string?` and optional, and `DelegateType` reports the delegate's declaring type rather than a closed generic `Func<,>` full name — which also removes assembly versions and public key tokens from the JSON response.
- `MiddlewarePipelineDebugSnapshot.IsPipelineCaptured` is a new `required` member, distinguishing "not captured yet" from "captured, and empty". A snapshot read from an `IHostedService` — which starts *before* the web host — always fell in the former case with no way to tell.
- `MapMiddlewarePipelineDebugEndpoint` returns a non-nullable `RouteHandlerBuilder` and always registers the route, responding 404 outside Development. Returning `null` meant the natural hardening call, `.RequireAuthorization()`, threw a `NullReferenceException` at startup in production only. It also now reports a missing `AddMiddlewarePipelineDebugging()` in every environment, and carries `[RequiresDynamicCode]` for Native AOT consumers.

## Tests

The suite could not detect any of the above: six tests asserted only that the pipeline was non-empty, which the framework-inserted middlewares satisfy on their own, and the exact-output test had approved a mislabeled name as expected. Now 10 → 21 tests per TFM:

- Real middleware names and registration order; branch capture for `Map`/`UseWhen`; the unattached-branch entry.
- **Framework middleware resolution** — pins eight middlewares across seven assemblies (`EndpointRoutingMiddleware`, `EndpointMiddleware`, `StaticFileMiddleware`, `HttpsRedirectionMiddleware`, `CorsMiddleware`, `AuthenticationMiddleware`, `ResponseCompressionMiddleware`, `ExceptionHandlerMiddleware`). These are internal types reachable only through the reflective walk, so this is the first coverage of it against real middleware; `ExceptionHandlerMiddleware` also covers the `analysis.NextMiddlewareName` branch, which had none. Verified the test fails when the resolver is disabled, and its failure message names which middleware went unresolved.
- Rendering is checked against a hand-built snapshot, so expected text no longer depends on ASP.NET internals or assembly versions — the previous inline snapshot would have broken on a routine framework bump.
- The response-already-started path, an emptied `Cache-Control`, a downstream `OnStarting` (pinning the LIFO ordering the "don't override" guarantee relies on), and an object graph that throws when the walk reads it.

## Reviewer notes

- Verified: 42/42 tests pass (21 × net10.0/net11.0) in Debug **and** Release, clean `Release /p:IsOfficialBuild=true` build with repo analyzers and IDE rules, `ref/` regenerated, `dotnet run ./eng/update-all.cs` clean.
- **Deliberately unchanged:** the debug endpoint stays anonymous by default. Defaulting to `RequireAuthorization()` throws at request time in an app with no authentication configured, which would break the documented Development flow. The environment gate remains the protection; the non-nullable return now makes `.RequireAuthorization()` compose, and the readme shows it.
- **Branch attribution is positional.** `IApplicationBuilder.New()` gives no signal about which later registration owns the branch it creates, so branches attach to the next registered middleware. Correct for `Map`/`MapWhen`/`UseWhen`; a hand-built branch followed by an unrelated registration is still attributed to it. Documented on `Branches`.
- Not addressed here: a trimmed-runtime smoke test proving name resolution survives trimming (needs a new CI leg), and the `eng/update-all.cs` `validate-testprojects` step that never runs despite its CI job name (enabling it affects every project in the repo, so it wants its own PR).
