### PR TITLE
Harden AvatarGenerator against untrusted display names

### DIFF
--- a/ref/Meziantou.Framework.Avatar.cs
+++ b/ref/Meziantou.Framework.Avatar.cs
@@ -19,6 +19,7 @@ namespace Meziantou.Framework
 
     public static class AvatarGenerator
     {
+        public static string CreateSvg(string name) => throw null;
         public static string CreateSvg(string name, Meziantou.Framework.AvatarOptions options) => throw null;
     }
 
@@ -27,6 +28,8 @@ namespace Meziantou.Framework
         public const int DefaultSize = 64;
         public System.Collections.Generic.IList<Meziantou.Framework.AvatarColorPair> Palette { get => throw null; }
         public string? Bigram { get => throw null; set { } }
+        public string? AccessibleLabel { get => throw null; set { } }
+        public bool IsDecorative { get => throw null; set { } }
         public Meziantou.Framework.AvatarShape Shape { get => throw null; set { } }
         public int Size { get => throw null; set { } }
     }

--- a/src/Meziantou.Framework.Avatar/AvatarColorPair.cs
+++ b/src/Meziantou.Framework.Avatar/AvatarColorPair.cs
@@ -1,8 +1,12 @@
 namespace Meziantou.Framework;
 
 /// <summary>
-/// Represents a foreground/background color pair used to render an avatar.
+/// Represents a background/foreground color pair used to render an avatar.
 /// </summary>
+/// <remarks>
+/// This is a struct, so <see langword="default"/> bypasses the constructor and leaves both colors null.
+/// <see cref="AvatarGenerator.CreateSvg(string, AvatarOptions)"/> rejects such an entry in the palette.
+/// </remarks>
 public readonly record struct AvatarColorPair
 {
     /// <summary>

--- a/src/Meziantou.Framework.Avatar/AvatarGenerator.cs
+++ b/src/Meziantou.Framework.Avatar/AvatarGenerator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO.Hashing;
 using System.Security;
 
@@ -8,40 +9,73 @@ namespace Meziantou.Framework;
 /// </summary>
 public static class AvatarGenerator
 {
+    private const double FontSizeRatio = 0.5;
+    private const double RoundedCornerRadiusRatio = 0.25;
+
+    /// <summary>Optical nudge that centers the glyph on the baseline.</summary>
+    private const string BaselineOffset = ".05em";
+
+    /// <summary>Every generated coordinate is a multiple of 0.25, so two decimals are always exact.</summary>
+    private const string NumberFormat = "0.##";
+
+    /// <summary>The observed length of a default-options document is 353 characters.</summary>
+    private const int SvgCapacity = 512;
+
+    /// <summary>Rendered when a name contains nothing that can be displayed.</summary>
+    private const string PlaceholderBigram = "?";
+
+    /// <summary>
+    /// A grapheme cluster has no length limit, so a name made of combining marks would otherwise
+    /// flow into the output unbounded. The longest legitimate cluster (a family emoji) is 11 UTF-16 units.
+    /// </summary>
+    private const int MaxBigramElementLength = 64;
+
+    /// <summary>
+    /// Creates an avatar SVG string for the specified name, using the default options.
+    /// </summary>
+    /// <param name="name">The full name used to compute the color and the bigram.</param>
+    /// <returns>The generated SVG string.</returns>
+    public static string CreateSvg(string name)
+    {
+        return CreateSvg(name, AvatarOptions.Default);
+    }
+
     /// <summary>
     /// Creates an avatar SVG string for the specified name and options.
     /// </summary>
     /// <param name="name">The full name used to compute the color and default bigram.</param>
     /// <param name="options">The generation options.</param>
     /// <returns>The generated SVG string.</returns>
+    /// <remarks>
+    /// Characters that are not valid in an XML document are removed from <paramref name="name"/>.
+    /// An explicit <see cref="AvatarOptions.Bigram"/> containing such characters is rejected instead.
+    /// </remarks>
     public static string CreateSvg(string name, AvatarOptions options)
     {
-        ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(options.Size);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(options.Size, $"{nameof(options)}.{nameof(options.Size)}");
+        ValidatePalette(options);
+        ValidateShape(options);
 
-        if (options.Palette.Count == 0)
-            throw new ArgumentException("The palette cannot be empty.", nameof(options));
-
-        var bigram = GetBigram(name, options.Bigram);
-        var colorPair = GetColorPair(name, options.Palette);
-        return CreateSvg(options.Size, options.Shape, bigram, colorPair);
+        var sanitizedName = RemoveInvalidXmlCharacters(name);
+        var bigram = GetBigram(sanitizedName, options);
+        var colorPair = GetColorPair(sanitizedName, options.Palette);
+        return CreateSvg(options, bigram, colorPair);
     }
 
-    private static string CreateSvg(int size, AvatarShape shape, string bigram, AvatarColorPair colorPair)
+    private static string CreateSvg(AvatarOptions options, string bigram, AvatarColorPair colorPair)
     {
+        var size = options.Size;
         var escapedBigram = Escape(bigram);
         var escapedBackgroundColor = Escape(colorPair.BackgroundColor);
         var escapedForegroundColor = Escape(colorPair.ForegroundColor);
-        var halfSize = size / 2d;
-        var fontSize = size * 0.5;
         var sizeString = size.ToString(CultureInfo.InvariantCulture);
-        var halfSizeString = halfSize.ToString("0.##", CultureInfo.InvariantCulture);
-        var roundedCornerRadiusString = (size * 0.25).ToString("0.##", CultureInfo.InvariantCulture);
-        var fontSizeString = fontSize.ToString("0.##", CultureInfo.InvariantCulture);
+        var halfSizeString = (size / 2d).ToString(NumberFormat, CultureInfo.InvariantCulture);
+        var roundedCornerRadiusString = (size * RoundedCornerRadiusRatio).ToString(NumberFormat, CultureInfo.InvariantCulture);
+        var fontSizeString = (size * FontSizeRatio).ToString(NumberFormat, CultureInfo.InvariantCulture);
 
-        var sb = new StringBuilder(capacity: 256);
+        var sb = new StringBuilder(capacity: SvgCapacity);
         sb.Append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"");
         sb.Append(sizeString);
         sb.Append("\" height=\"");
@@ -50,52 +84,63 @@ public static class AvatarGenerator
         sb.Append(sizeString);
         sb.Append(' ');
         sb.Append(sizeString);
-        sb.Append("\" role=\"img\" aria-label=\"");
-        sb.Append(escapedBigram);
-        sb.Append("\">");
 
-        if (shape == AvatarShape.Round)
+        if (options.IsDecorative)
         {
-            sb.Append("<circle cx=\"");
-            sb.Append(halfSizeString);
-            sb.Append("\" cy=\"");
-            sb.Append(halfSizeString);
-            sb.Append("\" r=\"");
-            sb.Append(halfSizeString);
-            sb.Append("\" fill=\"");
-            sb.Append(escapedBackgroundColor);
-            sb.Append("\"/>");
-        }
-        else if (shape == AvatarShape.Square)
-        {
-            sb.Append("<rect width=\"");
-            sb.Append(sizeString);
-            sb.Append("\" height=\"");
-            sb.Append(sizeString);
-            sb.Append("\" fill=\"");
-            sb.Append(escapedBackgroundColor);
-            sb.Append("\"/>");
-        }
-        else if (shape == AvatarShape.RoundedSquare)
-        {
-            sb.Append("<rect width=\"");
-            sb.Append(sizeString);
-            sb.Append("\" height=\"");
-            sb.Append(sizeString);
-            sb.Append("\" rx=\"");
-            sb.Append(roundedCornerRadiusString);
-            sb.Append("\" ry=\"");
-            sb.Append(roundedCornerRadiusString);
-            sb.Append("\" fill=\"");
-            sb.Append(escapedBackgroundColor);
-            sb.Append("\"/>");
+            sb.Append("\" aria-hidden=\"true\" focusable=\"false\">");
         }
         else
         {
-            throw new ArgumentOutOfRangeException(nameof(shape), shape, "Unsupported avatar shape.");
+            sb.Append("\" role=\"img\" aria-label=\"");
+            sb.Append(options.AccessibleLabel is null ? escapedBigram : Escape(RemoveInvalidXmlCharacters(options.AccessibleLabel)));
+            sb.Append("\">");
         }
 
-        sb.Append("<text x=\"50%\" y=\"50%\" text-anchor=\"middle\" dominant-baseline=\"middle\" alignment-baseline=\"middle\" dy=\".05em\" fill=\"");
+        switch (options.Shape)
+        {
+            case AvatarShape.Round:
+                sb.Append("<circle cx=\"");
+                sb.Append(halfSizeString);
+                sb.Append("\" cy=\"");
+                sb.Append(halfSizeString);
+                sb.Append("\" r=\"");
+                sb.Append(halfSizeString);
+                sb.Append("\" fill=\"");
+                sb.Append(escapedBackgroundColor);
+                sb.Append("\"/>");
+                break;
+
+            case AvatarShape.Square:
+                sb.Append("<rect width=\"");
+                sb.Append(sizeString);
+                sb.Append("\" height=\"");
+                sb.Append(sizeString);
+                sb.Append("\" fill=\"");
+                sb.Append(escapedBackgroundColor);
+                sb.Append("\"/>");
+                break;
+
+            case AvatarShape.RoundedSquare:
+                sb.Append("<rect width=\"");
+                sb.Append(sizeString);
+                sb.Append("\" height=\"");
+                sb.Append(sizeString);
+                sb.Append("\" rx=\"");
+                sb.Append(roundedCornerRadiusString);
+                sb.Append("\" ry=\"");
+                sb.Append(roundedCornerRadiusString);
+                sb.Append("\" fill=\"");
+                sb.Append(escapedBackgroundColor);
+                sb.Append("\"/>");
+                break;
+
+            default:
+                throw new UnreachableException($"The shape '{options.Shape}' was not rejected by {nameof(ValidateShape)}.");
+        }
+
+        sb.Append("<text x=\"50%\" y=\"50%\" text-anchor=\"middle\" dominant-baseline=\"middle\" alignment-baseline=\"middle\" dy=\"");
+        sb.Append(BaselineOffset);
+        sb.Append("\" fill=\"");
         sb.Append(escapedForegroundColor);
         sb.Append("\" font-family=\"monospace\" font-weight=\"700\" font-size=\"");
         sb.Append(fontSizeString);
@@ -106,88 +151,210 @@ public static class AvatarGenerator
         return sb.ToString();
     }
 
-    private static AvatarColorPair GetColorPair(string name, IList<AvatarColorPair> palette)
+    private static void ValidatePalette(AvatarOptions options)
     {
-        var normalizedName = name.Trim().Normalize(NormalizationForm.FormC);
+        var palette = options.Palette;
+        if (palette.Count == 0)
+            throw new ArgumentException("The palette cannot be empty.", nameof(options));
+
+        for (var i = 0; i < palette.Count; i++)
+        {
+            var pair = palette[i];
+
+            // AvatarColorPair is a struct, so default(AvatarColorPair) bypasses the constructor guards.
+            if (string.IsNullOrWhiteSpace(pair.BackgroundColor) || string.IsNullOrWhiteSpace(pair.ForegroundColor))
+                throw new ArgumentException($"The palette entry at index {i.ToString(CultureInfo.InvariantCulture)} has a null or whitespace color.", nameof(options));
+        }
+    }
+
+    private static void ValidateShape(AvatarOptions options)
+    {
+        if (options.Shape is not (AvatarShape.Round or AvatarShape.Square or AvatarShape.RoundedSquare))
+            throw new ArgumentOutOfRangeException(nameof(options), options.Shape, "Unsupported avatar shape.");
+    }
+
+    private static AvatarColorPair GetColorPair(string sanitizedName, IList<AvatarColorPair> palette)
+    {
+        // Normalization requires ICU. Under InvariantGlobalization it is a no-op, so a name that is not
+        // already in Form C selects a different entry there. See the readme.
+        var normalizedName = sanitizedName.Trim().Normalize(NormalizationForm.FormC);
         var hash = XxHash32.HashToUInt32(Encoding.UTF8.GetBytes(normalizedName));
         var index = (int)(hash % (uint)palette.Count);
         return palette[index];
     }
 
-    private static string GetBigram(string name, string? explicitBigram)
+    private static string GetBigram(string sanitizedName, AvatarOptions options)
     {
-        if (explicitBigram is not null)
-            return ValidateBigram(explicitBigram.Trim());
+        if (options.Bigram is not null)
+            return ValidateBigram(options);
 
-        var words = name.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (words.Length == 0)
-            throw new ArgumentException("The name cannot be empty or whitespace.", nameof(name));
+        string? firstElement = null;
+        string? lastElement = null;
+        string? singleWord = null;
+        var wordCount = 0;
 
-        if (words.Length > 1)
+        foreach (var word in EnumerateWords(sanitizedName))
         {
-            var first = GetFirstTextElement(words[0]);
-            var last = GetFirstTextElement(words[^1]);
-            return string.Concat(first, last);
+            var element = GetFirstVisibleTextElement(word);
+            if (element is null)
+                continue;
+
+            wordCount++;
+            if (firstElement is null)
+            {
+                firstElement = element;
+                singleWord = word;
+            }
+
+            lastElement = element;
         }
 
-        return TakeFirstTextElements(words[0], maxTextElements: 2);
+        if (wordCount == 0)
+            return PlaceholderBigram;
+
+        if (wordCount > 1)
+            return string.Concat(firstElement, lastElement);
+
+        return TakeFirstVisibleTextElements(singleWord!, maxTextElements: 2);
     }
 
-    private static string ValidateBigram(string bigram)
+    private static string ValidateBigram(AvatarOptions options)
     {
+        var bigram = options.Bigram!.Trim();
+        if (bigram.Length != RemoveInvalidXmlCharacters(bigram).Length)
+            throw new ArgumentException("The explicit bigram must not contain characters that are invalid in an XML document.", nameof(options));
+
         var textElementCount = 0;
         var enumerator = StringInfo.GetTextElementEnumerator(bigram);
         while (enumerator.MoveNext())
         {
             var textElement = enumerator.GetTextElement();
             if (ContainsWhiteSpace(textElement))
-                throw new ArgumentException("The explicit bigram must not contain whitespace.", nameof(bigram));
+                throw new ArgumentException("The explicit bigram must not contain whitespace.", nameof(options));
 
             textElementCount++;
             if (textElementCount > 2)
-                throw new ArgumentException("The explicit bigram must contain 1 or 2 characters.", nameof(bigram));
+                throw new ArgumentException("The explicit bigram must contain 1 or 2 characters.", nameof(options));
         }
 
         if (textElementCount == 0)
-            throw new ArgumentException("The explicit bigram must contain 1 or 2 characters.", nameof(bigram));
+            throw new ArgumentException("The explicit bigram must contain 1 or 2 characters.", nameof(options));
 
         return bigram;
     }
 
-    private static string TakeFirstTextElements(string text, int maxTextElements)
+    /// <summary>
+    /// Splits a name on whitespace and on the connectors used inside compound names, so that
+    /// "Jean-Pierre" and "O'Brien" yield two words rather than one.
+    /// </summary>
+    private static IEnumerable<string> EnumerateWords(string name)
     {
-        var enumerator = StringInfo.GetTextElementEnumerator(text);
-        if (!enumerator.MoveNext())
-            throw new ArgumentException("The value must contain at least one character.", nameof(text));
-
-        var textElementCount = 1;
-        while (textElementCount < maxTextElements && enumerator.MoveNext())
+        var start = -1;
+        for (var i = 0; i < name.Length; i++)
         {
-            textElementCount++;
+            if (IsWordSeparator(name[i]))
+            {
+                if (start >= 0)
+                {
+                    yield return name[start..i];
+                    start = -1;
+                }
+            }
+            else if (start < 0)
+            {
+                start = i;
+            }
         }
 
-        if (textElementCount < maxTextElements)
-            return text;
-
-        var endIndex = text.Length;
-        if (enumerator.MoveNext())
-            endIndex = enumerator.ElementIndex;
-
-        return text[..endIndex];
+        if (start >= 0)
+            yield return name[start..];
     }
 
-    private static string GetFirstTextElement(string text)
+    private static bool IsWordSeparator(char value)
+    {
+        return char.IsWhiteSpace(value)
+            || value is '-' or '‐' or '‑' or '‒' or '–' or '—' // hyphen and dash variants
+            or '\'' or '’' // straight and typographic apostrophes
+            or '.' or '_';
+    }
+
+    private static string TakeFirstVisibleTextElements(string text, int maxTextElements)
+    {
+        string? result = null;
+        var textElementCount = 0;
+
+        var enumerator = StringInfo.GetTextElementEnumerator(text);
+        while (enumerator.MoveNext())
+        {
+            var textElement = enumerator.GetTextElement();
+            if (!IsVisibleTextElement(textElement))
+                continue;
+
+            result = result is null ? LimitLength(textElement) : string.Concat(result, LimitLength(textElement));
+            if (++textElementCount == maxTextElements)
+                break;
+        }
+
+        return result ?? PlaceholderBigram;
+    }
+
+    private static string? GetFirstVisibleTextElement(string text)
     {
         var enumerator = StringInfo.GetTextElementEnumerator(text);
-        if (!enumerator.MoveNext())
-            throw new ArgumentException("The value must contain at least one character.", nameof(text));
+        while (enumerator.MoveNext())
+        {
+            var textElement = enumerator.GetTextElement();
+            if (IsVisibleTextElement(textElement))
+                return LimitLength(textElement);
+        }
 
-        var startIndex = enumerator.ElementIndex;
-        var endIndex = text.Length;
-        if (enumerator.MoveNext())
-            endIndex = enumerator.ElementIndex;
+        return null;
+    }
 
-        return text[startIndex..endIndex];
+    /// <summary>
+    /// Keeps a pathological grapheme cluster (a base character followed by thousands of combining
+    /// marks) from flowing into the output by reducing it to its base character.
+    /// </summary>
+    private static string LimitLength(string textElement)
+    {
+        if (textElement.Length <= MaxBigramElementLength)
+            return textElement;
+
+        var enumerator = textElement.EnumerateRunes();
+        return enumerator.MoveNext() ? enumerator.Current.ToString() : PlaceholderBigram;
+    }
+
+    /// <summary>
+    /// Determines whether a grapheme cluster renders anything. Zero-width and bidi control characters
+    /// are not whitespace, so without this check they can become the whole bigram.
+    /// </summary>
+    private static bool IsVisibleTextElement(string textElement)
+    {
+        foreach (var rune in textElement.EnumerateRunes())
+        {
+            if (Rune.IsWhiteSpace(rune))
+                continue;
+
+            switch (Rune.GetUnicodeCategory(rune))
+            {
+                case UnicodeCategory.Control:
+                case UnicodeCategory.Format:
+                case UnicodeCategory.NonSpacingMark:
+                case UnicodeCategory.SpacingCombiningMark:
+                case UnicodeCategory.EnclosingMark:
+                case UnicodeCategory.SpaceSeparator:
+                case UnicodeCategory.LineSeparator:
+                case UnicodeCategory.ParagraphSeparator:
+                case UnicodeCategory.Surrogate:
+                case UnicodeCategory.OtherNotAssigned:
+                    continue;
+
+                default:
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsWhiteSpace(string text)
@@ -201,8 +368,70 @@ public static class AvatarGenerator
         return false;
     }
 
+    /// <summary>
+    /// Removes the code points that the XML 1.0 Char production forbids, including unpaired surrogates.
+    /// <see cref="SecurityElement.Escape(string)"/> passes them through, and <see cref="string.Normalize(NormalizationForm)"/>
+    /// throws on some of them.
+    /// </summary>
+    private static string RemoveInvalidXmlCharacters(string value)
+    {
+        if (!ContainsInvalidXmlCharacter(value))
+            return value;
+
+        var sb = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (char.IsHighSurrogate(c))
+            {
+                // Any well-formed pair maps to U+10000..U+10FFFF, which the Char production allows.
+                if (i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+                {
+                    sb.Append(c);
+                    sb.Append(value[i + 1]);
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (!char.IsLowSurrogate(c) && IsValidXmlCharacter(c))
+                sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool ContainsInvalidXmlCharacter(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (char.IsHighSurrogate(c))
+            {
+                if (i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+                {
+                    i++;
+                    continue;
+                }
+
+                return true;
+            }
+
+            if (char.IsLowSurrogate(c) || !IsValidXmlCharacter(c))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsValidXmlCharacter(char value)
+    {
+        return value is '\t' or '\n' or '\r' or (>= '\u0020' and <= '\ud7ff') or (>= '\ue000' and <= '\ufffd');
+    }
+
     private static string Escape(string value)
     {
-        return SecurityElement.Escape(value) ?? string.Empty;
+        return SecurityElement.Escape(value);
     }
 }

--- a/src/Meziantou.Framework.Avatar/AvatarOptions.cs
+++ b/src/Meziantou.Framework.Avatar/AvatarOptions.cs
@@ -13,14 +13,43 @@ public class AvatarOptions
     public const int DefaultSize = 64;
 
     /// <summary>
-    /// Gets the list of colors used for rendering.
+    /// Gets the mutable list of colors used for rendering.
     /// </summary>
+    /// <remarks>
+    /// The color is selected with <c>hash(name) % Palette.Count</c>, so the number of entries and their
+    /// order are part of the name-to-color mapping: adding or removing one entry re-colors nearly every name.
+    /// This instance is not thread-safe; do not mutate it while <see cref="AvatarGenerator.CreateSvg(string, AvatarOptions)"/> is running.
+    /// </remarks>
     public IList<AvatarColorPair> Palette { get; }
 
     /// <summary>
     /// Gets or sets the explicit bigram to render. If null, the bigram is extracted from the name.
     /// </summary>
+    /// <remarks>
+    /// The value must contain 1 or 2 grapheme clusters, no whitespace, and no character that is invalid
+    /// in an XML document. It does not affect the selected color, which always derives from the name.
+    /// </remarks>
     public string? Bigram { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text announced by assistive technologies. If null, the bigram is used.
+    /// </summary>
+    /// <remarks>
+    /// Set this to the full name so the avatar announces as "John Doe" rather than "JD". Characters that
+    /// are invalid in an XML document are removed, so an untrusted display name can be passed directly.
+    /// Ignored when <see cref="IsDecorative"/> is <see langword="true"/>.
+    /// </remarks>
+    public string? AccessibleLabel { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the avatar is purely decorative and should be hidden
+    /// from assistive technologies. The default is <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Set this when the avatar sits next to the name it represents, so the name is not announced twice.
+    /// The generated element uses <c>aria-hidden</c> instead of <c>role</c> and <c>aria-label</c>.
+    /// </remarks>
+    public bool IsDecorative { get; set; }
 
     /// <summary>
     /// Gets or sets the shape of the avatar.

--- a/src/Meziantou.Framework.Avatar/Meziantou.Framework.Avatar.csproj
+++ b/src/Meziantou.Framework.Avatar/Meziantou.Framework.Avatar.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Generate deterministic avatar SVG images from names and bigrams</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Avatar/readme.md
+++ b/src/Meziantou.Framework.Avatar/readme.md
@@ -7,10 +7,10 @@ Generate deterministic avatar SVG strings from a name.
 ```c#
 using Meziantou.Framework;
 
-var svg = AvatarGenerator.CreateSvg("John Doe", new AvatarOptions());
+var svg = AvatarGenerator.CreateSvg("John Doe");
 ```
 
-`AvatarGenerator` extracts a 1-2 character bigram and selects a foreground/background pair from the palette using a hash of the provided name.
+`AvatarGenerator` extracts a 1-2 grapheme bigram from the name and selects a background/foreground pair from the palette using a hash of the name.
 
 ## Customize the output
 
@@ -19,12 +19,43 @@ using Meziantou.Framework;
 
 var options = new AvatarOptions
 {
-    Bigram = "JD", // optional explicit 1-2 character bigram
+    Bigram = "JD", // optional explicit 1-2 grapheme bigram
     Shape = AvatarShape.Round, // Round, Square, or RoundedSquare
     Size = 128,
 };
 options.Palette.Clear();
-options.Palette.Add(new AvatarColorPair("#CFDADE", "#153037"));
+options.Palette.Add(new AvatarColorPair("#CFDADE", "#153037")); // background, then foreground
 
 var svg = AvatarGenerator.CreateSvg("John Doe", options);
 ```
+
+## How the bigram is chosen
+
+The name is split on whitespace and on the connectors used inside compound names (`-`, `'`, `.`, `_`, and their typographic variants):
+
+- Two or more words: the first grapheme of the first word plus the first grapheme of the last word. `"John Michael Doe"` gives `JD`, not `JM`. `"Jean-Pierre"` gives `JP` and `"O'Brien"` gives `OB`.
+- A single word: its first two graphemes. `"John"` gives `Jo` and `"山田太郎"` gives `山田`.
+
+The unit is a grapheme cluster, not a `char`, so an emoji or a decomposed accent counts as one. Characters that render nothing (zero-width, bidi controls, standalone combining marks) are skipped, and a name with nothing visible renders `?`.
+
+Set `AvatarOptions.Bigram` to bypass this entirely. It does not affect the color, which always derives from the name.
+
+## Accessibility
+
+By default the avatar is exposed as `role="img"` with the bigram as its `aria-label`. Two options change this:
+
+- `AccessibleLabel` sets the announced text — pass the full name so it announces as "John Doe" rather than "JD".
+- `IsDecorative` hides the avatar from assistive technologies with `aria-hidden`. Use it when the avatar sits next to the name it represents, so the name is not announced twice.
+
+## Determinism
+
+The color is `hash(name) % Palette.Count`, so the same name always maps to the same pair — **for a fixed palette and a fixed package version**. Two consequences are worth knowing before caching or persisting generated avatars:
+
+- The number of entries in the palette and their order are part of the mapping. Adding or removing a single `AvatarColorPair` re-colors nearly every name, not just the names that mapped to the changed entry.
+- The name is trimmed and normalized to Unicode Form C before hashing, so surrounding whitespace is ignored but **case is not**: `"john doe"` and `"John Doe"` get different colors.
+
+Normalization requires ICU. Under `InvariantGlobalization` it is a no-op, so a name that is not already in Form C selects a different palette entry there than it does in a normal deployment. If you render avatars from both kinds of process and need them to agree, normalize the name yourself before calling `CreateSvg`.
+
+## Input handling
+
+The generated string is always well-formed XML. Characters that the XML 1.0 specification forbids — control characters, unpaired surrogates from a name truncated mid-emoji — are removed from `name` and from `AccessibleLabel`, so an untrusted display name can be passed straight through. An explicit `Bigram` containing such a character is rejected with an `ArgumentException` instead, since that indicates a bug in the calling code.

--- a/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
@@ -1,4 +1,6 @@
+using System.Xml;
 using Meziantou.Framework.SnapshotTesting;
+using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Tests;
 
@@ -10,6 +12,12 @@ public class AvatarGeneratorTests
         var svg = AvatarGenerator.CreateSvg("John Doe", new AvatarOptions());
 
         Snapshot.Validate(svg, SnapshotType.Svg);
+    }
+
+    [Fact]
+    public void CreateSvg_UsesDefaultOptionsWhenNoneProvided()
+    {
+        Assert.Equal(AvatarGenerator.CreateSvg("John Doe", new AvatarOptions()), AvatarGenerator.CreateSvg("John Doe"));
     }
 
     [Fact]
@@ -157,10 +165,12 @@ public class AvatarGeneratorTests
     public void CreateSvg_RendersRoundShape()
     {
         var options = new AvatarOptions();
+        options.Shape = AvatarShape.Round;
 
         var svg = AvatarGenerator.CreateSvg("John Doe", options);
 
-        Snapshot.Validate(svg, SnapshotType.Svg);
+        Assert.Contains("<circle cx=\"32\" cy=\"32\" r=\"32\" fill=\"#cfdade\"/>", svg);
+        Assert.DoesNotContain("<rect", svg);
     }
 
     [Fact]
@@ -190,7 +200,8 @@ public class AvatarGeneratorTests
     {
         var svg = AvatarGenerator.CreateSvg("John Doe", new AvatarOptions());
 
-        Snapshot.Validate(svg, SnapshotType.Svg);
+        Assert.Contains("width=\"64\" height=\"64\" viewBox=\"0 0 64 64\"", svg);
+        Assert.Contains("font-size=\"32\"", svg);
     }
 
     [Fact]
@@ -205,6 +216,31 @@ public class AvatarGeneratorTests
     }
 
     [Fact]
+    public void CreateSvg_UsesFractionalGeometryForOddSize()
+    {
+        var options = new AvatarOptions();
+        options.Size = 65;
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("width=\"65\" height=\"65\" viewBox=\"0 0 65 65\"", svg);
+        Assert.Contains("cx=\"32.5\" cy=\"32.5\" r=\"32.5\"", svg);
+        Assert.Contains("font-size=\"32.5\"", svg);
+    }
+
+    [Fact]
+    public void CreateSvg_UsesFractionalCornerRadiusForOddSize()
+    {
+        var options = new AvatarOptions();
+        options.Size = 65;
+        options.Shape = AvatarShape.RoundedSquare;
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("rx=\"16.25\" ry=\"16.25\"", svg);
+    }
+
+    [Fact]
     public void AvatarOptions_DefaultPaletteHasGoodContrast()
     {
         var options = new AvatarOptions();
@@ -215,16 +251,326 @@ public class AvatarGeneratorTests
         }
     }
 
-    [Fact]
-    public void CreateSvg_ThrowsWhenSizeIsInvalid()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void CreateSvg_ThrowsWhenSizeIsInvalid(int size)
     {
         var options = new AvatarOptions
         {
-            Size = 0,
+            Size = size,
         };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => AvatarGenerator.CreateSvg("John Doe", options));
     }
+
+    [Fact]
+    public void CreateSvg_ThrowsWhenOptionsIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => AvatarGenerator.CreateSvg("John Doe", options: null!));
+    }
+
+    [Fact]
+    public void CreateSvg_ThrowsWhenPaletteIsEmpty()
+    {
+        var options = new AvatarOptions();
+        options.Palette.Clear();
+
+        var exception = Assert.Throws<ArgumentException>(() => AvatarGenerator.CreateSvg("John Doe", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateSvg_ThrowsWhenShapeIsNotSupported()
+    {
+        var options = new AvatarOptions
+        {
+            Shape = (AvatarShape)42,
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => AvatarGenerator.CreateSvg("John Doe", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateSvg_ThrowsWhenPaletteEntryHasNoColor()
+    {
+        var options = new AvatarOptions();
+        options.Palette.Clear();
+        options.Palette.Add(default);
+
+        var exception = Assert.Throws<ArgumentException>(() => AvatarGenerator.CreateSvg("John Doe", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateSvg_ReportsInvalidBigramOnTheOptionsParameter()
+    {
+        var options = new AvatarOptions
+        {
+            Bigram = "abc",
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => AvatarGenerator.CreateSvg("John Doe", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateSvg_EscapesMarkupInTheNameDerivedBigram()
+    {
+        var svg = AvatarGenerator.CreateSvg("<& Doe", new AvatarOptions());
+
+        Assert.Contains("aria-label=\"&lt;D\"", svg);
+        Assert.Contains(">&lt;D</text>", svg);
+    }
+
+    [Fact]
+    public void CreateSvg_EscapesMarkupInTheExplicitBigram()
+    {
+        var options = new AvatarOptions
+        {
+            Bigram = "<\"",
+        };
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("aria-label=\"&lt;&quot;\"", svg);
+        Assert.Contains(">&lt;&quot;</text>", svg);
+    }
+
+    [Fact]
+    public void CreateSvg_EscapesMarkupInPaletteColors()
+    {
+        var options = new AvatarOptions();
+        options.Palette.Clear();
+        options.Palette.Add(new AvatarColorPair("red\"/><script>x</script><x y=\"", "#fff"));
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("fill=\"red&quot;/&gt;&lt;script&gt;x&lt;/script&gt;&lt;x y=&quot;\"", svg);
+        Assert.DoesNotContain("<script>", svg);
+    }
+
+    [Theory]
+    [InlineData("John Doe")]
+    [InlineData("<& Doe")]
+    [InlineData("\u0007Bob Smith")]
+    [InlineData("\u0001\u0002")]
+    [InlineData("\uFFFEA Doe")]
+    [InlineData("\U0001F469\U0001F3FD‍\U0001F4BB Smith")]
+    public void CreateSvg_ProducesWellFormedXml(string name)
+    {
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        var document = new XmlDocument();
+        document.LoadXml(svg);
+    }
+
+    [Theory]
+    [InlineData("\u0007Bob Smith", "BS")]
+    [InlineData("\u0000\u0000Bob Smith", "BS")]
+    [InlineData("\uFFFEAlice Smith", "AS")]
+    public void CreateSvg_RemovesCharactersThatAreInvalidInXmlFromTheName(string name, string expectedBigram)
+    {
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        Assert.Equal(expectedBigram, GetRenderedBigram(svg));
+    }
+
+    [Fact]
+    public void CreateSvg_RemovesAnUnpairedSurrogateFromTheName()
+    {
+        // A name truncated by char count splits an emoji and leaves a lone surrogate.
+        var svg = AvatarGenerator.CreateSvg("Bob \ud83d", new AvatarOptions());
+
+        Assert.Equal("Bo", GetRenderedBigram(svg));
+
+        var document = new XmlDocument();
+        document.LoadXml(svg);
+    }
+
+    [Fact]
+    public void CreateSvg_ThrowsWhenExplicitBigramContainsAnUnpairedSurrogate()
+    {
+        var options = new AvatarOptions
+        {
+            Bigram = "\ud800",
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => AvatarGenerator.CreateSvg("John Doe", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("\u0001")]
+    [InlineData("A\u0001")]
+    [InlineData("\uFFFE")]
+    public void CreateSvg_ThrowsWhenExplicitBigramContainsCharactersInvalidInXml(string bigram)
+    {
+        var options = new AvatarOptions
+        {
+            Bigram = bigram,
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => AvatarGenerator.CreateSvg("John Doe", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("\u0001\u0002")]
+    [InlineData("\u200B\u200B")]
+    [InlineData("\u202E")]
+    public void CreateSvg_RendersAPlaceholderWhenTheNameHasNothingVisible(string name)
+    {
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        Assert.Equal("?", GetRenderedBigram(svg));
+    }
+
+    [Theory]
+    [InlineData("O'Brien", "OB")]
+    [InlineData("Jean-Pierre", "JP")]
+    [InlineData("Mary-Jane Watson", "MW")]
+    [InlineData("J.R.R. Tolkien", "JT")]
+    [InlineData("O’Brien", "OB")]
+    [InlineData("van der Berg", "vB")]
+    [InlineData("山田太郎", "山田")]
+    public void CreateSvg_SplitsNamesOnConnectorsAsWellAsWhitespace(string name, string expectedBigram)
+    {
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        Assert.Equal(expectedBigram, GetRenderedBigram(svg));
+    }
+
+    [Theory]
+    [InlineData("\u200BAlice Smith", "AS")]
+    [InlineData("\u202EAlice Smith", "AS")]
+    [InlineData("\u0301abc", "ab")]
+    public void CreateSvg_SkipsZeroWidthAndFormatCharactersWhenPickingTheBigram(string name, string expectedBigram)
+    {
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        Assert.Equal(expectedBigram, GetRenderedBigram(svg));
+    }
+
+    [Fact]
+    public void CreateSvg_ExtractBigram_TakesTwoGraphemeClustersFromASingleWord()
+    {
+        var svg = AvatarGenerator.CreateSvg("\U0001F469\U0001F3FD‍\U0001F4BB\U0001F600x", new AvatarOptions());
+        var bigram = GetRenderedBigram(svg);
+
+        Assert.Equal("\U0001F469\U0001F3FD‍\U0001F4BB\U0001F600", bigram);
+        Assert.Equal(2, new StringInfo(bigram).LengthInTextElements);
+    }
+
+    [Fact]
+    public void CreateSvg_ReducesAPathologicalGraphemeClusterToItsBaseCharacter()
+    {
+        var name = "A" + new string('\u0301', 100_000) + " Doe";
+
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        Assert.Equal("AD", GetRenderedBigram(svg));
+        Assert.True(svg.Length < 512, $"Expected a bounded document, but got {svg.Length.ToString(CultureInfo.InvariantCulture)} characters.");
+    }
+
+    [Fact]
+    public void CreateSvg_UsesTheAccessibleLabelWhenProvided()
+    {
+        var options = new AvatarOptions
+        {
+            AccessibleLabel = "John Doe",
+        };
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("role=\"img\" aria-label=\"John Doe\"", svg);
+        Assert.Equal("JD", GetRenderedBigram(svg));
+    }
+
+    [Fact]
+    public void CreateSvg_RemovesCharactersThatAreInvalidInXmlFromTheAccessibleLabel()
+    {
+        var options = new AvatarOptions
+        {
+            AccessibleLabel = "John\u0001 Doe",
+        };
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("aria-label=\"John Doe\"", svg);
+        var document = new XmlDocument();
+        document.LoadXml(svg);
+    }
+
+    [Fact]
+    public void CreateSvg_HidesTheAvatarFromAssistiveTechnologiesWhenDecorative()
+    {
+        var options = new AvatarOptions
+        {
+            IsDecorative = true,
+            AccessibleLabel = "ignored",
+        };
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Assert.Contains("aria-hidden=\"true\" focusable=\"false\"", svg);
+        Assert.DoesNotContain("aria-label", svg);
+        Assert.DoesNotContain("role=\"img\"", svg);
+    }
+
+    [Theory]
+    [InlineData("John Doe", "#cfdade")]
+    [InlineData("John Michael Doe", "#1abc9c")]
+    [InlineData("JD", "#34495e")]
+    [InlineData("John", "#27ae60")]
+    [InlineData("J", "#2ecc71")]
+    [InlineData("Jane Roe", "#1abc9c")]
+    public void CreateSvg_MapsANameToAStableColor(string name, string expectedBackgroundColor)
+    {
+        // The name-to-color mapping is the package's contract. It changes if the hash algorithm,
+        // the palette order, or the palette size changes.
+        var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
+
+        Assert.Equal(expectedBackgroundColor, GetBackgroundFill(svg));
+    }
+
+    [Fact]
+    public void CreateSvg_IgnoresSurroundingWhitespaceWhenSelectingTheColor()
+    {
+        var padded = AvatarGenerator.CreateSvg("  John Doe  ", new AvatarOptions());
+
+        Assert.Equal(GetBackgroundFill(AvatarGenerator.CreateSvg("John Doe", new AvatarOptions())), GetBackgroundFill(padded));
+    }
+
+    [Fact]
+    public void CreateSvg_UsesDifferentColorsForDifferentNames()
+    {
+        var options = new AvatarOptions();
+        options.Palette.Clear();
+        options.Palette.Add(new AvatarColorPair("#010101", "#fefefe"));
+        options.Palette.Add(new AvatarColorPair("#020202", "#ededed"));
+        options.Palette.Add(new AvatarColorPair("#030303", "#dcdcdc"));
+
+        var first = GetBackgroundFill(AvatarGenerator.CreateSvg("John Doe", options));
+        var second = GetBackgroundFill(AvatarGenerator.CreateSvg("Jane Roe", options));
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void CreateSvg_UsesTheSameColorForComposedAndDecomposedNames()
+    {
+        // Normalization needs ICU. Under InvariantGlobalization these two names select different
+        // palette entries, which is why this test does not run in that mode. See the readme.
+        var composed = AvatarGenerator.CreateSvg("Éric Doe", new AvatarOptions());
+        var decomposed = AvatarGenerator.CreateSvg("E\u0301ric Doe", new AvatarOptions());
+
+        Assert.Equal(GetBackgroundFill(composed), GetBackgroundFill(decomposed));
+    }
+
 
     private static string GetBackgroundFill(string svg)
     {

--- a/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
@@ -472,7 +472,7 @@ public class AvatarGeneratorTests
         var svg = AvatarGenerator.CreateSvg(name, new AvatarOptions());
 
         Assert.Equal("AD", GetRenderedBigram(svg));
-        Assert.True(svg.Length < 512, $"Expected a bounded document, but got {svg.Length.ToString(CultureInfo.InvariantCulture)} characters.");
+        Assert.HasCountLessThan(512, svg);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Avatar.Tests/__snapshots__/AvatarGeneratorTests_CreateSvg_RendersRoundShape.verified.svg
+++ b/tests/Meziantou.Framework.Avatar.Tests/__snapshots__/AvatarGeneratorTests_CreateSvg_RendersRoundShape.verified.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="JD"><circle cx="32" cy="32" r="32" fill="#cfdade"/><text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" dy=".05em" fill="#153037" font-family="monospace" font-weight="700" font-size="32">JD</text></svg>

--- a/tests/Meziantou.Framework.Avatar.Tests/__snapshots__/AvatarGeneratorTests_CreateSvg_UsesDefaultSize.verified.svg
+++ b/tests/Meziantou.Framework.Avatar.Tests/__snapshots__/AvatarGeneratorTests_CreateSvg_UsesDefaultSize.verified.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="JD"><circle cx="32" cy="32" r="32" fill="#cfdade"/><text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" dy=".05em" fill="#153037" font-family="monospace" font-weight="700" font-size="32">JD</text></svg>


### PR DESCRIPTION
Fixes the findings from a whole-project audit of `Meziantou.Framework.Avatar`. The library turns a user-supplied display name into SVG markup, so most findings cluster on one theme: input that the type system and the documented contract said could not happen still reached the output.

**Escaping was already correct** — a hostile palette color and a `<script`-prefixed name both come out fully escaped, in the attribute and the element-text context alike. There was no injection path, and this PR does not change that behavior; it adds the tests that were missing for it.

## Correctness and robustness

- **Characters illegal in XML now removed.** `SecurityElement.Escape` handles `< > & ' "` but passes through everything the XML 1.0 `Char` production forbids, so a control character in a display name produced a document `XmlDocument` rejects outright. Those characters (and unpaired surrogates) are now stripped from `name` and `AccessibleLabel`; an explicit `Bigram` containing them is rejected with `ArgumentException`, since that indicates a caller bug rather than hostile data.
- **No more opaque crash on malformed UTF-16.** A name truncated mid-emoji (`VARCHAR(n)`, `name[..20]`) left a lone surrogate, and `String.Normalize` threw `ArgumentException` with `ParamName` `strInput` — a BCL internal the caller never passed. Sanitizing before normalizing fixes this as a side effect.
- **Palette entries validated.** `AvatarColorPair` is a `readonly record struct`, so `default` bypassed its own constructor guards and left both non-nullable colors null. That rendered `fill=""` — black on black, an invisible avatar, with no exception. The `?? string.Empty` that swallowed the null is gone.
- **`ParamName` now names a real parameter.** Every exception escaping `CreateSvg` reports `name` or `options`; callers previously saw the private `bigram` and `shape`. Shape validation moved into the guard block so it fires before the bigram and color work.
- **Output is bounded.** A grapheme cluster has no length limit, so "one text element" could be an entire name and the bigram is emitted twice. A 100k-character name produced a 200,353-character document; it now produces 353.

## Behavior changes worth reviewing

- Names split on connectors as well as whitespace: `O'Brien` → `OB`, `Jean-Pierre` → `JP`, `J.R.R. Tolkien` → `JT` (previously `O'`, `Je`, `J.`).
- Zero-width and bidi characters are skipped when picking the bigram (emoji ZWJ sequences preserved). A name with nothing visible renders `?`.

Initials change for affected users but their **color does not**, since the color still derives from the full name. Existing snapshots are byte-identical, confirming no current avatar changes appearance — `"John Doe"` still maps to `#cfdade`.

## New API (additive)

- `CreateSvg(string name)` — the obvious call now compiles, and it gives the previously dead internal `AvatarOptions.Default` a purpose.
- `AvatarOptions.AccessibleLabel` — announce the full name rather than `JD`.
- `AvatarOptions.IsDecorative` — emit `aria-hidden` for the common "avatar beside the username" layout, so the name is not announced twice.

## Documentation

Documents the bigram rule (first + last word; grapheme clusters, not `char`), that palette size and order are part of the name-to-color mapping, and that case matters while surrounding whitespace does not. Corrects `AvatarColorPair`'s summary, which read "foreground/background" while the constructor takes `(background, foreground)` — both parameters are `string`, so swapping them compiles and yields an inverted avatar.

## Known limitation, deliberately documented rather than fixed

`String.Normalize(FormC)` is a no-op under `InvariantGlobalization`, so a decomposed name selects a different palette entry there than in a normal deployment:

| input | normal | invariant |
|---|---|---|
| `"Éric Doe"` (precomposed) | `#e67e22` | `#e67e22` |
| `"Éric Doe"` (decomposed) | `#e67e22` | **`#3498db`** |

This undercuts the package's determinism guarantee across deployment configurations, and CI already runs an invariant leg where nothing detected it. Fixing it means either dropping normalization (a behavioral break) or vendoring ICU-independent NFC. Recorded in the readme for now; the new composed-vs-decomposed test is gated with `[RunIf(NotInvariant)]` so the guarantee is pinned where it holds and skipped where it does not.

## Tests

26 → 80. The gap that mattered most: **no test input contained `<`, `&` or `"`**, so replacing `Escape` with the identity function left the suite green — on a library whose output is markup embedded in HTML. Now covered, along with the name-to-color mapping (hardcoded pairs, so a hash or palette-order change fails a test that says what broke), argument guards, odd-size geometry, and the single-word grapheme-cluster path.

Two snapshots were byte-identical to a third (all three called `CreateSvg("John Doe", new AvatarOptions())` with no option changes). The duplicated tests now use targeted assertions that isolate the behavior in their names, and their orphaned `.verified.svg` files are removed.

Green on net10.0 and net11.0 in both normal and `InvariantGlobalization` modes; `ref/` regenerated and `eng/update-all.cs` clean.

## Note for the reviewer

Version bumped to **2.1.0**. That is a judgment call worth a second opinion: the API additions are purely additive, but the bigram rule change alters rendered output for hyphenated and apostrophe names. If rendered output counts as part of the contract, this should be **3.0.0**.
