### PR TITLE
Fix silent state corruption in nested transactions (UndoRedo 4.0)

### DIFF
--- a/ref/Meziantou.Framework.UndoRedo.cs
+++ b/ref/Meziantou.Framework.UndoRedo.cs
@@ -7,15 +7,23 @@ namespace Meziantou.Framework.UndoRedo
     public interface IUndoRedoAction
     {
         bool AllowToMergeWithPrevious { get; }
+        public string? Description { get => throw null; }
         System.Threading.Tasks.ValueTask ExecuteAsync(System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction, System.Threading.CancellationToken cancellationToken = null);
     }
 
+    public enum TransactionExecutionMode
+    {
+        Deferred = 0,
+        Immediate = 1
+    }
+
     public abstract class UndoRedoActionBase : Meziantou.Framework.UndoRedo.IUndoRedoAction
     {
-        protected int ExecuteCount { get => throw null; }
+        protected bool IsApplied { get => throw null; }
         public bool AllowToMergeWithPrevious { get => throw null; set { } }
+        public virtual string? Description { get => throw null; set { } }
         public System.Threading.Tasks.ValueTask ExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         protected abstract System.Threading.Tasks.ValueTask ExecuteCoreAsync(System.Threading.CancellationToken cancellationToken);
         public System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
@@ -33,14 +41,18 @@ namespace Meziantou.Framework.UndoRedo
         protected override System.Threading.Tasks.ValueTask UnExecuteCoreAsync(System.Threading.CancellationToken cancellationToken) => throw null;
     }
 
-    public sealed class UndoRedoManager
+    public sealed class UndoRedoManager : System.ComponentModel.INotifyPropertyChanged
     {
+        public int MaxHistoryDepth { get => throw null; }
         public bool ActionIsExecuting { get => throw null; }
+        public int TransactionDepth { get => throw null; }
         public bool CanUndo { get => throw null; }
         public bool CanRedo { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.UndoRedo.IUndoRedoAction> UndoableActions { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.UndoRedo.IUndoRedoAction> RedoableActions { get => throw null; }
-        public event System.EventHandler? CollectionChanged;
+        public event System.EventHandler? HistoryChanged;
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+        public UndoRedoManager(int maxHistoryDepth) { }
         public System.Threading.Tasks.ValueTask RecordActionAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction action, System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RecordActionAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> execute, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> unexecute, System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RecordActionAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> execute, System.Action unexecute, System.Threading.CancellationToken cancellationToken = null) => throw null;
@@ -49,14 +61,21 @@ namespace Meziantou.Framework.UndoRedo
         public System.Threading.Tasks.ValueTask UndoAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RedoAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public void Clear() { }
-        public Meziantou.Framework.UndoRedo.UndoRedoTransaction CreateTransaction(bool isDelayed = true) => throw null;
-        public System.Threading.Tasks.ValueTask CommitTransactionAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
-        public System.Threading.Tasks.ValueTask RollbackTransactionAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public Meziantou.Framework.UndoRedo.UndoRedoTransaction CreateTransaction(Meziantou.Framework.UndoRedo.TransactionExecutionMode mode = 0) => throw null;
+    }
+
+    public sealed class UndoRedoNotificationException : System.Exception
+    {
+        public UndoRedoNotificationException(string message) { }
+        public UndoRedoNotificationException(string message, System.Exception innerException) { }
     }
 
     public sealed class UndoRedoTransaction : Meziantou.Framework.UndoRedo.IUndoRedoAction, System.IAsyncDisposable
     {
+        public Meziantou.Framework.UndoRedo.TransactionExecutionMode Mode { get => throw null; }
+        public bool IsCompleted { get => throw null; }
         public bool AllowToMergeWithPrevious { get => throw null; set { } }
+        public string? Description { get => throw null; set { } }
         System.Threading.Tasks.ValueTask Meziantou.Framework.UndoRedo.IUndoRedoAction.ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
         System.Threading.Tasks.ValueTask Meziantou.Framework.UndoRedo.IUndoRedoAction.UnExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
         System.Threading.Tasks.ValueTask<bool> Meziantou.Framework.UndoRedo.IUndoRedoAction.TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction, System.Threading.CancellationToken cancellationToken) => throw null;

--- a/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
+++ b/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
@@ -4,45 +4,93 @@ namespace Meziantou.Framework.UndoRedo;
 /// Stores the recorded actions as an undo buffer and a redo buffer. Recording a new action clears
 /// the redo buffer, mirroring the behavior of a typical undo/redo stack.
 /// </summary>
-internal sealed class ActionHistory
+/// <remarks>
+/// The undo buffer is a list ordered from oldest to most recent so the oldest entries can be dropped
+/// once <see cref="MaxDepth"/> is reached; a <see cref="Stack{T}"/> cannot remove its oldest element.
+/// The snapshots handed out by <see cref="UndoableActions"/> and <see cref="RedoableActions"/> are built
+/// once per change instead of once per read, so binding to them does not copy the buffer on every access.
+/// </remarks>
+internal sealed class ActionHistory(int maxDepth)
 {
-    private readonly Stack<IUndoRedoAction> _undo = new();
-    private readonly Stack<IUndoRedoAction> _redo = new();
+    private readonly List<IUndoRedoAction> _undo = [];
+    private readonly List<IUndoRedoAction> _redo = [];
+
+    private IReadOnlyList<IUndoRedoAction>? _undoSnapshot;
+    private IReadOnlyList<IUndoRedoAction>? _redoSnapshot;
+
+    public int MaxDepth { get; } = maxDepth;
 
     public bool CanUndo => _undo.Count > 0;
     public bool CanRedo => _redo.Count > 0;
 
     /// <summary>
-    /// Records a new action. When the action allows merging and the most recent undoable action absorbs it,
-    /// no new entry is added. The redo buffer is cleared either way as the history moved forward.
+    /// Records an action that is not merged into the previous one, dropping the oldest entries once
+    /// <see cref="MaxDepth"/> is exceeded. The redo buffer is cleared as the history moved forward.
     /// </summary>
-    public async ValueTask RecordAsync(IUndoRedoAction action, CancellationToken cancellationToken)
+    public void Record(IUndoRedoAction action)
     {
-        if (!action.AllowToMergeWithPrevious || PeekUndo() is not { } previous || !await previous.TryToMergeAsync(action, cancellationToken).ConfigureAwait(false))
+        _undo.Add(action);
+        if (_undo.Count > MaxDepth)
         {
-            _undo.Push(action);
+            _undo.RemoveRange(0, _undo.Count - MaxDepth);
         }
 
         _redo.Clear();
+        InvalidateSnapshots();
     }
 
-    public IUndoRedoAction? PeekUndo() => _undo.Count > 0 ? _undo.Peek() : null;
+    /// <summary>Clears the redo buffer without recording anything, for an action merged into the previous one.</summary>
+    public void RecordMerged()
+    {
+        _redo.Clear();
+        InvalidateSnapshots();
+    }
 
-    public IUndoRedoAction? PeekRedo() => _redo.Count > 0 ? _redo.Peek() : null;
+    public IUndoRedoAction? PeekUndo() => _undo.Count > 0 ? _undo[^1] : null;
+
+    public IUndoRedoAction? PeekRedo() => _redo.Count > 0 ? _redo[^1] : null;
 
     /// <summary>Moves the most recent undoable action to the redo buffer once it has been reverted.</summary>
-    public void MoveTopUndoToRedo() => _redo.Push(_undo.Pop());
+    public void MoveTopUndoToRedo()
+    {
+        _redo.Add(_undo[^1]);
+        _undo.RemoveAt(_undo.Count - 1);
+        InvalidateSnapshots();
+    }
 
     /// <summary>Moves the most recent redoable action back to the undo buffer once it has been re-executed.</summary>
-    public void MoveTopRedoToUndo() => _undo.Push(_redo.Pop());
+    public void MoveTopRedoToUndo()
+    {
+        _undo.Add(_redo[^1]);
+        _redo.RemoveAt(_redo.Count - 1);
+        InvalidateSnapshots();
+    }
 
     public void Clear()
     {
         _undo.Clear();
         _redo.Clear();
+        InvalidateSnapshots();
     }
 
-    public IReadOnlyList<IUndoRedoAction> UndoableActions => _undo.ToArray();
+    public IReadOnlyList<IUndoRedoAction> UndoableActions => _undoSnapshot ??= CreateSnapshot(_undo);
 
-    public IReadOnlyList<IUndoRedoAction> RedoableActions => _redo.ToArray();
+    public IReadOnlyList<IUndoRedoAction> RedoableActions => _redoSnapshot ??= CreateSnapshot(_redo);
+
+    private void InvalidateSnapshots()
+    {
+        _undoSnapshot = null;
+        _redoSnapshot = null;
+    }
+
+    /// <summary>Copies a buffer into an immutable snapshot ordered from most recent to oldest.</summary>
+    private static IUndoRedoAction[] CreateSnapshot(List<IUndoRedoAction> actions)
+    {
+        if (actions.Count == 0)
+            return [];
+
+        var snapshot = actions.ToArray();
+        Array.Reverse(snapshot);
+        return snapshot;
+    }
 }

--- a/src/Meziantou.Framework.UndoRedo/IUndoRedoAction.cs
+++ b/src/Meziantou.Framework.UndoRedo/IUndoRedoAction.cs
@@ -4,6 +4,10 @@ namespace Meziantou.Framework.UndoRedo;
 /// Represents a single undoable/redoable action. Implementations encapsulate both how to apply
 /// a change (<see cref="ExecuteAsync"/>) and how to revert it (<see cref="UnExecuteAsync"/>).
 /// </summary>
+/// <remarks>
+/// <see cref="UndoRedoManager"/> alternates the two methods: it never applies an action that is already
+/// applied, nor reverts one that is not.
+/// </remarks>
 public interface IUndoRedoAction
 {
     /// <summary>Applies the change encapsulated by this action.</summary>
@@ -19,8 +23,24 @@ public interface IUndoRedoAction
     /// <param name="followingAction">The action recorded right after this one.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns><see langword="true"/> if <paramref name="followingAction"/> was merged into this action; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="followingAction"/> is in the same applied state as this action: both are already
+    /// applied at the top level and inside an <see cref="TransactionExecutionMode.Immediate"/> transaction,
+    /// and neither is applied inside a <see cref="TransactionExecutionMode.Deferred"/> one. An implementation
+    /// must therefore absorb <paramref name="followingAction"/>'s effect without applying it.
+    /// </para>
+    /// <para>
+    /// Returning <see langword="true"/> discards <paramref name="followingAction"/>: it is never executed nor
+    /// reverted by the manager again, so this action becomes responsible for applying and reverting both
+    /// effects from its own <see cref="ExecuteAsync"/> and <see cref="UnExecuteAsync"/>.
+    /// </para>
+    /// </remarks>
     ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken = default);
 
     /// <summary>Gets a value indicating whether this action may be merged with the previous action in the undo buffer.</summary>
     bool AllowToMergeWithPrevious { get; }
+
+    /// <summary>Gets a human-readable description of the action, for display in an undo history. Defaults to <see langword="null"/>.</summary>
+    string? Description => null;
 }

--- a/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
+++ b/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>3.0.1</Version>
+    <Version>4.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Async-first undo/redo framework based on the command pattern, with transactions and action merging.</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.UndoRedo/TransactionExecutionMode.cs
+++ b/src/Meziantou.Framework.UndoRedo/TransactionExecutionMode.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.UndoRedo;
+
+/// <summary>Determines when the actions recorded in an <see cref="UndoRedoTransaction"/> are executed.</summary>
+public enum TransactionExecutionMode
+{
+    /// <summary>The actions are executed when the transaction is committed. Reading the model between two recordings shows the state from before the transaction.</summary>
+    Deferred,
+
+    /// <summary>The actions are executed as they are recorded, so the model stays up to date while the transaction is open.</summary>
+    Immediate,
+}

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoActionBase.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoActionBase.cs
@@ -1,42 +1,47 @@
 namespace Meziantou.Framework.UndoRedo;
 
 /// <summary>
-/// Base class for <see cref="IUndoRedoAction"/> implementations. It tracks how many times the action
-/// has been executed so it cannot be executed or reverted twice in a row, and delegates the actual
-/// work to <see cref="ExecuteCoreAsync"/> and <see cref="UnExecuteCoreAsync"/>.
+/// Base class for <see cref="IUndoRedoAction"/> implementations. It tracks whether the action is currently
+/// applied so it cannot be executed or reverted twice in a row, and delegates the actual work to
+/// <see cref="ExecuteCoreAsync"/> and <see cref="UnExecuteCoreAsync"/>.
 /// </summary>
 public abstract class UndoRedoActionBase : IUndoRedoAction
 {
-    /// <summary>Gets the number of times the action has been executed minus the number of times it has been reverted (0 or 1).</summary>
-    protected int ExecuteCount { get; private set; }
+    /// <summary>Gets a value indicating whether the action is currently applied.</summary>
+    protected bool IsApplied { get; private set; }
 
     /// <inheritdoc />
     public bool AllowToMergeWithPrevious { get; set; }
 
     /// <inheritdoc />
+    public virtual string? Description { get; set; }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">The action is already applied. Recording the same instance twice would add an undo step that reverts nothing.</exception>
     public async ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        if (ExecuteCount > 0)
-            return;
+        if (IsApplied)
+            throw new InvalidOperationException("The action is already applied. An action instance can only be recorded once at a time.");
 
         await ExecuteCoreAsync(cancellationToken).ConfigureAwait(false);
-        ExecuteCount++;
+        IsApplied = true;
     }
 
-    /// <summary>Contains the logic that applies the change. Called by <see cref="ExecuteAsync"/> unless the action is already executed.</summary>
+    /// <summary>Contains the logic that applies the change. Called by <see cref="ExecuteAsync"/>.</summary>
     protected abstract ValueTask ExecuteCoreAsync(CancellationToken cancellationToken);
 
     /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">The action is not currently applied.</exception>
     public async ValueTask UnExecuteAsync(CancellationToken cancellationToken = default)
     {
-        if (ExecuteCount == 0)
-            return;
+        if (!IsApplied)
+            throw new InvalidOperationException("The action is not applied, so it cannot be reverted.");
 
         await UnExecuteCoreAsync(cancellationToken).ConfigureAwait(false);
-        ExecuteCount--;
+        IsApplied = false;
     }
 
-    /// <summary>Contains the logic that reverts the change. Called by <see cref="UnExecuteAsync"/> unless the action is not currently executed.</summary>
+    /// <summary>Contains the logic that reverts the change. Called by <see cref="UnExecuteAsync"/>.</summary>
     protected abstract ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken);
 
     /// <inheritdoc />

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel;
+using System.Runtime.ExceptionServices;
+
 namespace Meziantou.Framework.UndoRedo;
 
 /// <summary>
@@ -24,10 +27,31 @@ namespace Meziantou.Framework.UndoRedo;
 /// await manager.RedoAsync();
 /// </code>
 /// </example>
-public sealed class UndoRedoManager
+public sealed class UndoRedoManager : INotifyPropertyChanged
 {
-    private readonly ActionHistory _history = new();
-    private readonly Stack<UndoRedoTransaction> _transactions = new();
+    private readonly ActionHistory _history;
+
+    // A list rather than a stack so the transaction being completed can reach the one enclosing it.
+    private readonly List<UndoRedoTransaction> _transactions = [];
+
+    /// <summary>Initializes a new instance of the <see cref="UndoRedoManager"/> class with an unbounded history.</summary>
+    public UndoRedoManager()
+        : this(int.MaxValue)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="UndoRedoManager"/> class keeping at most <paramref name="maxHistoryDepth"/> undo steps.</summary>
+    /// <param name="maxHistoryDepth">The maximum number of undo steps to keep. Once exceeded, the oldest steps are dropped and can no longer be undone.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxHistoryDepth"/> is not strictly positive.</exception>
+    public UndoRedoManager(int maxHistoryDepth)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxHistoryDepth, 1);
+
+        _history = new ActionHistory(maxHistoryDepth);
+    }
+
+    /// <summary>Gets the maximum number of undo steps kept in the history.</summary>
+    public int MaxHistoryDepth => _history.MaxDepth;
 
     /// <summary>Gets a value indicating whether an action is currently being executed, undone, or redone.</summary>
     /// <remarks>
@@ -36,40 +60,57 @@ public sealed class UndoRedoManager
     /// </remarks>
     public bool ActionIsExecuting { get; private set; }
 
-    /// <summary>Gets a value indicating whether there is at least one action that can be undone.</summary>
-    public bool CanUndo => _history.CanUndo;
+    /// <summary>Gets the number of transactions that are currently open.</summary>
+    /// <remarks>Undo, redo and <see cref="Clear"/> are unavailable while this is greater than zero.</remarks>
+    public int TransactionDepth => _transactions.Count;
 
-    /// <summary>Gets a value indicating whether there is at least one action that can be redone.</summary>
-    public bool CanRedo => _history.CanRedo;
+    /// <summary>Gets a value indicating whether <see cref="UndoAsync"/> would revert an action right now.</summary>
+    /// <remarks>This is <see langword="false"/> while a transaction is open or an action is executing, so it can be bound directly to a command's availability.</remarks>
+    public bool CanUndo => _transactions.Count == 0 && !ActionIsExecuting && _history.CanUndo;
+
+    /// <summary>Gets a value indicating whether <see cref="RedoAsync"/> would re-execute an action right now.</summary>
+    /// <remarks>This is <see langword="false"/> while a transaction is open or an action is executing, so it can be bound directly to a command's availability.</remarks>
+    public bool CanRedo => _transactions.Count == 0 && !ActionIsExecuting && _history.CanRedo;
 
     /// <summary>Occurs when the undo/redo buffers change (an action is recorded, undone, redone, or the history is cleared).</summary>
-    public event EventHandler? CollectionChanged;
+    /// <remarks>A handler that throws surfaces to the caller as an <see cref="UndoRedoNotificationException"/>, after the operation itself has completed.</remarks>
+    public event EventHandler? HistoryChanged;
+
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>Executes an action and records it so it can later be undone.</summary>
     /// <param name="action">The action to execute and record.</param>
     /// <param name="cancellationToken">A token to cancel the execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">An action is currently executing, or <paramref name="action"/> is a transaction that is still open or belongs to another manager.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is cancelled.</exception>
+    /// <exception cref="UndoRedoNotificationException">A <see cref="HistoryChanged"/> handler failed. The action was recorded.</exception>
     public async ValueTask RecordActionAsync(IUndoRedoAction action, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(action);
         EnsureNoActionIsExecuting();
+        EnsureCanBeRecorded(action);
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (_transactions.Count > 0)
         {
-            var transaction = _transactions.Peek();
+            var transaction = _transactions[^1];
 
             // An action that fails to execute must not become part of the transaction, otherwise it
             // would be reverted on rollback and executed for the first time on redo.
-            if (!transaction.IsDelayed)
+            if (transaction.Mode is TransactionExecutionMode.Immediate)
             {
                 await ExecuteAsync(action, cancellationToken).ConfigureAwait(false);
-                transaction.Add(action);
-                transaction.MarkExecuted();
             }
-            else
+
+            var (merged, mergeFailure) = await TryToMergeAsync(transaction.LastAction, action, cancellationToken).ConfigureAwait(false);
+            if (!merged)
             {
                 transaction.Add(action);
             }
 
+            mergeFailure?.Throw();
             return;
         }
 
@@ -80,6 +121,7 @@ public sealed class UndoRedoManager
     /// <param name="execute">The delegate invoked to apply the change.</param>
     /// <param name="unexecute">The delegate invoked to revert the change.</param>
     /// <param name="cancellationToken">A token to cancel the execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="execute"/> or <paramref name="unexecute"/> is <see langword="null"/>.</exception>
     public ValueTask RecordActionAsync(Func<CancellationToken, ValueTask> execute, Func<CancellationToken, ValueTask> unexecute, CancellationToken cancellationToken = default)
         => RecordActionAsync(new UndoRedoDelegateAction(execute, unexecute), cancellationToken);
 
@@ -87,6 +129,7 @@ public sealed class UndoRedoManager
     /// <param name="execute">The delegate invoked to apply the change.</param>
     /// <param name="unexecute">The delegate invoked to revert the change.</param>
     /// <param name="cancellationToken">A token to cancel the execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="execute"/> or <paramref name="unexecute"/> is <see langword="null"/>.</exception>
     public ValueTask RecordActionAsync(Func<CancellationToken, ValueTask> execute, Action unexecute, CancellationToken cancellationToken = default)
         => RecordActionAsync(new UndoRedoDelegateAction(execute, unexecute), cancellationToken);
 
@@ -94,6 +137,7 @@ public sealed class UndoRedoManager
     /// <param name="execute">The delegate invoked to apply the change.</param>
     /// <param name="unexecute">The delegate invoked to revert the change.</param>
     /// <param name="cancellationToken">A token to cancel the execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="execute"/> or <paramref name="unexecute"/> is <see langword="null"/>.</exception>
     public ValueTask RecordActionAsync(Action execute, Func<CancellationToken, ValueTask> unexecute, CancellationToken cancellationToken = default)
         => RecordActionAsync(new UndoRedoDelegateAction(execute, unexecute), cancellationToken);
 
@@ -101,17 +145,21 @@ public sealed class UndoRedoManager
     /// <param name="execute">The delegate invoked to apply the change.</param>
     /// <param name="unexecute">The delegate invoked to revert the change.</param>
     /// <param name="cancellationToken">A token to cancel the execution.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="execute"/> or <paramref name="unexecute"/> is <see langword="null"/>.</exception>
     public ValueTask RecordActionAsync(Action execute, Action unexecute, CancellationToken cancellationToken = default)
         => RecordActionAsync(new UndoRedoDelegateAction(execute, unexecute), cancellationToken);
 
-    /// <summary>Reverts the most recently recorded action.</summary>
+    /// <summary>Reverts the most recently recorded action. Does nothing when there is none.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="InvalidOperationException">An action is currently executing, or a transaction is open.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is cancelled.</exception>
+    /// <exception cref="AggregateException">A grouped action failed to revert and re-applying the actions already reverted failed too.</exception>
+    /// <exception cref="UndoRedoNotificationException">A <see cref="HistoryChanged"/> handler failed. The action was reverted.</exception>
     public async ValueTask UndoAsync(CancellationToken cancellationToken = default)
     {
         EnsureNoActionIsExecuting();
-
-        if (_transactions.Count > 0)
-            throw new InvalidOperationException("Cannot undo while a transaction is open.");
+        EnsureNoOpenTransaction("undo");
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (_history.PeekUndo() is not { } action)
             return;
@@ -127,17 +175,20 @@ public sealed class UndoRedoManager
         }
 
         _history.MoveTopUndoToRedo();
-        OnCollectionChanged();
+        OnHistoryChanged();
     }
 
-    /// <summary>Re-executes the most recently undone action.</summary>
+    /// <summary>Re-executes the most recently undone action. Does nothing when there is none.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="InvalidOperationException">An action is currently executing, or a transaction is open.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is cancelled.</exception>
+    /// <exception cref="AggregateException">A grouped action failed and reverting the actions that already ran failed too.</exception>
+    /// <exception cref="UndoRedoNotificationException">A <see cref="HistoryChanged"/> handler failed. The action was re-executed.</exception>
     public async ValueTask RedoAsync(CancellationToken cancellationToken = default)
     {
         EnsureNoActionIsExecuting();
-
-        if (_transactions.Count > 0)
-            throw new InvalidOperationException("Cannot redo while a transaction is open.");
+        EnsureNoOpenTransaction("redo");
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (_history.PeekRedo() is not { } action)
             return;
@@ -153,131 +204,106 @@ public sealed class UndoRedoManager
         }
 
         _history.MoveTopRedoToUndo();
-        OnCollectionChanged();
+        OnHistoryChanged();
     }
 
     /// <summary>Empties both the undo and redo buffers.</summary>
+    /// <exception cref="InvalidOperationException">An action is currently executing, or a transaction is open.</exception>
+    /// <exception cref="UndoRedoNotificationException">A <see cref="HistoryChanged"/> handler failed. The history was cleared.</exception>
     public void Clear()
     {
         EnsureNoActionIsExecuting();
-
-        if (_transactions.Count > 0)
-            throw new InvalidOperationException("Cannot clear the history while a transaction is open.");
+        EnsureNoOpenTransaction("clear the history");
 
         _history.Clear();
-        OnCollectionChanged();
+        OnHistoryChanged();
     }
 
     /// <summary>Gets a snapshot of the actions that can be undone, most recent first.</summary>
-    /// <remarks>Each access allocates a new snapshot, so it stays stable while the history changes.</remarks>
+    /// <remarks>The snapshot is rebuilt when the history changes rather than on every access, so an instance obtained earlier stays unchanged.</remarks>
     public IReadOnlyList<IUndoRedoAction> UndoableActions => _history.UndoableActions;
 
     /// <summary>Gets a snapshot of the actions that can be redone, most recent first.</summary>
-    /// <remarks>Each access allocates a new snapshot, so it stays stable while the history changes.</remarks>
+    /// <remarks>The snapshot is rebuilt when the history changes rather than on every access, so an instance obtained earlier stays unchanged.</remarks>
     public IReadOnlyList<IUndoRedoAction> RedoableActions => _history.RedoableActions;
 
     /// <summary>Begins a transaction that groups subsequent recorded actions into a single undo step.</summary>
-    /// <param name="isDelayed">
-    /// When <see langword="true"/> (the default), actions added to the transaction are executed only when the
-    /// transaction is committed. When <see langword="false"/>, actions are executed as soon as they are recorded.
+    /// <param name="mode">
+    /// Whether the recorded actions run when the transaction is committed (<see cref="TransactionExecutionMode.Deferred"/>,
+    /// the default) or as they are recorded (<see cref="TransactionExecutionMode.Immediate"/>).
     /// </param>
     /// <returns>
-    /// A transaction that should be committed or rolled back. Disposing it commits the transaction unless it was already
-    /// completed, including when the scope is left because of an exception. Nested transactions must be completed from
-    /// the innermost out.
+    /// A transaction that must be committed with <see cref="UndoRedoTransaction.CommitAsync"/> to be kept. Disposing it
+    /// rolls it back unless it was already completed. Nested transactions must use the same <paramref name="mode"/> as the
+    /// transaction they are nested in, and must be completed from the innermost out.
     /// </returns>
-    public UndoRedoTransaction CreateTransaction(bool isDelayed = true)
+    /// <exception cref="InvalidOperationException">An action is currently executing, or <paramref name="mode"/> differs from the enclosing transaction's mode.</exception>
+    public UndoRedoTransaction CreateTransaction(TransactionExecutionMode mode = TransactionExecutionMode.Deferred)
     {
         EnsureNoActionIsExecuting();
 
-        var transaction = new UndoRedoTransaction(this, isDelayed);
-        _transactions.Push(transaction);
+        // Mixing the two modes would execute a nested immediate action before the deferred actions recorded
+        // before it, so undoing the group would not be the inverse of applying it.
+        if (_transactions.Count > 0 && _transactions[^1].Mode != mode)
+            throw new InvalidOperationException($"Cannot create a {mode} transaction inside a {_transactions[^1].Mode} one. Nested transactions must use the same execution mode.");
+
+        var transaction = new UndoRedoTransaction(this, mode);
+        _transactions.Add(transaction);
+        OnAvailabilityChanged();
         return transaction;
     }
 
-    /// <summary>Commits the innermost open transaction, recording it as a single undo step (or merging it into its parent transaction).</summary>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public ValueTask CommitTransactionAsync(CancellationToken cancellationToken = default)
-    {
-        EnsureNoActionIsExecuting();
-
-        if (_transactions.Count == 0)
-            throw new InvalidOperationException("There is no transaction to commit.");
-
-        return CommitTransactionCoreAsync(cancellationToken);
-    }
-
     /// <summary>Commits <paramref name="transaction"/>, which must be the innermost open transaction.</summary>
-    internal ValueTask CommitTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
+    internal async ValueTask CommitTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
     {
         EnsureNoActionIsExecuting();
         EnsureIsInnermostTransaction(transaction, "commit");
+        cancellationToken.ThrowIfCancellationRequested();
 
-        return CommitTransactionCoreAsync(cancellationToken);
-    }
-
-    private async ValueTask CommitTransactionCoreAsync(CancellationToken cancellationToken)
-    {
-        var transaction = _transactions.Pop();
-        transaction.MarkCompleted();
-
-        if (!transaction.HasActions)
-            return;
-
-        // When the transaction is not delayed, its actions have already been executed.
-        var execute = transaction.IsDelayed;
-
-        if (_transactions.Count > 0)
+        if (transaction.HasActions)
         {
-            var parent = _transactions.Peek();
-            parent.Add(transaction);
-            if (execute && !parent.IsDelayed)
+            if (_transactions.Count > 1)
             {
-                await ExecuteAsync(transaction, cancellationToken).ConfigureAwait(false);
-                parent.MarkExecuted();
+                // The parent shares this transaction's mode, so the group is either already applied
+                // (immediate) or applied by the parent when it is itself committed (deferred).
+                _transactions[^2].Add(transaction);
             }
-
-            return;
+            else
+            {
+                // Record before completing the transaction: if an action fails, the transaction stays open
+                // so the caller can roll it back or retry once the cause is resolved.
+                await RecordActionCoreAsync(transaction, execute: transaction.Mode is TransactionExecutionMode.Deferred, cancellationToken).ConfigureAwait(false);
+            }
         }
 
-        await RecordActionCoreAsync(transaction, execute, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>Rolls back the innermost open transaction, reverting any actions that were already executed.</summary>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public ValueTask RollbackTransactionAsync(CancellationToken cancellationToken = default)
-    {
-        EnsureNoActionIsExecuting();
-
-        if (_transactions.Count == 0)
-            throw new InvalidOperationException("There is no transaction to roll back.");
-
-        return RollbackTransactionCoreAsync(cancellationToken);
+        CompleteTransaction(transaction);
     }
 
     /// <summary>Rolls back <paramref name="transaction"/>, which must be the innermost open transaction.</summary>
-    internal ValueTask RollbackTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
+    internal async ValueTask RollbackTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
     {
         EnsureNoActionIsExecuting();
         EnsureIsInnermostTransaction(transaction, "roll back");
 
-        return RollbackTransactionCoreAsync(cancellationToken);
-    }
-
-    private async ValueTask RollbackTransactionCoreAsync(CancellationToken cancellationToken)
-    {
-        var transaction = _transactions.Pop();
-        transaction.MarkCompleted();
-
         ActionIsExecuting = true;
         try
         {
+            // The transaction is only completed once the revert succeeded, so a failed rollback can be retried.
             await transaction.UnExecuteCoreAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
             ActionIsExecuting = false;
         }
+
+        CompleteTransaction(transaction);
+    }
+
+    private void CompleteTransaction(UndoRedoTransaction transaction)
+    {
+        _transactions.RemoveAt(_transactions.Count - 1);
+        transaction.MarkCompleted();
+        OnAvailabilityChanged();
     }
 
     private void EnsureNoActionIsExecuting()
@@ -288,19 +314,74 @@ public sealed class UndoRedoManager
             throw new InvalidOperationException("Cannot change the undo/redo history while an action is executing.");
     }
 
+    private void EnsureNoOpenTransaction(string operation)
+    {
+        if (_transactions.Count > 0)
+            throw new InvalidOperationException($"Cannot {operation} while a transaction is open ({_transactions.Count} open). Commit or roll back the open transactions first.");
+    }
+
     private void EnsureIsInnermostTransaction(UndoRedoTransaction transaction, string operation)
     {
-        if (_transactions.Count == 0 || _transactions.Peek() != transaction)
+        if (_transactions.Count == 0 || _transactions[^1] != transaction)
             throw new InvalidOperationException($"Cannot {operation} this transaction because it is not the innermost open transaction. Complete the nested transactions first.");
+    }
+
+    private void EnsureCanBeRecorded(IUndoRedoAction action)
+    {
+        if (action is not UndoRedoTransaction transaction)
+            return;
+
+        if (!ReferenceEquals(transaction.Manager, this))
+            throw new InvalidOperationException("Cannot record a transaction created by another UndoRedoManager.");
+
+        if (!transaction.IsCompleted)
+            throw new InvalidOperationException("Cannot record a transaction that is still open. Commit it instead.");
     }
 
     private async ValueTask RecordActionCoreAsync(IUndoRedoAction action, bool execute, CancellationToken cancellationToken)
     {
         if (execute)
+        {
             await ExecuteAsync(action, cancellationToken).ConfigureAwait(false);
+        }
 
-        await _history.RecordAsync(action, cancellationToken).ConfigureAwait(false);
-        OnCollectionChanged();
+        var (merged, mergeFailure) = await TryToMergeAsync(_history.PeekUndo(), action, cancellationToken).ConfigureAwait(false);
+        if (merged)
+        {
+            _history.RecordMerged();
+        }
+        else
+        {
+            _history.Record(action);
+        }
+
+        OnHistoryChanged();
+
+        // The action is applied either way, so the buffers are made consistent before a failing merge
+        // implementation is reported; otherwise the change would stay applied with no undo entry.
+        mergeFailure?.Throw();
+    }
+
+    /// <summary>Attempts to merge <paramref name="action"/> into <paramref name="previous"/>, capturing rather than propagating a failure.</summary>
+    private async ValueTask<(bool Merged, ExceptionDispatchInfo? Failure)> TryToMergeAsync(IUndoRedoAction? previous, IUndoRedoAction action, CancellationToken cancellationToken)
+    {
+        if (!action.AllowToMergeWithPrevious || previous is null)
+            return (false, null);
+
+        // TryToMergeAsync is user code just like execute and unexecute, so it gets the same reentrancy guard.
+        ActionIsExecuting = true;
+        try
+        {
+            return (await previous.TryToMergeAsync(action, cancellationToken).ConfigureAwait(false), null);
+        }
+        catch (Exception exception)
+        {
+            return (false, ExceptionDispatchInfo.Capture(exception));
+        }
+        finally
+        {
+            ActionIsExecuting = false;
+        }
     }
 
     private async ValueTask ExecuteAsync(IUndoRedoAction action, CancellationToken cancellationToken)
@@ -316,5 +397,28 @@ public sealed class UndoRedoManager
         }
     }
 
-    private void OnCollectionChanged() => CollectionChanged?.Invoke(this, EventArgs.Empty);
+    private void OnHistoryChanged()
+    {
+        OnPropertyChanged(nameof(UndoableActions));
+        OnPropertyChanged(nameof(RedoableActions));
+        OnAvailabilityChanged();
+
+        try
+        {
+            HistoryChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception exception)
+        {
+            throw new UndoRedoNotificationException($"A {nameof(HistoryChanged)} handler threw an exception. The undo/redo operation itself completed successfully and must not be retried.", exception);
+        }
+    }
+
+    private void OnAvailabilityChanged()
+    {
+        OnPropertyChanged(nameof(CanUndo));
+        OnPropertyChanged(nameof(CanRedo));
+        OnPropertyChanged(nameof(TransactionDepth));
+    }
+
+    private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoNotificationException.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoNotificationException.cs
@@ -1,0 +1,30 @@
+namespace Meziantou.Framework.UndoRedo;
+
+/// <summary>
+/// Thrown when a <see cref="UndoRedoManager.HistoryChanged"/> handler fails. The operation that raised the
+/// notification (recording, undoing, redoing or clearing) has already completed successfully, so the caller
+/// must not retry it; only the notification failed.
+/// </summary>
+public sealed class UndoRedoNotificationException : Exception
+{
+    /// <summary>Initializes a new instance of the <see cref="UndoRedoNotificationException"/> class.</summary>
+    public UndoRedoNotificationException()
+        : base("A HistoryChanged handler threw an exception. The undo/redo operation itself completed successfully.")
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="UndoRedoNotificationException"/> class.</summary>
+    /// <param name="message">The message that describes the error.</param>
+    public UndoRedoNotificationException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="UndoRedoNotificationException"/> class.</summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception thrown by the handler.</param>
+    public UndoRedoNotificationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
@@ -2,22 +2,24 @@ namespace Meziantou.Framework.UndoRedo;
 
 /// <summary>
 /// Groups several actions into a single undoable/redoable unit. Create one with
-/// <see cref="UndoRedoManager.CreateTransaction"/> and commit it (explicitly or by disposal) to
-/// record it as a single step. Committing is all-or-nothing: if one of the actions fails, the
-/// actions that already ran are reverted before the exception is propagated.
+/// <see cref="UndoRedoManager.CreateTransaction"/> and commit it to record it as a single step.
+/// Committing is all-or-nothing: if one of the actions fails, the actions that already ran are
+/// reverted before the exception is propagated.
 /// </summary>
 /// <remarks>
-/// Disposal commits the transaction, including when the scope is left because of an exception. Call
-/// <see cref="RollbackAsync"/> explicitly to discard the actions recorded so far. Nested transactions
-/// must be completed from the innermost out.
+/// Disposal rolls the transaction back unless <see cref="CommitAsync"/> was called, so leaving the scope
+/// because of an exception discards the work instead of applying it. Nested transactions must use the same
+/// <see cref="TransactionExecutionMode"/> as the transaction they are nested in, and must be completed from
+/// the innermost out.
 /// </remarks>
 /// <example>
 /// <code>
-/// await using (manager.CreateTransaction())
+/// await using (var transaction = manager.CreateTransaction())
 /// {
 ///     await manager.RecordActionAsync(addFirst, removeFirst);
 ///     await manager.RecordActionAsync(addSecond, removeSecond);
-/// } // committed on dispose: a single UndoAsync reverts both actions
+///     await transaction.CommitAsync();
+/// } // a single UndoAsync reverts both actions
 /// </code>
 /// </example>
 public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
@@ -25,25 +27,46 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     private readonly UndoRedoManager _manager;
     private readonly List<IUndoRedoAction> _actions = [];
     private bool _completed;
-    private bool _executed;
+    private bool _applied;
 
-    internal UndoRedoTransaction(UndoRedoManager manager, bool isDelayed)
+    internal UndoRedoTransaction(UndoRedoManager manager, TransactionExecutionMode mode)
     {
         _manager = manager;
-        IsDelayed = isDelayed;
+        Mode = mode;
     }
 
-    /// <summary>Gets a value indicating whether the actions are executed on commit (<see langword="true"/>) or as they are recorded (<see langword="false"/>).</summary>
-    internal bool IsDelayed { get; }
+    /// <summary>Gets a value indicating when the actions recorded in this transaction are executed.</summary>
+    public TransactionExecutionMode Mode { get; }
 
-    internal bool HasActions => _actions.Count > 0;
+    /// <summary>Gets a value indicating whether the transaction has been committed or rolled back.</summary>
+    public bool IsCompleted => _completed;
 
     /// <inheritdoc />
     public bool AllowToMergeWithPrevious { get; set; }
 
-    internal void Add(IUndoRedoAction action) => _actions.Add(action);
+    /// <inheritdoc />
+    public string? Description { get; set; }
 
-    internal void MarkExecuted() => _executed = true;
+    internal UndoRedoManager Manager => _manager;
+
+    internal bool HasActions => _actions.Count > 0;
+
+    internal IUndoRedoAction? LastAction => _actions.Count > 0 ? _actions[^1] : null;
+
+    /// <summary>
+    /// Adds an action to the transaction. In <see cref="TransactionExecutionMode.Immediate"/> mode the action
+    /// has already been applied by the manager, which is what makes the transaction itself applied — this is
+    /// the only place that state comes from, so a transaction that merely holds applied children still reverts
+    /// them on undo or rollback.
+    /// </summary>
+    internal void Add(IUndoRedoAction action)
+    {
+        _actions.Add(action);
+        if (Mode is TransactionExecutionMode.Immediate)
+        {
+            _applied = true;
+        }
+    }
 
     internal void MarkCompleted() => _completed = true;
 
@@ -63,11 +86,13 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     /// </summary>
     internal async ValueTask ExecuteCoreAsync(CancellationToken cancellationToken)
     {
-        if (_executed)
+        if (_applied)
             return;
 
         for (var i = 0; i < _actions.Count; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 await _actions[i].ExecuteAsync(cancellationToken).ConfigureAwait(false);
@@ -79,7 +104,7 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
             }
         }
 
-        _executed = true;
+        _applied = true;
     }
 
     /// <summary>
@@ -89,11 +114,13 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     /// </summary>
     internal async ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken)
     {
-        if (!_executed)
+        if (!_applied)
             return;
 
         for (var i = _actions.Count - 1; i >= 0; i--)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 await _actions[i].UnExecuteAsync(cancellationToken).ConfigureAwait(false);
@@ -105,7 +132,7 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
             }
         }
 
-        _executed = false;
+        _applied = false;
     }
 
     private static async ValueTask CompensateAsync(Exception exception, Func<ValueTask> compensate)
@@ -141,7 +168,8 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
 
     /// <summary>Commits the transaction, recording it as a single undo step.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <exception cref="InvalidOperationException">The transaction is already completed, or it is not the innermost open transaction.</exception>
+    /// <exception cref="InvalidOperationException">The transaction is already completed, it is not the innermost open transaction, or an action is currently executing.</exception>
+    /// <exception cref="AggregateException">An action failed and reverting the actions that already ran failed too, leaving them applied.</exception>
     public ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
         EnsureNotCompleted();
@@ -151,7 +179,9 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
 
     /// <summary>Rolls back the transaction, reverting any actions that were already executed.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <exception cref="InvalidOperationException">The transaction is already completed, or it is not the innermost open transaction.</exception>
+    /// <remarks>The transaction stays open if the rollback fails, so it can be retried once the cause is resolved.</remarks>
+    /// <exception cref="InvalidOperationException">The transaction is already completed, it is not the innermost open transaction, or an action is currently executing.</exception>
+    /// <exception cref="AggregateException">An action failed to revert and re-applying the actions that were already reverted failed too.</exception>
     public ValueTask RollbackAsync(CancellationToken cancellationToken = default)
     {
         EnsureNotCompleted();
@@ -160,16 +190,16 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     }
 
     /// <summary>
-    /// Commits the transaction if it has not already been committed or rolled back. Note that this commits even
-    /// when the scope is left because of an exception; call <see cref="RollbackAsync"/> explicitly to discard the
-    /// actions recorded so far.
+    /// Rolls the transaction back if it has not already been committed or rolled back, so leaving the scope
+    /// because of an exception discards the recorded actions instead of applying them. Call
+    /// <see cref="CommitAsync"/> to keep them.
     /// </summary>
     public async ValueTask DisposeAsync()
     {
         if (_completed)
             return;
 
-        await CommitAsync().ConfigureAwait(false);
+        await RollbackAsync().ConfigureAwait(false);
     }
 
     private void EnsureNotCompleted()

--- a/src/Meziantou.Framework.UndoRedo/readme.md
+++ b/src/Meziantou.Framework.UndoRedo/readme.md
@@ -19,7 +19,7 @@ await manager.UndoAsync(); // list = []
 await manager.RedoAsync(); // list = [1]
 ````
 
-`CanUndo` and `CanRedo` indicate whether an operation is available, and `CollectionChanged` is raised whenever the history changes.
+`CanUndo` and `CanRedo` indicate whether the corresponding operation would succeed right now: they are `false` while a transaction is open or an action is running, so they can be bound directly to a command's availability. `UndoRedoManager` implements `INotifyPropertyChanged` and raises it for `CanUndo`, `CanRedo`, `UndoableActions`, `RedoableActions` and `TransactionDepth`; the `HistoryChanged` event is raised whenever the buffers change.
 
 The `execute` and `unexecute` delegates can each be synchronous or asynchronous, and the two may be mixed. Build the action with `UndoRedoDelegateAction` and record it:
 
@@ -32,9 +32,19 @@ var action = new UndoRedoDelegateAction(
 await manager.RecordActionAsync(action);
 ````
 
+Set `Description` on an action to label it in an undo history UI; it is exposed through `UndoableActions` and `RedoableActions`.
+
+## Limit how much history is kept
+
+By default the history is unbounded. Pass a maximum depth to drop the oldest steps instead of growing for the lifetime of the process:
+
+````c#
+var manager = new UndoRedoManager(maxHistoryDepth: 100);
+````
+
 ## Custom action
 
-For reusable actions, derive from `UndoRedoActionBase`. The base class guards against executing or reverting twice in a row.
+For reusable actions, derive from `UndoRedoActionBase`. The base class tracks whether the action is currently applied, and throws if it would be executed or reverted twice in a row.
 
 ````c#
 sealed class AddItemAction(IList<int> list, int value) : UndoRedoActionBase
@@ -55,59 +65,58 @@ sealed class AddItemAction(IList<int> list, int value) : UndoRedoActionBase
 await manager.RecordActionAsync(new AddItemAction(list, 42));
 ````
 
+An action instance can only be recorded once at a time: recording the same instance twice would add an undo step that reverts nothing, so it throws instead.
+
 ## Group actions in a transaction
 
-A transaction groups several actions into a single undo step. Disposing the transaction commits it (use `await using`), or call `RollbackAsync` to revert it.
+A transaction groups several actions into a single undo step. **It must be committed to be kept** — disposing it without committing rolls it back, so leaving the scope because of an exception discards the work rather than applying it.
 
 ````c#
-await using (manager.CreateTransaction())
+await using (var transaction = manager.CreateTransaction())
 {
     await manager.RecordActionAsync(addFirst, removeFirst);
     await manager.RecordActionAsync(addSecond, removeSecond);
+    await transaction.CommitAsync();
 }
 
 // A single UndoAsync reverts both actions
 await manager.UndoAsync();
 ````
 
-> **Disposing always commits**, including when the scope is left because of an exception. To discard the actions
-> recorded so far, call `RollbackAsync` explicitly:
->
-> ````c#
-> var transaction = manager.CreateTransaction();
-> try
-> {
->     await manager.RecordActionAsync(addFirst, removeFirst);
->     await manager.RecordActionAsync(addSecond, removeSecond);
->     await transaction.CommitAsync();
-> }
-> catch
-> {
->     await transaction.RollbackAsync();
->     throw;
-> }
-> ````
+### Execution mode
 
-Nested transactions must be completed from the innermost out; committing or rolling back a transaction while one of
-its nested transactions is still open throws an `InvalidOperationException`.
+`CreateTransaction` takes a `TransactionExecutionMode`:
 
-Committing a transaction is all-or-nothing: if one of its actions fails, the actions that already ran are reverted
-before the exception is propagated.
+| Mode | When the actions run | Failure semantics |
+| --- | --- | --- |
+| `Deferred` (default) | When the transaction is committed. Reading the model between two recordings shows the state from before the transaction. | All-or-nothing: if one action fails during the commit, the actions that already ran are reverted before the exception is propagated. |
+| `Immediate` | As they are recorded, so the model stays up to date while the transaction is open. | A failing action does not join the transaction, but the actions recorded before it stay applied. Call `RollbackAsync` to revert them. |
+
+Nested transactions must use the same mode as the transaction they are nested in; mixing them would execute the nested actions before the enclosing ones, so undo would not be the inverse of execute. `CreateTransaction` throws an `InvalidOperationException` instead.
+
+Nested transactions must also be completed from the innermost out; committing or rolling back a transaction while one of its nested transactions is still open throws an `InvalidOperationException`.
+
+A commit or a rollback that fails leaves the transaction open, so it can be rolled back or retried once the cause is resolved. If the compensating revert fails too, an `AggregateException` carrying both the original failure and the compensation failure is thrown, and the actions that could not be reverted stay applied.
 
 ## Merge consecutive actions
 
-When an action sets `AllowToMergeWithPrevious` and the previous action's `TryToMergeAsync` returns `true`, both collapse into a single undo step. This is useful for chains of similar operations such as typing or dragging.
+When an action sets `AllowToMergeWithPrevious` and the previous action's `TryToMergeAsync` returns `true`, both collapse into a single undo step. This is useful for chains of similar operations such as typing or dragging, and works both at the top level and inside a transaction.
 
-> Note: `UndoRedoManager` is not thread-safe; operate on it from a single logical flow. An action must not record,
-> undo, or redo anything while it is executing: those operations throw an `InvalidOperationException` as long as
-> `ActionIsExecuting` is `true`.
+`followingAction` is in the same applied state as the action absorbing it — both are already applied at the top level and in an `Immediate` transaction, neither is in a `Deferred` one — so an implementation must absorb its effect without applying it. Returning `true` discards `followingAction`: the merging action becomes responsible for applying and reverting both effects.
 
-## Migrating from 2.x
+> Note: `UndoRedoManager` is not thread-safe; operate on it from a single logical flow. An action must not record, undo, or redo anything while it is executing — including from `TryToMergeAsync`: those operations throw an `InvalidOperationException` as long as `ActionIsExecuting` is `true`.
 
-| 2.x | 3.0 |
+## Migrating from 3.x
+
+| 3.x | 4.0 |
 | --- | --- |
-| `IUndoRedoAction.CanExecute()` / `CanUnExecute()` | Removed. `UndoRedoManager` never called them; use `CanUndo` / `CanRedo` to know whether an operation is available. |
-| `TryToMergeAsync(IUndoRedoAction)` | `TryToMergeAsync(IUndoRedoAction, CancellationToken)` |
-| `UndoRedoTransaction.ExecuteAsync` / `UnExecuteAsync` / `TryToMergeAsync` | Explicit interface implementations; cast to `IUndoRedoAction` to reach them. |
-| `UndoableActions` / `RedoableActions` returning `IEnumerable<IUndoRedoAction>` | `IReadOnlyList<IUndoRedoAction>`, a snapshot taken on each access. |
-| Recording, undoing or redoing from inside a running action | Throws `InvalidOperationException`. |
+| `CreateTransaction(bool isDelayed = true)` | `CreateTransaction(TransactionExecutionMode mode = Deferred)`. `isDelayed: true` is `Deferred`, `isDelayed: false` is `Immediate`. |
+| Disposing a transaction committed it | Disposing rolls it back unless `CommitAsync` was called. Add an explicit `await transaction.CommitAsync()` before leaving the scope. |
+| Nesting transactions with different `isDelayed` values | Throws `InvalidOperationException`. Nested transactions must use the enclosing mode. |
+| `UndoRedoManager.CommitTransactionAsync()` / `RollbackTransactionAsync()` | Removed; they acted on the innermost transaction regardless of which handle the caller held. Use `transaction.CommitAsync()` / `RollbackAsync()`. |
+| `CollectionChanged` | `HistoryChanged`. `UndoRedoManager` now also implements `INotifyPropertyChanged`. |
+| `CanUndo` / `CanRedo` reported the buffer state | They report whether the operation would succeed, so they are `false` while a transaction is open or an action is executing. |
+| `UndoRedoActionBase.ExecuteCount` | `IsApplied`. Executing an already applied action, or reverting one that is not applied, now throws instead of being a silent no-op. |
+| A cancelled `CancellationToken` was only forwarded to the action | Every operation throws `OperationCanceledException` before running anything. |
+| A `CollectionChanged` handler that threw surfaced as if the operation had failed | Handler failures surface as `UndoRedoNotificationException` after the operation completed successfully. |
+| Unbounded history | Still the default; pass `new UndoRedoManager(maxHistoryDepth)` to bound it. |

--- a/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
+++ b/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
@@ -109,15 +109,131 @@ public sealed class UndoRedoManagerTests
     }
 
     [Fact]
+    public async Task Merge_ClearsRedoBuffer()
+    {
+        var manager = new UndoRedoManager();
+        var sum = 0;
+
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), CancellationToken);
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 2), CancellationToken);
+        await manager.UndoAsync(CancellationToken);
+        Assert.True(manager.CanRedo);
+
+        // Recording moves the history forward, so the redo buffer must be dropped even when the action is merged.
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 4) { AllowToMergeWithPrevious = true }, CancellationToken);
+
+        Assert.False(manager.CanRedo);
+        Assert.Equal(5, sum);
+        Assert.Single(manager.UndoableActions);
+
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(0, sum);
+    }
+
+    [Fact]
+    public async Task Merge_RefusedByPreviousAction_RecordsItsOwnStep()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+
+        // The previous action is a delegate action, whose TryToMergeAsync always refuses.
+        var refused = new UndoRedoDelegateAction(() => log.Add("do:b"), () => log.Add("undo:b")) { AllowToMergeWithPrevious = true };
+        await manager.RecordActionAsync(refused, CancellationToken);
+
+        Assert.Equal(2, manager.UndoableActions.Count);
+
+        await manager.UndoAsync(CancellationToken);
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["do:a", "do:b", "undo:b", "undo:a"], log);
+    }
+
+    [Fact]
+    public async Task Merge_OnAnEmptyHistory_RecordsItsOwnStep()
+    {
+        var manager = new UndoRedoManager();
+        var sum = 0;
+
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1) { AllowToMergeWithPrevious = true }, CancellationToken);
+
+        Assert.Equal(1, sum);
+        Assert.Single(manager.UndoableActions);
+    }
+
+    [Fact]
+    public async Task Merge_InsideATransaction_CollapsesTheActions()
+    {
+        var manager = new UndoRedoManager();
+        var sum = 0;
+
+        var transaction = manager.CreateTransaction(TransactionExecutionMode.Immediate);
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), CancellationToken);
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 2) { AllowToMergeWithPrevious = true }, CancellationToken);
+        await transaction.CommitAsync(CancellationToken);
+
+        Assert.Equal(3, sum);
+        Assert.Single(manager.UndoableActions);
+
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(0, sum);
+    }
+
+    [Fact]
+    public async Task Merge_ThatThrows_StillRecordsTheAppliedActionAndClearsRedo()
+    {
+        var manager = new UndoRedoManager();
+        var doc = new List<string>();
+
+        await manager.RecordActionAsync(new ThrowingMergeAction(doc, "p"), CancellationToken);
+        await manager.RecordActionAsync(() => doc.Add("y"), () => doc.Remove("y"), CancellationToken);
+        await manager.UndoAsync(CancellationToken);
+        Assert.True(manager.CanRedo);
+
+        var following = new UndoRedoDelegateAction(() => doc.Add("n"), () => doc.Remove("n")) { AllowToMergeWithPrevious = true };
+        await Assert.ThrowsAsync<InvalidCastException>(async () => await manager.RecordActionAsync(following, CancellationToken));
+
+        // The action was applied, so the history must describe it and the superseded redo entry must be gone.
+        Assert.Equal(["p", "n"], doc);
+        Assert.Equal(2, manager.UndoableActions.Count);
+        Assert.False(manager.CanRedo);
+
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["p"], doc);
+    }
+
+    [Fact]
+    public async Task Merge_FromInsideTryToMergeAsync_CannotChangeTheHistory()
+    {
+        var manager = new UndoRedoManager();
+        var doc = new List<string>();
+        var reentrant = new ReentrantMergeAction(doc, "p", manager);
+
+        await manager.RecordActionAsync(reentrant, CancellationToken);
+        await manager.RecordActionAsync(
+            new UndoRedoDelegateAction(() => doc.Add("n"), () => doc.Remove("n")) { AllowToMergeWithPrevious = true },
+            CancellationToken);
+
+        Assert.True(reentrant.ObservedActionIsExecuting);
+        Assert.True(reentrant.UndoWasRejected);
+        Assert.Equal(["p", "n"], doc);
+        Assert.Equal(2, manager.UndoableActions.Count);
+    }
+
+    [Fact]
     public async Task Transaction_GroupsActionsIntoSingleUndoStep()
     {
         var manager = new UndoRedoManager();
         var log = new List<string>();
 
-        await using (manager.CreateTransaction())
+        await using (var transaction = manager.CreateTransaction())
         {
             await manager.RecordActionAsync(_ => { log.Add("do:a"); return ValueTask.CompletedTask; }, _ => { log.Add("undo:a"); return ValueTask.CompletedTask; }, CancellationToken);
             await manager.RecordActionAsync(_ => { log.Add("do:b"); return ValueTask.CompletedTask; }, _ => { log.Add("undo:b"); return ValueTask.CompletedTask; }, CancellationToken);
+
+            // A deferred transaction runs nothing until it is committed.
+            Assert.Empty(log);
+            await transaction.CommitAsync(CancellationToken);
         }
 
         Assert.Equal(["do:a", "do:b"], log);
@@ -132,12 +248,34 @@ public sealed class UndoRedoManagerTests
     }
 
     [Fact]
+    public async Task Transaction_Immediate_RunsActionsAsTheyAreRecorded()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        await using (var transaction = manager.CreateTransaction(TransactionExecutionMode.Immediate))
+        {
+            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+            Assert.Equal(["do:a"], log);
+
+            await manager.RecordActionAsync(() => log.Add("do:b"), () => log.Add("undo:b"), CancellationToken);
+            await transaction.CommitAsync(CancellationToken);
+        }
+
+        Assert.Equal(["do:a", "do:b"], log);
+        Assert.Single(manager.UndoableActions);
+
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["do:a", "do:b", "undo:b", "undo:a"], log);
+    }
+
+    [Fact]
     public async Task Transaction_Rollback_RevertsExecutedActions()
     {
         var manager = new UndoRedoManager();
         var value = 0;
 
-        var transaction = manager.CreateTransaction(isDelayed: false);
+        var transaction = manager.CreateTransaction(TransactionExecutionMode.Immediate);
         await manager.RecordActionAsync(_ => { value += 1; return ValueTask.CompletedTask; }, _ => { value -= 1; return ValueTask.CompletedTask; }, CancellationToken);
         await manager.RecordActionAsync(_ => { value += 10; return ValueTask.CompletedTask; }, _ => { value -= 10; return ValueTask.CompletedTask; }, CancellationToken);
         Assert.Equal(11, value);
@@ -148,24 +286,302 @@ public sealed class UndoRedoManagerTests
         Assert.False(manager.CanUndo);
     }
 
+    [Theory]
+    [InlineData(TransactionExecutionMode.Deferred)]
+    [InlineData(TransactionExecutionMode.Immediate)]
+    public async Task Transaction_Nested_Commit_UndoRevertsEveryAction(TransactionExecutionMode mode)
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var outer = manager.CreateTransaction(mode);
+        var inner = manager.CreateTransaction(mode);
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await inner.CommitAsync(CancellationToken);
+        await outer.CommitAsync(CancellationToken);
+
+        Assert.Equal(["do:a"], log);
+        Assert.Single(manager.UndoableActions);
+
+        // The outer transaction only holds an already-applied nested transaction; undo must still revert it.
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["do:a", "undo:a"], log);
+        Assert.False(manager.CanUndo);
+        Assert.True(manager.CanRedo);
+
+        await manager.RedoAsync(CancellationToken);
+        Assert.Equal(["do:a", "undo:a", "do:a"], log);
+    }
+
+    [Theory]
+    [InlineData(TransactionExecutionMode.Deferred)]
+    [InlineData(TransactionExecutionMode.Immediate)]
+    public async Task Transaction_Nested_RollbackOuter_RevertsTheCommittedInnerTransaction(TransactionExecutionMode mode)
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var outer = manager.CreateTransaction(mode);
+        var inner = manager.CreateTransaction(mode);
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await inner.CommitAsync(CancellationToken);
+
+        await outer.RollbackAsync(CancellationToken);
+
+        // Whatever the inner transaction applied must be reverted; nothing may stay applied without a way back.
+        var expected = mode is TransactionExecutionMode.Immediate ? new[] { "do:a", "undo:a" } : [];
+        Assert.Equal(expected, log);
+        Assert.False(manager.CanUndo);
+        Assert.False(manager.CanRedo);
+    }
+
     [Fact]
     public async Task Transaction_Nested_RecordsSingleUndoStep()
     {
         var manager = new UndoRedoManager();
         var log = new List<string>();
 
-        await using (manager.CreateTransaction())
+        await using (var outer = manager.CreateTransaction())
         {
             await manager.RecordActionAsync(_ => { log.Add("do:a"); return ValueTask.CompletedTask; }, _ => { log.Add("undo:a"); return ValueTask.CompletedTask; }, CancellationToken);
-            await using (manager.CreateTransaction())
+            await using (var inner = manager.CreateTransaction())
             {
                 await manager.RecordActionAsync(_ => { log.Add("do:b"); return ValueTask.CompletedTask; }, _ => { log.Add("undo:b"); return ValueTask.CompletedTask; }, CancellationToken);
+                await inner.CommitAsync(CancellationToken);
             }
+
+            await outer.CommitAsync(CancellationToken);
         }
 
         Assert.Single(manager.UndoableActions);
         await manager.UndoAsync(CancellationToken);
         Assert.Equal(["do:a", "do:b", "undo:b", "undo:a"], log);
+    }
+
+    [Theory]
+    [InlineData(TransactionExecutionMode.Deferred, TransactionExecutionMode.Immediate)]
+    [InlineData(TransactionExecutionMode.Immediate, TransactionExecutionMode.Deferred)]
+    public void Transaction_NestingADifferentExecutionMode_Throws(TransactionExecutionMode outerMode, TransactionExecutionMode innerMode)
+    {
+        var manager = new UndoRedoManager();
+        _ = manager.CreateTransaction(outerMode);
+
+        // Mixing the modes would execute the nested actions before the enclosing ones, so undo would
+        // not be the inverse of execute.
+        Assert.Throws<InvalidOperationException>(() => manager.CreateTransaction(innerMode));
+    }
+
+    [Fact]
+    public async Task Transaction_Dispose_RollsBackWhenNotCommitted()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        await using (manager.CreateTransaction(TransactionExecutionMode.Immediate))
+        {
+            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        }
+
+        Assert.Equal(["do:a", "undo:a"], log);
+        Assert.False(manager.CanUndo);
+        Assert.Equal(0, manager.TransactionDepth);
+    }
+
+    [Fact]
+    public async Task Transaction_ExceptionInTheScope_DiscardsTheWorkAndKeepsTheOriginalException()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var exception = await Assert.ThrowsAsync<FormatException>(async () =>
+        {
+            await using (manager.CreateTransaction())
+            {
+                await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+                throw new FormatException("the caller failed");
+            }
+        });
+
+        Assert.Equal("the caller failed", exception.Message);
+        Assert.Empty(log); // the abandoned work must never be applied on the way out
+        Assert.False(manager.CanUndo);
+    }
+
+    [Fact]
+    public async Task Transaction_ActionThatFailsToExecute_IsNotPartOfTheTransaction()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var transaction = manager.CreateTransaction(TransactionExecutionMode.Immediate);
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RecordActionAsync(
+            () => throw new InvalidOperationException("boom"),
+            () => log.Add("undo:b"),
+            CancellationToken));
+        await transaction.CommitAsync(CancellationToken);
+
+        Assert.Equal(["do:a"], log);
+
+        await manager.UndoAsync(CancellationToken);
+        await manager.RedoAsync(CancellationToken);
+
+        // The failed action must not run for the first time during redo.
+        Assert.Equal(["do:a", "undo:a", "do:a"], log);
+    }
+
+    [Fact]
+    public async Task Transaction_CommitOuterWhileInnerIsOpen_Throws()
+    {
+        var manager = new UndoRedoManager();
+        var outer = manager.CreateTransaction();
+        var inner = manager.CreateTransaction();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outer.CommitAsync(CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outer.RollbackAsync(CancellationToken));
+
+        await inner.CommitAsync(CancellationToken);
+        await outer.CommitAsync(CancellationToken);
+    }
+
+    [Fact]
+    public async Task Transaction_CompletedTwice_Throws()
+    {
+        var manager = new UndoRedoManager();
+
+        var outer = manager.CreateTransaction();
+        var inner = manager.CreateTransaction();
+        await inner.CommitAsync(CancellationToken);
+
+        // Completing an already completed transaction must not silently complete the enclosing one.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await inner.CommitAsync(CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await inner.RollbackAsync(CancellationToken));
+
+        // Disposing an already completed transaction stays a no-op.
+        await inner.DisposeAsync();
+
+        await outer.CommitAsync(CancellationToken);
+    }
+
+    [Fact]
+    public async Task Transaction_CommitFailure_RevertsAlreadyExecutedActionsAndStaysOpen()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var transaction = manager.CreateTransaction();
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await manager.RecordActionAsync(() => throw new InvalidOperationException("boom"), () => log.Add("undo:b"), CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await transaction.CommitAsync(CancellationToken));
+
+        Assert.Equal(["do:a", "undo:a"], log);
+        Assert.False(manager.CanUndo);
+
+        // The transaction is left open so the caller can still roll it back or retry.
+        Assert.False(transaction.IsCompleted);
+        Assert.Equal(1, manager.TransactionDepth);
+
+        await transaction.RollbackAsync(CancellationToken);
+        Assert.True(transaction.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Transaction_RollbackFailure_StaysOpenSoItCanBeRetried()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+        var failOnUndo = true;
+
+        var transaction = manager.CreateTransaction(TransactionExecutionMode.Immediate);
+        await manager.RecordActionAsync(
+            () => log.Add("do:a"),
+            () => { if (failOnUndo) throw new InvalidOperationException("boom"); log.Add("undo:a"); },
+            CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await transaction.RollbackAsync(CancellationToken));
+        Assert.False(transaction.IsCompleted);
+        Assert.Equal(1, manager.TransactionDepth);
+
+        failOnUndo = false;
+        await transaction.RollbackAsync(CancellationToken);
+
+        Assert.Equal(["do:a", "undo:a"], log);
+        Assert.True(transaction.IsCompleted);
+        Assert.Equal(0, manager.TransactionDepth);
+    }
+
+    [Fact]
+    public async Task Transaction_UndoFailure_ReappliesRevertedActions()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+        var failOnUndo = true;
+
+        await using (var transaction = manager.CreateTransaction())
+        {
+            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+            await manager.RecordActionAsync(
+                () => log.Add("do:b"),
+                () => { if (failOnUndo) throw new InvalidOperationException("boom"); log.Add("undo:b"); },
+                CancellationToken);
+            await manager.RecordActionAsync(() => log.Add("do:c"), () => log.Add("undo:c"), CancellationToken);
+            await transaction.CommitAsync(CancellationToken);
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.UndoAsync(CancellationToken));
+
+        // "b" failed to revert, so "c" is re-applied and the step stays fully executed and undoable.
+        Assert.Equal(["do:a", "do:b", "do:c", "undo:c", "do:c"], log);
+        Assert.True(manager.CanUndo);
+        Assert.False(manager.CanRedo);
+
+        failOnUndo = false;
+        log.Clear();
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["undo:c", "undo:b", "undo:a"], log);
+    }
+
+    [Fact]
+    public async Task Transaction_CompensationFailure_ThrowsAggregateExceptionPreservingBothCauses()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var transaction = manager.CreateTransaction();
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => throw new NotSupportedException("cannot revert a"), CancellationToken);
+        await manager.RecordActionAsync(() => throw new InvalidOperationException("boom"), () => log.Add("undo:b"), CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(async () => await transaction.CommitAsync(CancellationToken));
+
+        Assert.Collection(
+            exception.InnerExceptions,
+            first => Assert.IsType<InvalidOperationException>(first),
+            second => Assert.IsType<NotSupportedException>(second));
+        Assert.Equal(["do:a"], log); // "a" is knowingly left applied
+    }
+
+    [Fact]
+    public async Task Transaction_FromAnotherManager_CannotBeRecorded()
+    {
+        var first = new UndoRedoManager();
+        var second = new UndoRedoManager();
+
+        var transaction = first.CreateTransaction();
+        await first.RecordActionAsync(() => { }, () => { }, CancellationToken);
+        await transaction.CommitAsync(CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await second.RecordActionAsync(transaction, CancellationToken));
+    }
+
+    [Fact]
+    public async Task Transaction_ThatIsStillOpen_CannotBeRecorded()
+    {
+        var manager = new UndoRedoManager();
+        var other = new UndoRedoManager();
+        var transaction = manager.CreateTransaction();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await other.RecordActionAsync(transaction, CancellationToken));
     }
 
     [Fact]
@@ -183,11 +599,48 @@ public sealed class UndoRedoManagerTests
     }
 
     [Fact]
-    public async Task CollectionChanged_RaisedOnRecordUndoRedoAndClear()
+    public async Task CancelledToken_RunsNothing()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+        using var cts = new CancellationTokenSource();
+
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await manager.RecordActionAsync(() => log.Add("do:b"), () => log.Add("undo:b"), cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await manager.UndoAsync(cts.Token));
+
+        Assert.Equal(["do:a"], log);
+        Assert.True(manager.CanUndo);
+        Assert.Single(manager.UndoableActions);
+    }
+
+    [Fact]
+    public async Task Merge_ForwardsCancellationToken()
+    {
+        var manager = new UndoRedoManager();
+        var sum = 0;
+        using var cts = new CancellationTokenSource();
+
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), cts.Token);
+
+        await cts.CancelAsync();
+        var second = new AddAction(v => sum += v, v => sum -= v, value: 2) { AllowToMergeWithPrevious = true };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await manager.RecordActionAsync(second, cts.Token));
+
+        // The cancelled recording must leave neither the model nor the history changed.
+        Assert.Equal(1, sum);
+        Assert.Single(manager.UndoableActions);
+    }
+
+    [Fact]
+    public async Task HistoryChanged_RaisedOnRecordUndoRedoAndClear()
     {
         var manager = new UndoRedoManager();
         var count = 0;
-        manager.CollectionChanged += (_, _) => count++;
+        manager.HistoryChanged += (_, _) => count++;
 
         await manager.RecordActionAsync(CreateLoggingAction("a").Action, CancellationToken);
         await manager.UndoAsync(CancellationToken);
@@ -198,12 +651,98 @@ public sealed class UndoRedoManagerTests
     }
 
     [Fact]
-    public async Task Undo_WhenTransactionOpen_Throws()
+    public async Task HistoryChanged_RaisedOnceForACommittedTransactionAndNotForARollback()
     {
         var manager = new UndoRedoManager();
+        var count = 0;
+        manager.HistoryChanged += (_, _) => count++;
+
+        await using (var transaction = manager.CreateTransaction())
+        {
+            await manager.RecordActionAsync(() => { }, () => { }, CancellationToken);
+            await manager.RecordActionAsync(() => { }, () => { }, CancellationToken);
+            await transaction.CommitAsync(CancellationToken);
+        }
+
+        Assert.Equal(1, count);
+
+        await using (manager.CreateTransaction(TransactionExecutionMode.Immediate))
+        {
+            await manager.RecordActionAsync(() => { }, () => { }, CancellationToken);
+        }
+
+        Assert.Equal(1, count); // a rollback does not change the history
+    }
+
+    [Fact]
+    public async Task HistoryChanged_HandlerThatThrows_ReportsTheOperationAsCompleted()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        manager.HistoryChanged += (_, _) => throw new InvalidOperationException("a binding blew up");
+
+        var exception = await Assert.ThrowsAsync<UndoRedoNotificationException>(async () => await manager.UndoAsync(CancellationToken));
+
+        // The undo did happen, so the caller must be able to tell this apart from a failed undo and not retry.
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal(["do:a", "undo:a"], log);
+        Assert.False(manager.CanUndo);
+        Assert.True(manager.CanRedo);
+    }
+
+    [Fact]
+    public async Task PropertyChanged_RaisedForTheBindableMembers()
+    {
+        var manager = new UndoRedoManager();
+        var changed = new List<string>();
+        manager.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        await manager.RecordActionAsync(CreateLoggingAction("a").Action, CancellationToken);
+
+        Assert.Contains(nameof(UndoRedoManager.CanUndo), changed);
+        Assert.Contains(nameof(UndoRedoManager.CanRedo), changed);
+        Assert.Contains(nameof(UndoRedoManager.UndoableActions), changed);
+        Assert.Contains(nameof(UndoRedoManager.RedoableActions), changed);
+
+        changed.Clear();
+        var transaction = manager.CreateTransaction();
+        Assert.Contains(nameof(UndoRedoManager.CanUndo), changed);
+
+        await transaction.RollbackAsync(CancellationToken);
+    }
+
+    [Fact]
+    public async Task CanUndoAndCanRedo_AreFalseWhileATransactionIsOpen()
+    {
+        var manager = new UndoRedoManager();
+        await manager.RecordActionAsync(CreateLoggingAction("a").Action, CancellationToken);
+        await manager.UndoAsync(CancellationToken);
+        await manager.RedoAsync(CancellationToken);
+        Assert.True(manager.CanUndo);
+
+        var transaction = manager.CreateTransaction();
+
+        // They gate the operations, so they must not advertise something that is guaranteed to throw.
+        Assert.False(manager.CanUndo);
+        Assert.False(manager.CanRedo);
+        Assert.Equal(1, manager.TransactionDepth);
+
+        await transaction.RollbackAsync(CancellationToken);
+        Assert.True(manager.CanUndo);
+    }
+
+    [Fact]
+    public async Task UndoRedoAndClear_WhenTransactionOpen_Throw()
+    {
+        var manager = new UndoRedoManager();
+        await manager.RecordActionAsync(CreateLoggingAction("a").Action, CancellationToken);
         var transaction = manager.CreateTransaction();
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.UndoAsync(CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RedoAsync(CancellationToken));
+        Assert.Throws<InvalidOperationException>(manager.Clear);
 
         await transaction.RollbackAsync(CancellationToken);
     }
@@ -282,131 +821,6 @@ public sealed class UndoRedoManagerTests
     }
 
     [Fact]
-    public async Task Merge_ClearsRedoBuffer()
-    {
-        var manager = new UndoRedoManager();
-        var sum = 0;
-
-        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), CancellationToken);
-        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 2), CancellationToken);
-        await manager.UndoAsync(CancellationToken);
-        Assert.True(manager.CanRedo);
-
-        // Recording moves the history forward, so the redo buffer must be dropped even when the action is merged.
-        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 4) { AllowToMergeWithPrevious = true }, CancellationToken);
-
-        Assert.False(manager.CanRedo);
-        Assert.Equal(5, sum);
-        Assert.Single(manager.UndoableActions);
-
-        await manager.UndoAsync(CancellationToken);
-        Assert.Equal(0, sum);
-    }
-
-    [Fact]
-    public async Task Transaction_ActionThatFailsToExecute_IsNotPartOfTheTransaction()
-    {
-        var manager = new UndoRedoManager();
-        var log = new List<string>();
-
-        await using (manager.CreateTransaction(isDelayed: false))
-        {
-            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RecordActionAsync(
-                () => throw new InvalidOperationException("boom"),
-                () => log.Add("undo:b"),
-                CancellationToken));
-        }
-
-        Assert.Equal(["do:a"], log);
-
-        await manager.UndoAsync(CancellationToken);
-        await manager.RedoAsync(CancellationToken);
-
-        // The failed action must not run for the first time during redo.
-        Assert.Equal(["do:a", "undo:a", "do:a"], log);
-    }
-
-    [Fact]
-    public async Task Transaction_CommitOuterWhileInnerIsOpen_Throws()
-    {
-        var manager = new UndoRedoManager();
-        var outer = manager.CreateTransaction();
-        var inner = manager.CreateTransaction();
-
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outer.CommitAsync(CancellationToken));
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outer.RollbackAsync(CancellationToken));
-
-        await inner.CommitAsync(CancellationToken);
-        await outer.CommitAsync(CancellationToken);
-    }
-
-    [Fact]
-    public async Task Transaction_CompletedTwice_Throws()
-    {
-        var manager = new UndoRedoManager();
-
-        var outer = manager.CreateTransaction();
-        var inner = manager.CreateTransaction();
-        await inner.CommitAsync(CancellationToken);
-
-        // Completing an already completed transaction must not silently complete the enclosing one.
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await inner.CommitAsync(CancellationToken));
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await inner.RollbackAsync(CancellationToken));
-
-        // Disposing an already completed transaction stays a no-op.
-        await inner.DisposeAsync();
-
-        await outer.CommitAsync(CancellationToken);
-    }
-
-    [Fact]
-    public async Task Transaction_CommitFailure_RevertsAlreadyExecutedActions()
-    {
-        var manager = new UndoRedoManager();
-        var log = new List<string>();
-
-        var transaction = manager.CreateTransaction();
-        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
-        await manager.RecordActionAsync(() => throw new InvalidOperationException("boom"), () => log.Add("undo:b"), CancellationToken);
-
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await transaction.CommitAsync(CancellationToken));
-
-        Assert.Equal(["do:a", "undo:a"], log);
-        Assert.False(manager.CanUndo);
-    }
-
-    [Fact]
-    public async Task Transaction_UndoFailure_ReappliesRevertedActions()
-    {
-        var manager = new UndoRedoManager();
-        var log = new List<string>();
-        var failOnUndo = true;
-
-        await using (manager.CreateTransaction())
-        {
-            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
-            await manager.RecordActionAsync(
-                () => log.Add("do:b"),
-                () => { if (failOnUndo) throw new InvalidOperationException("boom"); log.Add("undo:b"); },
-                CancellationToken);
-            await manager.RecordActionAsync(() => log.Add("do:c"), () => log.Add("undo:c"), CancellationToken);
-        }
-
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.UndoAsync(CancellationToken));
-
-        // "b" failed to revert, so "c" is re-applied and the step stays fully executed and undoable.
-        Assert.Equal(["do:a", "do:b", "do:c", "undo:c", "do:c"], log);
-        Assert.True(manager.CanUndo);
-        Assert.False(manager.CanRedo);
-
-        failOnUndo = false;
-        log.Clear();
-        await manager.UndoAsync(CancellationToken);
-        Assert.Equal(["undo:c", "undo:b", "undo:a"], log);
-    }
-
-    [Fact]
     public async Task RecordAction_FromInsideAnExecutingAction_Throws()
     {
         var manager = new UndoRedoManager();
@@ -447,18 +861,19 @@ public sealed class UndoRedoManagerTests
     }
 
     [Fact]
-    public async Task Merge_ForwardsCancellationToken()
+    public async Task RecordAction_SameInstanceTwice_Throws()
     {
         var manager = new UndoRedoManager();
-        var sum = 0;
-        using var cts = new CancellationTokenSource();
+        var count = 0;
+        var action = new UndoRedoDelegateAction(() => count++, () => count--);
 
-        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), cts.Token);
+        await manager.RecordActionAsync(action, CancellationToken);
 
-        await cts.CancelAsync();
-        var second = new AddAction(v => sum += v, v => sum -= v, value: 2) { AllowToMergeWithPrevious = true };
+        // Recording it again would add an undo step that reverts nothing.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RecordActionAsync(action, CancellationToken));
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await manager.RecordActionAsync(second, cts.Token));
+        Assert.Equal(1, count);
+        Assert.Single(manager.UndoableActions);
     }
 
     [Fact]
@@ -474,6 +889,9 @@ public sealed class UndoRedoManagerTests
         var snapshot = manager.UndoableActions;
         Assert.Equal([second, first], snapshot);
 
+        // Reading again without a change reuses the same snapshot instead of copying the buffer.
+        Assert.Same(snapshot, manager.UndoableActions);
+
         // Recording more actions must not change a snapshot taken earlier.
         await manager.RecordActionAsync(CreateLoggingAction("c").Action, CancellationToken);
         Assert.Equal([second, first], snapshot);
@@ -482,6 +900,43 @@ public sealed class UndoRedoManagerTests
         await manager.UndoAsync(CancellationToken);
         Assert.Equal(2, manager.UndoableActions.Count);
         Assert.Single(manager.RedoableActions);
+    }
+
+    [Fact]
+    public async Task MaxHistoryDepth_DropsTheOldestSteps()
+    {
+        var manager = new UndoRedoManager(maxHistoryDepth: 2);
+        var log = new List<string>();
+
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await manager.RecordActionAsync(() => log.Add("do:b"), () => log.Add("undo:b"), CancellationToken);
+        await manager.RecordActionAsync(() => log.Add("do:c"), () => log.Add("undo:c"), CancellationToken);
+
+        Assert.Equal(2, manager.MaxHistoryDepth);
+        Assert.Equal(2, manager.UndoableActions.Count);
+
+        log.Clear();
+        await manager.UndoAsync(CancellationToken);
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["undo:c", "undo:b"], log); // "a" was dropped and can no longer be undone
+        Assert.False(manager.CanUndo);
+    }
+
+    [Fact]
+    public void MaxHistoryDepth_MustBeStrictlyPositive()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UndoRedoManager(maxHistoryDepth: 0));
+    }
+
+    [Fact]
+    public async Task Description_IsExposedOnTheRecordedActions()
+    {
+        var manager = new UndoRedoManager();
+        var action = new UndoRedoDelegateAction(() => { }, () => { }) { Description = "Insert paragraph" };
+
+        await manager.RecordActionAsync(action, CancellationToken);
+
+        Assert.Equal("Insert paragraph", manager.UndoableActions[0].Description);
     }
 
     private sealed class AddAction(Action<int> add, Action<int> subtract, int value) : UndoRedoActionBase
@@ -505,7 +960,7 @@ public sealed class UndoRedoManagerTests
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // The following action already executed its own effect; absorb its value so a single
+            // The following action is in the same applied state as this one; absorb its value so a single
             // UnExecute reverts both actions.
             if (followingAction is AddAction other)
             {
@@ -514,6 +969,58 @@ public sealed class UndoRedoManagerTests
             }
 
             return new(false);
+        }
+    }
+
+    private sealed class ThrowingMergeAction(List<string> document, string tag) : UndoRedoActionBase
+    {
+        protected override ValueTask ExecuteCoreAsync(CancellationToken cancellationToken)
+        {
+            document.Add(tag);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken)
+        {
+            document.Remove(tag);
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken = default)
+            => throw new InvalidCastException("the merge implementation did not expect this action type");
+    }
+
+    private sealed class ReentrantMergeAction(List<string> document, string tag, UndoRedoManager manager) : UndoRedoActionBase
+    {
+        public bool ObservedActionIsExecuting { get; private set; }
+
+        public bool UndoWasRejected { get; private set; }
+
+        protected override ValueTask ExecuteCoreAsync(CancellationToken cancellationToken)
+        {
+            document.Add(tag);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken)
+        {
+            document.Remove(tag);
+            return ValueTask.CompletedTask;
+        }
+
+        public override async ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken = default)
+        {
+            ObservedActionIsExecuting = manager.ActionIsExecuting;
+            try
+            {
+                await manager.UndoAsync(cancellationToken);
+            }
+            catch (InvalidOperationException)
+            {
+                UndoWasRejected = true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Why

A whole-project audit of `Meziantou.Framework.UndoRedo` turned up a Critical bug plus 20 smaller findings. The Critical one is silent state corruption in the one guarantee the library exists to provide:

```csharp
var parent = m.CreateTransaction(isDelayed: false);
await using (m.CreateTransaction(isDelayed: false))
    await m.RecordActionAsync(() => log.Add("do"), () => log.Add("undo"));
await parent.CommitAsync();
await m.UndoAsync();
// -> log == ["do"].  "undo" never ran.
//    But CanUndo flipped True->False, CanRedo->True, and CollectionChanged fired.
```

`UndoRedoTransaction._executed` was a single `bool` set from **outside** by the manager via `MarkExecuted()`, and only inside the `execute && !parent.IsDelayed` branch. A non-delayed child committing into a parent therefore left the parent unmarked, and both `ExecuteCoreAsync` and `UnExecuteCoreAsync` short-circuit on that flag. No exception, no signal — undo reports success and the document is untouched, so the next save writes the un-reverted document. The same flag also made `parent.RollbackAsync()` leave a committed child's work applied with no history entry, so it could never be undone at all.

Nothing in the previous 28-test suite nested a transaction that records actions in any mode combination except delayed-inside-delayed, so this shipped green.

## The fix

**The obvious one-line fix does not work.** Adding `else if (!execute) parent.MarkExecuted();` fixes both shapes above but breaks a delayed parent that commits a child and *then* records a further action of its own — `_executed` is already true, so `ExecuteCoreAsync` returns early and that action never runs. One bool cannot describe a transaction whose children were applied at different times.

So nesting is now **mode-uniform**: `CreateTransaction` rejects a mode that differs from the enclosing transaction's. That single constraint resolves three findings at once:

- The parent's applied state becomes derivable *inside* the transaction (`Immediate` as soon as it holds an action, `Deferred` once `ExecuteCoreAsync` ran), so `MarkExecuted()` and the special case are deleted rather than patched.
- Mixed nesting used to execute a nested immediate action *before* deferred actions recorded earlier, so undo was not the inverse of execute. That shape is now unbuildable.
- A nested commit no longer executes anything, so the `parent.Add(child)`-before-`ExecuteAsync(child)` ordering hazard — which let a failed and rolled-back nested commit reappear on redo — has no code path left.

## Also fixed

- **Disposal rolls back** unless `CommitAsync` was called, matching `TransactionScope`. Leaving an `await using` scope by throwing no longer applies the abandoned work, nor replaces the caller's exception with the commit's.
- **A throwing `TryToMergeAsync`** no longer leaves the applied action orphaned outside the history with a stale redo buffer behind it. The merge runs under the reentrancy guard and its failure is rethrown only once the buffers are consistent.
- **`TryToMergeAsync` is covered by `ActionIsExecuting`** — a reentrant `UndoAsync` from inside it used to succeed and make an action unreachable from both stacks. Merging also works inside a transaction now.
- **A failed commit or rollback leaves the transaction open**, so it can be retried instead of stranding half-applied state with no handle.
- **Cancellation is observed** at every entry point and between grouped actions (previously the token was only forwarded, so a pre-cancelled token still ran everything).
- **A `HistoryChanged` handler that throws** surfaces as `UndoRedoNotificationException` *after* the operation completed, so a caller can't mistake it for a failed undo and retry into a double-undo.
- **`CanUndo`/`CanRedo` report whether the operation would succeed**, not just buffer emptiness — they used to be `true` while a transaction was open, i.e. while `UndoAsync` was guaranteed to throw.
- **`INotifyPropertyChanged`** is implemented; the event named `CollectionChanged` on a class implementing no notification interface meant `{Binding CanUndo}` never refreshed.
- **Misuse throws instead of corrupting**: recording an already-applied action instance, a transaction still open, or one owned by another manager.
- **The history can be bounded** via `new UndoRedoManager(maxHistoryDepth)`, and snapshots are rebuilt on change rather than on every read (the per-read copy crossed the LOH threshold at ~10,600 entries).

## Breaking changes (4.0)

Full migration table in the [readme](https://github.com/meziantou/Meziantou.Framework/blob/feature/meziantou-undoredo-review-c3ffe5/src/Meziantou.Framework.UndoRedo/readme.md). The notable ones:

| 3.x | 4.0 |
| --- | --- |
| `CreateTransaction(bool isDelayed = true)` | `CreateTransaction(TransactionExecutionMode mode = Deferred)` |
| Disposing committed | Disposing rolls back; add an explicit `await transaction.CommitAsync()` |
| Nesting different `isDelayed` values | Throws `InvalidOperationException` |
| `manager.CommitTransactionAsync()` / `RollbackTransactionAsync()` | Removed — they acted on the innermost transaction regardless of which handle the caller held |
| `CollectionChanged` | `HistoryChanged` |
| `UndoRedoActionBase.ExecuteCount` | `IsApplied`; double execute/revert throws instead of silently no-oping |

## Reviewer notes

- **`UndoRedoActionBase` now throws** where it used to silently no-op. This is the fix for the dead-undo-step finding, and it's only safe because the transaction no longer leans on leaf idempotence — but it will surface as a new exception in consumer code that reuses action instances.
- **Two findings were deliberately left alone.** No `Reset()` escape hatch for a leaked transaction: rollback-on-dispose makes the leak far less likely and `TransactionDepth` makes it diagnosable, whereas a reset that discarded open transactions could strand applied state with no way back — exactly the failure mode this PR removes. And the snapshot API was not redesigned into a live view: caching until the history changes removes the per-read O(n) copy without giving up the documented stability guarantee.

## Verification

- 53 tests, up from 28 (106 across both TFMs), all passing in Debug and Release. Every finding's original reproduction is now a test, including the full nested matrix (`Deferred`/`Immediate` × commit/rollback) that had no coverage before.
- Library, tests and the `tests/Trimmable` consumer all build clean under `-c Release -p:IsOfficialBuild=true -p:TreatWarningsAsErrors=true`.
- `ref/Meziantou.Framework.UndoRedo.cs` regenerated; `dotnet run ./eng/update-all.cs` produced no further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
