### PR TITLE
Fix correctness and rendering bugs in Meziantou.AspNetCore.Components

### DIFF
--- a/ref/Meziantou.AspNetCore.Components.cs
+++ b/ref/Meziantou.AspNetCore.Components.cs
@@ -24,7 +24,7 @@ namespace Meziantou.AspNetCore.Components
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddClipboard(this Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) => throw null;
     }
 
-    public class DataGridColumn<TRowData> : Microsoft.AspNetCore.Components.ComponentBase
+    public class DataGridColumn<TRowData> : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
     {
         public Meziantou.AspNetCore.Components.DataGrid<TRowData>? OwnerGrid { get => throw null; set { } }
         public string? Title { get => throw null; set { } }
@@ -33,6 +33,7 @@ namespace Meziantou.AspNetCore.Components
         public Microsoft.AspNetCore.Components.RenderFragment<TRowData>? ChildContent { get => throw null; set { } }
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder? __builder) { }
         protected override void OnInitialized() { }
+        public void Dispose() { }
         protected override void OnParametersSet() { }
     }
 
@@ -42,8 +43,8 @@ namespace Meziantou.AspNetCore.Components
         public System.Collections.Generic.IEnumerable<TRowData>? Items { get => throw null; set { } }
         public Microsoft.AspNetCore.Components.RenderFragment? ChildContent { get => throw null; set { } }
         public System.Func<TRowData, int, string?>? RowClass { get => throw null; set { } }
+        public System.Func<TRowData, object>? RowKey { get => throw null; set { } }
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder? __builder) { }
-        protected override void OnAfterRender(bool firstRender) { }
     }
 
     public sealed class GenericFormField<TModel>
@@ -98,6 +99,7 @@ namespace Meziantou.AspNetCore.Components
 
     public class InputDateTime<TValue> : Microsoft.AspNetCore.Components.Forms.InputDate<TValue>
     {
+        public System.TimeSpan? Offset { get => throw null; set { } }
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder) { }
         protected override string FormatValueAsString(TValue value) => throw null;
         protected override bool TryParseValueFromString(string? value, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TValue result, [System.Diagnostics.CodeAnalysis.NotNullWhen(false)] out string? validationErrorMessage) => throw null;
@@ -105,6 +107,7 @@ namespace Meziantou.AspNetCore.Components
 
     public sealed class InputEnumSelect<TEnum> : Microsoft.AspNetCore.Components.Forms.InputBase<TEnum>
     {
+        public string EmptyOptionText { get => throw null; set { } }
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder) { }
         protected override bool TryParseValueFromString(string? value, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TEnum result, [System.Diagnostics.CodeAnalysis.NotNullWhen(false)] out string? validationErrorMessage) => throw null;
     }
@@ -171,6 +174,8 @@ namespace Meziantou.AspNetCore.Components
     {
         public TimeZoneService(Microsoft.JSInterop.IJSRuntime jsRuntime) { }
         public System.Threading.Tasks.ValueTask<System.TimeSpan> GetOffsetAsync() => throw null;
+        public System.Threading.Tasks.ValueTask<System.TimeSpan> GetOffsetAsync(System.DateTimeOffset instant) => throw null;
+        public System.Threading.Tasks.ValueTask<System.TimeZoneInfo?> GetTimeZoneAsync() => throw null;
         public System.Threading.Tasks.ValueTask<System.DateTimeOffset> GetLocalDateTimeAsync(System.DateTimeOffset dateTime) => throw null;
         public System.Threading.Tasks.ValueTask<System.DateTimeOffset> GetUtcDateTimeAsync(System.DateTime dateTime) => throw null;
         public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;

--- a/src/Meziantou.AspNetCore.Components/AnchorNavigation.razor
+++ b/src/Meziantou.AspNetCore.Components/AnchorNavigation.razor
@@ -18,7 +18,13 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await ScrollToFragment();
+        // Only scroll on the first render. Doing it on every render re-runs scrollIntoView whenever anything on the
+        // page re-renders, which fights the user for control of the scroll position. Later navigations are handled
+        // by OnLocationChanged.
+        if (firstRender)
+        {
+            await ScrollToFragment();
+        }
     }
 
     public ValueTask DisposeAsync()
@@ -37,7 +43,16 @@
 
     private async void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
-        await ScrollToFragment();
+        // This is an event handler, so it must be async void and nothing observes the returned task. Any exception
+        // escaping here is unhandled and tears down the circuit, so the whole body has to be guarded. Importing the
+        // JS module is the realistic failure: navigating while the circuit is going away throws from that await.
+        try
+        {
+            await ScrollToFragment();
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or OperationCanceledException or ObjectDisposedException)
+        {
+        }
     }
 
     private async Task ScrollToFragment()

--- a/src/Meziantou.AspNetCore.Components/ClipboardService.cs
+++ b/src/Meziantou.AspNetCore.Components/ClipboardService.cs
@@ -1,4 +1,3 @@
-using Meziantou.AspNetCore.Components.Internals;
 using Microsoft.JSInterop;
 
 namespace Meziantou.AspNetCore.Components;
@@ -54,8 +53,15 @@ public sealed class ClipboardService
     /// <param name="text">The text to write to the clipboard.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="JSException">
+    /// The browser refused the write. This happens in a non-secure (non-HTTPS) context, when the clipboard permission
+    /// is denied, or when the call does not originate from a user gesture. The failure is reported rather than
+    /// swallowed so the caller does not report success for a copy that never happened.
+    /// </exception>
     public ValueTask WriteTextAsync(string text, CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.SafeInvokeVoidAsync("navigator.clipboard.writeText", cancellationToken, text);
+#pragma warning disable BL0016 // Unguarded JS interop call
+        return _jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", cancellationToken, text);
+#pragma warning restore BL0016 // Unguarded JS interop call
     }
 }

--- a/src/Meziantou.AspNetCore.Components/DataGrid.razor
+++ b/src/Meziantou.AspNetCore.Components/DataGrid.razor
@@ -28,13 +28,16 @@
                 var index = 0;
                 foreach (var item in Items)
                 {
-                    @* Use @key to help the diff algorithm when updating the collection *@
-                    <tr @key="item?.GetHashCode()" class="@(RowClass?.Invoke(item, index++))">
+                    var rowIndex = index;
+                    @* Use @key to help the diff algorithm when updating the collection. The key must be unique among
+                       siblings, so it falls back to the row index unless the caller supplies a real key. *@
+                    <tr @key="RowKey is null ? rowIndex : RowKey(item)" class="@(RowClass?.Invoke(item, rowIndex))">
                         @foreach (var column in columns)
                         {
                             @column.CellTemplate(item)
                         }
                     </tr>
+                    index++;
                 }
             }
         }
@@ -59,22 +62,31 @@
     [Parameter]
     public Func<TRowData, int, string>? RowClass { get; set; }
 
+    /// <summary>
+    /// Gets or sets a function that returns a stable, unique key for each row, used as the <c>@key</c> of the row element.
+    /// Keys must be unique among the rendered rows; a duplicate key makes the renderer throw.
+    /// When not specified, the row index is used, which is always unique.
+    /// </summary>
+    [Parameter]
+    public Func<TRowData, object>? RowKey { get; set; }
+
     private readonly List<DataGridColumn<TRowData>> columns = new List<DataGridColumn<TRowData>>();
 
-    // GridColumn uses this method to add a column
+    // GridColumn uses these methods to register and unregister itself
     internal void AddColumn(DataGridColumn<TRowData> column)
     {
         columns.Add(column);
+
+        // Columns are instantiated while rendering ChildContent, so the columns collection is still empty when the
+        // table is first built. Requesting another render makes the renderer pick the columns up. This must not rely
+        // on OnAfterRender: static server-side rendering never calls it, which would leave the table permanently empty.
+        StateHasChanged();
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    internal void RemoveColumn(DataGridColumn<TRowData> column)
     {
-        if (firstRender)
+        if (columns.Remove(column))
         {
-            // The first render will instantiate the GridColumn defined in the ChildContent.
-            // GridColumn calls AddColumn during its initialization. This means that until
-            // the first render is completed, the columns collection is empty.
-            // Calling StateHasChanged() will re-render the component, so the second time it will know the columns
             StateHasChanged();
         }
     }

--- a/src/Meziantou.AspNetCore.Components/DataGridColumn.razor
+++ b/src/Meziantou.AspNetCore.Components/DataGridColumn.razor
@@ -1,5 +1,6 @@
 ﻿@typeparam TRowData
 @using System.Linq.Expressions
+@implements IDisposable
 @code {
     /// <summary>Gets or sets the parent <see cref="DataGrid{TRowData}"/> component. This is set automatically via cascading parameter.</summary>
     [CascadingParameter]
@@ -34,6 +35,13 @@
             throw new InvalidOperationException("The column must be a child of a DataGrid component");
 
         OwnerGrid.AddColumn(this);
+    }
+
+    public void Dispose()
+    {
+        // Without this, a column removed from the ChildContent stays in the grid and keeps rendering,
+        // and toggling it back on registers it a second time
+        OwnerGrid?.RemoveColumn(this);
     }
 
     protected override void OnParametersSet()
@@ -96,7 +104,7 @@
         {
             MemberExpression m => m.Member.Name,
             UnaryExpression u when u.Operand is MemberExpression m => m.Member.Name,
-            _ => throw new NotSupportedException("Expression of type '" + expression.GetType().ToString() + "' is not supported")
+            _ => throw new NotSupportedException("Expression body of type '" + expression.Body.GetType().ToString() + "' is not supported. Only simple member accessors such as 'row => row.Name' can be used to infer a column title; set Title explicitly instead.")
         };
     }
 }

--- a/src/Meziantou.AspNetCore.Components/GenericForm.razor
+++ b/src/Meziantou.AspNetCore.Components/GenericForm.razor
@@ -22,6 +22,8 @@
 @code{
     internal string BaseEditorId { get; } = "form-" + Guid.NewGuid().ToString();
     private List<GenericFormField<TModel>>? fields;
+    private TModel? currentModel;
+    private bool hasBuiltFields;
 
     /// <summary>Gets or sets the model instance to edit in the form.</summary>
     [Parameter]
@@ -47,6 +49,11 @@
     {
         base.OnParametersSet();
 
+        // Rebuilding the fields recreates every cached render fragment and recompiles the expression trees behind them,
+        // so only do it when the model actually changed. OnParametersSet runs on every parameter change of the parent.
+        if (hasBuiltFields && EqualityComparer<TModel?>.Default.Equals(currentModel, Model))
+            return;
+
         if (fields != null)
         {
             foreach (var field in fields)
@@ -67,10 +74,17 @@
         {
             fields = null;
         }
+
+        currentModel = Model;
+        hasBuiltFields = true;
     }
 
     private void OnValueChanged(object? sender, EventArgs e)
     {
-        InvokeAsync(() => ModelChanged.InvokeAsync(Model));
+        _ = InvokeAsync(async () =>
+        {
+            await ModelChanged.InvokeAsync(Model);
+            StateHasChanged();
+        });
     }
 }

--- a/src/Meziantou.AspNetCore.Components/GenericFormField.cs
+++ b/src/Meziantou.AspNetCore.Components/GenericFormField.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNetCore.Components;
+using Meziantou.AspNetCore.Components.Internals;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace Meziantou.AspNetCore.Components;
@@ -19,6 +20,7 @@ namespace Meziantou.AspNetCore.Components;
 public sealed class GenericFormField<TModel>
 {
     private static readonly MethodInfo EventCallbackFactoryCreate = GetEventCallbackFactoryCreate();
+    private static readonly PropertyInfo[] EditableProperties = GetEditableProperties();
 
     private readonly GenericForm<TModel> _form;
 
@@ -33,7 +35,18 @@ public sealed class GenericFormField<TModel>
 
     internal static List<GenericFormField<TModel>> Create(GenericForm<TModel> form)
     {
-        var result = new List<GenericFormField<TModel>>();
+        var result = new List<GenericFormField<TModel>>(EditableProperties.Length);
+        foreach (var prop in EditableProperties)
+        {
+            result.Add(new GenericFormField<TModel>(form, prop));
+        }
+
+        return result;
+    }
+
+    private static PropertyInfo[] GetEditableProperties()
+    {
+        var result = new List<PropertyInfo>();
         var properties = typeof(TModel).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
         foreach (var prop in properties)
         {
@@ -44,11 +57,10 @@ public sealed class GenericFormField<TModel>
             if (prop.GetCustomAttribute<EditableAttribute>() is { } editor && !editor.AllowEdit)
                 continue;
 
-            var field = new GenericFormField<TModel>(form, prop);
-            result.Add(field);
+            result.Add(prop);
         }
 
-        return result;
+        return result.ToArray();
     }
 
     /// <summary>Gets the <see cref="PropertyInfo"/> representing the model property for this field.</summary>
@@ -322,13 +334,17 @@ public sealed class GenericFormField<TModel>
         if (property.PropertyType == typeof(Uri))
             return (typeof(InputUrl<Uri>), null);
 
-        if (property.PropertyType.IsEnum)
+        // Note underlyingType unwraps Nullable<T>, so nullable enums are handled here too
+        if (underlyingType.IsEnum)
         {
-            if (!property.PropertyType.IsDefined(typeof(FlagsAttribute), inherit: true))
+            if (!underlyingType.IsDefined(typeof(FlagsAttribute), inherit: true))
                 return (typeof(InputEnumSelect<>).MakeGenericType(property.PropertyType), null);
         }
 
-        return (typeof(InputText), null);
+        // No dedicated editor for this type. InputText cannot be used because it is an InputBase<string> while the
+        // value, the change callback and the value expression are all built from the property type, so use a text
+        // input that stays generic over the property type instead.
+        return (typeof(InputTextFallback<>).MakeGenericType(property.PropertyType), null);
     }
 
     private static MethodInfo GetEventCallbackFactoryCreate()

--- a/src/Meziantou.AspNetCore.Components/InfiniteScrolling/InfiniteScrolling.razor
+++ b/src/Meziantou.AspNetCore.Components/InfiniteScrolling/InfiniteScrolling.razor
@@ -97,7 +97,14 @@
         }
         finally
         {
-            _loadItemsCts = null;
+            // RefreshDataAsync may have cancelled this operation and started a new one. Clearing the field
+            // unconditionally would clobber the new operation's token source, which disables the re-entrancy guard
+            // above and lets the same page be loaded and appended twice.
+            if (ReferenceEquals(_loadItemsCts, cts))
+            {
+                _loadItemsCts = null;
+            }
+
             cts.Dispose();
         }
 
@@ -148,10 +155,11 @@
 
     public async ValueTask DisposeAsync()
     {
-        // Cancel the current load items operation
+        // Cancel the current load items operation. Without the Cancel the items provider keeps running after the
+        // component is gone, then appends items and calls StateHasChanged on a disposed component.
         if (_loadItemsCts != null)
         {
-            _loadItemsCts.Dispose();
+            await _loadItemsCts.CancelAsync();
             _loadItemsCts = null;
         }
 

--- a/src/Meziantou.AspNetCore.Components/InputDatetime.cs
+++ b/src/Meziantou.AspNetCore.Components/InputDatetime.cs
@@ -9,7 +9,17 @@ namespace Meziantou.AspNetCore.Components;
 /// <typeparam name="TValue">The type of the value. Supported types are <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, and their nullable variants.</typeparam>
 public class InputDateTime<TValue> : InputDate<TValue>
 {
+    // datetime-local has no seconds component, so values round-tripped through this input are truncated to the minute
     private const string DateFormat = "yyyy-MM-ddTHH:mm";
+
+    /// <summary>
+    /// Gets or sets the UTC offset to apply when the bound value is a <see cref="DateTimeOffset"/>.
+    /// An HTML <c>datetime-local</c> input carries no timezone, so without this the offset of the machine running the
+    /// component is used, which is the server's offset under Blazor Server rather than the user's.
+    /// Use <see cref="TimeZoneService"/> to obtain the user's offset.
+    /// </summary>
+    [Parameter]
+    public TimeSpan? Offset { get; set; }
 
     /// <inheritdoc />
     protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -48,7 +58,7 @@ public class InputDateTime<TValue> : InputDate<TValue>
         }
         else if (targetType == typeof(DateTimeOffset))
         {
-            success = TryParseDateTimeOffset(value, out result);
+            success = TryParseDateTimeOffset(value, Offset, out result);
         }
         else
         {
@@ -83,11 +93,17 @@ public class InputDateTime<TValue> : InputDate<TValue>
         }
     }
 
-    private static bool TryParseDateTimeOffset(string? value, out TValue? result)
+    private static bool TryParseDateTimeOffset(string? value, TimeSpan? offset, out TValue? result)
     {
         var success = BindConverter.TryConvertToDateTimeOffset(value, CultureInfo.InvariantCulture, DateFormat, out var parsedValue);
         if (success)
         {
+            if (offset is { } userOffset)
+            {
+                // Reinterpret the wall-clock time the user typed as being in their timezone rather than the machine's
+                parsedValue = new DateTimeOffset(DateTime.SpecifyKind(parsedValue.DateTime, DateTimeKind.Unspecified), userOffset);
+            }
+
             result = (TValue)(object)parsedValue;
             return true;
         }

--- a/src/Meziantou.AspNetCore.Components/InputEnumSelect.cs
+++ b/src/Meziantou.AspNetCore.Components/InputEnumSelect.cs
@@ -17,6 +17,13 @@ namespace Meziantou.AspNetCore.Components;
 // Note that adding a constraint on TEnum (where T : Enum) doesn't work when used in the view, Razor raises an error at build time. Also, this would prevent using nullable types...
 public sealed class InputEnumSelect<TEnum> : InputBase<TEnum>
 {
+    private static readonly bool IsNullable = Nullable.GetUnderlyingType(typeof(TEnum)) is not null;
+    private static readonly (string Value, string? DisplayName)[] Options = GetOptions();
+
+    /// <summary>Gets or sets the text of the empty option rendered for nullable enum types. Defaults to an empty string.</summary>
+    [Parameter]
+    public string EmptyOptionText { get; set; } = "";
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "select");
@@ -25,13 +32,22 @@ public sealed class InputEnumSelect<TEnum> : InputBase<TEnum>
         builder.AddAttribute(3, "value", BindConverter.FormatValue(CurrentValueAsString));
         builder.AddAttribute(4, "onchange", EventCallback.Factory.CreateBinder<string?>(this, value => CurrentValueAsString = value, CurrentValueAsString, culture: null));
 
-        // Add an option element per enum value
-        var enumType = InputEnumSelect<TEnum>.GetEnumType();
-        foreach (var value in Enum.GetValues(enumType))
+        // A nullable enum needs an empty option, otherwise null is not selectable and a null value silently displays
+        // as the first member of the enum
+        if (IsNullable)
         {
             builder.OpenElement(5, "option");
-            builder.AddAttribute(6, "value", value.ToString());
-            builder.AddContent(7, GetDisplayName(value));
+            builder.AddAttribute(6, "value", "");
+            builder.AddContent(7, EmptyOptionText);
+            builder.CloseElement();
+        }
+
+        // Add an option element per enum value
+        foreach (var option in Options)
+        {
+            builder.OpenElement(8, "option");
+            builder.AddAttribute(9, "value", option.Value);
+            builder.AddContent(10, option.DisplayName);
             builder.CloseElement();
         }
 
@@ -64,6 +80,20 @@ public sealed class InputEnumSelect<TEnum> : InputBase<TEnum>
         result = default;
         validationErrorMessage = $"The {FieldIdentifier.FieldName} field is not valid.";
         return false;
+    }
+
+    // Reflecting over the enum members on every render is wasteful: the set of options cannot change at runtime
+    private static (string Value, string? DisplayName)[] GetOptions()
+    {
+        var values = Enum.GetValues(GetEnumType());
+        var result = new (string, string?)[values.Length];
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = values.GetValue(i);
+            result[i] = (value?.ToString() ?? "", GetDisplayName(value));
+        }
+
+        return result;
     }
 
     // Get the display text for an enum value:

--- a/src/Meziantou.AspNetCore.Components/InputGuid.cs
+++ b/src/Meziantou.AspNetCore.Components/InputGuid.cs
@@ -10,7 +10,7 @@ namespace Meziantou.AspNetCore.Components;
 public class InputGuid<TValue> : InputBase<TValue>
 {
     /// <summary>Gets or sets the error message to display when the input value cannot be parsed.</summary>
-    [Parameter] public string ParsingErrorMessage { get; set; } = "";
+    [Parameter] public string ParsingErrorMessage { get; set; } = "The {0} field must be a valid GUID.";
 
     /// <summary>Gets a reference to the rendered input element.</summary>
     [DisallowNull] public ElementReference? Element { get; protected set; }
@@ -19,7 +19,7 @@ public class InputGuid<TValue> : InputBase<TValue>
     {
         builder.OpenElement(0, "input");
         builder.AddMultipleAttributes(1, AdditionalAttributes);
-        builder.AddAttribute(2, "type", "url");
+        builder.AddAttribute(2, "type", "text");
         builder.AddAttribute(3, "class", CssClass);
         builder.AddAttribute(4, "value", BindConverter.FormatValue(CurrentValueAsString));
         builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, value => CurrentValueAsString = value, CurrentValueAsString));
@@ -50,7 +50,7 @@ public class InputGuid<TValue> : InputBase<TValue>
         }
         else
         {
-            throw new InvalidOperationException($"The type '{targetType}' is not a supported date type.");
+            throw new InvalidOperationException($"The type '{targetType}' is not supported. Use Guid or Guid?.");
         }
 
         if (success)

--- a/src/Meziantou.AspNetCore.Components/InputUrl.cs
+++ b/src/Meziantou.AspNetCore.Components/InputUrl.cs
@@ -10,7 +10,7 @@ namespace Meziantou.AspNetCore.Components;
 public class InputUrl<TValue> : InputBase<TValue>
 {
     /// <summary>Gets or sets the error message to display when the input value cannot be parsed.</summary>
-    [Parameter] public string ParsingErrorMessage { get; set; } = "";
+    [Parameter] public string ParsingErrorMessage { get; set; } = "The {0} field must be a valid URL.";
 
     /// <summary>Gets a reference to the rendered input element.</summary>
     [DisallowNull] public ElementReference? Element { get; protected set; }
@@ -56,7 +56,7 @@ public class InputUrl<TValue> : InputBase<TValue>
         }
         else
         {
-            throw new InvalidOperationException($"The type '{targetType}' is not a supported date type.");
+            throw new InvalidOperationException($"The type '{targetType}' is not supported. Use string or Uri.");
         }
 
         if (success)
@@ -72,9 +72,27 @@ public class InputUrl<TValue> : InputBase<TValue>
         }
     }
 
+    // The component renders <input type="url">, but the parser also runs for programmatic binding and for forms that
+    // never submit natively, so schemes that execute script are rejected here. Consumers commonly render the result
+    // into an anchor href, and this is the only place that can prevent that becoming a script injection.
+    private static bool HasDangerousScheme(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return false;
+
+        var separatorIndex = value.IndexOf(':', StringComparison.Ordinal);
+        if (separatorIndex < 0)
+            return false;
+
+        var scheme = value.AsSpan(0, separatorIndex).Trim();
+        return scheme.Equals("javascript", StringComparison.OrdinalIgnoreCase)
+            || scheme.Equals("vbscript", StringComparison.OrdinalIgnoreCase)
+            || scheme.Equals("data", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool TryParseString(string? value, out TValue? result)
     {
-        if (value is not null)
+        if (value is not null && !HasDangerousScheme(value))
         {
             result = (TValue)(object)value;
             return true;
@@ -88,7 +106,7 @@ public class InputUrl<TValue> : InputBase<TValue>
 
     private static bool TryParseUri(string? value, out TValue? result)
     {
-        if (Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out var uri))
+        if (!HasDangerousScheme(value) && Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out var uri))
         {
             result = (TValue)(object)uri;
             return true;

--- a/src/Meziantou.AspNetCore.Components/Internals/InputTextFallback.cs
+++ b/src/Meziantou.AspNetCore.Components/Internals/InputTextFallback.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Meziantou.AspNetCore.Components.Internals;
+
+/// <summary>
+/// A text input bound to an arbitrary <typeparamref name="TValue"/>, used by <see cref="GenericForm{TModel}"/> for
+/// property types that have no dedicated editor. Unlike <see cref="InputText"/> (which is an
+/// <see cref="InputBase{TValue}"/> of <see cref="string"/>) this stays generic, so the value, the change callback and
+/// the value expression all agree on the property type.
+/// </summary>
+internal sealed class InputTextFallback<TValue> : InputBase<TValue>
+{
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "input");
+        builder.AddMultipleAttributes(1, AdditionalAttributes);
+        builder.AddAttribute(2, "type", "text");
+        builder.AddAttribute(3, "class", CssClass);
+        builder.AddAttribute(4, "value", BindConverter.FormatValue(CurrentValueAsString));
+        builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, value => CurrentValueAsString = value, CurrentValueAsString));
+        builder.CloseElement();
+    }
+
+    protected override string? FormatValueAsString(TValue? value) => ValueConverter.ConvertToString(value);
+
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (ValueConverter.TryConvertFromString(value, typeof(TValue), out var converted))
+        {
+            result = (TValue)converted!;
+            validationErrorMessage = null;
+            return true;
+        }
+
+        result = default;
+        validationErrorMessage = $"The {DisplayName ?? FieldIdentifier.FieldName} field is not valid.";
+        return false;
+    }
+}

--- a/src/Meziantou.AspNetCore.Components/Internals/JsRuntimeExtensions.cs
+++ b/src/Meziantou.AspNetCore.Components/Internals/JsRuntimeExtensions.cs
@@ -4,13 +4,18 @@ namespace Meziantou.AspNetCore.Components.Internals;
 
 internal static class JsRuntimeExtensions
 {
+    // Only the failures caused by the component or the circuit going away are ignored. Errors raised by the
+    // JavaScript code itself must reach the caller: swallowing them turns a failed operation into a silent no-op.
+    private static bool IsIgnorable(Exception exception)
+        => exception is JSDisconnectedException or OperationCanceledException or ObjectDisposedException;
+
     public static async ValueTask SafeInvokeVoidAsync(this IJSRuntime jsRuntime, string identifier, params object?[] args)
     {
         try
         {
             await jsRuntime.InvokeVoidAsync(identifier, args);
         }
-        catch
+        catch (Exception ex) when (IsIgnorable(ex))
         {
         }
     }
@@ -21,7 +26,7 @@ internal static class JsRuntimeExtensions
         {
             await jsRuntime.InvokeVoidAsync(identifier, cancellationToken, args);
         }
-        catch
+        catch (Exception ex) when (IsIgnorable(ex))
         {
         }
     }
@@ -32,7 +37,7 @@ internal static class JsRuntimeExtensions
         {
             await jsRuntime.InvokeVoidAsync(identifier, cancellationToken, args);
         }
-        catch
+        catch (Exception ex) when (IsIgnorable(ex))
         {
         }
     }
@@ -43,7 +48,7 @@ internal static class JsRuntimeExtensions
         {
             await jsRuntime.InvokeVoidAsync(identifier, args);
         }
-        catch
+        catch (Exception ex) when (IsIgnorable(ex))
         {
         }
     }

--- a/src/Meziantou.AspNetCore.Components/Internals/QueryHelpers.cs
+++ b/src/Meziantou.AspNetCore.Components/Internals/QueryHelpers.cs
@@ -103,7 +103,7 @@ internal static class QueryHelpers
 
         if (result is null)
         {
-            return new Dictionary<string, StringValues>(StringComparer.Ordinal);
+            return new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
         }
 
         return result;

--- a/src/Meziantou.AspNetCore.Components/Internals/ValueConverter.cs
+++ b/src/Meziantou.AspNetCore.Components/Internals/ValueConverter.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel;
+
+namespace Meziantou.AspNetCore.Components.Internals;
+
+/// <summary>
+/// Converts values between <see cref="string"/> and arbitrary CLR types using <see cref="TypeConverter"/>.
+/// Query string services and text-based inputs share this so a value written by one is readable by the other.
+/// </summary>
+internal static class ValueConverter
+{
+    public static bool TryConvertFromString(string? value, Type type, out object? result)
+    {
+        if (type == typeof(string))
+        {
+            result = value;
+            return true;
+        }
+
+        if (string.IsNullOrEmpty(value))
+        {
+            // An empty value maps to null for reference and nullable types, and to the default value otherwise
+            var isNullable = !type.IsValueType || Nullable.GetUnderlyingType(type) is not null;
+            result = isNullable ? null : Activator.CreateInstance(type);
+            return true;
+        }
+
+        var converter = TypeDescriptor.GetConverter(type);
+        if (!converter.CanConvertFrom(typeof(string)))
+        {
+            result = null;
+            return false;
+        }
+
+        try
+        {
+            result = converter.ConvertFromString(context: null, CultureInfo.InvariantCulture, value);
+            return true;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            // TypeConverter reports invalid input by throwing, and the exception type is not part of its contract.
+            // For instance BaseNumberConverter throws a plain Exception wrapping the original FormatException.
+            result = null;
+            return false;
+        }
+    }
+
+    public static string? ConvertToString(object? value)
+    {
+        if (value is null)
+            return null;
+
+        if (value is string s)
+            return s;
+
+        var converter = TypeDescriptor.GetConverter(value.GetType());
+        if (converter.CanConvertTo(typeof(string)))
+        {
+            try
+            {
+                return converter.ConvertToString(context: null, CultureInfo.InvariantCulture, value);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031
+            {
+                // Fall back to ToString below
+            }
+        }
+
+        return value.ToString();
+    }
+}

--- a/src/Meziantou.AspNetCore.Components/NavigationManagerExtensions.cs
+++ b/src/Meziantou.AspNetCore.Components/NavigationManagerExtensions.cs
@@ -52,7 +52,7 @@ public static class NavigationManagerExtensions
                 continue;
 
             var value = property.GetValue(component);
-            parameters[parameterName] = value;
+            parameters[parameterName] = NormalizeQueryValue(value);
         }
 
         // Compute the new URL
@@ -61,6 +61,28 @@ public static class NavigationManagerExtensions
         {
             navigationManager.NavigateTo(newUri, new NavigationOptions() { ReplaceHistoryEntry = replaceHistory });
         }
+    }
+
+    // GetUriWithQueryParameters only accepts a fixed set of types and throws for anything else. Values it cannot
+    // handle (enums, TimeSpan, custom types, ...) are converted to their string representation instead.
+    private static object? NormalizeQueryValue(object? value)
+    {
+        if (value is null)
+            return null;
+
+        var type = value.GetType();
+        if (type == typeof(string) || type == typeof(bool) || type == typeof(int) || type == typeof(long)
+            || type == typeof(float) || type == typeof(double) || type == typeof(decimal)
+            || type == typeof(Guid) || type == typeof(DateTime) || type == typeof(DateOnly) || type == typeof(TimeOnly))
+        {
+            return value;
+        }
+
+        // Collections of supported types are handled natively by GetUriWithQueryParameters
+        if (value is System.Collections.IEnumerable)
+            return value;
+
+        return ValueConverter.ConvertToString(value);
     }
 
     private static PropertyInfo[] GetProperties(Type type)

--- a/src/Meziantou.AspNetCore.Components/QueryStringService.cs
+++ b/src/Meziantou.AspNetCore.Components/QueryStringService.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Text.Json;
 using Meziantou.AspNetCore.Components.Internals;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Primitives;
@@ -83,9 +82,12 @@ public sealed class QueryStringService
 
             if (queryString.TryGetValue(parameterName, out var value))
             {
-                // Convert the value from string to the actual property type
-                var convertedValue = ConvertValue(value, property.PropertyType);
-                property.SetValue(component, convertedValue);
+                // Convert the value from string to the actual property type. The query string is user-controlled,
+                // so an unparsable value must leave the property untouched instead of throwing.
+                if (ValueConverter.TryConvertFromString(value.Count > 0 ? value[0] : null, property.PropertyType, out var convertedValue))
+                {
+                    property.SetValue(component, convertedValue);
+                }
             }
         }
     }
@@ -93,7 +95,7 @@ public sealed class QueryStringService
     /// <summary>Updates the URL query string with values from component properties marked with <see cref="SupplyParameterFromQueryAttribute"/>.</summary>
     /// <typeparam name="T">The type of the component.</typeparam>
     /// <param name="component">The component whose properties should be written to the query string.</param>
-    /// <param name="reloadPage">Whether to reload the page after updating the query string. If <see langword="false"/>, the URL is updated using the browser's history API without reloading.</param>
+    /// <param name="reloadPage">When <see langword="true"/> (the default), the new URL is applied by navigating to it, so the Blazor router re-renders the page. This is a client-side navigation, not a full browser reload. When <see langword="false"/>, the URL is updated in place using the browser's history API and nothing is re-rendered.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async ValueTask UpdateQueryString<T>(T component, bool reloadPage = true, CancellationToken cancellationToken = default)
@@ -117,13 +119,12 @@ public sealed class QueryStringService
             }
             else
             {
-                var convertedValue = ConvertToString(value);
-                parameters[parameterName] = convertedValue;
+                parameters[parameterName] = ValueConverter.ConvertToString(value);
             }
         }
 
         // Compute the new URL
-        var newUri = uri.GetComponents(UriComponents.Scheme | UriComponents.Host | UriComponents.Port | UriComponents.Path, UriFormat.UriEscaped);
+        var newUri = uri.GetComponents(UriComponents.Scheme | UriComponents.Host | UriComponents.Port | UriComponents.Path | UriComponents.Fragment, UriFormat.UriEscaped);
         foreach (var parameter in parameters)
         {
             foreach (var value in parameter.Value)
@@ -140,26 +141,6 @@ public sealed class QueryStringService
         {
             await _jsRuntime.SafeInvokeVoidAsync("window.history.replaceState", cancellationToken, args: [null, "", newUri]);
         }
-    }
-
-    private static object? ConvertValue(StringValues value, Type type)
-    {
-        var firstValue = value[0];
-        if (type == typeof(string))
-            return firstValue;
-
-        if (firstValue is null)
-            return Activator.CreateInstance(type);
-
-        return JsonSerializer.Deserialize(firstValue, type);
-    }
-
-    private static string ConvertToString(object value)
-    {
-        if (value is string s)
-            return s;
-
-        return JsonSerializer.Serialize(value);
     }
 
     private static PropertyInfo[] GetProperties<T>()

--- a/src/Meziantou.AspNetCore.Components/Repeater.razor
+++ b/src/Meziantou.AspNetCore.Components/Repeater.razor
@@ -3,13 +3,13 @@
 @* You can specify it manually by using <Repeater T=Person /> *@
 @typeparam T
 
-@if (Items == null)
+@if (materializedItems == null)
 {
     @LoadingTemplate
 }
 else
 {
-    if (EmptyTemplate != null && !Items.Any())
+    if (EmptyTemplate != null && materializedItems.Count == 0)
     {
         @EmptyTemplate
     }
@@ -18,7 +18,7 @@ else
         @RepeaterContainerTemplate(
             @: @{
                 var first = true;
-                foreach (var item in Items)
+                foreach (var item in materializedItems)
                 {
                     if (!first && ItemSeparatorTemplate != null)
                     {
@@ -37,7 +37,9 @@ else
 }
 
 @code {
-    private static RenderFragment<RenderFragment> s_defaultContainerTemplate = new RenderFragment<RenderFragment>(fragment => fragment);
+    private static readonly RenderFragment<RenderFragment> s_defaultContainerTemplate = new RenderFragment<RenderFragment>(fragment => fragment);
+
+    private IReadOnlyCollection<T>? materializedItems;
 
     /// <summary>Gets or sets the collection of items to render. When <see langword="null"/>, the <see cref="LoadingTemplate"/> is displayed.</summary>
     [Parameter]
@@ -67,5 +69,14 @@ else
     {
         // Create empty template in case the user doesn't provide it
         RepeaterContainerTemplate ??= s_defaultContainerTemplate;
+
+        // Items is enumerated once for the emptiness check and once for rendering. For a lazy sequence such as a
+        // LINQ query that means the underlying work runs twice per render, so materialize it here.
+        materializedItems = Items switch
+        {
+            null => null,
+            IReadOnlyCollection<T> collection => collection,
+            _ => Items.ToList(),
+        };
     }
 }

--- a/src/Meziantou.AspNetCore.Components/TimeZoneService.cs
+++ b/src/Meziantou.AspNetCore.Components/TimeZoneService.cs
@@ -5,8 +5,12 @@ namespace Meziantou.AspNetCore.Components;
 /// <summary>Provides timezone information and conversion services based on the user's browser timezone.</summary>
 /// <remarks>
 /// <para>
-/// This service retrieves the user's timezone offset from the browser and provides methods to convert between UTC and local times.
+/// This service retrieves the user's timezone from the browser and provides methods to convert between UTC and local times.
 /// To use this service, register it in your dependency injection container using <see cref="TimeZoneServiceExtensions.AddTimeZoneServices"/>.
+/// </para>
+/// <para>
+/// The offset of a timezone is not a constant: it changes at daylight saving transitions. Conversions therefore take
+/// the instant into account rather than applying a single cached offset to every value.
 /// </para>
 /// </remarks>
 /// <example>
@@ -31,10 +35,12 @@ public sealed class TimeZoneService : IAsyncDisposable
     private const string ImportPath = "./_content/Meziantou.AspNetCore.Components/Timezone.js";
 
     private readonly IJSRuntime _jsRuntime;
-    private Task<IJSObjectReference>? _module;
-    private TimeSpan? _userOffset;
-
     private readonly CancellationTokenSource _cts = new();
+
+    private Task<IJSObjectReference>? _module;
+    private TimeZoneInfo? _timeZone;
+    private bool _timeZoneResolved;
+    private bool _disposed;
 
     private Task<IJSObjectReference> Module => _module ??= _jsRuntime.InvokeAsync<IJSObjectReference>("import", _cts.Token, ImportPath).AsTask();
 
@@ -45,18 +51,43 @@ public sealed class TimeZoneService : IAsyncDisposable
         _jsRuntime = jsRuntime;
     }
 
-    /// <summary>Gets the user's timezone offset from UTC.</summary>
+    /// <summary>Gets the user's offset from UTC at the current instant.</summary>
     /// <returns>A task that represents the asynchronous operation. The task result contains the timezone offset.</returns>
-    public async ValueTask<TimeSpan> GetOffsetAsync()
+    public ValueTask<TimeSpan> GetOffsetAsync() => GetOffsetAsync(DateTimeOffset.UtcNow);
+
+    /// <summary>Gets the user's offset from UTC at the given instant.</summary>
+    /// <param name="instant">The instant at which the offset is evaluated. Daylight saving time makes the offset depend on it.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the timezone offset.</returns>
+    public async ValueTask<TimeSpan> GetOffsetAsync(DateTimeOffset instant)
     {
-        if (_userOffset == null)
+        var timeZone = await GetTimeZoneAsync();
+        if (timeZone is not null)
+            return timeZone.GetUtcOffset(instant);
+
+        // The browser did not report a timezone identifier the runtime knows about, which happens when globalization
+        // data is unavailable. Fall back to asking the browser for the offset at that specific instant.
+        var module = await Module;
+        var offsetInMinutes = await module.InvokeAsync<int>("blazorGetTimezoneOffset", _cts.Token, instant.ToUnixTimeMilliseconds());
+        return TimeSpan.FromMinutes(-offsetInMinutes);
+    }
+
+    /// <summary>Gets the user's timezone, or <see langword="null"/> when the browser reports an identifier this runtime does not know.</summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the user's timezone.</returns>
+    public async ValueTask<TimeZoneInfo?> GetTimeZoneAsync()
+    {
+        if (_timeZoneResolved)
+            return _timeZone;
+
+        var module = await Module;
+        var id = await module.InvokeAsync<string?>("blazorGetTimezone", _cts.Token);
+        if (id is not null)
         {
-            var module = await Module;
-            var offsetInMinutes = await module.InvokeAsync<int>("blazorGetTimezoneOffset", _cts.Token);
-            _userOffset = TimeSpan.FromMinutes(-offsetInMinutes);
+            // The identifier is stable for the lifetime of the scope, unlike an offset, so it is safe to cache
+            TimeZoneInfo.TryFindSystemTimeZoneById(id, out _timeZone);
         }
 
-        return _userOffset.GetValueOrDefault();
+        _timeZoneResolved = true;
+        return _timeZone;
     }
 
     /// <summary>Converts a <see cref="DateTimeOffset"/> to the user's local timezone.</summary>
@@ -64,7 +95,7 @@ public sealed class TimeZoneService : IAsyncDisposable
     /// <returns>A task that represents the asynchronous operation. The task result contains the converted date and time.</returns>
     public async ValueTask<DateTimeOffset> GetLocalDateTimeAsync(DateTimeOffset dateTime)
     {
-        var offset = await GetOffsetAsync();
+        var offset = await GetOffsetAsync(dateTime);
         return dateTime.ToOffset(offset);
     }
 
@@ -76,14 +107,32 @@ public sealed class TimeZoneService : IAsyncDisposable
         if (dateTime.Kind == DateTimeKind.Utc)
             return new DateTimeOffset(dateTime, TimeSpan.Zero);
 
-        var offset = await GetOffsetAsync();
-        return new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified).Add(-offset), TimeSpan.Zero);
+        var unspecified = DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+
+        var timeZone = await GetTimeZoneAsync();
+        if (timeZone is not null)
+        {
+            // GetUtcOffset resolves ambiguous and skipped local times deterministically instead of throwing,
+            // which ConvertTimeToUtc does for a local time that daylight saving time skipped over.
+            var localOffset = timeZone.GetUtcOffset(unspecified);
+            return new DateTimeOffset(unspecified, localOffset).ToUniversalTime();
+        }
+
+        // Without a known timezone the offset has to be evaluated at an instant. The local time is a good enough
+        // approximation of it: the two only disagree within a few hours of a daylight saving transition.
+        var offset = await GetOffsetAsync(new DateTimeOffset(unspecified, TimeSpan.Zero));
+        return new DateTimeOffset(unspecified.Add(-offset), TimeSpan.Zero);
     }
 
     /// <summary>Disposes the service and releases all resources.</summary>
     /// <returns>A task that represents the asynchronous disposal operation.</returns>
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
         await _cts.CancelAsync();
         if (_module is not null)
         {
@@ -92,7 +141,7 @@ public sealed class TimeZoneService : IAsyncDisposable
                 var module = await _module;
                 await module.DisposeAsync();
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is JSDisconnectedException or OperationCanceledException or ObjectDisposedException)
             {
             }
         }

--- a/src/Meziantou.AspNetCore.Components/wwwroot/InfiniteScrolling.js
+++ b/src/Meziantou.AspNetCore.Components/wwwroot/InfiniteScrolling.js
@@ -63,6 +63,9 @@ function isValidTableElement(element) {
     if (element === null) {
         return false;
     }
-    return ((element instanceof HTMLTableElement && element.style.display === '') || element.style.display === 'table')
-        || ((element instanceof HTMLTableSectionElement && element.style.display === '') || element.style.display === 'table-row-group');
+    // Use the computed style: element.style only exposes the inline attribute, so a table styled by a
+    // stylesheet would not be detected.
+    const display = getComputedStyle(element).display;
+    return (element instanceof HTMLTableElement && (display === '' || display === 'table'))
+        || (element instanceof HTMLTableSectionElement && (display === '' || display === 'table-row-group'));
 }

--- a/src/Meziantou.AspNetCore.Components/wwwroot/Timezone.js
+++ b/src/Meziantou.AspNetCore.Components/wwwroot/Timezone.js
@@ -1,3 +1,21 @@
-export function blazorGetTimezoneOffset() {
-    return new Date().getTimezoneOffset();
+/**
+ * Returns the IANA timezone identifier of the browser (for instance "Europe/Paris"),
+ * or null when the environment does not expose it.
+ * @returns {string | null}
+ */
+export function blazorGetTimezone() {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? null;
+}
+
+/**
+ * Returns the offset from UTC, in minutes, at the given instant. The offset of a timezone depends on the
+ * instant it is evaluated at because of daylight saving time, so the caller must pass the instant of interest.
+ * @param {number | null} epochMilliseconds Milliseconds since the Unix epoch, or null for the current instant.
+ * @returns {number}
+ */
+export function blazorGetTimezoneOffset(epochMilliseconds) {
+    const date = epochMilliseconds === null || epochMilliseconds === undefined
+        ? new Date()
+        : new Date(epochMilliseconds);
+    return date.getTimezoneOffset();
 }

--- a/tests/Meziantou.AspNetCore.Components.Tests/BlazorTestRenderer.cs
+++ b/tests/Meziantou.AspNetCore.Components.Tests/BlazorTestRenderer.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meziantou.AspNetCore.Components.Tests;
+
+/// <summary>Renders a component the way static server-side rendering does, and returns the produced markup.</summary>
+internal static class BlazorTestRenderer
+{
+    public static Task<string> RenderAsync<T>(params (string Name, object? Value)[] parameters)
+        where T : IComponent
+    {
+        var dictionary = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var (name, value) in parameters)
+        {
+            dictionary[name] = value;
+        }
+
+        return RenderAsync<T>(dictionary);
+    }
+
+    public static async Task<string> RenderAsync<T>(Dictionary<string, object?> parameters)
+        where T : IComponent
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        await using var renderer = new HtmlRenderer(serviceProvider, NullLoggerFactory.Instance);
+
+        return await renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var component = await renderer.RenderComponentAsync<T>(ParameterView.FromDictionary(parameters));
+            return component.ToHtmlString();
+        });
+    }
+}

--- a/tests/Meziantou.AspNetCore.Components.Tests/DataGridTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.Tests/DataGridTests.cs
@@ -1,0 +1,157 @@
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Meziantou.AspNetCore.Components.Tests;
+
+public sealed class DataGridTests
+{
+    private static RenderFragment SingleColumn(string title) => builder =>
+    {
+        builder.OpenComponent<DataGridColumn<int>>(0);
+        builder.AddComponentParameter(1, nameof(DataGridColumn<int>.Title), title);
+        builder.AddComponentParameter(2, nameof(DataGridColumn<int>.Expression), (Expression<Func<int, object>>)(value => value));
+        builder.CloseComponent();
+    };
+
+    [Fact]
+    public async Task ColumnsAreRenderedDuringStaticServerSideRendering()
+    {
+        // Static server-side rendering never calls OnAfterRender, so the grid must not depend on it to
+        // discover the columns declared in its ChildContent
+        var html = await BlazorTestRenderer.RenderAsync<DataGrid<int>>(
+            (nameof(DataGrid<int>.Items), new[] { 1, 2, 3 }),
+            (nameof(DataGrid<int>.ChildContent), SingleColumn("Value")));
+
+        Assert.Contains("<th>Value</th>", html);
+        Assert.Contains("<td>1</td>", html);
+        Assert.Contains("<td>2</td>", html);
+        Assert.Contains("<td>3</td>", html);
+    }
+
+    [Fact]
+    public async Task DuplicateItemsDoNotProduceDuplicateKeys()
+    {
+        // Sibling keys must be unique. Keying on the item (or its hash code) makes equal rows collide,
+        // which the renderer rejects on the next diff.
+        var html = await BlazorTestRenderer.RenderAsync<Rerenderer>(
+            (nameof(Rerenderer.First), new[] { 1, 2, 3 }),
+            (nameof(Rerenderer.Second), new[] { 1, 2, 2 }));
+
+        Assert.Contains("<td>1</td>", html);
+        Assert.Equal(2, html.Split("<td>2</td>", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public async Task RowKeyIsUsedWhenProvided()
+    {
+        var html = await BlazorTestRenderer.RenderAsync<Rerenderer>(
+            (nameof(Rerenderer.First), new[] { 1, 2, 3 }),
+            (nameof(Rerenderer.Second), new[] { 3, 2, 1 }),
+            (nameof(Rerenderer.RowKey), (Func<int, object>)(item => item)));
+
+        Assert.Contains("<td>3</td>", html);
+        Assert.Contains("<td>1</td>", html);
+    }
+
+    [Fact]
+    public async Task RowClassReceivesTheRowIndex()
+    {
+        var html = await BlazorTestRenderer.RenderAsync<DataGrid<int>>(
+            (nameof(DataGrid<int>.Items), new[] { 10, 20, 30 }),
+            (nameof(DataGrid<int>.ChildContent), SingleColumn("Value")),
+            (nameof(DataGrid<int>.RowClass), (Func<int, int, string>)((item, index) => "row-" + index.ToString(CultureInfo.InvariantCulture))));
+
+        Assert.Contains("class=\"row-0\"", html);
+        Assert.Contains("class=\"row-1\"", html);
+        Assert.Contains("class=\"row-2\"", html);
+    }
+
+    [Fact]
+    public async Task ColumnRemovedFromChildContentIsUnregistered()
+    {
+        var html = await BlazorTestRenderer.RenderAsync<ToggleColumnGrid>();
+
+        Assert.Contains("<th>Kept</th>", html);
+        Assert.DoesNotContain("Removed", html);
+    }
+
+    [Fact]
+    public async Task InferringATitleFromAnUnsupportedExpressionReportsTheExpressionBody()
+    {
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => BlazorTestRenderer.RenderAsync<DataGrid<int>>(
+            (nameof(DataGrid<int>.Items), new[] { 1 }),
+            (nameof(DataGrid<int>.ChildContent), (RenderFragment)(builder =>
+            {
+                builder.OpenComponent<DataGridColumn<int>>(0);
+                builder.AddComponentParameter(1, nameof(DataGridColumn<int>.Expression), (Expression<Func<int, object>>)(value => value));
+                builder.CloseComponent();
+            }))));
+
+        // The message must name the expression body, not the Expression<Func<...>> wrapper around it
+        Assert.Contains("UnaryExpression", exception.Message);
+        Assert.DoesNotContain("Func`2", exception.Message);
+    }
+
+    /// <summary>Renders the grid once, then swaps the items and renders again, so the keyed diff actually runs.</summary>
+    internal sealed class Rerenderer : ComponentBase
+    {
+        private int[] _current = [];
+
+        [Parameter] public int[] First { get; set; } = [];
+
+        [Parameter] public int[] Second { get; set; } = [];
+
+        [Parameter] public Func<int, object>? RowKey { get; set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            _current = First;
+            await Task.Yield();
+            _current = Second;
+        }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<DataGrid<int>>(0);
+            builder.AddComponentParameter(1, nameof(DataGrid<int>.Items), _current);
+            builder.AddComponentParameter(2, nameof(DataGrid<int>.RowKey), RowKey);
+            builder.AddComponentParameter(3, nameof(DataGrid<int>.ChildContent), SingleColumn("Value"));
+            builder.CloseComponent();
+        }
+    }
+
+    /// <summary>Renders two columns, then drops one of them, so the column has to unregister itself.</summary>
+    internal sealed class ToggleColumnGrid : ComponentBase
+    {
+        private bool _showRemoved = true;
+
+        protected override async Task OnInitializedAsync()
+        {
+            await Task.Yield();
+            _showRemoved = false;
+        }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<DataGrid<int>>(0);
+            builder.AddComponentParameter(1, nameof(DataGrid<int>.Items), new[] { 1 });
+            builder.AddComponentParameter(2, nameof(DataGrid<int>.ChildContent), (RenderFragment)(inner =>
+            {
+                inner.OpenComponent<DataGridColumn<int>>(0);
+                inner.AddComponentParameter(1, nameof(DataGridColumn<int>.Title), "Kept");
+                inner.AddComponentParameter(2, nameof(DataGridColumn<int>.Expression), (Expression<Func<int, object>>)(value => value));
+                inner.CloseComponent();
+
+                if (_showRemoved)
+                {
+                    inner.OpenComponent<DataGridColumn<int>>(3);
+                    inner.AddComponentParameter(4, nameof(DataGridColumn<int>.Title), "Removed");
+                    inner.AddComponentParameter(5, nameof(DataGridColumn<int>.Expression), (Expression<Func<int, object>>)(value => value));
+                    inner.CloseComponent();
+                }
+            }));
+            builder.CloseComponent();
+        }
+    }
+}

--- a/tests/Meziantou.AspNetCore.Components.Tests/GenericFormTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.Tests/GenericFormTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Meziantou.AspNetCore.Components.Tests;
+
+public sealed class GenericFormTests
+{
+    // Field validation is enabled by default and ValidationMessage needs an EditContext,
+    // so the form is rendered the way it is meant to be used
+    private static Task<string> RenderAsync<TModel>(TModel model)
+        => BlazorTestRenderer.RenderAsync<FormHost<TModel>>((nameof(FormHost<TModel>.Model), model));
+
+    internal sealed class FormHost<TModel> : ComponentBase
+    {
+        [Parameter] public TModel? Model { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<EditForm>(0);
+            builder.AddComponentParameter(1, nameof(EditForm.Model), Model);
+            builder.AddComponentParameter(2, nameof(EditForm.ChildContent), (RenderFragment<EditContext>)(_ => inner =>
+            {
+                inner.OpenComponent<GenericForm<TModel>>(0);
+                inner.AddComponentParameter(1, nameof(GenericForm<TModel>.Model), Model);
+                inner.CloseComponent();
+            }));
+            builder.CloseComponent();
+        }
+    }
+
+    // Every type here has no dedicated editor and used to fall back to InputText, which is an InputBase<string>.
+    // The value, the change callback and the value expression are built from the property type, so binding them
+    // to InputText threw an InvalidCastException and took the whole form down.
+    public sealed class UnmappedTypesModel
+    {
+        public TimeSpan Duration { get; set; }
+        public char Initial { get; set; }
+        public uint Count { get; set; }
+        public byte Level { get; set; }
+        public DateOnly Day { get; set; }
+        public TimeOnly Time { get; set; }
+    }
+
+    [Fact]
+    public async Task PropertiesWithoutADedicatedEditorRenderATextInput()
+    {
+        var html = await RenderAsync(new UnmappedTypesModel { Duration = TimeSpan.FromMinutes(90), Initial = 'a', Count = 3 });
+
+        Assert.Contains("<label for=\"", html);
+        Assert.Equal(6, html.Split("type=\"text\"", StringSplitOptions.None).Length - 1);
+        Assert.Contains("value=\"01:30:00\"", html);
+        Assert.Contains("value=\"a\"", html);
+        Assert.Contains("value=\"3\"", html);
+    }
+
+    public sealed class NullableEnumModel
+    {
+        public DayOfWeek? Day { get; set; }
+    }
+
+    [Fact]
+    public async Task NullableEnumUsesTheEnumSelect()
+    {
+        var html = await RenderAsync(new NullableEnumModel());
+
+        Assert.Contains("<select", html);
+        Assert.Contains("<option value=\"Monday\">Monday</option>", html);
+        Assert.Contains("<option value=\"\">", html);
+    }
+
+    public sealed class FlagsModel
+    {
+        public FileAccess Access { get; set; }
+    }
+
+    [Fact]
+    public async Task FlagsEnumRendersATextInput()
+    {
+        // A select cannot represent a combination of flags, so these keep using a text editor
+        var html = await RenderAsync(new FlagsModel { Access = FileAccess.ReadWrite });
+
+        Assert.Contains("type=\"text\"", html);
+        Assert.Contains("value=\"ReadWrite\"", html);
+        Assert.DoesNotContain("<select", html);
+    }
+
+    public sealed class MappedTypesModel
+    {
+        public string? Name { get; set; }
+        public bool Enabled { get; set; }
+        public int Count { get; set; }
+        public Guid Id { get; set; }
+        public DayOfWeek Day { get; set; }
+    }
+
+    [Fact]
+    public async Task MappedTypesKeepTheirDedicatedEditors()
+    {
+        var html = await RenderAsync(new MappedTypesModel());
+
+        Assert.Contains("type=\"checkbox\"", html);
+        Assert.Contains("type=\"number\"", html);
+        Assert.Contains("<select", html);
+    }
+
+    [Fact]
+    public async Task NoModelRendersNothing()
+    {
+        var html = await BlazorTestRenderer.RenderAsync<GenericForm<MappedTypesModel?>>(
+            (nameof(GenericForm<MappedTypesModel?>.Model), null));
+
+        Assert.Empty(html.Trim());
+    }
+}

--- a/tests/Meziantou.AspNetCore.Components.Tests/InputTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.Tests/InputTests.cs
@@ -1,0 +1,111 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+namespace Meziantou.AspNetCore.Components.Tests;
+
+public sealed class InputTests
+{
+    private static Task<string> RenderInputAsync<TComponent, TValue>(TValue value, Expression<Func<TValue>> valueExpression)
+        where TComponent : IComponent
+        => BlazorTestRenderer.RenderAsync<TComponent>(
+            ("Value", value),
+            ("ValueExpression", valueExpression));
+
+    private sealed class Holder
+    {
+        public Guid Id { get; set; }
+        public DayOfWeek? Day { get; set; }
+        public Uri? Url { get; set; }
+        public string? Text { get; set; }
+    }
+
+    [Fact]
+    public async Task InputGuidRendersATextInput()
+    {
+        // A GUID is not a URL, so type="url" made the browser mark every correctly filled field as invalid
+        var holder = new Holder { Id = Guid.Empty };
+        var html = await RenderInputAsync<InputGuid<Guid>, Guid>(holder.Id, () => holder.Id);
+
+        Assert.Contains("type=\"text\"", html);
+        Assert.DoesNotContain("type=\"url\"", html);
+        Assert.Contains("value=\"00000000-0000-0000-0000-000000000000\"", html);
+    }
+
+    [Fact]
+    public void InputGuidHasANonEmptyParsingErrorMessage()
+    {
+        // Formatting an empty message produced an empty validation error, so the field turned red with no explanation
+        using var input = new InputGuid<Guid>();
+        var message = input.ParsingErrorMessage;
+
+        Assert.NotEmpty(message);
+        Assert.Contains("{0}", message);
+    }
+
+    [Fact]
+    public void InputUrlHasANonEmptyParsingErrorMessage()
+    {
+        using var input = new InputUrl<Uri>();
+        var message = input.ParsingErrorMessage;
+
+        Assert.NotEmpty(message);
+        Assert.Contains("{0}", message);
+    }
+
+    [Fact]
+    public async Task InputEnumSelectRendersAnEmptyOptionForNullableEnums()
+    {
+        var holder = new Holder();
+        var html = await RenderInputAsync<InputEnumSelect<DayOfWeek?>, DayOfWeek?>(holder.Day, () => holder.Day);
+
+        Assert.Contains("<option value=\"\">", html);
+        Assert.Contains("<option value=\"Sunday\">Sunday</option>", html);
+    }
+
+    [Fact]
+    public async Task InputEnumSelectHasNoEmptyOptionForNonNullableEnums()
+    {
+        var day = DayOfWeek.Monday;
+        var html = await BlazorTestRenderer.RenderAsync<InputEnumSelect<DayOfWeek>>(
+            ("Value", DayOfWeek.Monday),
+            ("ValueExpression", (Expression<Func<DayOfWeek>>)(() => day)));
+
+        Assert.DoesNotContain("<option value=\"\">", html);
+        Assert.Equal(7, html.Split("<option", StringSplitOptions.None).Length - 1);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("JavaScript:alert(1)")]
+    [InlineData("  javascript:alert(1)")]
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4=")]
+    public void InputUrlRejectsSchemesThatExecuteScript(string value)
+    {
+        Assert.False(TryParse<InputUrl<Uri>, Uri>(value, out _));
+        Assert.False(TryParse<InputUrl<string>, string>(value, out _));
+    }
+
+    [Theory]
+    [InlineData("https://example.com/")]
+    [InlineData("http://example.com/a?b=c")]
+    [InlineData("/relative/path")]
+    public void InputUrlAcceptsOrdinaryUrls(string value)
+    {
+        Assert.True(TryParse<InputUrl<Uri>, Uri>(value, out var parsed));
+        Assert.Equal(value, parsed?.ToString());
+    }
+
+    // TryParseValueFromString is protected, so reach it the way the framework does
+    private static bool TryParse<TComponent, TValue>(string value, out TValue? result)
+        where TComponent : IDisposable, new()
+    {
+        using var component = new TComponent();
+        var method = typeof(TComponent).GetMethod("TryParseValueFromString", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var args = new object?[] { value, null, null };
+        var success = (bool)method.Invoke(component, args)!;
+        result = success ? (TValue?)args[1] : default;
+        return success;
+    }
+}

--- a/tests/Meziantou.AspNetCore.Components.Tests/QueryStringServiceTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.Tests/QueryStringServiceTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Meziantou.AspNetCore.Components.Tests;
+
+public sealed class QueryStringServiceTests
+{
+    private sealed class TestNavigationManager : NavigationManager
+    {
+        public TestNavigationManager(string uri) => Initialize("https://example.com/", uri);
+
+        public string? NavigatedTo { get; private set; }
+
+        protected override void NavigateToCore(string uri, NavigationOptions options) => NavigatedTo = uri;
+    }
+
+    private sealed class TestComponent : ComponentBase
+    {
+        [Parameter, SupplyParameterFromQuery] public string? Search { get; set; }
+
+        [Parameter, SupplyParameterFromQuery] public int Page { get; set; }
+
+        [Parameter, SupplyParameterFromQuery] public DayOfWeek Day { get; set; }
+
+        [Parameter, SupplyParameterFromQuery] public DateTime? When { get; set; }
+
+        [Parameter, SupplyParameterFromQuery] public bool Enabled { get; set; }
+
+        // Assigning parameters from inside the component keeps BL0005 happy. Populating them from the outside is
+        // exactly what QueryStringService does, which is what these tests exercise.
+        public static TestComponent Create(string? search = null, int page = 0, DayOfWeek day = default, DateTime? when = null, bool enabled = false)
+            => new() { Search = search, Page = page, Day = day, When = when, Enabled = enabled };
+    }
+
+    private static (QueryStringService Service, TestNavigationManager Navigation) Create(string uri)
+    {
+        var navigation = new TestNavigationManager(uri);
+        return (new QueryStringService(navigation, jsRuntime: null!), navigation);
+    }
+
+    [Fact]
+    public void ReadsPlainValuesWithoutJsonQuoting()
+    {
+        var (service, _) = Create("https://example.com/?Search=hello&Page=42&Day=Monday&When=2024-01-02&Enabled=true");
+        var component = new TestComponent();
+
+        service.SetParametersFromQueryString(component);
+
+        Assert.Equal("hello", component.Search);
+        Assert.Equal(42, component.Page);
+        Assert.Equal(DayOfWeek.Monday, component.Day);
+        Assert.Equal(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Unspecified), component.When);
+        Assert.True(component.Enabled);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/?Page=abc")]
+    [InlineData("https://example.com/?Day=NotADay")]
+    [InlineData("https://example.com/?When=not-a-date")]
+    public void UnparsableValuesLeaveThePropertyUntouchedInsteadOfThrowing(string uri)
+    {
+        // The query string is user-controlled and this runs from OnInitialized, so throwing here tears down the circuit
+        var (service, _) = Create(uri);
+        var component = TestComponent.Create(page: 7, day: DayOfWeek.Friday);
+
+        service.SetParametersFromQueryString(component);
+
+        Assert.Equal(7, component.Page);
+        Assert.Equal(DayOfWeek.Friday, component.Day);
+        Assert.Null(component.When);
+    }
+
+    [Fact]
+    public void MissingParametersLeaveThePropertiesUntouched()
+    {
+        var (service, _) = Create("https://example.com/");
+        var component = TestComponent.Create(page: 7);
+
+        service.SetParametersFromQueryString(component);
+
+        Assert.Equal(7, component.Page);
+    }
+
+    [Fact]
+    public void EmptyValueResetsToTheDefault()
+    {
+        var (service, _) = Create("https://example.com/?Page=&When=");
+        var component = TestComponent.Create(page: 7, when: DateTime.UtcNow);
+
+        service.SetParametersFromQueryString(component);
+
+        Assert.Equal(0, component.Page);
+        Assert.Null(component.When);
+    }
+
+    [Fact]
+    public async Task WritesPlainValuesAndRoundTrips()
+    {
+        var (service, navigation) = Create("https://example.com/page");
+        var component = TestComponent.Create(search: "hello", page: 42, day: DayOfWeek.Monday, enabled: true);
+
+        await service.UpdateQueryString(component);
+
+        Assert.NotNull(navigation.NavigatedTo);
+        Assert.Contains("Day=Monday", navigation.NavigatedTo);
+        Assert.Contains("Page=42", navigation.NavigatedTo);
+        Assert.DoesNotContain("%22", navigation.NavigatedTo);
+
+        var (readBack, _) = Create(navigation.NavigatedTo);
+        var target = new TestComponent();
+        readBack.SetParametersFromQueryString(target);
+
+        Assert.Equal("hello", target.Search);
+        Assert.Equal(42, target.Page);
+        Assert.Equal(DayOfWeek.Monday, target.Day);
+        Assert.True(target.Enabled);
+    }
+
+    [Fact]
+    public async Task TheFragmentIsPreserved()
+    {
+        var (service, navigation) = Create("https://example.com/page#section");
+        var component = TestComponent.Create(page: 3);
+
+        await service.UpdateQueryString(component);
+
+        Assert.Contains("#section", navigation.NavigatedTo);
+        Assert.Contains("Page=3", navigation.NavigatedTo);
+    }
+
+    [Fact]
+    public void UpdateUrlUsingParametersSupportsTypesTheFrameworkRejects()
+    {
+        // GetUriWithQueryParameters throws for values it does not know, such as enums
+        var navigation = new TestNavigationManager("https://example.com/page");
+        var component = TestComponent.Create(day: DayOfWeek.Monday, page: 5);
+
+        navigation.UpdateUrlUsingParameters(component);
+
+        Assert.Contains("Day=Monday", navigation.NavigatedTo);
+        Assert.Contains("Page=5", navigation.NavigatedTo);
+    }
+}


### PR DESCRIPTION
An audit of `Meziantou.AspNetCore.Components` turned up a set of defects that make several components fail outright rather than degrade. This fixes them and adds test coverage.

Every fix was reproduced first by rendering the component with `HtmlRenderer` and observing the actual exception or markup, then covered by a test. After writing the tests I re-introduced each original defect and confirmed the matching tests fail, so they are real guards rather than tautologies.

## The serious ones

**`GenericForm` threw `InvalidCastException` for most non-`string` property types.** `GetEditorType` fell back to `InputText` — an `InputBase<string>` — while the value, change callback and value expression were all built from the property type. Binding them together threw and took the whole form down. Confirmed for `TimeSpan`, `char`, `uint`, `byte`, `DateOnly`, `TimeOnly`, `[Flags]` enums, nullable enums and any custom type. The fallback is now a generic `InputTextFallback<TValue>`, so all four agree. Nullable enums were a second, independent gap: the enum check tested `PropertyType.IsEnum`, which is `false` for `MyEnum?`.

**`DataGrid` rendered an empty table under static SSR.** Columns were discovered via `OnAfterRender` + `StateHasChanged()`, and `StaticHtmlRenderer` never calls `OnAfterRender`. The observed output was `<table><thead><tr></tr></thead><tbody><tr></tr><tr></tr><tr></tr></tbody></table>` — right row count, zero headers, zero cells. Static SSR is a default render mode in .NET 8+.

**`DataGrid` crashed on re-render when two rows were equal.** Rows were keyed by `item.GetHashCode()`, so duplicates produced duplicate sibling keys: `InvalidOperationException: More than one sibling of element 'tr' has the same key value`. The first render was fine, so it surfaced later on a data refresh and looked intermittent.

**`QueryStringService` threw `JsonException` on ordinary URLs.** Values were round-tripped through `JsonSerializer`, so `?Page=abc`, `?Day=Monday` and `?When=2024-01-02` all threw. The documented usage calls this from `OnInitialized` where that is unhandled, and the input is the URL, so any visitor could trigger it. It also meant enums and dates only round-tripped when JSON-quoted in the URL.

**`InfiniteScrolling` could append the same page twice.** A cancelled load's `finally` cleared `_loadItemsCts` unconditionally, clobbering the token source of the load that replaced it. That disables the re-entrancy guard, so the observer could fire again before the first load returned.

**`AnchorNavigation` re-scrolled on every render** — `OnAfterRenderAsync` ignored `firstRender`, so any re-render yanked the page back to the anchor — and its `async void` handler let a disconnect exception escape unhandled.

## Also fixed

- `TimeZoneService` cached one offset forever, so every conversion across a DST boundary was off by an hour. It now resolves the IANA zone once and evaluates offsets per instant, falling back to a per-instant browser call when globalization data is unavailable.
- `ClipboardService.WriteTextAsync` reported success even when the browser refused the write. The shared JS helper no longer swallows every exception, only those caused by the circuit or component going away.
- `InputGuid` rendered `type="url"`, so the browser marked every valid GUID `:invalid`.
- `InputGuid` and `InputUrl` defaulted `ParsingErrorMessage` to `""`, producing a blank validation message.
- `InputEnumSelect` rendered no empty option for nullable enums, so `null` was unreachable and displayed as the first member.
- `InputDateTime` gained an `Offset` parameter — `datetime-local` carries no timezone, so `DateTimeOffset` binding otherwise picks up the server's offset.
- `InputUrl` now rejects `javascript:`, `vbscript:` and `data:`.
- `DataGridColumn` unregisters on dispose; previously a removed column kept rendering and re-adding it registered a duplicate.
- `GenericForm` no longer rebuilds fields and recompiles expression trees on every parameter change of its parent.
- `Repeater` no longer enumerates `Items` twice.
- `InfiniteScrolling.js`: operator precedence bug in the table detection, and it now reads the computed style rather than the inline attribute.
- `NavigationManagerExtensions` and `QueryStringService` now share one converter, so a URL written by one is readable by the other and enums no longer throw.

## Notes for the reviewer

Two consumer-visible behavior changes come out of the fixes:

- Query string values are now plain text (`?day=Monday`) rather than JSON-quoted (`?day=%22Monday%22`). URLs produced by earlier versions no longer read back. This is unavoidable given the fix and is the reason enums and dates work at all now.
- `ClipboardService.WriteTextAsync` now throws instead of failing silently. The alternative was a `bool` return, which breaks the signature.

One judgment call worth confirming: the `reloadPage` parameter on `UpdateQueryString` is documented as reloading the page, but `NavigateTo` without `forceLoad` does a client-side navigation. I corrected the documentation rather than the behavior, since `reloadPage` defaults to `true` and switching it to a full browser reload would surprise existing callers. Happy to flip it the other way.

`DataGrid.OnAfterRender` is removed from the public surface — a `protected override` of a base no-op, so only a subclass calling `base.OnAfterRender` would notice. The rest of the `ref/` diff is additive.

The `InfiniteScrolling`, `AnchorNavigation` and `TimeZoneService` fixes are **not** covered by tests: they need JS interop or an interactive renderer and there is no harness for that in this repo. Those are code-review-verified only.

## Verification

- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` — clean
- 76/76 tests pass across net10.0 and net11.0 (up from 5 tests, 33 added)
- `dotnet run ./eng/update-all.cs` exits 0
- `ref/Meziantou.AspNetCore.Components.cs` regenerated and committed
