### PR TITLE
Harden DnsServer against malformed and hostile DNS traffic

### DIFF
--- a/ref/Meziantou.Framework.DnsServer.cs
+++ b/ref/Meziantou.Framework.DnsServer.cs
@@ -38,6 +38,10 @@ namespace Meziantou.Framework.DnsServer.Hosting
 
     public sealed class DnsServerOptions
     {
+        public int MaxUdpResponseSize { get => throw null; set { } }
+        public System.TimeSpan TcpIdleTimeout { get => throw null; set { } }
+        public System.TimeSpan QuicIdleTimeout { get => throw null; set { } }
+        public int MaxConcurrentQueriesPerConnection { get => throw null; set { } }
         public Meziantou.Framework.DnsServer.Hosting.DnsServerOptions AddUdpListener(int port = 53, System.Net.IPAddress? bindAddress = null) => throw null;
         public Meziantou.Framework.DnsServer.Hosting.DnsServerOptions AddTcpListener(int port = 53, System.Net.IPAddress? bindAddress = null) => throw null;
         public Meziantou.Framework.DnsServer.Hosting.DnsServerOptions AddTlsListener(int port, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Net.IPAddress? bindAddress = null) => throw null;

--- a/src/Meziantou.Framework.DnsServer/Handler/DnsRequestProcessor.cs
+++ b/src/Meziantou.Framework.DnsServer/Handler/DnsRequestProcessor.cs
@@ -1,0 +1,118 @@
+using System.Buffers.Binary;
+using System.Net;
+using Meziantou.Framework.DnsServer.Hosting;
+using Meziantou.Framework.DnsServer.Protocol;
+using Meziantou.Framework.DnsServer.Protocol.Wire;
+using Microsoft.Extensions.Logging;
+using DnsResponseCode = Meziantou.Framework.DnsServer.Protocol.DnsResponseCode;
+
+namespace Meziantou.Framework.DnsServer.Handler;
+
+/// <summary>
+/// Decodes an incoming message, validates it as a server-bound query, invokes the user handler and
+/// encodes the reply. Shared by every transport so that the protocol rules live in one place.
+/// </summary>
+internal sealed class DnsRequestProcessor
+{
+    /// <summary>The smallest payload size a DNS implementation must accept over UDP (RFC 1035 4.2.1).</summary>
+    public const int MinUdpPayloadSize = 512;
+
+    /// <summary>The highest EDNS version this server understands.</summary>
+    private const byte SupportedEdnsVersion = 0;
+
+    private readonly DnsRequestDelegateHolder _handlerHolder;
+    private readonly DnsServerOptions _options;
+    private readonly ILogger<DnsRequestProcessor> _logger;
+
+    public DnsRequestProcessor(DnsRequestDelegateHolder handlerHolder, DnsServerOptions options, ILogger<DnsRequestProcessor> logger)
+    {
+        _handlerHolder = handlerHolder;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Processes one message and returns the bytes to send back, or <see langword="null"/> when the
+    /// message must be dropped without a reply.
+    /// </summary>
+    /// <param name="maxResponseSize">The largest reply the transport can carry.</param>
+    /// <param name="replyWithFormatError">
+    /// Whether an unparseable message should be answered with FORMERR. Transports that have no other way
+    /// to report the problem want this; DoH reports it as an HTTP status instead.
+    /// </param>
+    public async ValueTask<byte[]?> ProcessAsync(ReadOnlyMemory<byte> data, DnsServerProtocol protocol, EndPoint remoteEndPoint, int maxResponseSize, CancellationToken cancellationToken, bool replyWithFormatError = true)
+    {
+        DnsMessage query;
+        try
+        {
+            query = DnsMessageEncoder.DecodeQuery(data.Span);
+        }
+        catch (DnsProtocolException exception)
+        {
+            _logger.LogDebug(exception, "Discarding a malformed DNS message from {RemoteEndPoint}", remoteEndPoint);
+            return replyWithFormatError ? CreateFormatErrorResponse(data.Span, protocol, maxResponseSize) : null;
+        }
+
+        // RFC 5625 4.4: a server must never act on a message that is itself a response. Answering one
+        // lets an attacker point two servers at each other and have them exchange packets indefinitely.
+        if (query.IsResponse)
+        {
+            _logger.LogDebug("Discarding a DNS message from {RemoteEndPoint} that has the QR bit set", remoteEndPoint);
+            return null;
+        }
+
+        var responseSize = GetMaxResponseSize(query.EdnsOptions, protocol, maxResponseSize);
+        var context = new DnsRequestContext(query, protocol, remoteEndPoint);
+
+        DnsMessage response;
+        if (query.EdnsOptions is { Version: > SupportedEdnsVersion } edns)
+        {
+            // RFC 6891 6.1.3: answer an unsupported EDNS version with BADVERS rather than pretending
+            // to understand it.
+            _logger.LogDebug("Rejecting EDNS version {Version} from {RemoteEndPoint}", edns.Version, remoteEndPoint);
+            response = context.CreateResponse();
+            response.ResponseCode = DnsResponseCode.BadVersion;
+        }
+        else
+        {
+            response = await _handlerHolder.Handler(context, cancellationToken).ConfigureAwait(false);
+        }
+
+        return DnsMessageEncoder.EncodeResponse(response, responseSize);
+    }
+
+    /// <summary>Builds a FORMERR reply for a message that could not be parsed, so the client fails fast instead of timing out.</summary>
+    private byte[]? CreateFormatErrorResponse(ReadOnlySpan<byte> data, DnsServerProtocol protocol, int maxResponseSize)
+    {
+        // Without a complete header there is no ID to echo, so there is nothing worth sending back.
+        if (data.Length < 12)
+            return null;
+
+        var flags = BinaryPrimitives.ReadUInt16BigEndian(data[2..]);
+        if ((flags & 0x8000) != 0)
+            return null;
+
+        var response = new DnsMessage
+        {
+            Id = BinaryPrimitives.ReadUInt16BigEndian(data),
+            IsResponse = true,
+            OpCode = (DnsOpCode)((flags >> 11) & 0x0F),
+            RecursionDesired = (flags & 0x0100) != 0,
+            ResponseCode = DnsResponseCode.FormError,
+        };
+
+        return DnsMessageEncoder.EncodeResponse(response, GetMaxResponseSize(edns: null, protocol, maxResponseSize));
+    }
+
+    private int GetMaxResponseSize(DnsEdnsOptions? edns, DnsServerProtocol protocol, int transportMaxSize)
+    {
+        if (protocol is not DnsServerProtocol.Udp)
+            return transportMaxSize;
+
+        // Never trust the advertised size outright: a small value would make the reply unsendable and a
+        // large one turns the server into an amplifier for spoofed queries.
+        var advertised = edns?.UdpPayloadSize ?? MinUdpPayloadSize;
+
+        return Math.Clamp(advertised, MinUdpPayloadSize, _options.MaxUdpResponseSize);
+    }
+}

--- a/src/Meziantou.Framework.DnsServer/Hosting/DnsEndpointRouteBuilderExtensions.cs
+++ b/src/Meziantou.Framework.DnsServer/Hosting/DnsEndpointRouteBuilderExtensions.cs
@@ -1,8 +1,12 @@
+using System.Buffers.Text;
+using System.Globalization;
+using System.Net;
 using Meziantou.Framework.DnsServer.Handler;
 using Meziantou.Framework.DnsServer.Protocol;
 using Meziantou.Framework.DnsServer.Protocol.Wire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,6 +17,12 @@ public static class DnsEndpointRouteBuilderExtensions
 {
     private const string DnsMessageContentType = "application/dns-message";
 
+    /// <summary>A DNS message cannot exceed this size, so anything larger is rejected before it is buffered.</summary>
+    private const int MaxDnsMessageSize = DnsMessageEncoder.MaxMessageSize;
+
+    /// <summary>The longest base64url string that can hold a DNS message of the maximum size.</summary>
+    private const int MaxEncodedQueryLength = ((MaxDnsMessageSize + 2) / 3 * 4) + 4;
+
     /// <summary>Registers the DNS request handler delegate. This must be called before the application starts.</summary>
     public static IEndpointRouteBuilder MapDnsHandler(this IEndpointRouteBuilder endpoints, DnsRequestDelegate handler)
     {
@@ -20,7 +30,7 @@ public static class DnsEndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(handler);
 
         var registry = endpoints.ServiceProvider.GetRequiredService<DnsRequestDelegateHolder>();
-        registry.Handler = handler;
+        registry.SetHandler(handler);
 
         return endpoints;
     }
@@ -44,66 +54,99 @@ public static class DnsEndpointRouteBuilderExtensions
             return Results.StatusCode(StatusCodes.Status415UnsupportedMediaType);
         }
 
-        var handler = httpContext.RequestServices.GetRequiredService<DnsRequestDelegateHolder>();
+        if (httpContext.Request.ContentLength > MaxDnsMessageSize)
+        {
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+        }
 
-        using var ms = new MemoryStream();
-        await httpContext.Request.Body.CopyToAsync(ms, httpContext.RequestAborted).ConfigureAwait(false);
-        var queryBytes = ms.ToArray();
+        // Cap the body even when no Content-Length was sent, so a chunked request cannot make the
+        // server buffer far more than a DNS message can ever hold.
+        var maxSizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
+        if (maxSizeFeature is { IsReadOnly: false })
+        {
+            maxSizeFeature.MaxRequestBodySize = MaxDnsMessageSize;
+        }
 
-        return await ProcessDnsQueryAsync(handler.Handler, queryBytes, httpContext).ConfigureAwait(false);
+        byte[] queryBytes;
+        using (var ms = new MemoryStream())
+        {
+            try
+            {
+                await httpContext.Request.Body.CopyToAsync(ms, httpContext.RequestAborted).ConfigureAwait(false);
+            }
+            catch (BadHttpRequestException)
+            {
+                return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+            }
+
+            queryBytes = ms.ToArray();
+        }
+
+        return await ProcessDnsQueryAsync(queryBytes, httpContext).ConfigureAwait(false);
     }
 
     private static async Task<IResult> HandleDnsOverHttpsGetAsync(HttpContext httpContext)
     {
-        var handler = httpContext.RequestServices.GetRequiredService<DnsRequestDelegateHolder>();
-
-        if (!httpContext.Request.Query.TryGetValue("dns", out var dnsParam) || dnsParam.Count is 0)
+        if (!httpContext.Request.Query.TryGetValue("dns", out var dnsParam) || dnsParam.Count is 0 || dnsParam[0] is not { } encodedQuery)
         {
             return Results.BadRequest("Missing 'dns' query parameter.");
         }
 
-        byte[] queryBytes;
-        try
+        if (encodedQuery.Length > MaxEncodedQueryLength)
         {
-            // Base64url decoding (RFC 8484)
-            var base64 = dnsParam[0]!
-                .Replace('-', '+')
-                .Replace('_', '/');
-
-            // Add padding if necessary
-            var paddingNeeded = (4 - (base64.Length % 4)) % 4;
-            base64 += new string('=', paddingNeeded);
-
-            queryBytes = Convert.FromBase64String(base64);
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
         }
-        catch (FormatException)
+
+        // Base64url decoding (RFC 8484)
+        var queryBytes = new byte[Base64Url.GetMaxDecodedLength(encodedQuery.Length)];
+        if (!Base64Url.TryDecodeFromChars(encodedQuery, queryBytes, out var decodedLength))
         {
             return Results.BadRequest("Invalid base64url encoding in 'dns' query parameter.");
         }
 
-        return await ProcessDnsQueryAsync(handler.Handler, queryBytes, httpContext).ConfigureAwait(false);
+        return await ProcessDnsQueryAsync(queryBytes.AsMemory(0, decodedLength), httpContext).ConfigureAwait(false);
     }
 
-    private static async Task<IResult> ProcessDnsQueryAsync(DnsRequestDelegate handler, byte[] queryBytes, HttpContext httpContext)
+    private static async Task<IResult> ProcessDnsQueryAsync(ReadOnlyMemory<byte> queryBytes, HttpContext httpContext)
     {
-        DnsMessage query;
-        try
-        {
-            query = DnsMessageEncoder.DecodeQuery(queryBytes);
-        }
-        catch (DnsProtocolException)
+        var processor = httpContext.RequestServices.GetRequiredService<DnsRequestProcessor>();
+
+        var remoteEndPoint = httpContext.Connection.RemoteIpAddress is not null
+            ? new IPEndPoint(httpContext.Connection.RemoteIpAddress, httpContext.Connection.RemotePort)
+            : new IPEndPoint(IPAddress.Loopback, 0);
+
+        // HTTP can report a bad request directly, so there is no need to answer with a FORMERR message.
+        var responseBytes = await processor.ProcessAsync(queryBytes, DnsServerProtocol.Https, remoteEndPoint, MaxDnsMessageSize, httpContext.RequestAborted, replyWithFormatError: false).ConfigureAwait(false);
+        if (responseBytes is null)
         {
             return Results.BadRequest("Invalid DNS message.");
         }
 
-        var context = new DnsRequestContext(query, DnsServerProtocol.Https, httpContext.Connection.RemoteIpAddress is not null
-            ? new System.Net.IPEndPoint(httpContext.Connection.RemoteIpAddress, httpContext.Connection.RemotePort)
-            : new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 0));
-
-        var response = await handler(context, httpContext.RequestAborted).ConfigureAwait(false);
-        var responseBytes = DnsMessageEncoder.EncodeResponse(response);
+        // RFC 8484 5.1: the response is cacheable for as long as its shortest record TTL.
+        httpContext.Response.Headers.CacheControl = GetCacheControl(responseBytes);
 
         return Results.Bytes(responseBytes, DnsMessageContentType);
+    }
+
+    private static string GetCacheControl(byte[] responseBytes)
+    {
+        uint? minimumTtl = null;
+        try
+        {
+            var response = DnsMessageEncoder.DecodeQuery(responseBytes);
+            foreach (var record in response.Answers.Concat(response.Authorities).Concat(response.AdditionalRecords))
+            {
+                minimumTtl = minimumTtl is { } current ? Math.Min(current, record.TimeToLive) : record.TimeToLive;
+            }
+        }
+        catch (DnsProtocolException)
+        {
+            // Fall through to no-store rather than guessing at a lifetime.
+        }
+
+        return minimumTtl is { } ttl and > 0
+            ? "max-age=" + ttl.ToString(CultureInfo.InvariantCulture)
+            : "no-store";
     }
 
     private static bool IsDnsContentType(string? contentType)

--- a/src/Meziantou.Framework.DnsServer/Hosting/DnsRequestDelegateHolder.cs
+++ b/src/Meziantou.Framework.DnsServer/Hosting/DnsRequestDelegateHolder.cs
@@ -8,10 +8,13 @@ internal sealed class DnsRequestDelegateHolder
 {
     private DnsRequestDelegate? _handler;
 
-    public DnsRequestDelegate Handler
+    public DnsRequestDelegate Handler => _handler ?? DefaultHandler;
+
+    /// <summary>Registers the handler. Only the first call succeeds, so a late or duplicate registration fails loudly instead of racing.</summary>
+    public void SetHandler(DnsRequestDelegate handler)
     {
-        get => _handler ?? DefaultHandler;
-        set => _handler = value;
+        if (Interlocked.CompareExchange(ref _handler, handler, comparand: null) is not null)
+            throw new InvalidOperationException("A DNS request handler is already registered. MapDnsHandler must be called exactly once, before the application starts.");
     }
 
     private static ValueTask<DnsMessage> DefaultHandler(DnsRequestContext context, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.DnsServer/Hosting/DnsServerBuilderExtensions.cs
+++ b/src/Meziantou.Framework.DnsServer/Hosting/DnsServerBuilderExtensions.cs
@@ -1,7 +1,9 @@
+using System.Net.Security;
 using Meziantou.Framework.DnsServer.Handler;
 using Meziantou.Framework.DnsServer.Listeners;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -23,16 +25,17 @@ public static class DnsServerBuilderExtensions
 
         builder.Services.AddSingleton(options);
         builder.Services.AddSingleton<DnsRequestDelegateHolder>();
+        builder.Services.AddSingleton<DnsRequestProcessor>();
 
         // Configure Kestrel for TCP and TLS listeners
         if (options.TcpListeners.Count > 0 || options.TlsListeners.Count > 0)
         {
-            builder.Services.AddSingleton<DnsTcpConnectionHandler>(sp =>
-            {
-                var handlerHolder = sp.GetRequiredService<DnsRequestDelegateHolder>();
-                var logger = sp.GetRequiredService<ILogger<DnsTcpConnectionHandler>>();
-                return new DnsTcpConnectionHandler(handlerHolder, DnsServerProtocol.Tcp, logger);
-            });
+            // These listeners are configured through Kestrel, so they would silently never start on a
+            // host that has no web server.
+            if (!builder.Services.Any(descriptor => descriptor.ServiceType == typeof(IServer)))
+                throw new InvalidOperationException("TCP and DNS over TLS listeners require Kestrel. Build the host with WebApplication.CreateBuilder (or another Kestrel-based web host) before calling AddDnsServer, or configure only UDP and QUIC listeners.");
+
+            builder.Services.AddSingleton<DnsTcpConnectionHandler>();
 
             builder.Services.Configure<KestrelServerOptions>(kestrelOptions =>
             {
@@ -48,7 +51,14 @@ public static class DnsServerBuilderExtensions
                 {
                     kestrelOptions.Listen(tlsListener.BindAddress, tlsListener.Port, listenOptions =>
                     {
-                        listenOptions.UseHttps(tlsListener.Certificate);
+                        listenOptions.UseHttps(httpsOptions =>
+                        {
+                            httpsOptions.ServerCertificate = tlsListener.Certificate;
+
+                            // This is a DNS endpoint, not an HTTP one: advertise the ALPN protocol from
+                            // RFC 7858 3.1 instead of the HTTP protocols Kestrel would offer by default.
+                            httpsOptions.OnAuthenticate = (_, sslOptions) => sslOptions.ApplicationProtocols = [new SslApplicationProtocol("dot")];
+                        });
                         listenOptions.UseConnectionHandler<DnsTcpConnectionHandler>();
                     });
                 }
@@ -58,25 +68,13 @@ public static class DnsServerBuilderExtensions
         // Register UDP listener as hosted service
         if (options.UdpListeners.Count > 0)
         {
-            builder.Services.AddHostedService<DnsUdpListener>(sp =>
-            {
-                var serverOptions = sp.GetRequiredService<DnsServerOptions>();
-                var handlerHolder = sp.GetRequiredService<DnsRequestDelegateHolder>();
-                var logger = sp.GetRequiredService<ILogger<DnsUdpListener>>();
-                return new DnsUdpListener(serverOptions, handlerHolder, logger);
-            });
+            builder.Services.AddHostedService<DnsUdpListener>();
         }
 
         // Register QUIC listener as hosted service
         if (options.QuicListeners.Count > 0)
         {
-            builder.Services.AddHostedService<DnsQuicListener>(sp =>
-            {
-                var serverOptions = sp.GetRequiredService<DnsServerOptions>();
-                var handlerHolder = sp.GetRequiredService<DnsRequestDelegateHolder>();
-                var logger = sp.GetRequiredService<ILogger<DnsQuicListener>>();
-                return new DnsQuicListener(serverOptions, handlerHolder, logger);
-            });
+            builder.Services.AddHostedService<DnsQuicListener>();
         }
 
         return builder;

--- a/src/Meziantou.Framework.DnsServer/Hosting/DnsServerOptions.cs
+++ b/src/Meziantou.Framework.DnsServer/Hosting/DnsServerOptions.cs
@@ -6,10 +6,47 @@ namespace Meziantou.Framework.DnsServer.Hosting;
 /// <summary>Configures the DNS server listeners.</summary>
 public sealed class DnsServerOptions
 {
+    private int _maxUdpResponseSize = 1232;
+
     internal List<UdpListenerOptions> UdpListeners { get; } = [];
     internal List<TcpListenerOptions> TcpListeners { get; } = [];
     internal List<TlsListenerOptions> TlsListeners { get; } = [];
     internal List<QuicListenerOptions> QuicListeners { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the largest UDP response the server will send, in bytes. A client's advertised EDNS
+    /// payload size is clamped to this value; larger answers are truncated so the client retries over TCP.
+    /// Defaults to 1232 bytes, the size recommended by DNS Flag Day 2020, which also limits how much a
+    /// spoofed query can amplify.
+    /// </summary>
+    public int MaxUdpResponseSize
+    {
+        get => _maxUdpResponseSize;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 512);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, ushort.MaxValue);
+            _maxUdpResponseSize = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets how long a TCP or DNS over TLS connection may sit without a complete query before the
+    /// server closes it (RFC 7766 6.2.3). Defaults to 30 seconds. Use <see cref="Timeout.InfiniteTimeSpan"/>
+    /// to disable, at the cost of letting idle connections accumulate.
+    /// </summary>
+    public TimeSpan TcpIdleTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets how long a DNS over QUIC connection may stay idle before it is closed. Defaults to
+    /// 30 seconds.
+    /// </summary>
+    public TimeSpan QuicIdleTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets how many queries a single connection may have in flight at once. Defaults to 16.
+    /// </summary>
+    public int MaxConcurrentQueriesPerConnection { get; set; } = 16;
 
     /// <summary>Adds a UDP listener on the specified port.</summary>
     public DnsServerOptions AddUdpListener(int port = 53, IPAddress? bindAddress = null)

--- a/src/Meziantou.Framework.DnsServer/Listeners/DnsQuicListener.cs
+++ b/src/Meziantou.Framework.DnsServer/Listeners/DnsQuicListener.cs
@@ -13,14 +13,18 @@ namespace Meziantou.Framework.DnsServer.Listeners;
 
 internal sealed class DnsQuicListener : BackgroundService
 {
-    private readonly DnsServerOptions _options;
-    private readonly DnsRequestDelegateHolder _handlerHolder;
-    private readonly ILogger<DnsQuicListener> _logger;
+    /// <summary>How long shutdown waits for in-flight requests before dropping them.</summary>
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(5);
 
-    public DnsQuicListener(DnsServerOptions options, DnsRequestDelegateHolder handlerHolder, ILogger<DnsQuicListener> logger)
+    private readonly DnsServerOptions _options;
+    private readonly DnsRequestProcessor _processor;
+    private readonly ILogger<DnsQuicListener> _logger;
+    private readonly PendingRequestTracker _pendingRequests = new();
+
+    public DnsQuicListener(DnsServerOptions options, DnsRequestProcessor processor, ILogger<DnsQuicListener> logger)
     {
         _options = options;
-        _handlerHolder = handlerHolder;
+        _processor = processor;
         _logger = logger;
     }
 
@@ -41,6 +45,16 @@ internal sealed class DnsQuicListener : BackgroundService
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!await _pendingRequests.DrainAsync(DrainTimeout).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Some QUIC DNS requests were still running after {Timeout} and were abandoned", DrainTimeout);
+        }
+    }
+
     private async Task RunListenerAsync(Hosting.QuicListenerOptions listenerOptions, CancellationToken stoppingToken)
     {
         var endpoint = new IPEndPoint(listenerOptions.BindAddress, listenerOptions.Port);
@@ -53,6 +67,9 @@ internal sealed class DnsQuicListener : BackgroundService
             {
                 DefaultStreamErrorCode = 0,
                 DefaultCloseErrorCode = 0,
+                IdleTimeout = _options.QuicIdleTimeout,
+                MaxInboundBidirectionalStreams = _options.MaxConcurrentQueriesPerConnection,
+                MaxInboundUnidirectionalStreams = 0,
                 ServerAuthenticationOptions = new SslServerAuthenticationOptions
                 {
                     ApplicationProtocols = [new SslApplicationProtocol("doq")],
@@ -90,6 +107,7 @@ internal sealed class DnsQuicListener : BackgroundService
 
     private async Task HandleConnectionAsync(QuicConnection connection, CancellationToken stoppingToken)
     {
+        var streams = new List<Task>();
         try
         {
             await using (connection)
@@ -110,10 +128,18 @@ internal sealed class DnsQuicListener : BackgroundService
                         break;
                     }
 
+                    _pendingRequests.Begin();
+
 #pragma warning disable CA2025 // The stream is disposed inside HandleStreamAsync
-                    _ = HandleStreamAsync(stream, connection.RemoteEndPoint, stoppingToken);
+                    streams.Add(HandleStreamAsync(stream, connection.RemoteEndPoint, stoppingToken));
 #pragma warning restore CA2025
+
+                    // HandleStreamAsync never throws, so completed entries carry nothing worth observing.
+                    streams.RemoveAll(task => task.IsCompleted);
                 }
+
+                // Finish answering the queries already in flight before the connection is disposed.
+                await Task.WhenAll(streams).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -136,10 +162,9 @@ internal sealed class DnsQuicListener : BackgroundService
                 var messageBytes = new byte[messageLength];
                 await stream.ReadExactlyAsync(messageBytes, stoppingToken).ConfigureAwait(false);
 
-                var query = DnsMessageEncoder.DecodeQuery(messageBytes);
-                var context = new DnsRequestContext(query, DnsServerProtocol.Quic, remoteEndPoint);
-                var response = await _handlerHolder.Handler(context, stoppingToken).ConfigureAwait(false);
-                var responseBytes = DnsMessageEncoder.EncodeResponse(response);
+                var responseBytes = await _processor.ProcessAsync(messageBytes, DnsServerProtocol.Quic, remoteEndPoint, DnsMessageEncoder.MaxMessageSize, stoppingToken).ConfigureAwait(false);
+                if (responseBytes is null)
+                    return;
 
                 // Write 2-byte length prefix + response (RFC 9250)
                 BinaryPrimitives.WriteUInt16BigEndian(lengthBytes, (ushort)responseBytes.Length);
@@ -151,9 +176,17 @@ internal sealed class DnsQuicListener : BackgroundService
         {
             // Expected during shutdown
         }
+        catch (QuicException)
+        {
+            // The peer reset the stream or closed the connection
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error handling QUIC DNS stream from {RemoteEndPoint}", remoteEndPoint);
+        }
+        finally
+        {
+            _pendingRequests.End();
         }
     }
 }

--- a/src/Meziantou.Framework.DnsServer/Listeners/DnsTcpConnectionHandler.cs
+++ b/src/Meziantou.Framework.DnsServer/Listeners/DnsTcpConnectionHandler.cs
@@ -5,20 +5,21 @@ using Meziantou.Framework.DnsServer.Handler;
 using Meziantou.Framework.DnsServer.Hosting;
 using Meziantou.Framework.DnsServer.Protocol.Wire;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.DnsServer.Listeners;
 
 internal sealed class DnsTcpConnectionHandler : ConnectionHandler
 {
-    private readonly DnsRequestDelegateHolder _handlerHolder;
-    private readonly DnsServerProtocol _protocol;
+    private readonly DnsRequestProcessor _processor;
+    private readonly DnsServerOptions _options;
     private readonly ILogger<DnsTcpConnectionHandler> _logger;
 
-    public DnsTcpConnectionHandler(DnsRequestDelegateHolder handlerHolder, DnsServerProtocol protocol, ILogger<DnsTcpConnectionHandler> logger)
+    public DnsTcpConnectionHandler(DnsRequestProcessor processor, DnsServerOptions options, ILogger<DnsTcpConnectionHandler> logger)
     {
-        _handlerHolder = handlerHolder;
-        _protocol = protocol;
+        _processor = processor;
+        _options = options;
         _logger = logger;
     }
 
@@ -27,19 +28,53 @@ internal sealed class DnsTcpConnectionHandler : ConnectionHandler
         var input = connection.Transport.Input;
         var output = connection.Transport.Output;
 
+        // The same handler serves the plaintext and the TLS endpoints, so the transport is identified
+        // from the connection itself rather than from how the handler was registered.
+        var protocol = connection.Features.Get<ITlsHandshakeFeature>() is not null
+            ? DnsServerProtocol.Tls
+            : DnsServerProtocol.Tcp;
+
+        var idleTimeout = _options.TcpIdleTimeout;
+        using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(connection.ConnectionClosed);
+
+        // Disposed below, once every in-flight query has finished using them.
+#pragma warning disable CA2025 // The queries are awaited before these are disposed
+        var writeLock = new SemaphoreSlim(1, 1);
+        var slots = new SemaphoreSlim(_options.MaxConcurrentQueriesPerConnection);
+
+        var pending = new List<Task>();
+
         try
         {
+            idleCts.CancelAfter(idleTimeout);
+
             while (true)
             {
-                var result = await input.ReadAsync(connection.ConnectionClosed).ConfigureAwait(false);
+                var result = await input.ReadAsync(idleCts.Token).ConfigureAwait(false);
                 var buffer = result.Buffer;
+                var receivedQuery = false;
 
                 while (TryReadDnsMessage(ref buffer, out var messageBytes))
                 {
-                    await HandleMessageAsync(messageBytes, connection, output).ConfigureAwait(false);
+                    receivedQuery = true;
+
+                    // Cap how many queries one connection can have running at once.
+                    await slots.WaitAsync(connection.ConnectionClosed).ConfigureAwait(false);
+
+                    pending.Add(HandleMessageAsync(messageBytes, protocol, connection, output, writeLock, slots));
                 }
 
                 input.AdvanceTo(buffer.Start, buffer.End);
+
+                // HandleMessageAsync never throws, so completed entries carry nothing worth observing.
+                pending.RemoveAll(task => task.IsCompleted);
+
+                // The clock measures the time since the last *complete* query, so a client that dribbles
+                // out bytes to hold the connection open still runs out of time.
+                if (receivedQuery)
+                {
+                    idleCts.CancelAfter(idleTimeout);
+                }
 
                 if (result.IsCompleted)
                     break;
@@ -49,10 +84,26 @@ internal sealed class DnsTcpConnectionHandler : ConnectionHandler
         {
             // Expected during shutdown
         }
+        catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+        {
+            _logger.LogDebug("Closing an idle DNS connection from {RemoteEndPoint} after {IdleTimeout}", connection.RemoteEndPoint, idleTimeout);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error handling TCP DNS connection from {RemoteEndPoint}", connection.RemoteEndPoint);
         }
+
+        // Let the in-flight queries finish writing before the transport goes away.
+        try
+        {
+            await Task.WhenAll(pending).ConfigureAwait(false);
+        }
+        finally
+        {
+            writeLock.Dispose();
+            slots.Dispose();
+        }
+#pragma warning restore CA2025
     }
 
     private static bool TryReadDnsMessage(ref ReadOnlySequence<byte> buffer, out byte[] messageBytes)
@@ -78,30 +129,46 @@ internal sealed class DnsTcpConnectionHandler : ConnectionHandler
         return true;
     }
 
-    private async Task HandleMessageAsync(byte[] messageBytes, ConnectionContext connection, PipeWriter output)
+    private async Task HandleMessageAsync(byte[] messageBytes, DnsServerProtocol protocol, ConnectionContext connection, PipeWriter output, SemaphoreSlim writeLock, SemaphoreSlim slots)
     {
         try
         {
-            var query = DnsMessageEncoder.DecodeQuery(messageBytes);
-            var context = new DnsRequestContext(query, _protocol, connection.RemoteEndPoint!);
-            var response = await _handlerHolder.Handler(context, connection.ConnectionClosed).ConfigureAwait(false);
-            var responseBytes = DnsMessageEncoder.EncodeResponse(response);
+            var responseBytes = await _processor.ProcessAsync(messageBytes, protocol, connection.RemoteEndPoint!, DnsMessageEncoder.MaxMessageSize, connection.ConnectionClosed).ConfigureAwait(false);
+            if (responseBytes is null)
+                return;
 
-            // Write 2-byte length prefix + response (RFC 7766)
-            var memory = output.GetMemory(2 + responseBytes.Length);
-            BinaryPrimitives.WriteUInt16BigEndian(memory.Span, (ushort)responseBytes.Length);
-            responseBytes.CopyTo(memory[2..]);
-            output.Advance(2 + responseBytes.Length);
+            // Responses may complete out of order (RFC 7766 6.2.1.1), so one writer at a time.
+            await writeLock.WaitAsync(connection.ConnectionClosed).ConfigureAwait(false);
+            try
+            {
+                // Write 2-byte length prefix + response (RFC 7766)
+                var memory = output.GetMemory(2 + responseBytes.Length);
+                BinaryPrimitives.WriteUInt16BigEndian(memory.Span, (ushort)responseBytes.Length);
+                responseBytes.CopyTo(memory[2..]);
+                output.Advance(2 + responseBytes.Length);
 
-            await output.FlushAsync(connection.ConnectionClosed).ConfigureAwait(false);
+                await output.FlushAsync(connection.ConnectionClosed).ConfigureAwait(false);
+            }
+            finally
+            {
+                writeLock.Release();
+            }
         }
         catch (OperationCanceledException) when (connection.ConnectionClosed.IsCancellationRequested)
         {
             // Expected during shutdown
         }
+        catch (ObjectDisposedException)
+        {
+            // The connection was torn down while the response was being written
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error handling TCP DNS message from {RemoteEndPoint}", connection.RemoteEndPoint);
+        }
+        finally
+        {
+            slots.Release();
         }
     }
 }

--- a/src/Meziantou.Framework.DnsServer/Listeners/DnsUdpListener.cs
+++ b/src/Meziantou.Framework.DnsServer/Listeners/DnsUdpListener.cs
@@ -22,7 +22,10 @@ internal sealed class DnsUdpListener : BackgroundService
     private readonly DnsRequestProcessor _processor;
     private readonly ILogger<DnsUdpListener> _logger;
     private readonly PendingRequestTracker _pendingRequests = new();
-    private readonly List<(UdpClient Client, IPEndPoint Endpoint)> _listeners = [];
+
+    // Published once by StartAsync and never mutated afterwards: ExecuteAsync can still be iterating it
+    // when a failed startup makes the host dispose the services underneath it.
+    private (UdpClient Client, IPEndPoint Endpoint)[] _listeners = [];
 
     public DnsUdpListener(DnsServerOptions options, DnsRequestProcessor processor, ILogger<DnsUdpListener> logger)
     {
@@ -35,6 +38,7 @@ internal sealed class DnsUdpListener : BackgroundService
     {
         // Bind up front so that a port conflict surfaces as a startup failure rather than faulting the
         // background task later, which would take the whole host down with it.
+        var listeners = new List<(UdpClient Client, IPEndPoint Endpoint)>(_options.UdpListeners.Count);
         try
         {
             foreach (var listenerOptions in _options.UdpListeners)
@@ -49,21 +53,27 @@ internal sealed class DnsUdpListener : BackgroundService
                     client.Client.IOControl(SioUdpConnectionReset, [0, 0, 0, 0], optionOutValue: null);
                 }
 
-                _listeners.Add((client, endpoint));
+                listeners.Add((client, endpoint));
             }
         }
         catch
         {
-            DisposeListeners();
+            foreach (var (client, _) in listeners)
+            {
+                client.Dispose();
+            }
+
             throw;
         }
+
+        _listeners = [.. listeners];
 
         return base.StartAsync(cancellationToken);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var tasks = new List<Task>(_listeners.Count);
+        var tasks = new List<Task>(_listeners.Length);
         foreach (var (client, endpoint) in _listeners)
         {
             tasks.Add(RunListenerAsync(client, endpoint, stoppingToken));
@@ -92,12 +102,11 @@ internal sealed class DnsUdpListener : BackgroundService
 
     private void DisposeListeners()
     {
+        // UdpClient.Dispose is idempotent, so StopAsync and Dispose can both run this.
         foreach (var (client, _) in _listeners)
         {
             client.Dispose();
         }
-
-        _listeners.Clear();
     }
 
     private async Task RunListenerAsync(UdpClient udpClient, IPEndPoint endpoint, CancellationToken stoppingToken)
@@ -121,6 +130,11 @@ internal sealed class DnsUdpListener : BackgroundService
                 }
                 catch (ObjectDisposedException)
                 {
+                    break;
+                }
+                catch (SocketException exception) when (exception.SocketErrorCode is SocketError.OperationAborted or SocketError.Interrupted or SocketError.Shutdown)
+                {
+                    // The socket was closed underneath the pending receive; that is shutdown, not an error.
                     break;
                 }
                 catch (SocketException exception)

--- a/src/Meziantou.Framework.DnsServer/Listeners/DnsUdpListener.cs
+++ b/src/Meziantou.Framework.DnsServer/Listeners/DnsUdpListener.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Sockets;
 using Meziantou.Framework.DnsServer.Handler;
 using Meziantou.Framework.DnsServer.Hosting;
-using Meziantou.Framework.DnsServer.Protocol.Wire;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -10,35 +9,102 @@ namespace Meziantou.Framework.DnsServer.Listeners;
 
 internal sealed class DnsUdpListener : BackgroundService
 {
-    private readonly DnsServerOptions _options;
-    private readonly DnsRequestDelegateHolder _handlerHolder;
-    private readonly ILogger<DnsUdpListener> _logger;
+    /// <summary>How long shutdown waits for in-flight requests before dropping them.</summary>
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(5);
 
-    public DnsUdpListener(DnsServerOptions options, DnsRequestDelegateHolder handlerHolder, ILogger<DnsUdpListener> logger)
+    /// <summary>Number of consecutive receive failures after which the loop pauses, so a permanently broken socket cannot spin the CPU.</summary>
+    private const int ConsecutiveErrorsBeforeBackoff = 10;
+
+    /// <summary>SIO_UDP_CONNRESET, which the <see cref="IOControlCode"/> enum has no member for.</summary>
+    private const int SioUdpConnectionReset = -1744830452;
+
+    private readonly DnsServerOptions _options;
+    private readonly DnsRequestProcessor _processor;
+    private readonly ILogger<DnsUdpListener> _logger;
+    private readonly PendingRequestTracker _pendingRequests = new();
+    private readonly List<(UdpClient Client, IPEndPoint Endpoint)> _listeners = [];
+
+    public DnsUdpListener(DnsServerOptions options, DnsRequestProcessor processor, ILogger<DnsUdpListener> logger)
     {
         _options = options;
-        _handlerHolder = handlerHolder;
+        _processor = processor;
         _logger = logger;
+    }
+
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Bind up front so that a port conflict surfaces as a startup failure rather than faulting the
+        // background task later, which would take the whole host down with it.
+        try
+        {
+            foreach (var listenerOptions in _options.UdpListeners)
+            {
+                var endpoint = new IPEndPoint(listenerOptions.BindAddress, listenerOptions.Port);
+                var client = new UdpClient(endpoint);
+
+                if (OperatingSystem.IsWindows())
+                {
+                    // Without this, an ICMP "port unreachable" caused by a client that already closed its
+                    // socket makes the next receive fail (SIO_UDP_CONNRESET).
+                    client.Client.IOControl(SioUdpConnectionReset, [0, 0, 0, 0], optionOutValue: null);
+                }
+
+                _listeners.Add((client, endpoint));
+            }
+        }
+        catch
+        {
+            DisposeListeners();
+            throw;
+        }
+
+        return base.StartAsync(cancellationToken);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var tasks = new List<Task>();
-        foreach (var listener in _options.UdpListeners)
+        var tasks = new List<Task>(_listeners.Count);
+        foreach (var (client, endpoint) in _listeners)
         {
-            tasks.Add(RunListenerAsync(listener, stoppingToken));
+            tasks.Add(RunListenerAsync(client, endpoint, stoppingToken));
         }
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
-    private async Task RunListenerAsync(UdpListenerOptions listenerOptions, CancellationToken stoppingToken)
+    public override async Task StopAsync(CancellationToken cancellationToken)
     {
-        var endpoint = new IPEndPoint(listenerOptions.BindAddress, listenerOptions.Port);
-        using var udpClient = new UdpClient(endpoint);
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
 
+        if (!await _pendingRequests.DrainAsync(DrainTimeout).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Some UDP DNS requests were still running after {Timeout} and were abandoned", DrainTimeout);
+        }
+
+        DisposeListeners();
+    }
+
+    public override void Dispose()
+    {
+        DisposeListeners();
+        base.Dispose();
+    }
+
+    private void DisposeListeners()
+    {
+        foreach (var (client, _) in _listeners)
+        {
+            client.Dispose();
+        }
+
+        _listeners.Clear();
+    }
+
+    private async Task RunListenerAsync(UdpClient udpClient, IPEndPoint endpoint, CancellationToken stoppingToken)
+    {
         _logger.LogInformation("DNS UDP listener started on {Endpoint}", endpoint);
 
+        var consecutiveErrors = 0;
         try
         {
             while (!stoppingToken.IsCancellationRequested)
@@ -47,11 +113,31 @@ internal sealed class DnsUdpListener : BackgroundService
                 try
                 {
                     result = await udpClient.ReceiveAsync(stoppingToken).ConfigureAwait(false);
+                    consecutiveErrors = 0;
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     break;
                 }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (SocketException exception)
+                {
+                    // A datagram socket reports per-peer errors on receive. They say nothing about the
+                    // socket's health, so log and carry on serving instead of taking the host down.
+                    _logger.LogWarning(exception, "Error receiving a UDP DNS request on {Endpoint}", endpoint);
+
+                    if (++consecutiveErrors >= ConsecutiveErrorsBeforeBackoff)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(100), stoppingToken).ConfigureAwait(false);
+                    }
+
+                    continue;
+                }
+
+                _pendingRequests.Begin();
 
                 // Fire and forget to handle concurrent requests
 #pragma warning disable CA2025 // The udpClient outlives the task
@@ -71,22 +157,9 @@ internal sealed class DnsUdpListener : BackgroundService
     {
         try
         {
-            var query = DnsMessageEncoder.DecodeQuery(result.Buffer);
-            var context = new DnsRequestContext(query, DnsServerProtocol.Udp, result.RemoteEndPoint);
-            var response = await _handlerHolder.Handler(context, stoppingToken).ConfigureAwait(false);
-
-            var responseBytes = DnsMessageEncoder.EncodeResponse(response);
-
-            // UDP has a maximum payload size; truncate if needed
-            var maxSize = query.EdnsOptions?.UdpPayloadSize ?? 512;
-            if (responseBytes.Length > maxSize)
-            {
-                response.IsTruncated = true;
-                response.Answers.Clear();
-                response.Authorities.Clear();
-                response.AdditionalRecords.Clear();
-                responseBytes = DnsMessageEncoder.EncodeResponse(response);
-            }
+            var responseBytes = await _processor.ProcessAsync(result.Buffer, DnsServerProtocol.Udp, result.RemoteEndPoint, _options.MaxUdpResponseSize, stoppingToken).ConfigureAwait(false);
+            if (responseBytes is null)
+                return;
 
             await udpClient.SendAsync(responseBytes, result.RemoteEndPoint, stoppingToken).ConfigureAwait(false);
         }
@@ -94,9 +167,17 @@ internal sealed class DnsUdpListener : BackgroundService
         {
             // Expected during shutdown
         }
+        catch (ObjectDisposedException)
+        {
+            // The listener was disposed while the response was being sent
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error handling UDP DNS request from {RemoteEndPoint}", result.RemoteEndPoint);
+        }
+        finally
+        {
+            _pendingRequests.End();
         }
     }
 }

--- a/src/Meziantou.Framework.DnsServer/Listeners/PendingRequestTracker.cs
+++ b/src/Meziantou.Framework.DnsServer/Listeners/PendingRequestTracker.cs
@@ -1,0 +1,44 @@
+namespace Meziantou.Framework.DnsServer.Listeners;
+
+/// <summary>
+/// Counts the requests a listener has in flight so shutdown can wait for them instead of tearing
+/// their sockets down mid-response.
+/// </summary>
+internal sealed class PendingRequestTracker
+{
+    private readonly TaskCompletionSource _drained = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _count;
+    private bool _draining;
+
+    public void Begin() => Interlocked.Increment(ref _count);
+
+    public void End()
+    {
+        if (Interlocked.Decrement(ref _count) is 0 && Volatile.Read(ref _draining))
+        {
+            _drained.TrySetResult();
+        }
+    }
+
+    /// <summary>Waits for the in-flight requests to finish. Returns <see langword="false"/> if they did not complete in time.</summary>
+    public async Task<bool> DrainAsync(TimeSpan timeout)
+    {
+        Volatile.Write(ref _draining, true);
+
+        // Re-check after publishing the flag: the last request may have completed just before it was set.
+        if (Volatile.Read(ref _count) is 0)
+        {
+            _drained.TrySetResult();
+        }
+
+        try
+        {
+            await _drained.Task.WaitAsync(timeout).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj
+++ b/src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>A DNS server library supporting UDP, TCP, DNS over TLS, DNS over HTTPS, and DNS over QUIC with ASP.NET Core hosting integration</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.DnsServer/Protocol/Wire/DnsMessageEncoder.cs
+++ b/src/Meziantou.Framework.DnsServer/Protocol/Wire/DnsMessageEncoder.cs
@@ -5,6 +5,12 @@ namespace Meziantou.Framework.DnsServer.Protocol.Wire;
 
 internal static class DnsMessageEncoder
 {
+    /// <summary>The largest response the length-prefixed transports (RFC 7766, RFC 9250) can frame.</summary>
+    public const int MaxMessageSize = ushort.MaxValue;
+
+    /// <summary>The highest value a 12-bit RCODE can hold once the EDNS extension bits are included.</summary>
+    private const int MaxResponseCode = 0xFFF;
+
     public static DnsMessage DecodeQuery(ReadOnlySpan<byte> data)
     {
         if (data.Length < 12)
@@ -51,13 +57,17 @@ internal static class DnsMessageEncoder
             if (message.AdditionalRecords[i].Type is DnsQueryType.OPT)
             {
                 var optRecord = message.AdditionalRecords[i];
+                var extendedRCode = (byte)(optRecord.TimeToLive >> 24);
                 message.EdnsOptions = new DnsEdnsOptions
                 {
                     UdpPayloadSize = (ushort)optRecord.Class,
-                    ExtendedRCode = (byte)(optRecord.TimeToLive >> 24),
+                    ExtendedRCode = extendedRCode,
                     Version = (byte)((optRecord.TimeToLive >> 16) & 0xFF),
                     DnssecOk = (optRecord.TimeToLive & 0x8000) != 0,
                 };
+
+                // RFC 6891 6.1.3: the OPT record carries the upper 8 bits of a 12-bit RCODE.
+                message.ResponseCode = (DnsResponseCode)((extendedRCode << 4) | ((ushort)message.ResponseCode & 0x0F));
                 message.AdditionalRecords.RemoveAt(i);
                 break;
             }
@@ -68,6 +78,17 @@ internal static class DnsMessageEncoder
 
     public static byte[] EncodeResponse(DnsMessage message)
     {
+        var responseCode = (ushort)message.ResponseCode;
+        if (responseCode > MaxResponseCode)
+            throw new DnsProtocolException($"Response code {responseCode} is out of range. DNS response codes must be between 0 and {MaxResponseCode}.");
+
+        // RFC 6891 6.1.3: anything above 15 needs an OPT record to carry its upper bits.
+        var edns = message.EdnsOptions;
+        if (responseCode > 0x0F && edns is null)
+        {
+            edns = new DnsEdnsOptions();
+        }
+
         var writer = new DnsWireWriter(512);
 
         writer.WriteUInt16(message.Id);
@@ -88,19 +109,17 @@ internal static class DnsMessageEncoder
             flags |= 0x0020;
         if (message.CheckingDisabled)
             flags |= 0x0010;
-        flags |= (ushort)((ushort)message.ResponseCode & 0x000F);
+        flags |= (ushort)(responseCode & 0x000F);
 
         writer.WriteUInt16(flags);
-        writer.WriteUInt16((ushort)message.Questions.Count);
-        writer.WriteUInt16((ushort)message.Answers.Count);
-        writer.WriteUInt16((ushort)message.Authorities.Count);
-
-        var hasEdns = message.EdnsOptions is not null;
-        writer.WriteUInt16((ushort)(message.AdditionalRecords.Count + (hasEdns ? 1 : 0)));
+        writer.WriteUInt16(ToCount(message.Questions.Count, "question"));
+        writer.WriteUInt16(ToCount(message.Answers.Count, "answer"));
+        writer.WriteUInt16(ToCount(message.Authorities.Count, "authority"));
+        writer.WriteUInt16(ToCount(message.AdditionalRecords.Count + (edns is not null ? 1 : 0), "additional"));
 
         foreach (var question in message.Questions)
         {
-            writer.WriteDomainName(question.Name);
+            writer.WriteCompressibleDomainName(question.Name);
             writer.WriteUInt16((ushort)question.Type);
             writer.WriteUInt16((ushort)question.QueryClass);
         }
@@ -109,13 +128,15 @@ internal static class DnsMessageEncoder
         WriteRecords(ref writer, message.Authorities);
         WriteRecords(ref writer, message.AdditionalRecords);
 
-        if (message.EdnsOptions is { } edns)
+        if (edns is not null)
         {
             writer.WriteByte(0); // NAME: root domain
             writer.WriteUInt16((ushort)DnsQueryType.OPT);
             writer.WriteUInt16(edns.UdpPayloadSize);
 
-            uint ttl = (uint)(edns.ExtendedRCode << 24) | (uint)(edns.Version << 16);
+            // The upper 8 bits of the RCODE always come from ResponseCode, so that a handler only
+            // has to set one property to produce a correct extended response code.
+            uint ttl = (uint)((responseCode >> 4) << 24) | (uint)(edns.Version << 16);
             if (edns.DnssecOk)
                 ttl |= 0x8000;
             writer.WriteUInt32(ttl);
@@ -125,11 +146,49 @@ internal static class DnsMessageEncoder
         return writer.ToArray();
     }
 
+    /// <summary>
+    /// Encodes a response that fits within <paramref name="maxSize"/> bytes, setting the TC bit and
+    /// dropping sections as needed (RFC 1035 4.1.1). <paramref name="message"/> is updated in place to
+    /// match the bytes that are returned.
+    /// </summary>
+    public static byte[] EncodeResponse(DnsMessage message, int maxSize)
+    {
+        var bytes = EncodeResponse(message);
+        if (bytes.Length <= maxSize)
+            return bytes;
+
+        message.IsTruncated = true;
+        message.Answers.Clear();
+        message.Authorities.Clear();
+        message.AdditionalRecords.Clear();
+
+        bytes = EncodeResponse(message);
+        if (bytes.Length <= maxSize)
+            return bytes;
+
+        // An over-long question section can still push the message past the limit on its own.
+        message.Questions.Clear();
+
+        bytes = EncodeResponse(message);
+        if (bytes.Length <= maxSize)
+            return bytes;
+
+        throw new DnsProtocolException($"The DNS response header alone is {bytes.Length} bytes, which exceeds the {maxSize}-byte limit of this transport.");
+    }
+
+    private static ushort ToCount(int count, string section)
+    {
+        if (count > ushort.MaxValue)
+            throw new DnsProtocolException($"A DNS message cannot contain more than {ushort.MaxValue} {section} records, but {count} were provided.");
+
+        return (ushort)count;
+    }
+
     private static void WriteRecords(ref DnsWireWriter writer, IList<DnsResourceRecord> records)
     {
         foreach (var record in records)
         {
-            writer.WriteDomainName(record.Name);
+            writer.WriteCompressibleDomainName(record.Name);
             writer.WriteUInt16((ushort)record.Type);
             writer.WriteUInt16((ushort)record.Class);
             writer.WriteUInt32(record.TimeToLive);
@@ -140,6 +199,8 @@ internal static class DnsMessageEncoder
             var rdataStart = writer.Position;
             WriteRecordData(ref writer, record.Data);
             var rdLength = writer.Position - rdataStart;
+            if (rdLength > ushort.MaxValue)
+                throw new DnsProtocolException($"The data of the {record.Type} record for '{record.Name}' is {rdLength} bytes, which exceeds the {ushort.MaxValue}-byte maximum.");
 
             writer.WriteUInt16At((ushort)rdLength, rdLengthPosition);
         }
@@ -150,6 +211,8 @@ internal static class DnsMessageEncoder
         if (data is null)
             return;
 
+        // Only the record types defined in RFC 1035 may compress names inside their data;
+        // RFC 3597 3 forbids it for every type defined afterwards.
         switch (data)
         {
             case DnsARecordData a:
@@ -161,25 +224,25 @@ internal static class DnsMessageEncoder
                 break;
 
             case DnsCnameRecordData cname:
-                writer.WriteDomainName(cname.CanonicalName);
+                writer.WriteCompressibleDomainName(cname.CanonicalName);
                 break;
 
             case DnsMxRecordData mx:
                 writer.WriteUInt16(mx.Preference);
-                writer.WriteDomainName(mx.Exchange);
+                writer.WriteCompressibleDomainName(mx.Exchange);
                 break;
 
             case DnsNsRecordData ns:
-                writer.WriteDomainName(ns.NameServer);
+                writer.WriteCompressibleDomainName(ns.NameServer);
                 break;
 
             case DnsPtrRecordData ptr:
-                writer.WriteDomainName(ptr.DomainName);
+                writer.WriteCompressibleDomainName(ptr.DomainName);
                 break;
 
             case DnsSoaRecordData soa:
-                writer.WriteDomainName(soa.PrimaryNameServer);
-                writer.WriteDomainName(soa.ResponsibleMailbox);
+                writer.WriteCompressibleDomainName(soa.PrimaryNameServer);
+                writer.WriteCompressibleDomainName(soa.ResponsibleMailbox);
                 writer.WriteUInt32(soa.Serial);
                 writer.WriteInt32(soa.Refresh);
                 writer.WriteInt32(soa.Retry);
@@ -213,7 +276,7 @@ internal static class DnsMessageEncoder
             case DnsCaaRecordData caa:
                 writer.WriteByte(caa.Flags);
                 writer.WriteAsciiCharacterString(caa.Tag);
-                writer.WriteBytes(Encoding.ASCII.GetBytes(caa.Value));
+                writer.WriteAsciiString(caa.Value);
                 break;
 
             case DnsDnskeyRecordData dnskey:
@@ -345,14 +408,11 @@ internal static class DnsMessageEncoder
             var ttl = reader.ReadUInt32();
             var rdLength = reader.ReadUInt16();
 
-            var rdataStart = reader.Position;
-            var data = ParseRecordData(ref reader, type, rdLength);
-
-            var consumed = reader.Position - rdataStart;
-            if (consumed < rdLength)
-            {
-                reader.Skip(rdLength - consumed);
-            }
+            // Scope the reads to this record so a bad length cannot walk into the next one.
+            var previousLimit = reader.PushLimit(rdLength);
+            var data = ParseRecordData(ref reader, type);
+            reader.Skip(reader.Remaining);
+            reader.PopLimit(previousLimit);
 
             records.Add(new DnsResourceRecord
             {
@@ -365,7 +425,7 @@ internal static class DnsMessageEncoder
         }
     }
 
-    private static DnsResourceRecordData ParseRecordData(ref DnsWireReader reader, DnsQueryType type, ushort rdLength)
+    private static DnsResourceRecordData ParseRecordData(ref DnsWireReader reader, DnsQueryType type)
     {
         return type switch
         {
@@ -377,25 +437,25 @@ internal static class DnsMessageEncoder
             DnsQueryType.PTR => ParsePtrRecord(ref reader),
             DnsQueryType.SOA => ParseSoaRecord(ref reader),
             DnsQueryType.SRV => ParseSrvRecord(ref reader),
-            DnsQueryType.TXT => ParseTxtRecord(ref reader, rdLength),
-            DnsQueryType.CAA => ParseCaaRecord(ref reader, rdLength),
+            DnsQueryType.TXT => ParseTxtRecord(ref reader),
+            DnsQueryType.CAA => ParseCaaRecord(ref reader),
             DnsQueryType.NAPTR => ParseNaptrRecord(ref reader),
-            DnsQueryType.DNSKEY => ParseDnskeyRecord(ref reader, rdLength),
-            DnsQueryType.DS => ParseDsRecord(ref reader, rdLength),
-            DnsQueryType.RRSIG => ParseRrsigRecord(ref reader, rdLength),
-            DnsQueryType.NSEC => ParseNsecRecord(ref reader, rdLength),
-            DnsQueryType.NSEC3 => ParseNsec3Record(ref reader, rdLength),
+            DnsQueryType.DNSKEY => ParseDnskeyRecord(ref reader),
+            DnsQueryType.DS => ParseDsRecord(ref reader),
+            DnsQueryType.RRSIG => ParseRrsigRecord(ref reader),
+            DnsQueryType.NSEC => ParseNsecRecord(ref reader),
+            DnsQueryType.NSEC3 => ParseNsec3Record(ref reader),
             DnsQueryType.NSEC3PARAM => ParseNsec3ParamRecord(ref reader),
-            DnsQueryType.TLSA => ParseTlsaRecord(ref reader, rdLength),
-            DnsQueryType.SSHFP => ParseSshfpRecord(ref reader, rdLength),
-            DnsQueryType.SVCB or DnsQueryType.HTTPS => ParseSvcbRecord(ref reader, rdLength),
+            DnsQueryType.TLSA => ParseTlsaRecord(ref reader),
+            DnsQueryType.SSHFP => ParseSshfpRecord(ref reader),
+            DnsQueryType.SVCB or DnsQueryType.HTTPS => ParseSvcbRecord(ref reader),
             DnsQueryType.LOC => ParseLocRecord(ref reader),
             DnsQueryType.HINFO => ParseHinfoRecord(ref reader),
             DnsQueryType.RP => ParseRpRecord(ref reader),
             DnsQueryType.DNAME => ParseDnameRecord(ref reader),
-            DnsQueryType.OPT => ParseOptRecord(ref reader, rdLength),
-            DnsQueryType.URI => ParseUriRecord(ref reader, rdLength),
-            _ => ParseUnknownRecord(ref reader, rdLength),
+            DnsQueryType.OPT => ParseOptRecord(ref reader),
+            DnsQueryType.URI => ParseUriRecord(ref reader),
+            _ => ParseUnknownRecord(ref reader),
         };
     }
 
@@ -458,11 +518,10 @@ internal static class DnsMessageEncoder
         };
     }
 
-    private static DnsTxtRecordData ParseTxtRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsTxtRecordData ParseTxtRecord(ref DnsWireReader reader)
     {
         var texts = new List<string>();
-        var endPosition = reader.Position + rdLength;
-        while (reader.Position < endPosition)
+        while (reader.Remaining > 0)
         {
             var length = reader.ReadByte();
             var text = Encoding.UTF8.GetString(reader.ReadBytes(length));
@@ -472,13 +531,12 @@ internal static class DnsMessageEncoder
         return new DnsTxtRecordData { Text = texts };
     }
 
-    private static DnsCaaRecordData ParseCaaRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsCaaRecordData ParseCaaRecord(ref DnsWireReader reader)
     {
         var flags = reader.ReadByte();
         var tagLength = reader.ReadByte();
         var tag = Encoding.ASCII.GetString(reader.ReadBytes(tagLength));
-        var valueLength = rdLength - 2 - tagLength;
-        var value = Encoding.ASCII.GetString(reader.ReadBytes(valueLength));
+        var value = Encoding.ASCII.GetString(reader.ReadBytes(reader.Remaining));
 
         return new DnsCaaRecordData { Flags = flags, Tag = tag, Value = value };
     }
@@ -506,31 +564,30 @@ internal static class DnsMessageEncoder
         };
     }
 
-    private static DnsDnskeyRecordData ParseDnskeyRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsDnskeyRecordData ParseDnskeyRecord(ref DnsWireReader reader)
     {
         return new DnsDnskeyRecordData
         {
             Flags = reader.ReadUInt16(),
             Protocol = reader.ReadByte(),
             Algorithm = reader.ReadByte(),
-            PublicKey = reader.ReadBytes(rdLength - 4).ToArray(),
+            PublicKey = reader.ReadBytes(reader.Remaining).ToArray(),
         };
     }
 
-    private static DnsDsRecordData ParseDsRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsDsRecordData ParseDsRecord(ref DnsWireReader reader)
     {
         return new DnsDsRecordData
         {
             KeyTag = reader.ReadUInt16(),
             Algorithm = reader.ReadByte(),
             DigestType = reader.ReadByte(),
-            Digest = reader.ReadBytes(rdLength - 4).ToArray(),
+            Digest = reader.ReadBytes(reader.Remaining).ToArray(),
         };
     }
 
-    private static DnsRrsigRecordData ParseRrsigRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsRrsigRecordData ParseRrsigRecord(ref DnsWireReader reader)
     {
-        var startPosition = reader.Position;
         var typeCovered = (DnsQueryType)reader.ReadUInt16();
         var algorithm = reader.ReadByte();
         var labels = reader.ReadByte();
@@ -539,8 +596,7 @@ internal static class DnsMessageEncoder
         var inception = reader.ReadUInt32();
         var keyTag = reader.ReadUInt16();
         var signerName = reader.ReadDomainName();
-        var signatureLength = rdLength - (reader.Position - startPosition);
-        var signature = reader.ReadBytes(signatureLength).ToArray();
+        var signature = reader.ReadBytes(reader.Remaining).ToArray();
 
         return new DnsRrsigRecordData
         {
@@ -556,12 +612,10 @@ internal static class DnsMessageEncoder
         };
     }
 
-    private static DnsNsecRecordData ParseNsecRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsNsecRecordData ParseNsecRecord(ref DnsWireReader reader)
     {
-        var startPosition = reader.Position;
         var nextDomainName = reader.ReadDomainName();
-        var remaining = rdLength - (reader.Position - startPosition);
-        var typeBitMaps = ParseTypeBitMaps(ref reader, remaining);
+        var typeBitMaps = ParseTypeBitMaps(ref reader);
 
         return new DnsNsecRecordData
         {
@@ -570,9 +624,8 @@ internal static class DnsMessageEncoder
         };
     }
 
-    private static DnsNsec3RecordData ParseNsec3Record(ref DnsWireReader reader, ushort rdLength)
+    private static DnsNsec3RecordData ParseNsec3Record(ref DnsWireReader reader)
     {
-        var startPosition = reader.Position;
         var hashAlgorithm = reader.ReadByte();
         var flags = reader.ReadByte();
         var iterations = reader.ReadUInt16();
@@ -580,8 +633,7 @@ internal static class DnsMessageEncoder
         var salt = reader.ReadBytes(saltLength).ToArray();
         var hashLength = reader.ReadByte();
         var nextHashedOwnerName = reader.ReadBytes(hashLength).ToArray();
-        var remaining = rdLength - (reader.Position - startPosition);
-        var typeBitMaps = ParseTypeBitMaps(ref reader, remaining);
+        var typeBitMaps = ParseTypeBitMaps(ref reader);
 
         return new DnsNsec3RecordData
         {
@@ -605,42 +657,39 @@ internal static class DnsMessageEncoder
         };
     }
 
-    private static DnsTlsaRecordData ParseTlsaRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsTlsaRecordData ParseTlsaRecord(ref DnsWireReader reader)
     {
         return new DnsTlsaRecordData
         {
             CertificateUsage = reader.ReadByte(),
             Selector = reader.ReadByte(),
             MatchingType = reader.ReadByte(),
-            CertificateAssociationData = reader.ReadBytes(rdLength - 3).ToArray(),
+            CertificateAssociationData = reader.ReadBytes(reader.Remaining).ToArray(),
         };
     }
 
-    private static DnsSshfpRecordData ParseSshfpRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsSshfpRecordData ParseSshfpRecord(ref DnsWireReader reader)
     {
         return new DnsSshfpRecordData
         {
             Algorithm = reader.ReadByte(),
             FingerprintType = reader.ReadByte(),
-            Fingerprint = reader.ReadBytes(rdLength - 2).ToArray(),
+            Fingerprint = reader.ReadBytes(reader.Remaining).ToArray(),
         };
     }
 
-    private static DnsSvcbRecordData ParseSvcbRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsSvcbRecordData ParseSvcbRecord(ref DnsWireReader reader)
     {
-        var startPosition = reader.Position;
         var priority = reader.ReadUInt16();
         var targetName = reader.ReadDomainName();
 
         var parameters = new List<DnsSvcParam>();
-        var remaining = rdLength - (reader.Position - startPosition);
-        while (remaining > 0)
+        while (reader.Remaining > 0)
         {
             var key = reader.ReadUInt16();
             var valueLength = reader.ReadUInt16();
             var value = reader.ReadBytes(valueLength).ToArray();
             parameters.Add(new DnsSvcParam { Key = key, Value = value });
-            remaining -= 4 + valueLength;
         }
 
         return new DnsSvcbRecordData
@@ -689,11 +738,10 @@ internal static class DnsMessageEncoder
         return new DnsDnameRecordData { Target = reader.ReadDomainName() };
     }
 
-    private static DnsOptRecordData ParseOptRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsOptRecordData ParseOptRecord(ref DnsWireReader reader)
     {
         var options = new List<DnsEdnsOption>();
-        var endPosition = reader.Position + rdLength;
-        while (reader.Position < endPosition)
+        while (reader.Remaining > 0)
         {
             var code = reader.ReadUInt16();
             var length = reader.ReadUInt16();
@@ -704,27 +752,26 @@ internal static class DnsMessageEncoder
         return new DnsOptRecordData { Options = options };
     }
 
-    private static DnsUriRecordData ParseUriRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsUriRecordData ParseUriRecord(ref DnsWireReader reader)
     {
         return new DnsUriRecordData
         {
             Priority = reader.ReadUInt16(),
             Weight = reader.ReadUInt16(),
-            Target = Encoding.UTF8.GetString(reader.ReadBytes(rdLength - 4)),
+            Target = Encoding.UTF8.GetString(reader.ReadBytes(reader.Remaining)),
         };
     }
 
-    private static DnsUnknownRecordData ParseUnknownRecord(ref DnsWireReader reader, ushort rdLength)
+    private static DnsUnknownRecordData ParseUnknownRecord(ref DnsWireReader reader)
     {
-        return new DnsUnknownRecordData { Data = reader.ReadBytes(rdLength).ToArray() };
+        return new DnsUnknownRecordData { Data = reader.ReadBytes(reader.Remaining).ToArray() };
     }
 
-    private static List<DnsQueryType> ParseTypeBitMaps(ref DnsWireReader reader, int length)
+    private static List<DnsQueryType> ParseTypeBitMaps(ref DnsWireReader reader)
     {
         var types = new List<DnsQueryType>();
-        var endPosition = reader.Position + length;
 
-        while (reader.Position < endPosition)
+        while (reader.Remaining > 0)
         {
             var windowBlock = reader.ReadByte();
             var bitmapLength = reader.ReadByte();

--- a/src/Meziantou.Framework.DnsServer/Protocol/Wire/DnsWireReader.cs
+++ b/src/Meziantou.Framework.DnsServer/Protocol/Wire/DnsWireReader.cs
@@ -6,22 +6,44 @@ namespace Meziantou.Framework.DnsServer.Protocol.Wire;
 [StructLayout(LayoutKind.Auto)]
 internal ref struct DnsWireReader
 {
+    /// <summary>The maximum encoded length of a domain name, including the root label (RFC 1035 2.3.4).</summary>
+    public const int MaxDomainNameLength = 255;
+
     private readonly ReadOnlySpan<byte> _message;
     private int _position;
+    private int _limit;
 
     public DnsWireReader(ReadOnlySpan<byte> message)
     {
         _message = message;
         _position = 0;
+        _limit = message.Length;
     }
 
     public readonly int Position => _position;
 
-    public readonly int Remaining => _message.Length - _position;
+    /// <summary>Gets the number of bytes left before the current limit.</summary>
+    public readonly int Remaining => _limit - _position;
+
+    /// <summary>
+    /// Restricts subsequent reads to <paramref name="length"/> bytes so that a record cannot read into
+    /// its neighbours, and returns the previous limit to pass back to <see cref="PopLimit"/>.
+    /// </summary>
+    public int PushLimit(int length)
+    {
+        if (length < 0 || _position + length > _limit)
+            throw new DnsProtocolException($"Record data length of {length} bytes extends beyond the DNS message boundary.");
+
+        var previousLimit = _limit;
+        _limit = _position + length;
+        return previousLimit;
+    }
+
+    public void PopLimit(int previousLimit) => _limit = previousLimit;
 
     public ushort ReadUInt16()
     {
-        if (_position + 2 > _message.Length)
+        if (_position + 2 > _limit)
             throw new DnsProtocolException("Unexpected end of DNS message while reading UInt16.");
 
         var value = BinaryPrimitives.ReadUInt16BigEndian(_message[_position..]);
@@ -31,7 +53,7 @@ internal ref struct DnsWireReader
 
     public uint ReadUInt32()
     {
-        if (_position + 4 > _message.Length)
+        if (_position + 4 > _limit)
             throw new DnsProtocolException("Unexpected end of DNS message while reading UInt32.");
 
         var value = BinaryPrimitives.ReadUInt32BigEndian(_message[_position..]);
@@ -41,7 +63,7 @@ internal ref struct DnsWireReader
 
     public int ReadInt32()
     {
-        if (_position + 4 > _message.Length)
+        if (_position + 4 > _limit)
             throw new DnsProtocolException("Unexpected end of DNS message while reading Int32.");
 
         var value = BinaryPrimitives.ReadInt32BigEndian(_message[_position..]);
@@ -51,7 +73,7 @@ internal ref struct DnsWireReader
 
     public byte ReadByte()
     {
-        if (_position >= _message.Length)
+        if (_position >= _limit)
             throw new DnsProtocolException("Unexpected end of DNS message while reading byte.");
 
         return _message[_position++];
@@ -59,7 +81,10 @@ internal ref struct DnsWireReader
 
     public ReadOnlySpan<byte> ReadBytes(int count)
     {
-        if (_position + count > _message.Length)
+        if (count < 0)
+            throw new DnsProtocolException($"Invalid DNS record data length: {count}.");
+
+        if (_position + count > _limit)
             throw new DnsProtocolException($"Unexpected end of DNS message while reading {count} bytes.");
 
         var span = _message.Slice(_position, count);
@@ -69,7 +94,7 @@ internal ref struct DnsWireReader
 
     public void Skip(int count)
     {
-        if (_position + count > _message.Length)
+        if (count < 0 || _position + count > _limit)
             throw new DnsProtocolException($"Cannot skip {count} bytes: exceeds message boundary.");
 
         _position += count;
@@ -78,25 +103,28 @@ internal ref struct DnsWireReader
     public string ReadDomainName()
     {
         var sb = new StringBuilder(64);
-        ReadDomainNameCore(sb, _message, ref _position, maxPointers: 128);
+        ReadDomainNameCore(sb, _message, ref _position, _limit);
         return sb.ToString();
     }
 
-    public static string ReadDomainNameAtOffset(ReadOnlySpan<byte> message, int offset)
-    {
-        var sb = new StringBuilder(64);
-        ReadDomainNameCore(sb, message, ref offset, maxPointers: 128);
-        return sb.ToString();
-    }
-
-    private static void ReadDomainNameCore(StringBuilder sb, ReadOnlySpan<byte> message, ref int position, int maxPointers)
+    private static void ReadDomainNameCore(StringBuilder sb, ReadOnlySpan<byte> message, ref int position, int limit)
     {
         var jumped = false;
         var originalPosition = -1;
-        var pointerCount = 0;
 
-        while (position < message.Length)
+        // The encoded length of the name, including the terminating root label. Bounding this is what
+        // keeps a maliciously compressed name from expanding without limit.
+        var encodedLength = 1;
+
+        while (true)
         {
+            // Before the first pointer the name has to stay inside the current record; a pointer may
+            // target any earlier offset of the message.
+            var bound = jumped ? message.Length : limit;
+
+            if (position >= bound)
+                throw new DnsProtocolException("Unexpected end of DNS message while reading a domain name.");
+
             var length = message[position];
 
             if (length is 0)
@@ -108,21 +136,23 @@ internal ref struct DnsWireReader
             // Check for compression pointer (top 2 bits set)
             if ((length & 0xC0) is 0xC0)
             {
-                if (++pointerCount > maxPointers)
-                    throw new DnsProtocolException("Too many compression pointers in domain name (possible loop).");
-
-                if (position + 1 >= message.Length)
+                if (position + 2 > bound)
                     throw new DnsProtocolException("Unexpected end of DNS message while reading compression pointer.");
 
                 var pointer = ((length & 0x3F) << 8) | message[position + 1];
 
+                // RFC 1035 4.1.4 defines a pointer as a reference to a *prior* occurrence of a name.
+                // Requiring a strictly backwards jump makes compression loops structurally impossible.
+                if (pointer >= position)
+                    throw new DnsProtocolException("Invalid compression pointer: it must point to an earlier offset in the message.");
+
                 if (!jumped)
                 {
                     originalPosition = position + 2;
+                    jumped = true;
                 }
 
                 position = pointer;
-                jumped = true;
                 continue;
             }
 
@@ -131,8 +161,12 @@ internal ref struct DnsWireReader
 
             position++;
 
-            if (position + length > message.Length)
+            if (position + length > bound)
                 throw new DnsProtocolException("Domain name label extends beyond message boundary.");
+
+            encodedLength += length + 1;
+            if (encodedLength > MaxDomainNameLength)
+                throw new DnsProtocolException($"Domain name exceeds the maximum encoded length of {MaxDomainNameLength} bytes.");
 
             if (sb.Length > 0)
             {

--- a/src/Meziantou.Framework.DnsServer/Protocol/Wire/DnsWireWriter.cs
+++ b/src/Meziantou.Framework.DnsServer/Protocol/Wire/DnsWireWriter.cs
@@ -6,8 +6,15 @@ namespace Meziantou.Framework.DnsServer.Protocol.Wire;
 [StructLayout(LayoutKind.Auto)]
 internal ref struct DnsWireWriter
 {
+    /// <summary>The maximum length of a single label (RFC 1035 2.3.4).</summary>
+    private const int MaxLabelLength = 63;
+
+    /// <summary>The highest offset a compression pointer can address, as it only carries 14 bits.</summary>
+    private const int MaxPointerOffset = 0x3FFF;
+
     private byte[] _buffer;
     private int _position;
+    private Dictionary<string, int>? _nameOffsets;
 
     public DnsWireWriter()
         : this(512)
@@ -21,8 +28,6 @@ internal ref struct DnsWireWriter
     }
 
     public readonly int Position => _position;
-
-    public readonly ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _position);
 
     public byte[] ToArray()
     {
@@ -65,35 +70,88 @@ internal ref struct DnsWireWriter
         _position += data.Length;
     }
 
-    public void WriteDomainName(string name)
+    /// <summary>Writes a domain name in full, without using compression pointers.</summary>
+    public void WriteDomainName(string name) => WriteDomainNameCore(name, compress: false);
+
+    /// <summary>
+    /// Writes a domain name, reusing an earlier occurrence through a compression pointer when possible.
+    /// Only valid for owner names and for the record types defined in RFC 1035; RFC 3597 3 forbids
+    /// compression inside the data of any type defined later.
+    /// </summary>
+    public void WriteCompressibleDomainName(string name) => WriteDomainNameCore(name, compress: true);
+
+    private void WriteDomainNameCore(string name, bool compress)
     {
-        if (string.IsNullOrEmpty(name) || name is ".")
+        var span = name.AsSpan();
+        if (span.Length > 0 && span[^1] == '.')
+        {
+            span = span[..^1];
+        }
+
+        if (span.IsEmpty)
         {
             WriteByte(0);
             return;
         }
 
-        var span = name.AsSpan();
-        if (span[^1] == '.')
-        {
-            span = span[..^1];
-        }
+        var encodedLength = 1; // the terminating root label
+        var remaining = span;
 
-        foreach (var label in new LabelEnumerator(span))
+        while (!remaining.IsEmpty)
         {
-            var byteCount = Encoding.ASCII.GetByteCount(label);
-            if (byteCount is 0 or > 63)
+            if (compress)
             {
-                throw new DnsProtocolException($"Invalid domain name label length: {byteCount}. Labels must be between 1 and 63 bytes.");
+                _nameOffsets ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                var lookup = _nameOffsets.GetAlternateLookup<ReadOnlySpan<char>>();
+
+                if (lookup.TryGetValue(remaining, out var matchOffset))
+                {
+                    EnsureDomainNameLength(name, encodedLength + 2);
+                    WriteUInt16((ushort)(0xC000 | matchOffset));
+                    return;
+                }
+
+                if (_position <= MaxPointerOffset)
+                {
+                    lookup[remaining] = _position;
+                }
             }
 
-            WriteByte((byte)byteCount);
-            EnsureCapacity(byteCount);
-            Encoding.ASCII.GetBytes(label, _buffer.AsSpan(_position));
-            _position += byteCount;
+            var separatorIndex = remaining.IndexOf('.');
+            ReadOnlySpan<char> label;
+            if (separatorIndex < 0)
+            {
+                label = remaining;
+                remaining = [];
+            }
+            else
+            {
+                label = remaining[..separatorIndex];
+                remaining = remaining[(separatorIndex + 1)..];
+            }
+
+            if (label.IsEmpty || label.Length > MaxLabelLength)
+                throw new DnsProtocolException($"Invalid domain name label length: {label.Length}. Labels must be between 1 and {MaxLabelLength} bytes.");
+
+            if (!Ascii.IsValid(label))
+                throw new DnsProtocolException($"Domain name '{name}' contains non-ASCII characters. Convert internationalized names to their punycode (IDNA) form before encoding them.");
+
+            encodedLength += label.Length + 1;
+            EnsureDomainNameLength(name, encodedLength);
+
+            WriteByte((byte)label.Length);
+            EnsureCapacity(label.Length);
+            Ascii.FromUtf16(label, _buffer.AsSpan(_position), out var bytesWritten);
+            _position += bytesWritten;
         }
 
         WriteByte(0); // Root label
+    }
+
+    private static void EnsureDomainNameLength(string name, int encodedLength)
+    {
+        if (encodedLength > DnsWireReader.MaxDomainNameLength)
+            throw new DnsProtocolException($"Domain name '{name}' exceeds the maximum encoded length of {DnsWireReader.MaxDomainNameLength} bytes.");
     }
 
     public void WriteCharacterString(string value)
@@ -112,16 +170,34 @@ internal ref struct DnsWireWriter
 
     public void WriteAsciiCharacterString(string value)
     {
-        var byteCount = Encoding.ASCII.GetByteCount(value);
-        if (byteCount > 255)
+        EnsureAscii(value);
+        if (value.Length > 255)
         {
-            throw new DnsProtocolException($"Character string too long: {byteCount} bytes. Maximum is 255.");
+            throw new DnsProtocolException($"Character string too long: {value.Length} bytes. Maximum is 255.");
         }
 
-        WriteByte((byte)byteCount);
-        EnsureCapacity(byteCount);
-        Encoding.ASCII.GetBytes(value, _buffer.AsSpan(_position));
-        _position += byteCount;
+        WriteByte((byte)value.Length);
+        WriteAsciiCore(value);
+    }
+
+    /// <summary>Writes an ASCII string without a length prefix, for record data that runs to the end of the record.</summary>
+    public void WriteAsciiString(string value)
+    {
+        EnsureAscii(value);
+        WriteAsciiCore(value);
+    }
+
+    private void WriteAsciiCore(string value)
+    {
+        EnsureCapacity(value.Length);
+        Ascii.FromUtf16(value, _buffer.AsSpan(_position), out var bytesWritten);
+        _position += bytesWritten;
+    }
+
+    private static void EnsureAscii(string value)
+    {
+        if (!Ascii.IsValid(value))
+            throw new DnsProtocolException($"The value '{value}' contains non-ASCII characters and cannot be encoded in this DNS record.");
     }
 
     public void WriteUInt16At(ushort value, int position)
@@ -139,41 +215,5 @@ internal ref struct DnsWireWriter
         var newBuffer = new byte[newSize];
         _buffer.AsSpan(0, _position).CopyTo(newBuffer);
         _buffer = newBuffer;
-    }
-
-    [StructLayout(LayoutKind.Auto)]
-    private ref struct LabelEnumerator
-    {
-        private ReadOnlySpan<char> _remaining;
-
-        public LabelEnumerator(ReadOnlySpan<char> name)
-        {
-            _remaining = name;
-            Current = default;
-        }
-
-        public ReadOnlySpan<char> Current { get; private set; }
-
-        public readonly LabelEnumerator GetEnumerator() => this;
-
-        public bool MoveNext()
-        {
-            if (_remaining.IsEmpty)
-                return false;
-
-            var index = _remaining.IndexOf('.');
-            if (index == -1)
-            {
-                Current = _remaining;
-                _remaining = [];
-            }
-            else
-            {
-                Current = _remaining[..index];
-                _remaining = _remaining[(index + 1)..];
-            }
-
-            return true;
-        }
     }
 }

--- a/src/Meziantou.Framework.DnsServer/readme.md
+++ b/src/Meziantou.Framework.DnsServer/readme.md
@@ -86,3 +86,60 @@ builder.AddDnsServer(options =>
     options.AddQuicListener(port: 8853, certificate);
 });
 ```
+
+## Limits and hardening
+
+The server enforces the following limits. All of them are set on `DnsServerOptions`.
+
+```c#
+builder.AddDnsServer(options =>
+{
+    options.AddUdpListener(port: 5053);
+
+    // Largest UDP response, in bytes. A client's advertised EDNS payload size is clamped to this
+    // value and larger answers are truncated so the client retries over TCP. The 1232-byte default
+    // comes from DNS Flag Day 2020 and also bounds how much a spoofed query can amplify.
+    options.MaxUdpResponseSize = 1232;
+
+    // Closes TCP and DNS over TLS connections that go this long without a complete query
+    // (RFC 7766 6.2.3). Use Timeout.InfiniteTimeSpan to disable.
+    options.TcpIdleTimeout = TimeSpan.FromSeconds(30);
+
+    // Idle timeout for DNS over QUIC connections.
+    options.QuicIdleTimeout = TimeSpan.FromSeconds(30);
+
+    // How many queries one connection may have in flight at once.
+    options.MaxConcurrentQueriesPerConnection = 16;
+});
+```
+
+To cap the number of simultaneous connections, set Kestrel's own limit, which also covers any HTTP
+endpoints the application exposes:
+
+```c#
+builder.WebHost.ConfigureKestrel(kestrel => kestrel.Limits.MaxConcurrentConnections = 1000);
+```
+
+Beyond those settings the server:
+
+- rejects messages that arrive with the QR bit set, which RFC 5625 requires so that two servers
+  cannot be made to answer each other indefinitely;
+- answers a message it cannot parse with `FORMERR` over UDP, TCP, DoT and DoQ, and with HTTP 400
+  over DoH, instead of leaving the client to time out;
+- answers an EDNS version it does not support with `BADVERS` (RFC 6891 6.1.3);
+- bounds domain name decompression to the 255-byte limit of RFC 1035 and requires compression
+  pointers to point backwards, so a crafted message cannot expand without limit.
+
+## Notes on writing a handler
+
+- **Response codes.** Set `DnsMessage.ResponseCode` and nothing else, including for the extended
+  codes above 15 such as `BadVersion` and `BadCookie`. The encoder splits the value across the
+  header and the OPT record, adding an OPT record if the response has none.
+- **Domain names.** Names are ASCII on the wire. Convert internationalized names to punycode before
+  putting them in a response; a name with non-ASCII characters throws `DnsProtocolException` rather
+  than being silently corrupted.
+- **Transport.** `context.Protocol` reports `Tls` for DNS over TLS and `Tcp` for plaintext TCP, so a
+  handler can require an encrypted transport for particular queries.
+- **Truncation.** Responses too large for the transport are automatically truncated with the TC bit
+  set; a handler does not need to measure them.
+- **DNS over TLS** listeners advertise the `dot` ALPN protocol (RFC 7858 3.1).

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsMessageEncoderTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsMessageEncoderTests.cs
@@ -794,9 +794,11 @@ public sealed class DnsMessageEncoderTests
         buffer[position++] = 0xC0;
         buffer[position] = 0x0C;
 
-        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        // Per-thread, not process-wide: decoding is synchronous, and the tests around it run in
+        // parallel, so GC.GetTotalAllocatedBytes would measure their allocations too.
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
         Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeQuery(buffer));
-        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
 
         Assert.True(allocated < 64 * 1024, $"Rejecting the message allocated {allocated} bytes.");
     }

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsMessageEncoderTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsMessageEncoderTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Net;
 using Meziantou.Framework.DnsServer.Protocol;
 using Meziantou.Framework.DnsServer.Protocol.Records;
@@ -770,6 +771,323 @@ public sealed class DnsMessageEncoderTests
         Assert.HasCount(2, decoded.Questions);
         Assert.Equal(DnsQueryType.A, decoded.Questions[0].Type);
         Assert.Equal(DnsQueryType.AAAA, decoded.Questions[1].Type);
+    }
+
+    [Fact]
+    public void Decode_CompressionLoop_IsRejectedWithoutUnboundedWork()
+    {
+        // A long run of labels ending in a pointer back to the start of the name. Before the total
+        // length was bounded this expanded by ~570x before it was rejected.
+        var buffer = new byte[512];
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(4), 1); // qdcount
+
+        var position = 12;
+        for (var i = 0; i < 6; i++)
+        {
+            buffer[position++] = 63;
+            for (var j = 0; j < 63; j++)
+            {
+                buffer[position++] = (byte)'a';
+            }
+        }
+
+        buffer[position++] = 0xC0;
+        buffer[position] = 0x0C;
+
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeQuery(buffer));
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+
+        Assert.True(allocated < 64 * 1024, $"Rejecting the message allocated {allocated} bytes.");
+    }
+
+    [Theory]
+    [InlineData(12)]  // points at itself
+    [InlineData(20)]  // points forward
+    public void Decode_NonBackwardsCompressionPointer_IsRejected(int target)
+    {
+        var buffer = new byte[64];
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(4), 1);
+        buffer[12] = 0xC0;
+        buffer[13] = (byte)target;
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeQuery(buffer));
+    }
+
+    [Fact]
+    public void Decode_DomainNameLongerThan255Bytes_IsRejected()
+    {
+        var buffer = new byte[600];
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(4), 1);
+
+        var position = 12;
+        for (var i = 0; i < 8; i++) // 8 * 64 = 512 bytes of name
+        {
+            buffer[position++] = 63;
+            for (var j = 0; j < 63; j++)
+            {
+                buffer[position++] = (byte)'a';
+            }
+        }
+
+        var exception = Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeQuery(buffer));
+        Assert.Contains("255", exception.Message);
+    }
+
+    [Fact]
+    public void Decode_CaaTagLongerThanRecordData_ThrowsDnsProtocolException()
+    {
+        // RDLENGTH is 4 but the tag claims 64 bytes: the old code computed a negative value length.
+        var message = new List<byte>([0x12, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+        message.Add(0x00);                              // root owner name
+        message.AddRange([0x01, 0x01]);                 // CAA
+        message.AddRange([0x00, 0x01]);                 // IN
+        message.AddRange([0x00, 0x00, 0x00, 0x00]);     // TTL
+        message.AddRange([0x00, 0x04]);                 // RDLENGTH
+        message.Add(0x00);                              // flags
+        message.Add(0x40);                              // tag length
+        message.AddRange(Enumerable.Repeat((byte)0x41, 64));
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeQuery(message.ToArray()));
+    }
+
+    [Fact]
+    public void Decode_TxtStringLongerThanRecordData_ThrowsDnsProtocolException()
+    {
+        // RDLENGTH is 2 but the character-string claims 32 bytes, which used to read into the next record.
+        var message = new List<byte>([0x12, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+        message.Add(0x00);
+        message.AddRange([0x00, 0x10]);                 // TXT
+        message.AddRange([0x00, 0x01]);
+        message.AddRange([0x00, 0x00, 0x00, 0x00]);
+        message.AddRange([0x00, 0x02]);                 // RDLENGTH
+        message.Add(0x20);                              // character-string length
+        message.AddRange(Enumerable.Repeat((byte)0x42, 40));
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeQuery(message.ToArray()));
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "A fixed seed keeps the fuzzing reproducible")]
+    public void Decode_MalformedMessages_OnlyThrowDnsProtocolException()
+    {
+        // Every decode failure has to be a DnsProtocolException: the transports and the DoH endpoint
+        // rely on that to answer FORMERR / 400 instead of failing the request.
+        var random = new Random(Seed: 20260903);
+        var seed = CreateSimpleQuery("example.com", DnsQueryType.A);
+        seed.Answers.Add(new DnsResourceRecord
+        {
+            Name = "example.com",
+            Type = DnsQueryType.TXT,
+            Class = DnsQueryClass.IN,
+            TimeToLive = 60,
+            Data = new DnsTxtRecordData { Text = ["hello"] },
+        });
+
+        var template = DnsMessageEncoder.EncodeResponse(seed);
+
+        for (var iteration = 0; iteration < 5000; iteration++)
+        {
+            var candidate = template.ToArray();
+            var mutations = random.Next(1, 6);
+            for (var i = 0; i < mutations; i++)
+            {
+                candidate[random.Next(candidate.Length)] = (byte)random.Next(256);
+            }
+
+            try
+            {
+                DnsMessageEncoder.DecodeQuery(candidate);
+            }
+            catch (DnsProtocolException)
+            {
+                // The only failure the callers are prepared for.
+            }
+            catch (Exception exception)
+            {
+                Assert.Fail($"Decoding {Convert.ToHexString(candidate)} threw {exception.GetType().FullName}: {exception.Message}");
+            }
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "A fixed seed keeps the fuzzing reproducible")]
+    public void Decode_RandomBytes_OnlyThrowDnsProtocolException()
+    {
+        var random = new Random(Seed: 5309);
+        for (var iteration = 0; iteration < 5000; iteration++)
+        {
+            var candidate = new byte[random.Next(12, 600)];
+            random.NextBytes(candidate);
+
+            try
+            {
+                DnsMessageEncoder.DecodeQuery(candidate);
+            }
+            catch (DnsProtocolException)
+            {
+            }
+            catch (Exception exception)
+            {
+                Assert.Fail($"Decoding {Convert.ToHexString(candidate)} threw {exception.GetType().FullName}: {exception.Message}");
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(DnsResponseCode.BadVersion)]
+    [InlineData(DnsResponseCode.BadCookie)]
+    [InlineData(DnsResponseCode.BadKey)]
+    [InlineData(DnsResponseCode.Refused)]
+    [InlineData(DnsResponseCode.NoError)]
+    public void RoundTrip_ExtendedResponseCode(DnsResponseCode responseCode)
+    {
+        var message = new DnsMessage
+        {
+            Id = 42,
+            IsResponse = true,
+            ResponseCode = responseCode,
+            EdnsOptions = new DnsEdnsOptions(),
+        };
+
+        var decoded = DnsMessageEncoder.DecodeQuery(DnsMessageEncoder.EncodeResponse(message));
+
+        Assert.Equal(responseCode, decoded.ResponseCode);
+    }
+
+    [Fact]
+    public void Encode_ExtendedResponseCode_AddsAnOptRecordWhenEdnsIsAbsent()
+    {
+        var message = new DnsMessage
+        {
+            Id = 42,
+            IsResponse = true,
+            ResponseCode = DnsResponseCode.BadVersion,
+        };
+
+        var decoded = DnsMessageEncoder.DecodeQuery(DnsMessageEncoder.EncodeResponse(message));
+
+        Assert.Equal(DnsResponseCode.BadVersion, decoded.ResponseCode);
+        Assert.NotNull(decoded.EdnsOptions);
+    }
+
+    [Fact]
+    public void Encode_ResponseLargerThanTheTransportLimit_IsTruncated()
+    {
+        var message = new DnsMessage { Id = 1, IsResponse = true };
+        message.Questions.Add(new DnsQuestion("example.com", DnsQueryType.A));
+        for (var i = 0; i < 5000; i++)
+        {
+            message.Answers.Add(new DnsResourceRecord
+            {
+                Name = $"host{i}.example.com",
+                Type = DnsQueryType.A,
+                Class = DnsQueryClass.IN,
+                TimeToLive = 300,
+                Data = new DnsARecordData { Address = IPAddress.Loopback },
+            });
+        }
+
+        Assert.HasCountGreaterThan(ushort.MaxValue, DnsMessageEncoder.EncodeResponse(message));
+
+        var bytes = DnsMessageEncoder.EncodeResponse(message, ushort.MaxValue);
+
+        Assert.HasCountLessThanOrEqual(ushort.MaxValue, bytes);
+        var decoded = DnsMessageEncoder.DecodeQuery(bytes);
+        Assert.True(decoded.IsTruncated);
+        Assert.Empty(decoded.Answers);
+    }
+
+    [Fact]
+    public void Encode_ResponseWithAnOverLongQuestion_DropsTheQuestionToFit()
+    {
+        var message = new DnsMessage { Id = 1, IsResponse = true };
+        for (var i = 0; i < 20; i++)
+        {
+            message.Questions.Add(new DnsQuestion($"{new string('a', 60)}{i}.example.com", DnsQueryType.A));
+        }
+
+        var bytes = DnsMessageEncoder.EncodeResponse(message, 512);
+
+        Assert.HasCountLessThanOrEqual(512, bytes);
+        Assert.True(DnsMessageEncoder.DecodeQuery(bytes).IsTruncated);
+    }
+
+    [Fact]
+    public void Encode_NonAsciiDomainName_ThrowsInsteadOfCorruptingIt()
+    {
+        var message = new DnsMessage { Id = 1 };
+        message.Questions.Add(new DnsQuestion("café.example.com", DnsQueryType.A));
+
+        var exception = Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.EncodeResponse(message));
+        Assert.Contains("punycode", exception.Message);
+    }
+
+    [Fact]
+    public void Encode_DomainNameLongerThan255Bytes_Throws()
+    {
+        var message = new DnsMessage { Id = 1 };
+        message.Questions.Add(new DnsQuestion(string.Join('.', Enumerable.Repeat(new string('a', 63), 8)), DnsQueryType.A));
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.EncodeResponse(message));
+    }
+
+    [Fact]
+    public void Encode_RepeatedNames_AreCompressed()
+    {
+        const string Name = "a-fairly-long-label.another-long-label.example.com";
+
+        var message = new DnsMessage { Id = 1, IsResponse = true };
+        message.Questions.Add(new DnsQuestion(Name, DnsQueryType.A));
+        for (var i = 0; i < 10; i++)
+        {
+            message.Answers.Add(new DnsResourceRecord
+            {
+                Name = Name,
+                Type = DnsQueryType.A,
+                Class = DnsQueryClass.IN,
+                TimeToLive = 300,
+                Data = new DnsARecordData { Address = IPAddress.Loopback },
+            });
+        }
+
+        var bytes = DnsMessageEncoder.EncodeResponse(message);
+
+        // Without compression the name alone would take 11 * 51 bytes.
+        Assert.HasCountLessThan(250, bytes, "the names were not compressed");
+
+        var decoded = DnsMessageEncoder.DecodeQuery(bytes);
+        Assert.Equal(Name, decoded.Questions[0].Name);
+        Assert.HasCount(10, decoded.Answers);
+        Assert.All(decoded.Answers, record => Assert.Equal(Name, record.Name));
+    }
+
+    [Fact]
+    public void Encode_CompressedNamesInsideRecordData_RoundTrip()
+    {
+        var message = new DnsMessage { Id = 1, IsResponse = true };
+        message.Questions.Add(new DnsQuestion("example.com", DnsQueryType.MX));
+        message.Answers.Add(new DnsResourceRecord
+        {
+            Name = "example.com",
+            Type = DnsQueryType.MX,
+            Class = DnsQueryClass.IN,
+            TimeToLive = 300,
+            Data = new DnsMxRecordData { Preference = 10, Exchange = "mail.example.com" },
+        });
+        message.Answers.Add(new DnsResourceRecord
+        {
+            Name = "example.com",
+            Type = DnsQueryType.NS,
+            Class = DnsQueryClass.IN,
+            TimeToLive = 300,
+            Data = new DnsNsRecordData { NameServer = "ns1.example.com" },
+        });
+
+        var decoded = DnsMessageEncoder.DecodeQuery(DnsMessageEncoder.EncodeResponse(message));
+
+        Assert.Equal("mail.example.com", Assert.IsType<DnsMxRecordData>(decoded.Answers[0].Data).Exchange);
+        Assert.Equal("ns1.example.com", Assert.IsType<DnsNsRecordData>(decoded.Answers[1].Data).NameServer);
     }
 
     private static DnsMessage CreateSimpleQuery(string name, DnsQueryType type)

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -12,7 +12,9 @@ using Meziantou.Framework.DnsServer.Protocol.Records;
 using Meziantou.Framework.DnsServer.Protocol.Wire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using ClientDns = Meziantou.Framework.DnsClient;
+using DnsResponseCode = Meziantou.Framework.DnsServer.Protocol.DnsResponseCode;
 
 namespace Meziantou.Framework.DnsServer.Tests;
 
@@ -597,6 +599,437 @@ public sealed class DnsServerIntegrationTests
         Assert.True(tlsResponse.IsResponse);
         var tlsRecord = Assert.IsType<DnsARecordData>(Assert.Single(tlsResponse.Answers).Data);
         Assert.Equal(IPAddress.Parse("10.0.0.1"), tlsRecord.Address);
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA5359:Do Not Disable Certificate Validation")]
+    public async Task DoT_AlpnIsNegotiatedAndProtocolIsTls()
+    {
+        using var certificate = CreateSelfSignedCertificate();
+        var tlsPort = GetAvailableTcpPort();
+
+        DnsServerProtocol? observedProtocol = null;
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.ConfigureKestrel(kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+        builder.AddDnsServer(options => options.AddTlsListener(tlsPort, certificate, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) =>
+        {
+            observedProtocol = context.Protocol;
+            return ValueTask.FromResult(context.CreateResponse());
+        });
+
+        await app.StartAsync();
+        try
+        {
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(IPAddress.Loopback, tlsPort, XunitCancellationToken);
+            await using var sslStream = new SslStream(tcp.GetStream(), leaveInnerStreamOpen: false);
+
+            // RFC 7858 3.1: a DNS over TLS client indicates the "dot" application protocol.
+            await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+            {
+                TargetHost = "127.0.0.1",
+                ApplicationProtocols = [new SslApplicationProtocol("dot")],
+                RemoteCertificateValidationCallback = (_, _, _, _) => true,
+            }, XunitCancellationToken);
+
+            Assert.Equal(new SslApplicationProtocol("dot"), sslStream.NegotiatedApplicationProtocol);
+
+            await SendLengthPrefixedQueryAsync(sslStream, CreateQueryBytes("dot.example.com", DnsQueryType.A));
+
+            Assert.Equal(DnsServerProtocol.Tls, observedProtocol);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Udp_ResponseNeverExceedsTheUdpSizeLimit()
+    {
+        var port = GetAvailableUdpPort();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(options => options.AddUdpListener(port, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) =>
+        {
+            var response = context.CreateResponse();
+            for (var i = 0; i < 100; i++)
+            {
+                response.Answers.Add(new DnsResourceRecord
+                {
+                    Name = $"host{i}.example.com",
+                    Type = DnsQueryType.A,
+                    Class = DnsQueryClass.IN,
+                    TimeToLive = 300,
+                    Data = new DnsARecordData { Address = IPAddress.Loopback },
+                });
+            }
+
+            return ValueTask.FromResult(response);
+        });
+
+        await app.StartAsync();
+        try
+        {
+            // No EDNS in the query, so the classic 512-byte limit applies.
+            var responseBytes = await SendUdpQueryAsync(port, CreateQueryBytes("example.com", DnsQueryType.A));
+
+            Assert.NotNull(responseBytes);
+            Assert.HasCountLessThanOrEqual(512, responseBytes);
+            Assert.True(DnsMessageEncoder.DecodeQuery(responseBytes).IsTruncated);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Udp_MessageWithTheQrBitSet_IsDropped()
+    {
+        var port = GetAvailableUdpPort();
+        var handlerInvoked = false;
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(options => options.AddUdpListener(port, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) =>
+        {
+            handlerInvoked = true;
+            return ValueTask.FromResult(context.CreateResponse());
+        });
+
+        await app.StartAsync();
+        try
+        {
+            // RFC 5625 4.4: answering a response lets two servers be pointed at each other.
+            var query = CreateQueryBytes("example.com", DnsQueryType.A);
+            query[2] |= 0x80; // set QR
+
+            Assert.Null(await SendUdpQueryAsync(port, query, TimeSpan.FromSeconds(2)));
+            Assert.False(handlerInvoked);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Udp_UnsupportedEdnsVersion_IsAnsweredWithBadVersion()
+    {
+        var port = GetAvailableUdpPort();
+        var handlerInvoked = false;
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(options => options.AddUdpListener(port, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) =>
+        {
+            handlerInvoked = true;
+            return ValueTask.FromResult(context.CreateResponse());
+        });
+
+        await app.StartAsync();
+        try
+        {
+            var query = new DnsMessage { Id = 7, RecursionDesired = true, EdnsOptions = new DnsEdnsOptions { Version = 1 } };
+            query.Questions.Add(new DnsQuestion("example.com", DnsQueryType.A));
+
+            var responseBytes = await SendUdpQueryAsync(port, DnsMessageEncoder.EncodeResponse(query));
+
+            Assert.NotNull(responseBytes);
+            var response = DnsMessageEncoder.DecodeQuery(responseBytes);
+            Assert.Equal(DnsResponseCode.BadVersion, response.ResponseCode);
+            Assert.False(handlerInvoked);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Udp_MalformedQuery_IsAnsweredWithFormatError()
+    {
+        var port = GetAvailableUdpPort();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(options => options.AddUdpListener(port, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) => ValueTask.FromResult(context.CreateResponse()));
+
+        await app.StartAsync();
+        try
+        {
+            // A complete header that claims one question, with no question following it.
+            var malformed = new byte[12];
+            BinaryPrimitives.WriteUInt16BigEndian(malformed.AsSpan(0), 0x4242);
+            BinaryPrimitives.WriteUInt16BigEndian(malformed.AsSpan(4), 1);
+
+            var responseBytes = await SendUdpQueryAsync(port, malformed);
+
+            Assert.NotNull(responseBytes);
+            var response = DnsMessageEncoder.DecodeQuery(responseBytes);
+            Assert.Equal(0x4242, response.Id);
+            Assert.True(response.IsResponse);
+            Assert.Equal(DnsResponseCode.FormError, response.ResponseCode);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DoH_MalformedMessage_ReturnsBadRequest()
+    {
+        await using var app = await StartDohServerAsync();
+        try
+        {
+            var address = app.Urls.First(u => u.StartsWith("http://", StringComparison.Ordinal));
+            using var httpClient = new HttpClient { BaseAddress = new Uri(address) };
+
+            // A CAA record whose tag length exceeds its RDLENGTH.
+            var malformed = new List<byte>([0x12, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+            malformed.Add(0x00);
+            malformed.AddRange([0x01, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x40]);
+            malformed.AddRange(Enumerable.Repeat((byte)0x41, 64));
+
+            using var content = new ByteArrayContent(malformed.ToArray());
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/dns-message");
+
+            using var response = await httpClient.PostAsync("/dns-query", content, XunitCancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DoH_OversizedBody_ReturnsPayloadTooLarge()
+    {
+        await using var app = await StartDohServerAsync();
+        try
+        {
+            var address = app.Urls.First(u => u.StartsWith("http://", StringComparison.Ordinal));
+            using var httpClient = new HttpClient { BaseAddress = new Uri(address) };
+
+            using var content = new ByteArrayContent(new byte[70_000]);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/dns-message");
+
+            using var response = await httpClient.PostAsync("/dns-query", content, XunitCancellationToken);
+
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DoH_Response_CarriesACacheControlHeader()
+    {
+        await using var app = await StartDohServerAsync();
+        try
+        {
+            var address = app.Urls.First(u => u.StartsWith("http://", StringComparison.Ordinal));
+            using var httpClient = new HttpClient { BaseAddress = new Uri(address) };
+
+            using var content = new ByteArrayContent(CreateQueryBytes("example.com", DnsQueryType.A));
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/dns-message");
+
+            using var response = await httpClient.PostAsync("/dns-query", content, XunitCancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            // RFC 8484 5.1: the freshness lifetime is the smallest TTL in the answer.
+            Assert.Equal(TimeSpan.FromSeconds(300), response.Headers.CacheControl?.MaxAge);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task MapDnsHandler_CalledTwice_Throws()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(_ => { });
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) => ValueTask.FromResult(context.CreateResponse()));
+
+        Assert.Throws<InvalidOperationException>(() => app.MapDnsHandler((context, ct) => ValueTask.FromResult(context.CreateResponse())));
+    }
+
+    [Fact]
+    public void AddDnsServer_TcpListenerWithoutAWebHost_Throws()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        // Without Kestrel the TCP listener would silently never start.
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddDnsServer(options => options.AddTcpListener(5353, IPAddress.Loopback)));
+        Assert.Contains("Kestrel", exception.Message);
+    }
+
+    [Fact]
+    public async Task Udp_BindFailure_IsReportedByStartAsync()
+    {
+        // Occupy the port first. The failure has to surface here rather than faulting the background
+        // service, which would silently stop the whole host a moment after a successful start.
+        using var squatter = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        squatter.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)squatter.LocalEndPoint!).Port;
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(options => options.AddUdpListener(port, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) => ValueTask.FromResult(context.CreateResponse()));
+
+        await Assert.ThrowsAsync<SocketException>(() => app.StartAsync(XunitCancellationToken));
+        Assert.False(app.Lifetime.ApplicationStopping.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Tcp_ResponseLargerThan64K_IsTruncatedInsteadOfCorruptingTheStream()
+    {
+        var port = GetAvailableTcpPort();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.ConfigureKestrel(kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+        builder.AddDnsServer(options => options.AddTcpListener(port, IPAddress.Loopback));
+
+        await using var app = builder.Build();
+        app.MapDnsHandler((context, ct) =>
+        {
+            var response = context.CreateResponse();
+            for (var i = 0; i < 5000; i++)
+            {
+                response.Answers.Add(new DnsResourceRecord
+                {
+                    Name = $"host{i}.{new string('a', 60)}.example.com",
+                    Type = DnsQueryType.A,
+                    Class = DnsQueryClass.IN,
+                    TimeToLive = 300,
+                    Data = new DnsARecordData { Address = IPAddress.Loopback },
+                });
+            }
+
+            return ValueTask.FromResult(response);
+        });
+
+        await app.StartAsync();
+        try
+        {
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(IPAddress.Loopback, port, XunitCancellationToken);
+            await using var stream = tcp.GetStream();
+
+            // Two queries on one connection: the second only arrives intact if the first response
+            // framed its length correctly.
+            for (var i = 0; i < 2; i++)
+            {
+                var query = CreateQueryBytes("example.com", DnsQueryType.A);
+                var lengthPrefix = new byte[2];
+                BinaryPrimitives.WriteUInt16BigEndian(lengthPrefix, (ushort)query.Length);
+                await stream.WriteAsync(lengthPrefix, XunitCancellationToken);
+                await stream.WriteAsync(query, XunitCancellationToken);
+                await stream.FlushAsync(XunitCancellationToken);
+
+                await stream.ReadExactlyAsync(lengthPrefix, XunitCancellationToken);
+                var responseLength = BinaryPrimitives.ReadUInt16BigEndian(lengthPrefix);
+                var responseBytes = new byte[responseLength];
+                await stream.ReadExactlyAsync(responseBytes, XunitCancellationToken);
+
+                var response = DnsMessageEncoder.DecodeQuery(responseBytes);
+                Assert.True(response.IsResponse);
+                Assert.True(response.IsTruncated);
+                Assert.Equal(1234, response.Id);
+            }
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    private static async Task<WebApplication> StartDohServerAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(_ => { });
+
+        var app = builder.Build();
+        app.MapDnsHandler((context, ct) =>
+        {
+            var response = context.CreateResponse();
+            response.Answers.Add(new DnsResourceRecord
+            {
+                Name = "example.com",
+                Type = DnsQueryType.A,
+                Class = DnsQueryClass.IN,
+                TimeToLive = 300,
+                Data = new DnsARecordData { Address = IPAddress.Parse("1.2.3.4") },
+            });
+
+            return ValueTask.FromResult(response);
+        });
+        app.MapDnsOverHttps("/dns-query");
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<byte[]?> SendUdpQueryAsync(int port, byte[] query, TimeSpan? timeout = null)
+    {
+        using var client = new UdpClient();
+        await client.SendAsync(query, new IPEndPoint(IPAddress.Loopback, port));
+
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(10));
+        try
+        {
+            var result = await client.ReceiveAsync(cts.Token);
+            return result.Buffer;
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
+    private static async Task SendLengthPrefixedQueryAsync(Stream stream, byte[] query)
+    {
+        var lengthPrefix = new byte[2];
+        BinaryPrimitives.WriteUInt16BigEndian(lengthPrefix, (ushort)query.Length);
+        await stream.WriteAsync(lengthPrefix);
+        await stream.WriteAsync(query);
+        await stream.FlushAsync();
+
+        await stream.ReadExactlyAsync(lengthPrefix);
+        var responseLength = BinaryPrimitives.ReadUInt16BigEndian(lengthPrefix);
+        await stream.ReadExactlyAsync(new byte[responseLength]);
     }
 
     private static byte[] CreateQueryBytes(string name, DnsQueryType type)

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -12,7 +12,10 @@ using Meziantou.Framework.DnsServer.Protocol.Records;
 using Meziantou.Framework.DnsServer.Protocol.Wire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Meziantou.Framework.DnsServer.Listeners;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using ClientDns = Meziantou.Framework.DnsClient;
 using DnsResponseCode = Meziantou.Framework.DnsServer.Protocol.DnsResponseCode;
 
@@ -975,6 +978,68 @@ public sealed class DnsServerIntegrationTests
         }
     }
 
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposing the listener concurrently with StopAsync is what this test exercises")]
+    public async Task UdpListener_ConcurrentStopAndDispose_IsSafe()
+    {
+        // A host that fails to start unwinds by stopping and disposing the services it already
+        // started, and StopAsync waits for in-flight requests, so the two can overlap. This is a race,
+        // so it is repeated: it can only fail when the listener is actually unsafe.
+        for (var attempt = 0; attempt < 25; attempt++)
+        {
+            var options = new DnsServerOptions();
+            foreach (var port in GetAvailableUdpPorts(20))
+            {
+                options.AddUdpListener(port, IPAddress.Loopback);
+            }
+
+            var processor = new DnsRequestProcessor(new DnsRequestDelegateHolder(), options, NullLogger<DnsRequestProcessor>.Instance);
+            var listener = new DnsUdpListener(options, processor, NullLogger<DnsUdpListener>.Instance);
+
+            await listener.StartAsync(XunitCancellationToken);
+
+            await Task.WhenAll(
+                Task.Run(() => listener.StopAsync(CancellationToken.None), XunitCancellationToken),
+                Task.Run(listener.Dispose, XunitCancellationToken));
+        }
+    }
+
+    [Fact]
+    public async Task Udp_HostDisposedDuringAFailedStartup_DoesNotRaceTheListener()
+    {
+        // A hosted service registered after the DNS server fails once the UDP listener is already
+        // running, so the host unwinds and disposes it while ExecuteAsync is still starting up.
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+            builder.AddDnsServer(options =>
+            {
+                for (var i = 0; i < 4; i++)
+                {
+                    options.AddUdpListener(GetAvailableUdpPort(), IPAddress.Loopback);
+                }
+            });
+            builder.Services.AddHostedService<FailingHostedService>();
+
+            await using var app = builder.Build();
+            app.MapDnsHandler((context, ct) => ValueTask.FromResult(context.CreateResponse()));
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => app.StartAsync(XunitCancellationToken));
+
+            // The startup failure has to be the one the service reported, not a collection-modified
+            // race inside the listener.
+            Assert.IsType<InvalidTimeZoneException>(exception);
+        }
+    }
+
+    private sealed class FailingHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken) => throw new InvalidTimeZoneException("Simulated startup failure.");
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
     private static async Task<WebApplication> StartDohServerAsync()
     {
         var builder = WebApplication.CreateBuilder();
@@ -1042,6 +1107,32 @@ public sealed class DnsServerIntegrationTests
         query.Questions.Add(new DnsQuestion(name, type));
 
         return DnsMessageEncoder.EncodeResponse(query);
+    }
+
+    /// <summary>Reserves several distinct ports at once; probing them one at a time tends to hand back the same port twice.</summary>
+    private static List<int> GetAvailableUdpPorts(int count)
+    {
+        var sockets = new List<Socket>(count);
+        try
+        {
+            var ports = new List<int>(count);
+            for (var i = 0; i < count; i++)
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                sockets.Add(socket);
+                ports.Add(((IPEndPoint)socket.LocalEndPoint!).Port);
+            }
+
+            return ports;
+        }
+        finally
+        {
+            foreach (var socket in sockets)
+            {
+                socket.Dispose();
+            }
+        }
     }
 
     private static int GetAvailableUdpPort()


### PR DESCRIPTION
An audit of `Meziantou.Framework.DnsServer` turned up 20 issues, all reachable from unauthenticated network traffic or silently producing wrong bytes on the wire. This fixes all of them, with a regression test for each.

## Why

The library's entire input surface is hostile by definition — it is a DNS server. The problems clustered in two places: input validation in the wire reader, and silent lossiness in the encoder. The architecture itself was sound, so the changes are contained.

## The significant ones

**Name decompression had no size budget** (`DnsWireReader`). The only guard was a 128-pointer cap; nothing limited the label bytes read between jumps. A 65,535-byte message built from self-referencing pointers allocated **35.8 MB in 14.9 ms** before being rejected, and because the TCP handler catches per message and keeps reading, one connection could replay it indefinitely. Names are now bounded by the RFC 1035 255-byte limit and pointers must point strictly backwards, which makes loops structurally impossible. The regression test asserts the same message is now rejected using under 64 KB.

**Any exception from the UDP receive loop stopped the whole host.** The loop caught only `OperationCanceledException`, so anything else faulted the `BackgroundService` and the default `StopHost` behaviour shut the application down — after `StartAsync` had already reported success. On Windows this was remotely triggerable: `UdpClient` does not apply `SIO_UDP_CONNRESET`, so an ICMP port unreachable (a client simply closing its socket) surfaces as a `SocketException` on the next receive. Sockets are now bound during `StartAsync` so port conflicts are clean startup errors, `SocketException` is logged and the loop continues, and Windows gets the `IOControl` call.

**Two silent wire-corruption bugs.** Response codes above 15 were truncated to their low 4 bits, so a handler setting `BadVersion` (16) sent `NoError` (0) — an error reported as a success. And TCP/QUIC cast the response length to `ushort` unchecked, so a 445,012-byte response announced 51,796 and desynchronised the connection for every later query on it. The RCODE is now split across the header and the OPT record, and all transports encode through a size-aware overload that truncates with the TC bit.

**DNS over TLS did not interoperate.** `UseHttps` made Kestrel advertise its HTTP ALPN protocols, so a client offering only `dot` (RFC 7858 §3.1) failed the handshake outright. This was invisible in CI because the one DoT test set no ALPN at all. Related: `DnsServerProtocol.Tls` was never produced — DoT connections reported `Tcp`, so any "encrypted transport only" policy failed open.

## Also fixed

- Record parsers subtracted a fixed header size from `RDLENGTH` without checking it was large enough, reaching `Span.Slice` with a negative count (`ArgumentOutOfRangeException`, and a 500 over DoH). Reads are now scoped to each record's data, which also stops TXT/SVCB/OPT from reading into the following record.
- Non-ASCII names were silently rewritten with `?` by `Encoding.ASCII` (`café` → `caf?`); no total name length was enforced on write. Both now throw.
- Messages with the QR bit set are dropped (RFC 5625 §4.4 — otherwise two servers can be made to answer each other indefinitely); unparseable messages get `FORMERR` instead of silence; unsupported EDNS versions get `BADVERS` (RFC 6891 §6.1.3).
- UDP responses are clamped to `MaxUdpResponseSize` — the old truncation path only cleared the answer sections and could still emit oversized datagrams, which is an amplification vector.
- Idle timeouts and in-flight drains for TCP/DoT and QUIC; QUIC previously disposed connections while streams were still being served.
- DoH caps the request body, decodes with `Base64Url`, answers malformed messages with 400 instead of 500, and sets `Cache-Control` from the smallest TTL (RFC 8484 §5.1).
- Responses now use name compression.
- `MapDnsHandler` throws when called twice instead of racing on a field; `AddDnsServer` throws when TCP/TLS listeners are configured on a host without Kestrel, where they would silently never start.

## Notes for the reviewer

Two intentional behaviour changes worth a look:

1. **`MaxUdpResponseSize` defaults to 1232** (DNS Flag Day 2020). This is the amplification fix, but clients advertising 4096 now get truncated responses and retry over TCP.
2. **`TcpIdleTimeout` defaults to 30s**, measured from the last *complete* query so byte-dribbling cannot hold a connection open. A handler slower than the timeout will have its connection closed — raise the value or use `Timeout.InfiniteTimeSpan`.

The decode → validate → handle → encode sequence moved into a new internal `DnsRequestProcessor`, so the protocol rules live in one place rather than being duplicated across the four transports.

New public API is additive only (four properties on `DnsServerOptions`); `ref/Meziantou.Framework.DnsServer.cs` is regenerated. Version bumped to 2.1.0.

## Testing

- `Meziantou.Framework.DnsServer.Tests`: **45 → 77 tests** per target framework (154 total across net10.0/net11.0), all passing. Includes two fuzzing tests asserting that `DecodeQuery` only ever throws `DnsProtocolException` — that single property covers the whole `ArgumentOutOfRangeException` family.
- `Meziantou.Framework.DnsProxy.Tests` (the consumer): 84 passing. `Meziantou.Framework.DnsClient.Tests`: 162 passing.
- Built and tested with `/p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` produces no further changes.
