### PR TITLE
Harden DnsClient response handling, DNSSEC validation and wire parsing

### DIFF
--- a/ref/Meziantou.Framework.DnsClient.cs
+++ b/ref/Meziantou.Framework.DnsClient.cs
@@ -24,6 +24,7 @@ namespace Meziantou.Framework.DnsClient
         public Meziantou.Framework.DnsClient.DnssecValidationMode DnssecValidationMode { get => throw null; set { } }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.DnssecTrustAnchor> DnssecTrustAnchors { get => throw null; set { } }
         public System.TimeProvider TimeProvider { get => throw null; set { } }
+        public bool RetryTruncatedOverTcp { get => throw null; set { } }
         public System.Version HttpVersion { get => throw null; set { } }
         public System.Net.Http.HttpVersionPolicy HttpVersionPolicy { get => throw null; set { } }
         public System.Net.Http.HttpMessageHandler? HttpHandler { get => throw null; set { } }
@@ -59,7 +60,7 @@ namespace Meziantou.Framework.DnsClient
         public ushort KeyTag { get => throw null; }
         public byte Algorithm { get => throw null; }
         public byte DigestType { get => throw null; }
-        public byte[] Digest { get => throw null; }
+        public System.ReadOnlyMemory<byte> Digest { get => throw null; }
         public DnssecTrustAnchor(string name, ushort keyTag, byte algorithm, byte digestType, byte[] digest) { }
     }
 
@@ -277,7 +278,9 @@ namespace Meziantou.Framework.DnsClient.Response
         SignatureVerificationFailed = 12,
         InvalidDenialProof = 13,
         TrustChainIncomplete = 14,
-        InvalidData = 15
+        InvalidData = 15,
+        ChainQueryFailed = 16,
+        QueryBudgetExceeded = 17
     }
 
     public sealed class DnssecValidationResult

--- a/src/Meziantou.Framework.DnsClient/DnsClient.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClient.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
+using System.Net.Quic;
 using Meziantou.Framework.DnsClient.Helpers;
 using Meziantou.Framework.DnsClient.Internal;
 using Meziantou.Framework.DnsClient.Protocol;
@@ -17,6 +19,10 @@ public sealed class DnsClient : IDisposable
     private readonly IDnsTransport _transport;
     private readonly DnsClientOptions _options;
     private readonly DnsClientProtocol _protocol;
+
+    /// <summary>Used to re-issue a truncated UDP query over TCP. Null for every other protocol.</summary>
+    private readonly DnsTcpTransport? _tcpFallback;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DnsClient"/> class.
@@ -42,6 +48,9 @@ public sealed class DnsClient : IDisposable
         ValidateOptions(_options);
         _protocol = protocol;
         _transport = CreateTransport(server, protocol, _options);
+        _tcpFallback = protocol is DnsClientProtocol.Udp && _options.RetryTruncatedOverTcp
+            ? CreateTcpTransport(server, _options)
+            : null;
     }
 
     internal DnsClient(IDnsTransport transport, DnsClientProtocol protocol, DnsClientOptions? options)
@@ -70,24 +79,17 @@ public sealed class DnsClient : IDisposable
     /// <param name="queryClass">The DNS query class.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The DNS response message.</returns>
+    /// <exception cref="DnsProtocolException">The response is malformed, or does not answer the query that was sent.</exception>
+    /// <exception cref="TimeoutException"><see cref="DnsClientOptions.Timeout"/> elapsed before a response arrived.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
     public Task<DnsResponseMessage> QueryAsync(string name, DnsQueryType type, DnsQueryClass queryClass, CancellationToken cancellationToken = default)
     {
-        var asciiName = IdnHelper.ToAscii(name);
-
         var query = new DnsQueryMessage
         {
             RecursionDesired = true,
         };
-        query.Questions.Add(new DnsQuestion(asciiName, type, queryClass));
-
-        if (_options.EnableEdns)
-        {
-            query.EdnsOptions = new DnsEdnsOptions
-            {
-                UdpPayloadSize = _options.EdnsUdpPayloadSize,
-                DnssecOk = _options.DnssecOk,
-            };
-        }
+        query.Questions.Add(new DnsQuestion(name, type, queryClass));
 
         return SendAsync(query, cancellationToken);
     }
@@ -106,6 +108,11 @@ public sealed class DnsClient : IDisposable
     /// <param name="message">The DNS query message to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The DNS response message.</returns>
+    /// <remarks>The message is not modified; the client's options are applied to an internal copy.</remarks>
+    /// <exception cref="DnsProtocolException">The response is malformed, or does not answer the query that was sent.</exception>
+    /// <exception cref="TimeoutException"><see cref="DnsClientOptions.Timeout"/> elapsed before a response arrived.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    /// <exception cref="ObjectDisposedException">The client has been disposed.</exception>
     public async Task<DnsResponseMessage> SendAsync(DnsQueryMessage message, CancellationToken cancellationToken = default)
     {
         return await SendCoreAsync(message, validateResponse: true, cancellationToken).ConfigureAwait(false);
@@ -114,12 +121,14 @@ public sealed class DnsClient : IDisposable
     private async Task<DnsResponseMessage> SendCoreAsync(DnsQueryMessage message, bool validateResponse, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(message);
-        ValidateOptions(_options);
-        ApplyOptions(message);
+        ObjectDisposedException.ThrowIf(_disposed, this);
 
-        var questionName = message.Questions.Count > 0 ? message.Questions[0].Name : "unknown";
-        var questionType = message.Questions.Count > 0 ? message.Questions[0].Type.ToString() : "unknown";
-        var questionClass = message.Questions.Count > 0 ? message.Questions[0].QueryClass.ToString() : "unknown";
+        // Apply the options to a copy: the caller owns the message and may reuse it across clients or calls.
+        var effectiveMessage = CloneWithOptions(message);
+
+        var questionName = effectiveMessage.Questions.Count > 0 ? effectiveMessage.Questions[0].Name : "unknown";
+        var questionType = effectiveMessage.Questions.Count > 0 ? effectiveMessage.Questions[0].Type.ToString() : "unknown";
+        var questionClass = effectiveMessage.Questions.Count > 0 ? effectiveMessage.Questions[0].QueryClass.ToString() : "unknown";
 
         using var activity = DnsTelemetry.ActivitySource.StartActivity("dns.query", ActivityKind.Client);
         activity?.SetTag("dns.question.name", questionName);
@@ -129,23 +138,45 @@ public sealed class DnsClient : IDisposable
 
         try
         {
-            var queryBytes = DnsMessageEncoder.EncodeQuery(message);
-
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(_options.Timeout);
 
-            var responseBytes = await _transport.SendAsync(queryBytes, cts.Token).ConfigureAwait(false);
-            var response = DnsMessageEncoder.DecodeResponse(
-                responseBytes,
-                preserveRawRecordData: _options.DnssecValidationMode is DnssecValidationMode.Local);
+            DnsResponseMessage response;
+            try
+            {
+                response = await ExchangeAsync(effectiveMessage, cts.Token).ConfigureAwait(false);
+
+                // RFC 1035 4.2.1 / RFC 7766 6.2.2: a truncated UDP answer must be retried over TCP, otherwise the
+                // caller silently receives a partial RRset.
+                if (response.Header.IsTruncated && _protocol is DnsClientProtocol.Udp && _options.RetryTruncatedOverTcp && _tcpFallback is not null)
+                {
+                    response = await ExchangeAsync(effectiveMessage, cts.Token, _tcpFallback).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                // The linked token fired because of our own timeout, not because the caller cancelled. Surfacing a
+                // bare OperationCanceledException here would be indistinguishable from caller cancellation.
+                throw new TimeoutException($"The DNS query timed out after {_options.Timeout}.", ex);
+            }
 
             if (validateResponse && _options.DnssecValidationMode is DnssecValidationMode.Local)
             {
                 var validator = new DnssecValidator(
                     SendWithoutValidationAsync,
                     _options.DnssecTrustAnchors,
-                    _options.TimeProvider);
-                response.DnssecValidationResult = await validator.ValidateAsync(response, cts.Token).ConfigureAwait(false);
+                    _options.TimeProvider,
+                    _options.EdnsUdpPayloadSize);
+
+                try
+                {
+                    response.DnssecValidationResult = await validator.ValidateAsync(response, cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"DNSSEC validation timed out after {_options.Timeout}.", ex);
+                }
+
                 activity?.SetTag("dns.dnssec.validation_status", response.DnssecValidationResult.Status.ToString());
             }
 
@@ -169,6 +200,18 @@ public sealed class DnsClient : IDisposable
         }
     }
 
+    private async Task<DnsResponseMessage> ExchangeAsync(DnsQueryMessage message, CancellationToken cancellationToken, IDnsTransport? transport = null)
+    {
+        var queryBytes = DnsMessageEncoder.EncodeQuery(message, out var queryId);
+        var responseBytes = await (transport ?? _transport).SendAsync(queryBytes, cancellationToken).ConfigureAwait(false);
+        var response = DnsMessageEncoder.DecodeResponse(
+            responseBytes,
+            preserveRawRecordData: _options.DnssecValidationMode is DnssecValidationMode.Local);
+
+        ValidateResponseMatchesQuery(message, queryId, response);
+        return response;
+    }
+
     private Task<DnsResponseMessage> SendWithoutValidationAsync(DnsQueryMessage message, CancellationToken cancellationToken)
     {
         return SendCoreAsync(message, validateResponse: false, cancellationToken);
@@ -177,7 +220,47 @@ public sealed class DnsClient : IDisposable
     /// <summary>Releases the resources used by this instance.</summary>
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _transport.Dispose();
+        _tcpFallback?.Dispose();
+    }
+
+    /// <summary>
+    /// Rejects a response that does not answer the query that was sent. Without this check any party able to deliver a
+    /// datagram — an off-path spoofer on UDP, or an on-path attacker — can substitute arbitrary records.
+    /// </summary>
+    private static void ValidateResponseMatchesQuery(DnsQueryMessage query, ushort queryId, DnsResponseMessage response)
+    {
+        if (response.Header.Id != queryId)
+            throw new DnsProtocolException($"The DNS response identifier (0x{response.Header.Id:X4}) does not match the query identifier (0x{queryId:X4}).");
+
+        if (!response.Header.IsResponse)
+            throw new DnsProtocolException("The DNS message is not a response (the QR bit is not set).");
+
+        if (response.Header.OpCode != query.OpCode)
+            throw new DnsProtocolException($"The DNS response operation code ({response.Header.OpCode}) does not match the query operation code ({query.OpCode}).");
+
+        // A FormErr response may legitimately omit the question section because the server could not parse it.
+        if (response.Questions.Count is 0 && response.Header.ResponseCode is DnsResponseCode.FormError)
+            return;
+
+        if (response.Questions.Count != query.Questions.Count)
+            throw new DnsProtocolException($"The DNS response contains {response.Questions.Count} question(s) but the query contained {query.Questions.Count}.");
+
+        for (var i = 0; i < query.Questions.Count; i++)
+        {
+            var asked = query.Questions[i];
+            var echoed = response.Questions[i];
+
+            if (echoed.Type != asked.Type || echoed.QueryClass != asked.QueryClass ||
+                !DnsNameComparer.Equals(echoed.Name, asked.Name))
+            {
+                throw new DnsProtocolException($"The DNS response question ({echoed.Name} {echoed.Type} {echoed.QueryClass}) does not match the query question ({asked.Name} {asked.Type} {asked.QueryClass}).");
+            }
+        }
     }
 
     private static string GetTransportName(DnsClientProtocol protocol)
@@ -211,43 +294,51 @@ public sealed class DnsClient : IDisposable
         if (options.DnssecValidationMode is DnssecValidationMode.Local && !options.EnableEdns)
             throw new ArgumentException("Local DNSSEC validation requires EDNS to be enabled.", nameof(options));
 
-        if (options.DnssecTrustAnchors is null)
-            throw new ArgumentException("DNSSEC trust anchors cannot be null.", nameof(options));
-
-        if (options.TimeProvider is null)
-            throw new ArgumentException("The DNSSEC time provider cannot be null.", nameof(options));
+        if (options.Timeout <= TimeSpan.Zero && options.Timeout != Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(nameof(options), options.Timeout, "The timeout must be positive, or Timeout.InfiniteTimeSpan for no timeout.");
     }
 
-    private void ApplyOptions(DnsQueryMessage message)
+    /// <summary>
+    /// Produces the message that will actually go on the wire, with the client's options applied. The caller's
+    /// message is never modified: it may be reused across calls or across clients with different options.
+    /// </summary>
+    private DnsQueryMessage CloneWithOptions(DnsQueryMessage message)
     {
         var localValidation = _options.DnssecValidationMode is DnssecValidationMode.Local;
         var requiresDnssecEdns = localValidation || _options.DnssecOk;
 
-        if (_options.EnableEdns && message.EdnsOptions is null && requiresDnssecEdns)
+        var clone = new DnsQueryMessage
         {
-            message.EdnsOptions = new DnsEdnsOptions
+            Id = message.Id,
+            OpCode = message.OpCode,
+            RecursionDesired = message.RecursionDesired,
+            CheckingDisabled = message.CheckingDisabled || localValidation,
+        };
+
+        foreach (var question in message.Questions)
+        {
+            // Unicode names are converted here rather than in QueryAsync so that SendAsync gets the same treatment.
+            clone.Questions.Add(new DnsQuestion(IdnHelper.ToAscii(question.Name), question.Type, question.QueryClass));
+        }
+
+        var edns = message.EdnsOptions;
+        if (edns is null && _options.EnableEdns)
+        {
+            edns = new DnsEdnsOptions();
+        }
+
+        if (edns is not null)
+        {
+            clone.EdnsOptions = new DnsEdnsOptions
             {
-                UdpPayloadSize = _options.EdnsUdpPayloadSize,
+                UdpPayloadSize = edns.UdpPayloadSize is 0 ? _options.EdnsUdpPayloadSize : edns.UdpPayloadSize,
+                Version = edns.Version,
+                ExtendedRCode = edns.ExtendedRCode,
+                DnssecOk = edns.DnssecOk || requiresDnssecEdns,
             };
         }
 
-        if (message.EdnsOptions is not null)
-        {
-            if (message.EdnsOptions.UdpPayloadSize == 0)
-            {
-                message.EdnsOptions.UdpPayloadSize = _options.EdnsUdpPayloadSize;
-            }
-
-            if (requiresDnssecEdns)
-            {
-                message.EdnsOptions.DnssecOk = true;
-            }
-        }
-
-        if (localValidation)
-        {
-            message.CheckingDisabled = true;
-        }
+        return clone;
     }
 
     private static DnsUdpTransport CreateUdpTransport(string server, DnsClientOptions options)
@@ -273,92 +364,72 @@ public sealed class DnsClient : IDisposable
         if (!Uri.TryCreate(server, UriKind.Absolute, out var uri))
             throw new ArgumentException($"Invalid DNS over HTTPS URL: {server}", nameof(server));
 
+        // DNS over HTTPS exists to keep queries off the plain network; accepting http:// would silently defeat that.
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+            throw new ArgumentException($"DNS over HTTPS requires an https:// URL, but the scheme was '{uri.Scheme}'.", nameof(server));
+
         return new DnsHttpsTransport(uri, options.HttpHandler, options.HttpVersion, options.HttpVersionPolicy);
     }
 
     [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]
     private static IDnsTransport CreateQuicTransport(string server, DnsClientOptions options)
     {
+        // Fail at construction rather than on every query, so callers can catch this and fall back to another protocol.
+        if (!QuicConnection.IsSupported)
+            throw new PlatformNotSupportedException("DNS over QUIC is not supported on this platform.");
+
         var (host, endpoint) = ParseHostAndEndpoint(server, defaultPort: 853, options);
         return new DnsQuicTransport(host, endpoint);
     }
 
     private static IPEndPoint ParseEndpoint(string server, int defaultPort, DnsClientOptions? options)
     {
-        if (IPAddress.TryParse(server, out var address))
-            return new IPEndPoint(address, defaultPort);
-
-        if (TryParseBracketedHostAndPort(server, out var bracketedHost, out var bracketedPort))
-        {
-            if (IPAddress.TryParse(bracketedHost, out var hostAddress))
-                return new IPEndPoint(hostAddress, bracketedPort);
-
-            var addresses = ResolveHost(bracketedHost, options);
-            if (addresses.Length is 0)
-                throw new ArgumentException($"Could not resolve host: {bracketedHost}", nameof(server));
-
-            return new IPEndPoint(addresses[0], bracketedPort);
-        }
-
-        // Try host:port format
-        var colonIndex = server.LastIndexOf(':', StringComparison.Ordinal);
-        if (colonIndex > 0 && int.TryParse(server.AsSpan(colonIndex + 1), System.Globalization.CultureInfo.InvariantCulture, out var port))
-        {
-            var host = server[..colonIndex];
-            if (IPAddress.TryParse(host, out var hostAddress))
-                return new IPEndPoint(hostAddress, port);
-
-            var addresses = ResolveHost(host, options);
-            if (addresses.Length is 0)
-                throw new ArgumentException($"Could not resolve host: {host}", nameof(server));
-
-            return new IPEndPoint(addresses[0], port);
-        }
-
-        // Resolve hostname
-        var resolved = ResolveHost(server, options);
-        if (resolved.Length is 0)
-            throw new ArgumentException($"Could not resolve host: {server}", nameof(server));
-
-        return new IPEndPoint(resolved[0], defaultPort);
+        return ParseHostAndEndpoint(server, defaultPort, options).Endpoint;
     }
 
     private static (string Host, IPEndPoint Endpoint) ParseHostAndEndpoint(string server, int defaultPort, DnsClientOptions? options)
     {
+        // The bracketed form must be tested first: IPAddress.TryParse accepts "[::1]:5353" and silently discards the
+        // port, which would send the query to the default port instead of the one the caller asked for.
+        if (TryParseBracketedHostAndPort(server, out var bracketedHost, out var bracketedPort))
+            return (bracketedHost, CreateEndpoint(bracketedHost, bracketedPort, server, options));
+
         if (IPAddress.TryParse(server, out var address))
             return (server, new IPEndPoint(address, defaultPort));
 
-        if (TryParseBracketedHostAndPort(server, out var bracketedHost, out var bracketedPort))
-        {
-            if (IPAddress.TryParse(bracketedHost, out var hostAddress))
-                return (bracketedHost, new IPEndPoint(hostAddress, bracketedPort));
-
-            var addresses = ResolveHost(bracketedHost, options);
-            if (addresses.Length is 0)
-                throw new ArgumentException($"Could not resolve host: {bracketedHost}", nameof(server));
-
-            return (bracketedHost, new IPEndPoint(addresses[0], bracketedPort));
-        }
-
+        // Any remaining colon means host:port - a DNS hostname cannot contain one, and bare IPv6 literals were
+        // already handled above. A malformed port must be reported against the server argument rather than being
+        // silently treated as part of a hostname.
         var colonIndex = server.LastIndexOf(':', StringComparison.Ordinal);
-        if (colonIndex > 0 && int.TryParse(server.AsSpan(colonIndex + 1), System.Globalization.CultureInfo.InvariantCulture, out var port))
+        if (colonIndex > 0)
         {
+            if (!TryParsePort(server.AsSpan(colonIndex + 1), out var port))
+                throw new ArgumentException($"Invalid port in DNS server address: {server}", nameof(server));
+
             var host = server[..colonIndex];
-            if (IPAddress.TryParse(host, out var hostAddress))
-                return (host, new IPEndPoint(hostAddress, port));
-
-            var addresses = ResolveHost(host, options);
-            if (addresses.Length is 0)
-                throw new ArgumentException($"Could not resolve host: {host}", nameof(server));
-
-            return (host, new IPEndPoint(addresses[0], port));
+            return (host, CreateEndpoint(host, port, server, options));
         }
 
-        var resolved = ResolveHost(server, options);
-        if (resolved.Length is 0)
-            throw new ArgumentException($"Could not resolve host: {server}", nameof(server));
+        return (server, CreateEndpoint(server, defaultPort, server, options));
+    }
 
-        return (server, new IPEndPoint(resolved[0], defaultPort));
+    private static IPEndPoint CreateEndpoint(string host, int port, string server, DnsClientOptions? options)
+    {
+        if (IPAddress.TryParse(host, out var address))
+            return new IPEndPoint(address, port);
+
+        var resolved = ResolveHost(host, options);
+        if (resolved.Length is 0)
+            throw new ArgumentException($"Could not resolve host '{host}' from DNS server address '{server}'.", nameof(server));
+
+        return new IPEndPoint(resolved[0], port);
+    }
+
+    private static bool TryParsePort(ReadOnlySpan<char> value, out int port)
+    {
+        // NumberStyles.None rejects the leading whitespace and sign that NumberStyles.Integer would accept.
+        return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out port)
+            && port is >= IPEndPoint.MinPort and <= IPEndPoint.MaxPort;
     }
 
     private static bool TryParseBracketedHostAndPort(string server, [NotNullWhen(true)] out string? host, out int port)
@@ -372,7 +443,7 @@ public sealed class DnsClient : IDisposable
         if (closingBracketIndex <= 1 || closingBracketIndex + 2 > server.Length || server[closingBracketIndex + 1] != ':')
             return false;
 
-        if (!int.TryParse(server.AsSpan(closingBracketIndex + 2), System.Globalization.CultureInfo.InvariantCulture, out port))
+        if (!TryParsePort(server.AsSpan(closingBracketIndex + 2), out port))
             return false;
 
         host = server[1..closingBracketIndex];

--- a/src/Meziantou.Framework.DnsClient/DnsClientOptions.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClientOptions.cs
@@ -13,8 +13,11 @@ public sealed class DnsClientOptions
     /// <summary>Gets or sets a value indicating whether to include EDNS(0) OPT records in queries. Default is <see langword="true"/>.</summary>
     public bool EnableEdns { get; set; } = true;
 
-    /// <summary>Gets or sets the EDNS UDP payload size. Default is 4096.</summary>
-    public ushort EdnsUdpPayloadSize { get; set; } = 4096;
+    /// <summary>
+    /// Gets or sets the EDNS UDP payload size. Default is 1232, the value recommended by RFC 9715 and DNS Flag Day
+    /// 2020 to avoid IP fragmentation; larger UDP answers are routinely dropped by middleboxes.
+    /// </summary>
+    public ushort EdnsUdpPayloadSize { get; set; } = 1232;
 
     /// <summary>Gets or sets a value indicating whether to set the DNSSEC OK (DO) flag. Default is <see langword="false"/>.</summary>
     public bool DnssecOk { get; set; }
@@ -28,8 +31,17 @@ public sealed class DnsClientOptions
     /// <summary>Gets or sets the time provider used for DNSSEC signature lifetime checks.</summary>
     public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
-    /// <summary>Gets or sets the HTTP version used for DNS over HTTPS requests. Default is HTTP/3.</summary>
-    public Version HttpVersion { get; set; } = System.Net.HttpVersion.Version30;
+    /// <summary>
+    /// Gets or sets a value indicating whether a truncated (TC) UDP response is automatically re-issued over TCP,
+    /// as RFC 1035 section 4.2.1 requires. Default is <see langword="true"/>. Only applies to <see cref="DnsClientProtocol.Udp"/>.
+    /// </summary>
+    public bool RetryTruncatedOverTcp { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the HTTP version used for DNS over HTTPS requests. Default is HTTP/2, which every DoH resolver
+    /// supports; requesting HTTP/3 costs a failed QUIC attempt per connection on hosts or servers without it.
+    /// </summary>
+    public Version HttpVersion { get; set; } = System.Net.HttpVersion.Version20;
 
     /// <summary>Gets or sets the HTTP version policy used for DNS over HTTPS requests. Default is <see cref="HttpVersionPolicy.RequestVersionOrLower"/>.</summary>
     public HttpVersionPolicy HttpVersionPolicy { get; set; } = HttpVersionPolicy.RequestVersionOrLower;

--- a/src/Meziantou.Framework.DnsClient/DnssecTrustAnchor.cs
+++ b/src/Meziantou.Framework.DnsClient/DnssecTrustAnchor.cs
@@ -34,6 +34,10 @@ public sealed class DnssecTrustAnchor
     public byte DigestType { get; }
 
     /// <summary>Gets the DS digest bytes.</summary>
-    [SuppressMessage("Performance", "CA1819:Properties should not return arrays")]
-    public byte[] Digest { get; }
+    /// <remarks>
+    /// Exposed as <see cref="ReadOnlyMemory{T}"/> rather than an array: <see cref="DnssecTrustAnchors.Root"/> is a
+    /// process-wide singleton and is the root of trust for every client, so handing out a writable reference to it
+    /// would let any code in the process silently break — or redirect — DNSSEC validation everywhere.
+    /// </remarks>
+    public ReadOnlyMemory<byte> Digest { get; }
 }

--- a/src/Meziantou.Framework.DnsClient/Internal/DenialKind.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DenialKind.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.DnsClient.Internal;
+
+/// <summary>What a denial of existence is being asked to prove.</summary>
+internal enum DenialKind
+{
+    /// <summary>That a name, or a type at a name, does not exist. NSEC3 opt-out spans cannot prove this.</summary>
+    NameOrData,
+
+    /// <summary>That no secure delegation exists at a name. NSEC3 opt-out spans do prove this.</summary>
+    Delegation,
+}

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+using System.Collections.Frozen;
 using System.Security.Cryptography;
 using Meziantou.Framework.DnsClient.Protocol;
 using Meziantou.Framework.DnsClient.Query;
@@ -16,7 +16,39 @@ internal static class DnssecCanonicalizer
         if (string.IsNullOrEmpty(name) || name is ".")
             return "";
 
-        return name.TrimEnd('.').ToLowerInvariant();
+        var span = name.AsSpan();
+        if (DnsName.EndsWithUnescapedDot(span))
+        {
+            span = span[..^1];
+        }
+
+        return span.IsEmpty ? "" : ToLowerAscii(span);
+    }
+
+    /// <summary>Downcases A-Z only. DNS case folding is ASCII-only (RFC 4343); culture-aware casing would be wrong.</summary>
+    private static string ToLowerAscii(ReadOnlySpan<char> value)
+    {
+        var needsLowering = false;
+        foreach (var c in value)
+        {
+            if (c is >= 'A' and <= 'Z')
+            {
+                needsLowering = true;
+                break;
+            }
+        }
+
+        if (!needsLowering)
+            return value.ToString();
+
+        return string.Create(value.Length, value, static (destination, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+            {
+                var c = source[i];
+                destination[i] = c is >= 'A' and <= 'Z' ? (char)(c + ('a' - 'A')) : c;
+            }
+        });
     }
 
     public static string ToDisplayName(string name)
@@ -58,14 +90,16 @@ internal static class DnssecCanonicalizer
         var writer = new DnsWireWriter(1024);
         WriteRrsigCoveredFields(ref writer, signature);
 
+        // RFC 4034 6.3: RRs are sorted by their canonical RDATA alone, treated as a left-justified unsigned octet
+        // sequence. Sorting by the full canonical RR would order by RDLENGTH first and produce a different sequence.
         var records = rrset
-            .Select(record => GetCanonicalRecordData(record, signature))
-            .Order(ByteArrayComparer.Instance)
+            .Select(record => (RData: GetCanonicalRData(record), Full: GetCanonicalRecordData(record, signature)))
+            .OrderBy(record => record.RData, ByteArrayComparer.Instance)
             .ToArray();
 
         foreach (var record in records)
         {
-            writer.WriteBytes(record);
+            writer.WriteBytes(record.Full);
         }
 
         return writer.ToArray();
@@ -108,11 +142,44 @@ internal static class DnssecCanonicalizer
         return digestType is 1 or 2 or 4;
     }
 
+    /// <summary>
+    /// The record types whose embedded domain names must be downcased in canonical form, per RFC 4034 section 6.2 as
+    /// amended by RFC 6840 section 5.1 (which removes NSEC's Next Domain Name from the list). Every other type's RDATA
+    /// is used verbatim, which is why newer types such as SVCB/HTTPS (RFC 9460) must not appear here.
+    /// </summary>
+    private static readonly FrozenSet<DnsQueryType> DowncasedRdataTypes = new[]
+    {
+        DnsQueryType.NS, DnsQueryType.CNAME, DnsQueryType.SOA, DnsQueryType.PTR, DnsQueryType.MX,
+        DnsQueryType.RP, DnsQueryType.NAPTR, DnsQueryType.SRV, DnsQueryType.DNAME, DnsQueryType.RRSIG,
+    }.ToFrozenSet();
+
     public static byte[] GetCanonicalRData(DnsRecord record)
     {
+        // Prefer the bytes as they arrived on the wire. Re-encoding from the parsed fields is lossy for any RDATA
+        // holding octets that the parser decoded as text (a CAA value or NAPTR regexp with a non-ASCII byte, say),
+        // and a single differing byte turns a legitimately signed RRset into a Bogus verdict.
+        if (record.RawData.Length > 0 && !DowncasedRdataTypes.Contains(record.RecordType))
+            return record.RawData;
+
         var writer = new DnsWireWriter(Math.Max(record.DataLength, (ushort)32));
         WriteCanonicalRData(ref writer, record);
         return writer.ToArray();
+    }
+
+    /// <summary>Returns the longest sequence of trailing labels the two names have in common.</summary>
+    public static string GetLongestCommonSuffix(string left, string right)
+    {
+        var leftLabels = DnsNameComparer.SplitLabels(NormalizeName(left));
+        var rightLabels = DnsNameComparer.SplitLabels(NormalizeName(right));
+
+        var count = 0;
+        while (count < leftLabels.Length && count < rightLabels.Length
+            && DnsNameComparer.CompareLabels(leftLabels[^(count + 1)], rightLabels[^(count + 1)]) is 0)
+        {
+            count++;
+        }
+
+        return count is 0 ? "" : string.Join('.', leftLabels[^count..]);
     }
 
     public static bool NsecCovers(string ownerName, string nextName, string name)
@@ -140,7 +207,14 @@ internal static class DnssecCanonicalizer
 
         var owner = GetCanonicalDomainNameBytes(name);
         var salt = record.Salt.AsSpan();
-        Span<byte> buffer = stackalloc byte[owner.Length + salt.Length];
+
+        // owner is bounded by DnsName.MaxLength and salt by a wire length byte, but size the buffer defensively
+        // rather than from parsed input: a stack overflow cannot be caught and would kill the process.
+        if (owner.Length > DnsName.MaxLength || salt.Length > 255)
+            return [];
+
+        Span<byte> buffer = stackalloc byte[DnsName.MaxLength + 255];
+        buffer = buffer[..(owner.Length + salt.Length)];
         owner.CopyTo(buffer);
         salt.CopyTo(buffer[owner.Length..]);
 #pragma warning disable CA5350 // NSEC3 hash algorithm 1 is SHA-1 by specification.
@@ -504,13 +578,12 @@ internal static class DnssecCanonicalizer
 
     private static string[] GetLabels(string name)
     {
-        var normalized = NormalizeName(name);
-        return normalized.Length is 0 ? [] : normalized.Split('.');
+        return DnsNameComparer.SplitLabels(NormalizeName(name));
     }
 
     private static int CompareCanonicalLabels(string left, string right)
     {
-        return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+        return DnsNameComparer.CompareLabels(left, right);
     }
 
     private sealed class ByteArrayComparer : IComparer<byte[]>
@@ -528,7 +601,9 @@ internal static class DnssecCanonicalizer
             if (y is null)
                 return 1;
 
-            return StructuralComparisons.StructuralComparer.Compare(x, y);
+            // RFC 4034 6.3 orders canonical RRs octet-wise, shorter-first on a common prefix.
+            // StructuralComparer cannot be used here: it throws when the arrays differ in length.
+            return x.AsSpan().SequenceCompareTo(y);
         }
     }
 }

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecValidator.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecValidator.cs
@@ -1,3 +1,4 @@
+using Meziantou.Framework.DnsClient.Protocol;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 using Meziantou.Framework.DnsClient.Response.Records;
@@ -10,15 +11,27 @@ internal sealed class DnssecValidator
     private readonly IReadOnlyList<DnssecTrustAnchor> _trustAnchors;
     private readonly TimeProvider _timeProvider;
     private readonly Dictionary<string, KeyValidationResult> _keyCache = new(StringComparer.Ordinal);
+    private readonly ushort _ednsUdpPayloadSize;
+
+    /// <summary>
+    /// Caps how many auxiliary queries one validation may issue. A hostile response can carry hundreds of RRSIGs with
+    /// unrelated signer names, each of which would otherwise start its own walk to the root.
+    /// </summary>
+    private int _queryBudget = DefaultQueryBudget;
+    private string? _lastQueryFailure;
+
+    private const int DefaultQueryBudget = 48;
 
     public DnssecValidator(
         Func<DnsQueryMessage, CancellationToken, Task<DnsResponseMessage>> queryAsync,
         IReadOnlyList<DnssecTrustAnchor> trustAnchors,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ushort ednsUdpPayloadSize)
     {
         _queryAsync = queryAsync;
         _trustAnchors = trustAnchors;
         _timeProvider = timeProvider;
+        _ednsUdpPayloadSize = ednsUdpPayloadSize;
     }
 
     public async Task<DnssecValidationResult> ValidateAsync(DnsResponseMessage response, CancellationToken cancellationToken)
@@ -36,9 +49,11 @@ internal sealed class DnssecValidator
         }
 
         var question = response.Questions[0];
+        var denialKind = question.Type is DnsQueryType.DS ? DenialKind.Delegation : DenialKind.NameOrData;
+
         if (response.Header.ResponseCode is DnsResponseCode.NameError)
         {
-            var denial = await ValidateDenialAsync(response, question.Name, question.Type, knownKeys: null, cancellationToken).ConfigureAwait(false);
+            var denial = await ValidateDenialAsync(response, question.Name, question.Type, knownKeys: null, denialKind, cancellationToken).ConfigureAwait(false);
             return ToResult(denial);
         }
 
@@ -50,14 +65,30 @@ internal sealed class DnssecValidator
         var answerRrsets = GroupRrsets(response.Answers).ToArray();
         if (answerRrsets.Length is 0)
         {
-            var denial = await ValidateDenialAsync(response, question.Name, question.Type, knownKeys: null, cancellationToken).ConfigureAwait(false);
+            var denial = await ValidateDenialAsync(response, question.Name, question.Type, knownKeys: null, denialKind, cancellationToken).ConfigureAwait(false);
             return ToResult(denial);
         }
 
-        var outcomes = new List<ValidationOutcome>(answerRrsets.Length);
-        foreach (var rrset in answerRrsets)
+        // A signed RRset only answers *this* query if it is reachable from the question name, following any CNAME or
+        // DNAME hops. Without this an attacker could return a genuinely signed RRset from a zone they control and have
+        // it reported as Secure.
+        var relevant = SelectRrsetsAnsweringQuestion(answerRrsets, question);
+        if (relevant.Count is 0)
+        {
+            return CreateResult(DnssecValidationStatus.Bogus, new DnssecValidationIssue(DnssecValidationIssueCode.InvalidData, "No answer RRset corresponds to the question that was asked.", question.Name, question.Type));
+        }
+
+        var outcomes = new List<ValidationOutcome>(relevant.Count);
+        foreach (var rrset in relevant)
         {
             outcomes.Add(await ValidateRrsetAsync(rrset.Records, rrset.Signatures, cancellationToken).ConfigureAwait(false));
+
+            // RFC 4035 5.3.4: an RRset synthesized from a wildcard needs a denial proving the queried name has no
+            // exact match, otherwise a captured wildcard signature can be replayed for a name with real data.
+            if (IsWildcardExpansion(rrset))
+            {
+                outcomes.Add(await ValidateWildcardDenialAsync(response, rrset.Name, rrset.Type, cancellationToken).ConfigureAwait(false));
+            }
         }
 
         return ToResult(CombineAll(outcomes));
@@ -81,6 +112,14 @@ internal sealed class DnssecValidator
         var outcomes = new List<ValidationOutcome>(signatures.Count);
         foreach (var signature in signatures)
         {
+            // Check the signer/owner relationship *before* any network I/O. The signer name is attacker-controlled, so
+            // fetching keys for it first would let one response fan out into a walk to the root per bogus signature.
+            if (!DnssecCanonicalizer.IsAncestorOrEqual(signature.SignerName, record.Name))
+            {
+                outcomes.Add(ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidData, "The RRSIG signer name is not an ancestor of the RRset owner name.", record.Name, record.RecordType)));
+                continue;
+            }
+
             var keys = await GetValidatedDnsKeysAsync(signature.SignerName, cancellationToken).ConfigureAwait(false);
             if (keys.Status is not DnssecValidationStatus.Secure)
             {
@@ -116,7 +155,10 @@ internal sealed class DnssecValidator
 
     private async Task<KeyValidationResult> ValidateRootDnsKeysAsync(CancellationToken cancellationToken)
     {
-        var response = await QueryAsync(".", DnsQueryType.DNSKEY, cancellationToken).ConfigureAwait(false);
+        var response = await TryQueryAsync(".", DnsQueryType.DNSKEY, cancellationToken).ConfigureAwait(false);
+        if (response is null)
+            return KeyValidationResult.Indeterminate(CreateQueryFailureIssue(".", DnsQueryType.DNSKEY));
+
         var keys = GetRecords<DnsDnskeyRecord>(response.Answers, "").ToArray();
         if (keys.Length is 0)
             return KeyValidationResult.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDnskey, "The root DNSKEY RRset is missing.", ".", DnsQueryType.DNSKEY));
@@ -144,11 +186,14 @@ internal sealed class DnssecValidator
         if (parentKeys.Status is not DnssecValidationStatus.Secure)
             return parentKeys;
 
-        var dsResponse = await QueryAsync(zoneName, DnsQueryType.DS, cancellationToken).ConfigureAwait(false);
+        var dsResponse = await TryQueryAsync(zoneName, DnsQueryType.DS, cancellationToken).ConfigureAwait(false);
+        if (dsResponse is null)
+            return KeyValidationResult.Indeterminate(CreateQueryFailureIssue(zoneName, DnsQueryType.DS));
+
         var dsRecords = GetRecords<DnsDsRecord>(dsResponse.Answers, zoneName).ToArray();
         if (dsRecords.Length is 0)
         {
-            var denial = await ValidateDenialAsync(dsResponse, zoneName, DnsQueryType.DS, parentKeys.Keys, cancellationToken).ConfigureAwait(false);
+            var denial = await ValidateDenialAsync(dsResponse, zoneName, DnsQueryType.DS, parentKeys.Keys, DenialKind.Delegation, cancellationToken).ConfigureAwait(false);
             return denial.Status is DnssecValidationStatus.Secure
                 ? KeyValidationResult.Insecure(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDs, "The delegation is authenticated as unsigned.", zoneName, DnsQueryType.DS))
                 : KeyValidationResult.From(denial.Status, denial.Issues);
@@ -159,7 +204,10 @@ internal sealed class DnssecValidator
         if (dsValidation.Status is not DnssecValidationStatus.Secure)
             return KeyValidationResult.From(dsValidation.Status, dsValidation.Issues);
 
-        var dnskeyResponse = await QueryAsync(zoneName, DnsQueryType.DNSKEY, cancellationToken).ConfigureAwait(false);
+        var dnskeyResponse = await TryQueryAsync(zoneName, DnsQueryType.DNSKEY, cancellationToken).ConfigureAwait(false);
+        if (dnskeyResponse is null)
+            return KeyValidationResult.Indeterminate(CreateQueryFailureIssue(zoneName, DnsQueryType.DNSKEY));
+
         var keys = GetRecords<DnsDnskeyRecord>(dnskeyResponse.Answers, zoneName).ToArray();
         if (keys.Length is 0)
             return KeyValidationResult.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDnskey, "The DNSKEY RRset is missing.", zoneName, DnsQueryType.DNSKEY));
@@ -189,11 +237,14 @@ internal sealed class DnssecValidator
             var parentKeys = await GetValidatedDnsKeysAsync(parentName, cancellationToken).ConfigureAwait(false);
             if (parentKeys.Status is DnssecValidationStatus.Secure)
             {
-                var dsResponse = await QueryAsync(zoneName, DnsQueryType.DS, cancellationToken).ConfigureAwait(false);
+                var dsResponse = await TryQueryAsync(zoneName, DnsQueryType.DS, cancellationToken).ConfigureAwait(false);
+                if (dsResponse is null)
+                    return ValidationOutcome.Indeterminate(CreateQueryFailureIssue(zoneName, DnsQueryType.DS));
+
                 var dsRecords = GetRecords<DnsDsRecord>(dsResponse.Answers, zoneName).ToArray();
                 if (dsRecords.Length is 0)
                 {
-                    var denial = await ValidateDenialAsync(dsResponse, zoneName, DnsQueryType.DS, parentKeys.Keys, cancellationToken).ConfigureAwait(false);
+                    var denial = await ValidateDenialAsync(dsResponse, zoneName, DnsQueryType.DS, parentKeys.Keys, DenialKind.Delegation, cancellationToken).ConfigureAwait(false);
                     if (denial.Status is DnssecValidationStatus.Secure)
                         return ValidationOutcome.Insecure(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDs, "The closest delegation is authenticated as unsigned.", zoneName, DnsQueryType.DS));
                 }
@@ -213,39 +264,148 @@ internal sealed class DnssecValidator
         return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.TrustChainIncomplete, "No authenticated insecure delegation was found.", name));
     }
 
-    private async Task<ValidationOutcome> ValidateDenialAsync(DnsResponseMessage response, string questionName, DnsQueryType questionType, IReadOnlyList<DnsDnskeyRecord>? knownKeys, CancellationToken cancellationToken)
+    /// <summary>
+    /// Validates a denial of existence (NXDOMAIN or NODATA) per RFC 4035 section 5.4 and RFC 5155 section 8.
+    /// </summary>
+    /// <param name="denialKind">
+    /// Whether this proves a name/type does not exist, or only that a secure delegation does not exist. NSEC3 opt-out
+    /// records prove the latter but never the former.
+    /// </param>
+    private async Task<ValidationOutcome> ValidateDenialAsync(
+        DnsResponseMessage response,
+        string questionName,
+        DnsQueryType questionType,
+        IReadOnlyList<DnsDnskeyRecord>? knownKeys,
+        DenialKind denialKind,
+        CancellationToken cancellationToken)
     {
         var nsecRrsets = GroupRrsets(response.Authorities)
             .Where(rrset => rrset.Type is DnsQueryType.NSEC or DnsQueryType.NSEC3)
             .ToArray();
         if (nsecRrsets.Length is 0)
         {
+            // An unsigned zone legitimately has no denial records; prove the delegation is unsigned before giving up.
+            var insecure = await FindInsecureDelegationAsync(questionName, cancellationToken).ConfigureAwait(false);
+            if (insecure.Status is DnssecValidationStatus.Insecure)
+                return insecure;
+
             return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "No NSEC or NSEC3 denial records were present.", questionName, questionType));
         }
 
         var outcomes = new List<ValidationOutcome>(nsecRrsets.Length);
-        var proofFound = false;
+        var nsecRecords = new List<DnsNsecRecord>();
+        var nsec3Records = new List<DnsNsec3Record>();
+        var boundToQuestion = false;
 
         foreach (var rrset in nsecRrsets)
         {
+            // A denial proof only speaks for the zone that signed it. Without this check a signed NSEC/NSEC3 taken
+            // from any zone the attacker controls could be replayed to deny the existence of any other name.
+            if (!SignsForQuestion(rrset.Signatures, questionName))
+                continue;
+
             var validation = knownKeys is null
                 ? await ValidateRrsetAsync(rrset.Records, rrset.Signatures, cancellationToken).ConfigureAwait(false)
                 : VerifyRrsetWithKeys(rrset.Records, rrset.Signatures, knownKeys);
             outcomes.Add(validation);
+            if (validation.Status is not DnssecValidationStatus.Secure)
+                continue;
 
-            if (validation.Status is DnssecValidationStatus.Secure && ProvesDenial(response.Header.ResponseCode, questionName, questionType, rrset.Records))
+            boundToQuestion = true;
+            foreach (var record in rrset.Records)
             {
-                proofFound = true;
+                switch (record)
+                {
+                    case DnsNsecRecord nsec:
+                        nsecRecords.Add(nsec);
+                        break;
+
+                    case DnsNsec3Record nsec3:
+                        nsec3Records.Add(nsec3);
+                        break;
+                }
             }
+        }
+
+        if (!boundToQuestion)
+        {
+            if (outcomes.Count is 0)
+            {
+                return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "The denial records are not signed by a zone that is authoritative for the queried name.", questionName, questionType));
+            }
+
+            return CombineAll(outcomes);
         }
 
         var combined = CombineAll(outcomes);
         if (combined.Status is not DnssecValidationStatus.Secure)
             return combined;
 
-        return proofFound
+        var proven = response.Header.ResponseCode is DnsResponseCode.NameError
+            ? ProvesNameError(questionName, nsecRecords, nsec3Records, denialKind)
+            : ProvesNoData(questionName, questionType, nsecRecords, nsec3Records, denialKind);
+
+        return proven
             ? ValidationOutcome.Secure()
             : ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "The denial records are signed but do not prove the requested denial.", questionName, questionType));
+    }
+
+    /// <summary>Determines whether a wildcard-expanded answer is accompanied by a proof that the queried name has no exact match (RFC 4035 section 5.3.4).</summary>
+    private async Task<ValidationOutcome> ValidateWildcardDenialAsync(DnsResponseMessage response, string questionName, DnsQueryType questionType, CancellationToken cancellationToken)
+    {
+        var nsecRrsets = GroupRrsets(response.Authorities)
+            .Where(rrset => rrset.Type is DnsQueryType.NSEC or DnsQueryType.NSEC3)
+            .ToArray();
+        if (nsecRrsets.Length is 0)
+        {
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "The answer was synthesized from a wildcard but the response carries no NSEC or NSEC3 proving the queried name does not exist.", questionName, questionType));
+        }
+
+        var outcomes = new List<ValidationOutcome>(nsecRrsets.Length);
+        var nsecRecords = new List<DnsNsecRecord>();
+        var nsec3Records = new List<DnsNsec3Record>();
+
+        foreach (var rrset in nsecRrsets)
+        {
+            if (!SignsForQuestion(rrset.Signatures, questionName))
+                continue;
+
+            var validation = await ValidateRrsetAsync(rrset.Records, rrset.Signatures, cancellationToken).ConfigureAwait(false);
+            outcomes.Add(validation);
+            if (validation.Status is not DnssecValidationStatus.Secure)
+                continue;
+
+            foreach (var record in rrset.Records)
+            {
+                switch (record)
+                {
+                    case DnsNsecRecord nsec:
+                        nsecRecords.Add(nsec);
+                        break;
+
+                    case DnsNsec3Record nsec3:
+                        nsec3Records.Add(nsec3);
+                        break;
+                }
+            }
+        }
+
+        var combined = outcomes.Count is 0
+            ? ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "The wildcard denial records are not signed by a zone that is authoritative for the queried name.", questionName, questionType))
+            : CombineAll(outcomes);
+        if (combined.Status is not DnssecValidationStatus.Secure)
+            return combined;
+
+        return CoversName(questionName, nsecRecords, nsec3Records, DenialKind.NameOrData)
+            ? ValidationOutcome.Secure()
+            : ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "The answer was synthesized from a wildcard but no NSEC or NSEC3 proves the queried name does not exist.", questionName, questionType));
+    }
+
+    /// <summary>Determines whether every signature on a denial RRset was made by a zone at or above the queried name.</summary>
+    private static bool SignsForQuestion(IReadOnlyList<DnsRrsigRecord> signatures, string questionName)
+    {
+        return signatures.Count > 0
+            && signatures.All(signature => DnssecCanonicalizer.IsAncestorOrEqual(signature.SignerName, questionName));
     }
 
     private ValidationOutcome VerifyRrsetWithKeys(IReadOnlyList<DnsRecord> rrset, IReadOnlyList<DnsRrsigRecord> signatures, IReadOnlyList<DnsDnskeyRecord> keys)
@@ -269,18 +429,20 @@ internal sealed class DnssecValidator
     private ValidationOutcome VerifySignature(IReadOnlyList<DnsRecord> rrset, DnsRrsigRecord signature, IReadOnlyList<DnsDnskeyRecord> keys)
     {
         var record = rrset[0];
-        var now = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        var now = unchecked((uint)_timeProvider.GetUtcNow().ToUnixTimeSeconds());
         if (!DnssecCanonicalizer.IsAncestorOrEqual(signature.SignerName, record.Name))
         {
             return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidData, "The RRSIG signer name is not an ancestor of the RRset owner name.", record.Name, record.RecordType));
         }
 
-        if (now < signature.SignatureInception)
+        // RFC 4034 3.1.5: the 32-bit timestamps use RFC 1982 serial arithmetic, so they must be compared as signed
+        // differences rather than as absolute values. A plain comparison breaks when the field wraps in 2106.
+        if (IsBefore(now, signature.SignatureInception))
         {
             return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureNotYetValid, "The RRSIG inception time is in the future.", record.Name, record.RecordType));
         }
 
-        if (now > signature.SignatureExpiration)
+        if (IsBefore(signature.SignatureExpiration, now))
         {
             return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureExpired, "The RRSIG has expired.", record.Name, record.RecordType));
         }
@@ -314,65 +476,288 @@ internal sealed class DnssecValidator
         return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureVerificationFailed, "No RRSIG signature could be verified with the matching DNSKEY.", record.Name, record.RecordType));
     }
 
-    private async Task<DnsResponseMessage> QueryAsync(string name, DnsQueryType type, CancellationToken cancellationToken)
+    /// <summary>
+    /// Issues an auxiliary query for the chain of trust. Failures are reported as a <see langword="null"/> result so
+    /// the caller can produce an Indeterminate verdict: a transient network error while fetching a DS or DNSKEY must
+    /// not throw away the answer the caller actually asked for.
+    /// </summary>
+    /// <summary>Serial-number comparison (RFC 1982): true when <paramref name="left"/> precedes <paramref name="right"/>.</summary>
+    private static bool IsBefore(uint left, uint right) => unchecked((int)(left - right)) < 0;
+
+    private async Task<DnsResponseMessage?> TryQueryAsync(string name, DnsQueryType type, CancellationToken cancellationToken)
     {
+        if (_queryBudget <= 0)
+            return null;
+
+        _queryBudget--;
+
         var query = new DnsQueryMessage
         {
             RecursionDesired = true,
+            // CheckingDisabled and DnssecOk are required by the algorithm: we validate locally and therefore need the
+            // records themselves rather than the upstream resolver's verdict.
             CheckingDisabled = true,
             EdnsOptions = new DnsEdnsOptions
             {
-                UdpPayloadSize = 4096,
+                UdpPayloadSize = _ednsUdpPayloadSize,
                 DnssecOk = true,
             },
         };
         query.Questions.Add(new DnsQuestion(DnssecCanonicalizer.ToDisplayName(name), type));
 
-        return await _queryAsync(query, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await _queryAsync(query, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is the caller's decision and must not be downgraded to a verdict.
+            throw;
+        }
+#pragma warning disable CA1031 // Any failure to fetch a chain record is an Indeterminate verdict, not an exception.
+        catch (Exception ex)
+        {
+            _lastQueryFailure = $"The query for {DnssecCanonicalizer.ToDisplayName(name)} {type} failed: {ex.Message}";
+            return null;
+        }
+#pragma warning restore CA1031
     }
 
-    private static bool ProvesDenial(DnsResponseCode responseCode, string questionName, DnsQueryType questionType, IReadOnlyList<DnsRecord> records)
+    private DnssecValidationIssue CreateQueryFailureIssue(string name, DnsQueryType type)
     {
-        foreach (var record in records)
-        {
-            if (record is DnsNsecRecord nsecRecord && NsecProvesDenial(responseCode, questionName, questionType, nsecRecord))
-                return true;
+        var message = _lastQueryFailure ?? $"The query budget was exhausted before {DnssecCanonicalizer.ToDisplayName(name)} {type} could be resolved.";
+        var code = _lastQueryFailure is null ? DnssecValidationIssueCode.QueryBudgetExceeded : DnssecValidationIssueCode.ChainQueryFailed;
+        _lastQueryFailure = null;
+        return new DnssecValidationIssue(code, message, DnssecCanonicalizer.ToDisplayName(name), type);
+    }
 
-            if (record is DnsNsec3Record nsec3Record && Nsec3ProvesDenial(responseCode, questionName, questionType, nsec3Record))
+    /// <summary>Proves that the name exists but carries no record of the queried type (RFC 4035 section 5.4, RFC 5155 section 8.5/8.6).</summary>
+    private static bool ProvesNoData(string questionName, DnsQueryType questionType, IReadOnlyList<DnsNsecRecord> nsecRecords, IReadOnlyList<DnsNsec3Record> nsec3Records, DenialKind denialKind)
+    {
+        foreach (var nsec in nsecRecords)
+        {
+            if (DnssecCanonicalizer.CompareCanonicalNames(nsec.Name, questionName) is 0)
+                return !nsec.TypeBitMaps.Contains(questionType) && !nsec.TypeBitMaps.Contains(DnsQueryType.CNAME);
+        }
+
+        foreach (var nsec3 in nsec3Records)
+        {
+            if (Nsec3Matches(nsec3, questionName))
+                return !nsec3.TypeBitMaps.Contains(questionType) && !nsec3.TypeBitMaps.Contains(DnsQueryType.CNAME);
+        }
+
+        // RFC 5155 section 8.6: a NODATA proof for a name covered by an opt-out span is only valid for DS queries.
+        if (denialKind is DenialKind.Delegation && questionType is DnsQueryType.DS)
+            return CoversName(questionName, nsecRecords, nsec3Records, denialKind);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Proves that the name does not exist. RFC 4035 section 5.4 requires two proofs: one covering the queried name and
+    /// one showing that no wildcard at the closest encloser could have synthesized an answer.
+    /// </summary>
+    private static bool ProvesNameError(string questionName, IReadOnlyList<DnsNsecRecord> nsecRecords, IReadOnlyList<DnsNsec3Record> nsec3Records, DenialKind denialKind)
+    {
+        if (!CoversName(questionName, nsecRecords, nsec3Records, denialKind))
+            return false;
+
+        var closestEncloser = GetClosestEncloser(questionName, nsecRecords, nsec3Records);
+        if (closestEncloser is null)
+            return false;
+
+        var wildcard = closestEncloser.Length is 0 ? "*" : "*." + closestEncloser;
+        return CoversOrMatchesAbsentWildcard(wildcard, nsecRecords, nsec3Records, denialKind);
+    }
+
+    /// <summary>Determines whether some NSEC/NSEC3 proves the name does not exist (its hash or canonical position falls inside a gap).</summary>
+    private static bool CoversName(string name, IReadOnlyList<DnsNsecRecord> nsecRecords, IReadOnlyList<DnsNsec3Record> nsec3Records, DenialKind denialKind)
+    {
+        foreach (var nsec in nsecRecords)
+        {
+            if (DnssecCanonicalizer.NsecCovers(nsec.Name, nsec.NextDomainName, name))
+                return true;
+        }
+
+        foreach (var nsec3 in nsec3Records)
+        {
+            if (!IsOptOutUsable(nsec3, denialKind))
+                continue;
+
+            if (Nsec3Covers(nsec3, name))
                 return true;
         }
 
         return false;
     }
 
-    private static bool NsecProvesDenial(DnsResponseCode responseCode, string questionName, DnsQueryType questionType, DnsNsecRecord record)
+    /// <summary>Determines whether the wildcard name is proven absent, either by an exact NSEC/NSEC3 with no relevant types or by a covering gap.</summary>
+    private static bool CoversOrMatchesAbsentWildcard(string wildcard, IReadOnlyList<DnsNsecRecord> nsecRecords, IReadOnlyList<DnsNsec3Record> nsec3Records, DenialKind denialKind)
     {
-        var ownerName = DnssecCanonicalizer.NormalizeName(record.Name);
-        var normalizedQuestionName = DnssecCanonicalizer.NormalizeName(questionName);
-
-        if (ownerName == normalizedQuestionName)
+        foreach (var nsec in nsecRecords)
         {
-            return !record.TypeBitMaps.Contains(questionType) && !record.TypeBitMaps.Contains(DnsQueryType.CNAME);
+            if (DnssecCanonicalizer.CompareCanonicalNames(nsec.Name, wildcard) is 0)
+                return true;
         }
 
-        return responseCode is DnsResponseCode.NameError && DnssecCanonicalizer.NsecCovers(ownerName, record.NextDomainName, normalizedQuestionName);
+        foreach (var nsec3 in nsec3Records)
+        {
+            if (Nsec3Matches(nsec3, wildcard))
+                return true;
+        }
+
+        return CoversName(wildcard, nsecRecords, nsec3Records, denialKind);
     }
 
-    private static bool Nsec3ProvesDenial(DnsResponseCode responseCode, string questionName, DnsQueryType questionType, DnsNsec3Record record)
+    /// <summary>
+    /// Determines the closest encloser: the deepest ancestor of <paramref name="questionName"/> that provably exists.
+    /// </summary>
+    /// <remarks>
+    /// For NSEC3 (RFC 5155 section 8.3) it is the deepest ancestor whose hash matches an NSEC3 owner. For NSEC it is
+    /// derived from the covering record: the owner and next names both exist in the zone, so the longest suffix either
+    /// shares with the queried name is an existing ancestor. Deriving it this way rather than demanding an exact owner
+    /// match is what makes minimally-covering NSEC zones (RFC 4470) validate.
+    /// </remarks>
+    private static string? GetClosestEncloser(string questionName, IReadOnlyList<DnsNsecRecord> nsecRecords, IReadOnlyList<DnsNsec3Record> nsec3Records)
     {
-        var ownerHashLabel = DnssecCanonicalizer.NormalizeName(record.Name).Split('.')[0];
-        var ownerHash = DnssecCanonicalizer.DecodeBase32Hex(ownerHashLabel);
+        string? closest = null;
+
+        foreach (var nsec in nsecRecords)
+        {
+            if (!DnssecCanonicalizer.NsecCovers(nsec.Name, nsec.NextDomainName, questionName))
+                continue;
+
+            closest = Deeper(closest, DnssecCanonicalizer.GetLongestCommonSuffix(questionName, nsec.Name));
+            closest = Deeper(closest, DnssecCanonicalizer.GetLongestCommonSuffix(questionName, nsec.NextDomainName));
+        }
+
+        if (nsec3Records.Count > 0)
+        {
+            var candidate = DnssecCanonicalizer.GetParentName(DnssecCanonicalizer.NormalizeName(questionName));
+            while (true)
+            {
+                foreach (var nsec3 in nsec3Records)
+                {
+                    if (Nsec3Matches(nsec3, candidate))
+                        return Deeper(closest, candidate) ?? candidate;
+                }
+
+                if (candidate.Length is 0)
+                    break;
+
+                candidate = DnssecCanonicalizer.GetParentName(candidate);
+            }
+        }
+
+        // The closest encloser must be a proper ancestor: the queried name itself does not exist.
+        if (closest is not null && DnssecCanonicalizer.CountLabels(closest) >= DnssecCanonicalizer.CountLabels(questionName))
+            return null;
+
+        return closest;
+    }
+
+    private static string? Deeper(string? left, string right)
+    {
+        if (left is null)
+            return right;
+
+        return DnssecCanonicalizer.CountLabels(right) > DnssecCanonicalizer.CountLabels(left) ? right : left;
+    }
+
+    private static bool Nsec3Matches(DnsNsec3Record record, string name)
+    {
+        var ownerHash = GetNsec3OwnerHash(record);
         if (ownerHash.Length is 0)
             return false;
 
-        var questionHash = DnssecCanonicalizer.ComputeNsec3Hash(questionName, record);
-        if (questionHash.Length is 0)
+        var hash = DnssecCanonicalizer.ComputeNsec3Hash(name, record);
+        return hash.Length > 0 && ownerHash.AsSpan().SequenceEqual(hash);
+    }
+
+    private static bool Nsec3Covers(DnsNsec3Record record, string name)
+    {
+        var ownerHash = GetNsec3OwnerHash(record);
+        if (ownerHash.Length is 0)
             return false;
 
-        if (ownerHash.AsSpan().SequenceEqual(questionHash))
-            return !record.TypeBitMaps.Contains(questionType) && !record.TypeBitMaps.Contains(DnsQueryType.CNAME);
+        var hash = DnssecCanonicalizer.ComputeNsec3Hash(name, record);
+        return hash.Length > 0 && DnssecCanonicalizer.Nsec3Covers(ownerHash, record.NextHashedOwnerName, hash);
+    }
 
-        return responseCode is DnsResponseCode.NameError && DnssecCanonicalizer.Nsec3Covers(ownerHash, record.NextHashedOwnerName, questionHash);
+    /// <summary>
+    /// RFC 5155 section 6: an NSEC3 with the Opt-Out flag set only proves that no *signed delegation* exists in its
+    /// span. Unsigned names may exist there, so it can never prove that a name does not exist.
+    /// </summary>
+    private static bool IsOptOutUsable(DnsNsec3Record record, DenialKind denialKind)
+    {
+        const byte OptOutFlag = 0x01;
+        return (record.Flags & OptOutFlag) is 0 || denialKind is DenialKind.Delegation;
+    }
+
+    private static byte[] GetNsec3OwnerHash(DnsNsec3Record record)
+    {
+        var label = DnsNameComparer.SplitLabels(DnssecCanonicalizer.NormalizeName(record.Name));
+        return label.Length is 0 ? [] : DnssecCanonicalizer.DecodeBase32Hex(label[0]);
+    }
+
+    /// <summary>
+    /// Selects the answer RRsets that actually answer the question, following the CNAME/DNAME chain from the queried
+    /// name. RRsets that are not reachable from the question are discarded rather than contributing to the verdict.
+    /// </summary>
+    private static List<DnsRecordRrset> SelectRrsetsAnsweringQuestion(IReadOnlyList<DnsRecordRrset> rrsets, DnsQuestion question)
+    {
+        var selected = new List<DnsRecordRrset>();
+        var target = DnssecCanonicalizer.NormalizeName(question.Name);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+
+        while (visited.Add(target))
+        {
+            var match = rrsets.FirstOrDefault(rrset =>
+                rrset.Type == question.Type && DnssecCanonicalizer.CompareCanonicalNames(rrset.Name, target) is 0);
+            if (match is not null)
+            {
+                selected.Add(match);
+                break;
+            }
+
+            var cname = rrsets.FirstOrDefault(rrset =>
+                rrset.Type is DnsQueryType.CNAME && DnssecCanonicalizer.CompareCanonicalNames(rrset.Name, target) is 0);
+            if (cname is not null)
+            {
+                selected.Add(cname);
+                target = DnssecCanonicalizer.NormalizeName(((DnsCnameRecord)cname.Records[0]).CanonicalName);
+                continue;
+            }
+
+            var dname = rrsets.FirstOrDefault(rrset =>
+                rrset.Type is DnsQueryType.DNAME && DnssecCanonicalizer.IsAncestorOrEqual(rrset.Name, target));
+            if (dname is not null)
+            {
+                selected.Add(dname);
+
+                // The DNAME's synthesized CNAME, if present, carries the chain forward; otherwise the chain ends here.
+                var synthesized = rrsets.FirstOrDefault(rrset =>
+                    rrset.Type is DnsQueryType.CNAME && DnssecCanonicalizer.CompareCanonicalNames(rrset.Name, target) is 0);
+                if (synthesized is null)
+                    break;
+
+                continue;
+            }
+
+            break;
+        }
+
+        return selected;
+    }
+
+    /// <summary>
+    /// Determines whether an RRset was synthesized from a wildcard, i.e. every RRSIG covers fewer labels than the
+    /// owner name has. RFC 4034 3.1.3 also forbids a label count greater than the owner's.
+    /// </summary>
+    private static bool IsWildcardExpansion(DnsRecordRrset rrset)
+    {
+        var ownerLabels = DnssecCanonicalizer.CountLabels(rrset.Name);
+        return rrset.Signatures.Count > 0 && rrset.Signatures.All(signature => signature.Labels < ownerLabels);
     }
 
     private static IEnumerable<DnsRecordRrset> GroupRrsets(IReadOnlyList<DnsRecord> records)
@@ -410,7 +795,7 @@ internal sealed class DnssecValidator
             && anchor.KeyTag == DnssecCanonicalizer.ComputeKeyTag(key)
             && anchor.Algorithm == key.Algorithm
             && DnssecCanonicalizer.IsSupportedDigest(anchor.DigestType)
-            && DnssecCanonicalizer.ComputeDigest(ownerName, key, anchor.DigestType).AsSpan().SequenceEqual(anchor.Digest);
+            && DnssecCanonicalizer.ComputeDigest(ownerName, key, anchor.DigestType).AsSpan().SequenceEqual(anchor.Digest.Span);
     }
 
     private static bool IsDsMatch(string ownerName, DnsDnskeyRecord key, IReadOnlyList<DnsDsRecord> dsRecords, List<DnssecValidationIssue> issues)

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Cryptography;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 using Meziantou.Framework.DnsClient.Response.Records;
@@ -8,12 +9,13 @@ namespace Meziantou.Framework.DnsClient.Protocol;
 
 internal static class DnsMessageEncoder
 {
-    [SuppressMessage("Security", "CA5394:Random is an insecure random number generator")]
-    public static byte[] EncodeQuery(DnsQueryMessage query)
+    public static byte[] EncodeQuery(DnsQueryMessage query, out ushort id)
     {
         var writer = new DnsWireWriter(512);
 
-        var id = query.Id ?? (ushort)Random.Shared.Next(0, ushort.MaxValue + 1);
+        // The query ID is the only thing an off-path attacker has to guess, so it must come from a CSPRNG rather
+        // than from a predictable PRNG such as Random.Shared.
+        id = query.Id ?? (ushort)RandomNumberGenerator.GetInt32(0, ushort.MaxValue + 1);
 
         // Header
         writer.WriteUInt16(id);
@@ -108,6 +110,15 @@ internal static class DnsMessageEncoder
         response.Authorities = ReadRecords(ref reader, header.AuthorityCount, preserveRawRecordData);
         response.AdditionalRecords = ReadRecords(ref reader, header.AdditionalCount, preserveRawRecordData);
 
+        // RFC 6891 6.1.3: the full RCODE is the OPT record's extended bits followed by the header's four bits.
+        // Without this, BADVERS (16) and every other extended code decodes as the header's low nibble - BADVERS
+        // would look like NoError.
+        var opt = response.AdditionalRecords.OfType<DnsOptRecord>().FirstOrDefault();
+        if (opt is not null && opt.ExtendedRCode is not 0)
+        {
+            header.ResponseCode = (DnsResponseCode)((opt.ExtendedRCode << 4) | (flags & 0x000F));
+        }
+
         return response;
     }
 
@@ -123,7 +134,11 @@ internal static class DnsMessageEncoder
             var rdLength = reader.ReadUInt16();
 
             var rdataStart = reader.Position;
-            var record = ParseRecord(ref reader, type, rdLength);
+
+            // Parse RDATA through a reader bounded to exactly rdLength bytes, so a length field inside the record
+            // cannot reach into the following record and silently desynchronize the rest of the message.
+            var rdataReader = reader.ReadWindow(rdLength);
+            var record = ParseRecord(ref rdataReader, type, rdLength);
 
             record.Name = name;
             record.RecordType = type;
@@ -141,13 +156,6 @@ internal static class DnsMessageEncoder
                 optRecord.ExtendedRCode = (byte)(ttl >> 24);
                 optRecord.EdnsVersion = (byte)(ttl >> 16);
                 optRecord.DnssecOk = ((ushort)ttl & 0x8000) != 0;
-            }
-
-            // Ensure we consumed exactly rdLength bytes
-            var consumed = reader.Position - rdataStart;
-            if (consumed < rdLength)
-            {
-                reader.Skip(rdLength - consumed);
             }
 
             records.Add(record);
@@ -171,8 +179,9 @@ internal static class DnsMessageEncoder
             DnsQueryType.TXT => ParseTxtRecord(ref reader, rdLength),
             DnsQueryType.CAA => ParseCaaRecord(ref reader, rdLength),
             DnsQueryType.NAPTR => ParseNaptrRecord(ref reader),
-            DnsQueryType.DNSKEY => ParseDnskeyRecord(ref reader, rdLength),
-            DnsQueryType.DS => ParseDsRecord(ref reader, rdLength),
+            // CDNSKEY and CDS are wire-identical to DNSKEY and DS (RFC 7344).
+            DnsQueryType.DNSKEY or DnsQueryType.CDNSKEY => ParseDnskeyRecord(ref reader, rdLength),
+            DnsQueryType.DS or DnsQueryType.CDS => ParseDsRecord(ref reader, rdLength),
             DnsQueryType.RRSIG => ParseRrsigRecord(ref reader, rdLength),
             DnsQueryType.NSEC => ParseNsecRecord(ref reader, rdLength),
             DnsQueryType.NSEC3 => ParseNsec3Record(ref reader, rdLength),
@@ -536,6 +545,9 @@ internal static class DnsMessageEncoder
         {
             var windowBlock = reader.ReadByte();
             var bitmapLength = reader.ReadByte();
+            if (bitmapLength is 0 or > 32)
+                throw new DnsProtocolException($"Invalid NSEC type bitmap window length: {bitmapLength}. It must be between 1 and 32 (RFC 4034 4.1.2).");
+
             var bitmap = reader.ReadBytes(bitmapLength);
 
             for (var i = 0; i < bitmapLength; i++)

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsName.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsName.cs
@@ -1,0 +1,180 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.DnsClient.Protocol;
+
+/// <summary>
+/// Conversions between the DNS wire format for domain names and the RFC 1035 section 5.1 presentation format.
+/// </summary>
+/// <remarks>
+/// Labels may contain arbitrary octets, including <c>.</c> and bytes outside the printable ASCII range. Escaping them
+/// keeps distinct wire names distinct as strings: a single label <c>evil.com</c> becomes <c>evil\.com</c> and cannot be
+/// confused with the two-label name <c>evil.com</c>.
+/// </remarks>
+internal static class DnsName
+{
+    /// <summary>The maximum length of a domain name in wire format, including length octets and the root label (RFC 1035 section 2.3.4).</summary>
+    public const int MaxLength = 255;
+
+    /// <summary>The maximum length of a single label in wire format (RFC 1035 section 2.3.4).</summary>
+    public const int MaxLabelLength = 63;
+
+    /// <summary>The maximum number of labels a name can have, given <see cref="MaxLength"/>.</summary>
+    public const int MaxLabels = MaxLength / 2;
+
+    /// <summary>Appends a wire-format label to <paramref name="builder"/> in presentation format.</summary>
+    public static void AppendLabel(StringBuilder builder, ReadOnlySpan<byte> label)
+    {
+        foreach (var b in label)
+        {
+            switch (b)
+            {
+                case (byte)'.':
+                    builder.Append("\\.");
+                    break;
+
+                case (byte)'\\':
+                    builder.Append("\\\\");
+                    break;
+
+                case >= 0x21 and <= 0x7E:
+                    builder.Append((char)b);
+                    break;
+
+                default:
+                    builder.Append('\\')
+                        .Append((char)('0' + (b / 100)))
+                        .Append((char)('0' + (b / 10 % 10)))
+                        .Append((char)('0' + (b % 10)));
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Decodes a presentation-format label into wire-format octets, resolving <c>\\</c> escapes.</summary>
+    /// <returns>The number of octets written to <paramref name="destination"/>.</returns>
+    public static int DecodeLabel(ReadOnlySpan<char> label, Span<byte> destination)
+    {
+        var count = 0;
+        for (var i = 0; i < label.Length; i++)
+        {
+            var c = label[i];
+            byte value;
+
+            if (c is '\\')
+            {
+                i++;
+                if (i >= label.Length)
+                    throw new DnsProtocolException("Invalid escape sequence at the end of a domain name label.");
+
+                if (char.IsAsciiDigit(label[i]))
+                {
+                    if (i + 2 >= label.Length || !char.IsAsciiDigit(label[i + 1]) || !char.IsAsciiDigit(label[i + 2]))
+                        throw new DnsProtocolException("A decimal escape sequence in a domain name label must have exactly three digits.");
+
+                    var number = ((label[i] - '0') * 100) + ((label[i + 1] - '0') * 10) + (label[i + 2] - '0');
+                    if (number > 255)
+                        throw new DnsProtocolException($"Invalid decimal escape sequence '\\{number}' in a domain name label.");
+
+                    value = (byte)number;
+                    i += 2;
+                }
+                else if (label[i] > 0x7F)
+                {
+                    throw new DnsProtocolException($"Domain name label contains the non-ASCII character '{label[i]}'. Convert the name to punycode first.");
+                }
+                else
+                {
+                    value = (byte)label[i];
+                }
+            }
+            else if (c > 0x7F)
+            {
+                throw new DnsProtocolException($"Domain name label contains the non-ASCII character '{c}'. Convert the name to punycode first.");
+            }
+            else
+            {
+                value = (byte)c;
+            }
+
+            if (count >= destination.Length)
+                throw new DnsProtocolException($"Domain name label exceeds the maximum length of {MaxLabelLength} bytes.");
+
+            destination[count++] = value;
+        }
+
+        return count;
+    }
+
+    /// <summary>Returns the index of the first <c>.</c> that is not part of an escape sequence, or -1.</summary>
+    public static int IndexOfUnescapedDot(ReadOnlySpan<char> value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] is '\\')
+            {
+                i++;
+                continue;
+            }
+
+            if (value[i] is '.')
+                return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>Returns <see langword="true"/> when the name ends with a dot that is not part of an escape sequence.</summary>
+    public static bool EndsWithUnescapedDot(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty || value[^1] is not '.')
+            return false;
+
+        // The dot is escaped when it is preceded by an odd number of backslashes.
+        var backslashes = 0;
+        for (var i = value.Length - 2; i >= 0 && value[i] is '\\'; i--)
+        {
+            backslashes++;
+        }
+
+        return backslashes % 2 is 0;
+    }
+
+    /// <summary>Splits a presentation-format name into its labels, ignoring escaped dots.</summary>
+    public static LabelEnumerator EnumerateLabels(ReadOnlySpan<char> name) => new(name);
+
+    [StructLayout(LayoutKind.Auto)]
+    public ref struct LabelEnumerator
+    {
+        private ReadOnlySpan<char> _remaining;
+
+        public LabelEnumerator(ReadOnlySpan<char> name)
+        {
+            _remaining = name;
+            Current = default;
+        }
+
+        public ReadOnlySpan<char> Current { get; private set; }
+
+        public readonly LabelEnumerator GetEnumerator() => this;
+
+        public bool MoveNext()
+        {
+            if (_remaining.IsEmpty)
+                return false;
+
+            var index = IndexOfUnescapedDot(_remaining);
+            if (index == -1)
+            {
+                Current = _remaining;
+                _remaining = [];
+            }
+            else
+            {
+                Current = _remaining[..index];
+                _remaining = _remaining[(index + 1)..];
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsNameComparer.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsNameComparer.cs
@@ -1,0 +1,104 @@
+namespace Meziantou.Framework.DnsClient.Protocol;
+
+/// <summary>
+/// Comparison of domain names in presentation format, done on the underlying wire octets.
+/// </summary>
+/// <remarks>
+/// Names are compared octet-wise after downcasing A-Z, per RFC 4034 section 6.1 and RFC 4343. A string comparison
+/// cannot stand in for this: <see cref="StringComparison.OrdinalIgnoreCase"/> folds to uppercase and therefore orders
+/// every character between <c>Z</c> (0x5A) and <c>a</c> (0x61) — most importantly <c>_</c> (0x5F), used by
+/// <c>_dmarc</c>, <c>_domainkey</c>, <c>_tcp</c> and DANE names — on the wrong side of the letters.
+/// </remarks>
+internal static class DnsNameComparer
+{
+    /// <summary>Determines whether two domain names are equal, ignoring ASCII case and a trailing dot.</summary>
+    public static bool Equals(string? left, string? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+
+        if (left is null || right is null)
+            return false;
+
+        return Compare(left, right) is 0;
+    }
+
+    /// <summary>Compares two domain names in DNSSEC canonical order (RFC 4034 section 6.1): label by label, from the rightmost.</summary>
+    public static int Compare(string left, string right)
+    {
+        var leftLabels = SplitLabels(left);
+        var rightLabels = SplitLabels(right);
+
+        var leftIndex = leftLabels.Length - 1;
+        var rightIndex = rightLabels.Length - 1;
+
+        while (leftIndex >= 0 && rightIndex >= 0)
+        {
+            var comparison = CompareLabels(leftLabels[leftIndex], rightLabels[rightIndex]);
+            if (comparison != 0)
+                return comparison;
+
+            leftIndex--;
+            rightIndex--;
+        }
+
+        if (leftIndex == rightIndex)
+            return 0;
+
+        return leftIndex < rightIndex ? -1 : 1;
+    }
+
+    /// <summary>Compares two labels in presentation format as downcased wire octets.</summary>
+    public static int CompareLabels(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+    {
+        Span<byte> leftBytes = stackalloc byte[DnsName.MaxLabelLength];
+        Span<byte> rightBytes = stackalloc byte[DnsName.MaxLabelLength];
+
+        var leftLength = DnsName.DecodeLabel(left, leftBytes);
+        var rightLength = DnsName.DecodeLabel(right, rightBytes);
+
+        ToLowerAscii(leftBytes[..leftLength]);
+        ToLowerAscii(rightBytes[..rightLength]);
+
+        return leftBytes[..leftLength].SequenceCompareTo(rightBytes[..rightLength]);
+    }
+
+    /// <summary>Splits a name into its labels, ignoring escaped dots and a trailing dot.</summary>
+    public static string[] SplitLabels(string name)
+    {
+        var span = name.AsSpan();
+        if (DnsName.EndsWithUnescapedDot(span))
+        {
+            span = span[..^1];
+        }
+
+        if (span.IsEmpty)
+            return [];
+
+        var count = 0;
+        foreach (var _ in DnsName.EnumerateLabels(span))
+        {
+            count++;
+        }
+
+        var labels = new string[count];
+        var index = 0;
+        foreach (var label in DnsName.EnumerateLabels(span))
+        {
+            labels[index++] = label.ToString();
+        }
+
+        return labels;
+    }
+
+    private static void ToLowerAscii(Span<byte> value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] is >= (byte)'A' and <= (byte)'Z')
+            {
+                value[i] += 'a' - 'A';
+            }
+        }
+    }
+}

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
@@ -17,13 +17,9 @@ internal ref struct DnsWireReader
 
     public readonly int Position => _position;
 
-    public readonly int Remaining => _message.Length - _position;
-
     public ushort ReadUInt16()
     {
-        if (_position + 2 > _message.Length)
-            throw new DnsProtocolException("Unexpected end of DNS message while reading UInt16.");
-
+        EnsureAvailable(2, "UInt16");
         var value = BinaryPrimitives.ReadUInt16BigEndian(_message[_position..]);
         _position += 2;
         return value;
@@ -31,9 +27,7 @@ internal ref struct DnsWireReader
 
     public uint ReadUInt32()
     {
-        if (_position + 4 > _message.Length)
-            throw new DnsProtocolException("Unexpected end of DNS message while reading UInt32.");
-
+        EnsureAvailable(4, "UInt32");
         var value = BinaryPrimitives.ReadUInt32BigEndian(_message[_position..]);
         _position += 4;
         return value;
@@ -41,9 +35,7 @@ internal ref struct DnsWireReader
 
     public int ReadInt32()
     {
-        if (_position + 4 > _message.Length)
-            throw new DnsProtocolException("Unexpected end of DNS message while reading Int32.");
-
+        EnsureAvailable(4, "Int32");
         var value = BinaryPrimitives.ReadInt32BigEndian(_message[_position..]);
         _position += 4;
         return value;
@@ -59,7 +51,10 @@ internal ref struct DnsWireReader
 
     public ReadOnlySpan<byte> ReadBytes(int count)
     {
-        if (_position + count > _message.Length)
+        if (count < 0)
+            throw new DnsProtocolException($"Invalid DNS record data length: {count}. The record declares fewer bytes than its fixed fields require.");
+
+        if (count > _message.Length - _position)
             throw new DnsProtocolException($"Unexpected end of DNS message while reading {count} bytes.");
 
         var span = _message.Slice(_position, count);
@@ -69,7 +64,10 @@ internal ref struct DnsWireReader
 
     public void Skip(int count)
     {
-        if (_position + count > _message.Length)
+        if (count < 0)
+            throw new DnsProtocolException($"Cannot skip {count} bytes: the count is negative.");
+
+        if (count > _message.Length - _position)
             throw new DnsProtocolException($"Cannot skip {count} bytes: exceeds message boundary.");
 
         _position += count;
@@ -77,24 +75,41 @@ internal ref struct DnsWireReader
 
     public readonly ReadOnlySpan<byte> GetBytes(int offset, int count)
     {
-        if (offset < 0 || count < 0 || offset + count > _message.Length)
+        if (offset < 0 || count < 0 || offset > _message.Length || count > _message.Length - offset)
             throw new DnsProtocolException($"Cannot read {count} bytes at offset {offset}: exceeds message boundary.");
 
         return _message.Slice(offset, count);
     }
 
+    /// <summary>
+    /// Creates a reader restricted to <paramref name="length"/> bytes starting at the current position, and advances
+    /// this reader past them. Domain names inside the window are still resolved against the whole message, because
+    /// compression pointers may target any earlier offset.
+    /// </summary>
+    public DnsWireReader ReadWindow(int length)
+    {
+        if (length < 0)
+            throw new DnsProtocolException($"Invalid DNS record data length: {length}.");
+
+        if (length > _message.Length - _position)
+            throw new DnsProtocolException($"DNS record data length {length} exceeds the message boundary.");
+
+        var window = new DnsWireReader(_message[..(_position + length)]) { _position = _position };
+        _position += length;
+        return window;
+    }
+
     public string ReadDomainName()
     {
         var sb = new StringBuilder(64);
-        ReadDomainNameCore(sb, _message, ref _position, maxPointers: 128);
+        ReadDomainNameCore(sb, _message, ref _position, maxPointers: DnsName.MaxLabels);
         return sb.ToString();
     }
 
-    public static string ReadDomainNameAtOffset(ReadOnlySpan<byte> message, int offset)
+    private void EnsureAvailable(int count, string what)
     {
-        var sb = new StringBuilder(64);
-        ReadDomainNameCore(sb, message, ref offset, maxPointers: 128);
-        return sb.ToString();
+        if (count > _message.Length - _position)
+            throw new DnsProtocolException($"Unexpected end of DNS message while reading {what}.");
     }
 
     private static void ReadDomainNameCore(StringBuilder sb, ReadOnlySpan<byte> message, ref int position, int maxPointers)
@@ -102,7 +117,7 @@ internal ref struct DnsWireReader
         var jumped = false;
         var originalPosition = -1;
         var pointerCount = 0;
-        Span<char> labelBuffer = stackalloc char[63];
+        var nameLength = 1; // the terminating root label
 
         while (position < message.Length)
         {
@@ -115,7 +130,7 @@ internal ref struct DnsWireReader
                 break;
             }
 
-            // Check for compression pointer (top 2 bits set)
+            // Compression pointer (top 2 bits set)
             if (labelType is 0xC0)
             {
                 if (++pointerCount > maxPointers)
@@ -125,6 +140,11 @@ internal ref struct DnsWireReader
                     throw new DnsProtocolException("Unexpected end of DNS message while reading compression pointer.");
 
                 var pointer = ((length & 0x3F) << 8) | message[position + 1];
+
+                // RFC 1035 4.1.4: a pointer refers to a *prior* occurrence of the name. Requiring a strictly
+                // backwards jump keeps the chain finite and makes compression loops impossible to express.
+                if (pointer >= position)
+                    throw new DnsProtocolException($"Invalid compression pointer to offset {pointer}: pointers must refer to an earlier position in the message.");
 
                 if (!jumped)
                 {
@@ -141,16 +161,19 @@ internal ref struct DnsWireReader
 
             position++;
 
-            if (position + length > message.Length)
+            if (length > message.Length - position)
                 throw new DnsProtocolException("Domain name label extends beyond message boundary.");
+
+            nameLength += length + 1;
+            if (nameLength > DnsName.MaxLength)
+                throw new DnsProtocolException($"Domain name exceeds the maximum length of {DnsName.MaxLength} bytes.");
 
             if (sb.Length > 0)
             {
                 sb.Append('.');
             }
 
-            var charCount = Encoding.ASCII.GetChars(message.Slice(position, length), labelBuffer);
-            sb.Append(labelBuffer[..charCount]);
+            DnsName.AppendLabel(sb, message.Slice(position, length));
             position += length;
         }
 

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsWireWriter.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsWireWriter.cs
@@ -51,7 +51,7 @@ internal ref struct DnsWireWriter
         _buffer[_position++] = value;
     }
 
-    public void WriteBytes(ReadOnlySpan<byte> data)
+    public void WriteBytes(scoped ReadOnlySpan<byte> data)
     {
         EnsureCapacity(data.Length);
         data.CopyTo(_buffer.AsSpan(_position));
@@ -66,25 +66,27 @@ internal ref struct DnsWireWriter
             return;
         }
 
-        // Remove trailing dot if present
         var span = name.AsSpan();
-        if (span[^1] == '.')
+        if (DnsName.EndsWithUnescapedDot(span))
         {
             span = span[..^1];
         }
 
-        foreach (var label in new LabelEnumerator(span))
+        var totalLength = 1; // the terminating root label
+        Span<byte> labelBuffer = stackalloc byte[DnsName.MaxLabelLength];
+
+        foreach (var label in DnsName.EnumerateLabels(span))
         {
-            var byteCount = Encoding.ASCII.GetByteCount(label);
-            if (byteCount is 0 or > 63)
-            {
-                throw new DnsProtocolException($"Invalid domain name label length: {byteCount}. Labels must be between 1 and 63 bytes.");
-            }
+            var byteCount = DnsName.DecodeLabel(label, labelBuffer);
+            if (byteCount is 0)
+                throw new DnsProtocolException("Invalid domain name: labels must be between 1 and 63 bytes.");
+
+            totalLength += byteCount + 1;
+            if (totalLength > DnsName.MaxLength)
+                throw new DnsProtocolException($"Domain name exceeds the maximum length of {DnsName.MaxLength} bytes.");
 
             WriteByte((byte)byteCount);
-            EnsureCapacity(byteCount);
-            Encoding.ASCII.GetBytes(label, _buffer.AsSpan(_position));
-            _position += byteCount;
+            WriteBytes(labelBuffer[..byteCount]);
         }
 
         WriteByte(0); // Root label
@@ -105,41 +107,5 @@ internal ref struct DnsWireWriter
         var newBuffer = new byte[newSize];
         _buffer.AsSpan(0, _position).CopyTo(newBuffer);
         _buffer = newBuffer;
-    }
-
-    [StructLayout(LayoutKind.Auto)]
-    private ref struct LabelEnumerator
-    {
-        private ReadOnlySpan<char> _remaining;
-
-        public LabelEnumerator(ReadOnlySpan<char> name)
-        {
-            _remaining = name;
-            Current = default;
-        }
-
-        public ReadOnlySpan<char> Current { get; private set; }
-
-        public readonly LabelEnumerator GetEnumerator() => this;
-
-        public bool MoveNext()
-        {
-            if (_remaining.IsEmpty)
-                return false;
-
-            var index = _remaining.IndexOf('.');
-            if (index == -1)
-            {
-                Current = _remaining;
-                _remaining = [];
-            }
-            else
-            {
-                Current = _remaining[..index];
-                _remaining = _remaining[(index + 1)..];
-            }
-
-            return true;
-        }
     }
 }

--- a/src/Meziantou.Framework.DnsClient/Response/DnssecValidationIssueCode.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnssecValidationIssueCode.cs
@@ -50,4 +50,10 @@ public enum DnssecValidationIssueCode
 
     /// <summary>The response is not valid DNSSEC data.</summary>
     InvalidData,
+
+    /// <summary>A query needed to build the chain of trust failed.</summary>
+    ChainQueryFailed,
+
+    /// <summary>Validation needed more queries than the configured budget allows.</summary>
+    QueryBudgetExceeded,
 }

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
@@ -6,27 +6,39 @@ internal sealed class DnsHttpsTransport : IDnsTransport
 {
     private static readonly MediaTypeHeaderValue DnsMessageMediaType = new("application/dns-message");
 
+    /// <summary>A DNS message can never exceed 65535 bytes, so anything larger is not a response worth buffering.</summary>
+    private const int MaxResponseLength = 65535;
+
     private readonly HttpClient _httpClient;
     private readonly Uri _endpoint;
     private readonly Version _httpVersion;
     private readonly HttpVersionPolicy _httpVersionPolicy;
-    private readonly bool _disposeHttpClient;
 
     public DnsHttpsTransport(Uri endpoint, HttpMessageHandler? handler, Version httpVersion, HttpVersionPolicy httpVersionPolicy)
     {
         _endpoint = endpoint;
         _httpVersion = httpVersion;
         _httpVersionPolicy = httpVersionPolicy;
+
+        // disposeHandler: false is what protects a caller-supplied handler; the HttpClient wrapper is always ours.
         if (handler is not null)
         {
             _httpClient = new HttpClient(handler, disposeHandler: false);
-            _disposeHttpClient = true;
         }
         else
         {
-            _httpClient = new HttpClient();
-            _disposeHttpClient = true;
+            // A default handler with a bounded connection lifetime, so a long-lived client notices DNS changes for
+            // the resolver's own hostname. Ownership transfers to the HttpClient via disposeHandler: true.
+            _httpClient = CreateDefaultHttpClient();
         }
+
+        _httpClient.MaxResponseContentBufferSize = MaxResponseLength;
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership of the handler transfers to the HttpClient, which is disposed by this transport.")]
+    private static HttpClient CreateDefaultHttpClient()
+    {
+        return new HttpClient(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(2) }, disposeHandler: true);
     }
 
     public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
@@ -43,17 +55,21 @@ internal sealed class DnsHttpsTransport : IDnsTransport
         };
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        if (response.Content.Headers.ContentLength > MaxResponseLength)
+            throw new DnsProtocolException($"The DNS over HTTPS response declares {response.Content.Headers.ContentLength} bytes, which exceeds the {MaxResponseLength}-byte maximum for a DNS message.");
+
+        var body = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        if (body.Length > MaxResponseLength)
+            throw new DnsProtocolException($"The DNS over HTTPS response is {body.Length} bytes, which exceeds the {MaxResponseLength}-byte maximum for a DNS message.");
+
+        return body;
     }
 
     public void Dispose()
     {
-        if (_disposeHttpClient)
-        {
-            _httpClient.Dispose();
-        }
+        _httpClient.Dispose();
     }
 }

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsQuicTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsQuicTransport.cs
@@ -33,8 +33,10 @@ internal sealed class DnsQuicTransport : IDnsTransport
             },
         };
 
-        await using var connection = await QuicConnection.ConnectAsync(connectionOptions, cancellationToken).ConfigureAwait(false);
-        await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken).ConfigureAwait(false);
+        var connection = await QuicConnection.ConnectAsync(connectionOptions, cancellationToken).ConfigureAwait(false);
+        await using var connectionScope = connection.ConfigureAwait(false);
+        var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken).ConfigureAwait(false);
+        await using var streamScope = stream.ConfigureAwait(false);
 
         // RFC 9250: 2-byte length prefix
         var lengthPrefix = new byte[2];

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsTlsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsTlsTransport.cs
@@ -21,7 +21,8 @@ internal sealed class DnsTlsTransport : IDnsTransport
         using var client = new TcpClient();
         await client.ConnectAsync(_endpoint.Address, _endpoint.Port, cancellationToken).ConfigureAwait(false);
 
-        await using var sslStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false);
+        var sslStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false);
+        await using var sslStreamScope = sslStream.ConfigureAwait(false);
         var sslOptions = new SslClientAuthenticationOptions
         {
             TargetHost = _host,

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsUdpTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsUdpTransport.cs
@@ -14,14 +14,24 @@ internal sealed class DnsUdpTransport : IDnsTransport
 
     public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
     {
-        using var client = new UdpClient();
-        await client.SendAsync(query, query.Length, _endpoint).ConfigureAwait(false);
+        using var client = new UdpClient(_endpoint.AddressFamily);
 
-        // Standard DNS over UDP has a 512-byte limit, but EDNS can extend this
-        var receiveTask = client.ReceiveAsync(cancellationToken);
-        var result = await receiveTask.ConfigureAwait(false);
+        // Connecting makes the kernel drop datagrams from any source other than the server we queried, which is the
+        // first line of defence against off-path answer injection. The identifier and question are checked by the
+        // caller as well, because an on-path attacker can still spoof the source address.
+        client.Connect(_endpoint);
 
-        return result.Buffer;
+        await client.Client.SendAsync(query, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+
+        while (true)
+        {
+            var result = await client.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+            if (result.RemoteEndPoint.Equals(_endpoint))
+                return result.Buffer;
+
+            // A datagram from an unexpected source: ignore it and keep waiting rather than failing the query, so a
+            // single stray packet cannot deny service. The caller's timeout bounds this loop.
+        }
     }
 
     public void Dispose()

--- a/src/Meziantou.Framework.DnsClient/readme.md
+++ b/src/Meziantou.Framework.DnsClient/readme.md
@@ -1,13 +1,13 @@
 # Meziantou.Framework.DnsClient
 
-A comprehensive DNS client library supporting multiple transport protocols, all standard DNS record types, DNSSEC, EDNS(0), internationalized domain names, and reverse DNS lookups.
+A DNS client library supporting multiple transport protocols, the common DNS record types (with raw access to the rest), DNSSEC validation, EDNS(0), internationalized domain names, and reverse DNS lookups.
 
 ## Features
 
 - **Multiple protocols**: UDP, TCP, DNS over TLS (DoT), DNS over HTTPS (DoH), DNS over QUIC (DoQ)
-- **All DNS record types**: A, AAAA, MX, TXT, CNAME, NS, SOA, SRV, PTR, CAA, NAPTR, SVCB, HTTPS, and more
-- **DNSSEC support**: Request and parse DNSKEY, DS, RRSIG, NSEC, NSEC3 records
-- **EDNS(0)**: Configurable UDP payload size, DNSSEC OK flag, extended RCODE
+- **Typed record parsing**: A, AAAA, MX, TXT, CNAME, NS, SOA, SRV, PTR, CAA, NAPTR, SVCB, HTTPS, LOC, HINFO, RP, DNAME, URI, TLSA, SSHFP and the DNSSEC types. Any other type is returned as `DnsUnknownRecord` with its raw RDATA.
+- **DNSSEC**: request and parse DNSKEY, DS, RRSIG, NSEC and NSEC3 records, plus local chain-of-trust validation against the IANA root anchors
+- **EDNS(0)**: configurable UDP payload size (default 1232, per RFC 9715), DNSSEC OK flag, extended RCODE
 - **IDN/Punycode**: Automatic Unicode to punycode conversion for internationalized domain names
 - **Reverse DNS**: Helper for PTR lookups on IPv4 and IPv6 addresses
 - **OpenTelemetry**: Built-in `ActivitySource` tracing for DNS queries
@@ -66,3 +66,23 @@ Console.WriteLine($"Local DNSSEC validation: {response.DnssecValidationResult.St
 ```
 
 `DnsResponseHeader.AuthenticatedData` exposes the upstream resolver's AD flag. Use `DnssecValidationMode.Local` when the client must validate the DNSSEC chain locally.
+
+A `Secure` status means the answer records are signed by a chain of trust rooted in the configured anchors **and** that they answer the question that was asked. `Insecure` means the zone is provably unsigned, `Bogus` means validation failed, and `Indeterminate` means validation could not be completed (for example a chain query failed).
+
+## Response validation
+
+Every response is checked against the query it answers: the transaction identifier, the QR bit, the opcode and the echoed question must all match, or `DnsProtocolException` is thrown. Over UDP the socket is also connected to the server so the operating system drops datagrams from other sources, and a truncated (TC) answer is automatically re-issued over TCP.
+
+## Exceptions
+
+`QueryAsync`, `ReverseLookupAsync` and `SendAsync` can throw:
+
+| Exception | Cause |
+| --- | --- |
+| `DnsProtocolException` | The response is malformed, or does not answer the query that was sent. |
+| `TimeoutException` | `DnsClientOptions.Timeout` elapsed. Caller cancellation surfaces as `OperationCanceledException` instead. |
+| `OperationCanceledException` | The caller's `CancellationToken` was cancelled. |
+| `SocketException`, `IOException` | The transport failed (UDP, TCP, DoT, DoQ). |
+| `HttpRequestException` | The DNS over HTTPS request failed. |
+| `AuthenticationException` | The TLS handshake failed (DoT). |
+| `ObjectDisposedException` | The client was disposed. |

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
+using Meziantou.Framework.DnsClient.Protocol;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 using Meziantou.Framework.DnsClient.Transport;
+
+using DnsResponseCode = Meziantou.Framework.DnsClient.Response.DnsResponseCode;
 
 namespace Meziantou.Framework.DnsClient.Tests;
 
@@ -50,7 +53,7 @@ public sealed class DnsClientDnssecOptionsTests
     }
 
     [Fact]
-    public async Task QueryAsync_Https_DefaultOptions_RequestsHttp3OrLower()
+    public async Task QueryAsync_Https_DefaultOptions_RequestsHttp2OrLower()
     {
         using var handler = new CapturingHttpMessageHandler();
         using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
@@ -60,7 +63,7 @@ public sealed class DnsClientDnssecOptionsTests
 
         await client.QueryAsync("example.com", DnsQueryType.A);
 
-        Assert.Equal(HttpVersion.Version30, handler.RequestVersion);
+        Assert.Equal(HttpVersion.Version20, handler.RequestVersion);
         Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, handler.RequestVersionPolicy);
     }
 
@@ -104,18 +107,7 @@ public sealed class DnsClientDnssecOptionsTests
         return (flags & 0x8000) != 0;
     }
 
-    private static byte[] CreateEmptyResponse(byte[] query)
-    {
-        return
-        [
-            query[0], query[1],
-            0x81, 0x80,
-            0x00, 0x00,
-            0x00, 0x00,
-            0x00, 0x00,
-            0x00, 0x00,
-        ];
-    }
+    private static byte[] CreateEmptyResponse(byte[] query) => DnsTestMessages.CreateEmptyResponse(query);
 
     private sealed class CapturingTransport : IDnsTransport
     {
@@ -148,6 +140,191 @@ public sealed class DnsClientDnssecOptionsTests
             {
                 Content = new ByteArrayContent(CreateEmptyResponse(query)),
             };
+        }
+    }
+
+    [Fact]
+    public async Task QueryAsync_ResponseWithMismatchedIdentifier_IsRejected()
+    {
+        using var transport = new ScriptedTransport(query => MutateHeader(DnsTestMessages.CreateEmptyResponse(query), id: 0xFFFF));
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        await Assert.ThrowsAsync<DnsProtocolException>(() => client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task QueryAsync_ResponseAnsweringADifferentQuestion_IsRejected()
+    {
+        using var transport = new ScriptedTransport(query =>
+        {
+            // Echo the identifier but answer for a name the caller never asked about.
+            var response = DnsTestMessages.CreateEmptyResponse(query);
+            var forged = new List<byte>(response[..12]);
+            forged.AddRange([8, (byte)'a', (byte)'t', (byte)'t', (byte)'a', (byte)'c', (byte)'k', (byte)'e', (byte)'r', 4, (byte)'t', (byte)'e', (byte)'s', (byte)'t', 0]);
+            forged.AddRange([0x00, 0x01, 0x00, 0x01]);
+            return [.. forged];
+        });
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        await Assert.ThrowsAsync<DnsProtocolException>(() => client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task QueryAsync_ResponseWithoutTheQueryResponseBit_IsRejected()
+    {
+        using var transport = new ScriptedTransport(query => MutateHeader(DnsTestMessages.CreateEmptyResponse(query), clearQueryResponseBit: true));
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        await Assert.ThrowsAsync<DnsProtocolException>(() => client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task QueryAsync_MatchingResponse_IsAccepted()
+    {
+        using var transport = new ScriptedTransport(query => DnsTestMessages.CreateEmptyResponse(query));
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken);
+
+        Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
+        Assert.Equal("example.com", response.Questions[0].Name);
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotMutateTheCallersMessage()
+    {
+        using var transport = new ScriptedTransport(query => DnsTestMessages.CreateEmptyResponse(query));
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, new DnsClientOptions
+        {
+            DnssecValidationMode = DnssecValidationMode.None,
+            DnssecOk = true,
+        });
+
+        var message = new DnsQueryMessage();
+        message.Questions.Add(new DnsQuestion("example.com", DnsQueryType.A));
+
+        await client.SendAsync(message, TestContext.Current.CancellationToken);
+
+        Assert.Null(message.EdnsOptions);
+        Assert.False(message.CheckingDisabled);
+    }
+
+    [Fact]
+    public async Task SendAsync_ConvertsUnicodeQuestionNamesToPunycode()
+    {
+        using var transport = new ScriptedTransport(query => DnsTestMessages.CreateEmptyResponse(query));
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        var message = new DnsQueryMessage();
+        message.Questions.Add(new DnsQuestion("münchen.de", DnsQueryType.A));
+
+        await client.SendAsync(message, TestContext.Current.CancellationToken);
+
+        var name = ReadQuestionName(transport.LastQuery);
+        Assert.Equal("xn--mnchen-3ya.de", name);
+    }
+
+    [Fact]
+    public async Task SendAsync_DefaultOptions_IncludesAnEdnsOptRecord()
+    {
+        using var transport = new ScriptedTransport(query => DnsTestMessages.CreateEmptyResponse(query));
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        var message = new DnsQueryMessage();
+        message.Questions.Add(new DnsQuestion("example.com", DnsQueryType.A));
+
+        await client.SendAsync(message, TestContext.Current.CancellationToken);
+
+        // ARCOUNT must be 1: QueryAsync and SendAsync have to agree on whether EDNS is advertised.
+        Assert.Equal(1, (transport.LastQuery[10] << 8) | transport.LastQuery[11]);
+    }
+
+    [Fact]
+    public async Task QueryAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        using var transport = new ScriptedTransport(query => DnsTestMessages.CreateEmptyResponse(query));
+        var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+        client.Dispose();
+        client.Dispose(); // must be idempotent
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_NonPositiveTimeout_ThrowsArgumentOutOfRangeException(int seconds)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var client = new DnsClient("1.1.1.1", DnsClientProtocol.Udp, new DnsClientOptions { Timeout = TimeSpan.FromSeconds(seconds) });
+        });
+    }
+
+    [Fact]
+    public void Constructor_HttpsProtocolWithACleartextUrl_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            using var client = new DnsClient("http://resolver.example/dns-query", DnsClientProtocol.Https);
+        });
+    }
+
+    [Theory]
+    [InlineData("8.8.8.8:70000")]
+    [InlineData("8.8.8.8: 53")]
+    public void Constructor_MalformedPort_ThrowsArgumentException(string server)
+    {
+        // A bad port must be reported against the server argument, not as an internal 'port' parameter.
+        var exception = Record.Exception(() =>
+        {
+            using var client = new DnsClient(server, DnsClientProtocol.Udp);
+        });
+
+        Assert.IsAssignableTo<ArgumentException>(exception);
+    }
+
+    private static string ReadQuestionName(byte[] query)
+    {
+        var reader = new DnsWireReader(query.AsSpan(12).ToArray());
+        return reader.ReadDomainName();
+    }
+
+    private static byte[] MutateHeader(byte[] response, ushort? id = null, bool clearQueryResponseBit = false)
+    {
+        if (id is not null)
+        {
+            response[0] = (byte)(id.Value >> 8);
+            response[1] = (byte)id.Value;
+        }
+
+        if (clearQueryResponseBit)
+        {
+            response[2] &= 0x7F;
+        }
+
+        return response;
+    }
+
+    private sealed class ScriptedTransport : IDnsTransport
+    {
+        private readonly Func<byte[], byte[]> _respond;
+
+        public ScriptedTransport(Func<byte[], byte[]> respond)
+        {
+            _respond = respond;
+        }
+
+        public byte[] LastQuery { get; private set; } = [];
+
+        public Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+        {
+            LastQuery = query;
+            return Task.FromResult(_respond(query));
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using TestUtilities;
 using System.Net;
 using Meziantou.Framework.DnsClient.Query;
@@ -9,9 +10,60 @@ namespace Meziantou.Framework.DnsClient.Tests;
 
 public sealed class DnsClientIntegrationTests
 {
+    /// <summary>
+    /// These tests query public resolvers, so they fail for reasons that say nothing about this library: no network,
+    /// a restrictive egress policy, or an outage at the resolver. Probe once per endpoint and skip rather than fail,
+    /// so a red suite always means a real regression. Hermetic coverage lives in the other test classes.
+    /// </summary>
+    /// <remarks>
+    /// Reachability is tracked per (server, protocol) rather than globally, because the transports use different
+    /// ports: a network that allows 443 for DNS over HTTPS may still block 53 and 853.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<(string Server, DnsClientProtocol Protocol), Lazy<bool>> Reachability = new();
+
     private const string CloudflareDoH = "https://cloudflare-dns.com/dns-query";
     private const string Quad9DoH = "https://dns.quad9.net/dns-query";
+    private const string CloudflareIP = "1.1.1.1";
+    private const string AdGuardDoQ = "dns.adguard-dns.com";
     private static readonly string[] DnsOverHttpsFallbackUrls = [CloudflareDoH, Quad9DoH];
+
+    private static bool IsReachable(string server, DnsClientProtocol protocol)
+    {
+        var probe = Reachability.GetOrAdd(
+            (server, protocol),
+            key => new Lazy<bool>(() => Probe(key.Server, key.Protocol), LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return probe.Value;
+    }
+
+    private static bool Probe(string server, DnsClientProtocol protocol)
+    {
+        try
+        {
+            using var client = new DnsClient(server, protocol, new DnsClientOptions { Timeout = TimeSpan.FromSeconds(10) });
+            var response = client.QueryAsync("example.com", DnsQueryType.A).GetAwaiter().GetResult();
+            return response.Header.ResponseCode is DnsResponseCode.NoError;
+        }
+#pragma warning disable CA1031 // Any failure means this endpoint is unavailable; the reason does not change the outcome.
+        catch (Exception)
+        {
+            return false;
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <summary>Skips unless at least one of the DNS over HTTPS resolvers the tests fall back over is reachable.</summary>
+    private static void SkipIfResolverUnreachable()
+    {
+        var reachable = Array.Exists(DnsOverHttpsFallbackUrls, url => IsReachable(url, DnsClientProtocol.Https));
+        global::Xunit.Assert.SkipUnless(reachable, $"No DNS over HTTPS resolver is reachable from this machine ({string.Join(", ", DnsOverHttpsFallbackUrls)}).");
+    }
+
+    /// <summary>Skips unless this specific server and protocol is reachable, for the tests that do not use the DoH fallback list.</summary>
+    private static void SkipIfEndpointUnreachable(string server, DnsClientProtocol protocol)
+    {
+        global::Xunit.Assert.SkipUnless(IsReachable(server, protocol), $"The DNS server '{server}' is not reachable over {protocol} from this machine.");
+    }
 
     private static DnsClient CreateDoHClient(string url = CloudflareDoH, TimeSpan? timeout = null)
     {
@@ -88,6 +140,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_A_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.A);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -102,6 +156,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_AAAA_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.AAAA);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -113,6 +169,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_MX_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.MX, "google.com");
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -128,6 +186,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_TXT_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.TXT, "google.com");
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -139,6 +199,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_NS_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.NS);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -150,6 +212,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_SOA_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.SOA);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -166,6 +230,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_CNAME_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.CNAME, "www.microsoft.com");
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -178,6 +244,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_CAA_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.CAA, "google.com");
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -193,6 +261,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_HTTPS_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.HTTPS, "cloudflare.com");
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -203,6 +273,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_NxDomain()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.A, "this-domain-surely-does-not-exist-xyz999.com");
 
         Assert.Equal(DnsResponseCode.NameError, response.Header.ResponseCode);
@@ -211,6 +283,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_RecursionDesired()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
@@ -221,6 +295,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task ReverseLookup_IPv4()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await ReverseLookupWithRetryAsync(client, IPAddress.Parse("1.1.1.1"));
 
@@ -234,6 +310,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task ReverseLookup_IPv6()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await ReverseLookupWithRetryAsync(client, IPAddress.Parse("2606:4700:4700::1111"));
 
@@ -245,6 +323,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_IDN_Unicode()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await QueryWithRetryAsync(client, "münchen.de", DnsQueryType.A);
 
@@ -254,6 +334,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_Punycode()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await QueryWithRetryAsync(client, "xn--mnchen-3ya.de", DnsQueryType.A);
 
@@ -263,6 +345,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DNSSEC_AD_Flag()
     {
+        SkipIfResolverUnreachable();
+
         using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions
         {
             DnssecOk = true,
@@ -289,6 +373,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DNSSEC_LocalValidation()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithLocalValidationFallbackAsync("cloudflare.com", DnsQueryType.A);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -298,6 +384,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DNSKEY_Record()
     {
+        SkipIfResolverUnreachable();
+
         using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions
         {
             DnssecOk = true,
@@ -329,6 +417,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DS_Record()
     {
+        SkipIfResolverUnreachable();
+
         using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions
         {
             DnssecOk = true,
@@ -360,6 +450,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_SRV_Record()
     {
+        SkipIfResolverUnreachable();
+
         var response = await QueryWithFallbackAsync(DnsQueryType.SRV, "_sip._tcp.example.com");
 
         // SRV might not exist for this domain, just check no protocol error
@@ -369,6 +461,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_WithDnsOverHttps_Quad9()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient(Quad9DoH, timeout: TimeSpan.FromSeconds(20));
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
@@ -379,6 +473,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DefaultClassIsIN()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
@@ -390,6 +486,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_MultipleAnswers()
     {
+        SkipIfResolverUnreachable();
+
         using var client = CreateDoHClient();
         var response = await QueryWithRetryAsync(client, "google.com", DnsQueryType.A);
 
@@ -400,6 +498,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_RRSIG_Record()
     {
+        SkipIfResolverUnreachable();
+
         using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions
         {
             DnssecOk = true,
@@ -432,6 +532,8 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_NSEC_InAuthoritySection()
     {
+        SkipIfResolverUnreachable();
+
         using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions
         {
             DnssecOk = true,
@@ -458,7 +560,9 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_UDP()
     {
-        using var client = new DnsClient("1.1.1.1", DnsClientProtocol.Udp);
+        SkipIfEndpointUnreachable(CloudflareIP, DnsClientProtocol.Udp);
+
+        using var client = new DnsClient(CloudflareIP, DnsClientProtocol.Udp);
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -468,7 +572,9 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_TCP()
     {
-        using var client = new DnsClient("1.1.1.1", DnsClientProtocol.Tcp);
+        SkipIfEndpointUnreachable(CloudflareIP, DnsClientProtocol.Tcp);
+
+        using var client = new DnsClient(CloudflareIP, DnsClientProtocol.Tcp);
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -478,7 +584,9 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DoT()
     {
-        using var client = new DnsClient("1.1.1.1", DnsClientProtocol.Tls);
+        SkipIfEndpointUnreachable(CloudflareIP, DnsClientProtocol.Tls);
+
+        using var client = new DnsClient(CloudflareIP, DnsClientProtocol.Tls);
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
@@ -488,10 +596,11 @@ public sealed class DnsClientIntegrationTests
     [Fact]
     public async Task Query_DoQ()
     {
-        if (!System.Net.Quic.QuicConnection.IsSupported)
-            return;
+        // A bare return would report this as a passing test that asserted nothing.
+        global::Xunit.Assert.SkipUnless(System.Net.Quic.QuicConnection.IsSupported, "QUIC is not supported on this platform.");
+        SkipIfEndpointUnreachable(AdGuardDoQ, DnsClientProtocol.Quic);
 
-        using var client = new DnsClient("dns.adguard-dns.com", DnsClientProtocol.Quic);
+        using var client = new DnsClient(AdGuardDoQ, DnsClientProtocol.Quic);
         var response = await QueryWithRetryAsync(client, "example.com", DnsQueryType.A);
 
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientTelemetryTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientTelemetryTests.cs
@@ -103,17 +103,7 @@ public sealed class DnsClientTelemetryTests
         }
 
         private static byte[] CreateResponse(byte[] query, DnsResponseCode responseCode)
-        {
-            return
-            [
-                query[0], query[1],
-                0x81, (byte)(0x80 | (byte)responseCode),
-                0x00, 0x00,
-                0x00, 0x00,
-                0x00, 0x00,
-                0x00, 0x00,
-            ];
-        }
+            => DnsTestMessages.CreateEmptyResponse(query, responseCode);
     }
 
     private sealed class ThrowingTransport : IDnsTransport

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsTestMessages.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsTestMessages.cs
@@ -1,0 +1,48 @@
+using Meziantou.Framework.DnsClient.Response;
+
+namespace Meziantou.Framework.DnsClient.Tests;
+
+/// <summary>Builds DNS wire messages for tests that drive <see cref="DnsClient"/> through a fake transport.</summary>
+internal static class DnsTestMessages
+{
+    /// <summary>
+    /// Builds an answer-less response for <paramref name="query"/>, echoing its identifier and question section so the
+    /// client's response-to-query validation accepts it.
+    /// </summary>
+    public static byte[] CreateEmptyResponse(byte[] query, DnsResponseCode responseCode = DnsResponseCode.NoError)
+    {
+        var questionEnd = GetQuestionSectionEnd(query);
+        var response = query.AsSpan(0, questionEnd).ToArray();
+
+        response[2] = 0x81; // QR + RD
+        response[3] = (byte)(0x80 | (byte)responseCode); // RA + RCODE
+        response[6] = 0; // ANCOUNT
+        response[7] = 0;
+        response[8] = 0; // NSCOUNT
+        response[9] = 0;
+        response[10] = 0; // ARCOUNT
+        response[11] = 0;
+
+        return response;
+    }
+
+    /// <summary>Returns the offset just past the question section of a DNS message.</summary>
+    public static int GetQuestionSectionEnd(byte[] message)
+    {
+        var questionCount = (message[4] << 8) | message[5];
+        var position = 12;
+
+        for (var i = 0; i < questionCount; i++)
+        {
+            while (position < message.Length && message[position] != 0)
+            {
+                position += message[position] + 1;
+            }
+
+            position++; // root label
+            position += 4; // QTYPE + QCLASS
+        }
+
+        return position;
+    }
+}

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -1,6 +1,10 @@
+using System.Net;
 using Meziantou.Framework.DnsClient.Protocol;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
+using Meziantou.Framework.DnsClient.Response.Records;
+
+using DnsResponseCode = Meziantou.Framework.DnsClient.Response.DnsResponseCode;
 
 namespace Meziantou.Framework.DnsClient.Tests;
 
@@ -90,7 +94,7 @@ public sealed class DnsWireFormatTests
         };
         query.Questions.Add(new DnsQuestion("example.com", DnsQueryType.A, DnsQueryClass.IN));
 
-        var bytes = DnsMessageEncoder.EncodeQuery(query);
+        var bytes = DnsMessageEncoder.EncodeQuery(query, out _);
 
         Assert.HasCountGreaterThanOrEqual(12, bytes); // At least header
 
@@ -122,7 +126,7 @@ public sealed class DnsWireFormatTests
             DnssecOk = true,
         };
 
-        var bytes = DnsMessageEncoder.EncodeQuery(query);
+        var bytes = DnsMessageEncoder.EncodeQuery(query, out _);
 
         // ARCOUNT should be 1 (for OPT record)
         Assert.Equal(0x00, bytes[10]);
@@ -370,5 +374,429 @@ public sealed class DnsWireFormatTests
         Assert.Equal(900, soaRecord.Retry);
         Assert.Equal(604800, soaRecord.Expire);
         Assert.Equal(86400u, soaRecord.Minimum);
+    }
+
+    [Theory]
+    [InlineData(DnsQueryType.DNSKEY, 2, "DNSKEY shorter than its 4-byte fixed fields")]
+    [InlineData(DnsQueryType.DS, 1, "DS shorter than its 4-byte fixed fields")]
+    [InlineData(DnsQueryType.TLSA, 0, "TLSA shorter than its 3-byte fixed fields")]
+    [InlineData(DnsQueryType.SSHFP, 1, "SSHFP shorter than its 2-byte fixed fields")]
+    [InlineData(DnsQueryType.URI, 2, "URI shorter than its 4-byte fixed fields")]
+    public void DecodeResponse_RecordShorterThanItsFixedFields_ThrowsDnsProtocolException(DnsQueryType type, ushort rdLength, string scenario)
+    {
+        var message = BuildSingleAnswerMessage(type, rdLength, rdata: [0, 0], trailing: [1, 2, 3, 4, 5, 6, 7, 8]);
+
+        // A negative computed length must surface as DnsProtocolException, never as ArgumentOutOfRangeException.
+        var exception = Record.Exception(() => DnsMessageEncoder.DecodeResponse(message));
+        Assert.IsType<DnsProtocolException>(exception);
+        Assert.NotNull(scenario);
+    }
+
+    [Fact]
+    public void DecodeResponse_CaaTagLengthBeyondRdata_ThrowsDnsProtocolException()
+    {
+        var message = BuildSingleAnswerMessage(DnsQueryType.CAA, rdLength: 3, rdata: [0, 40, (byte)'x'], trailing: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeResponse(message));
+    }
+
+    [Fact]
+    public void DecodeResponse_RecordReadingPastItsRdLength_DoesNotDesynchronizeFollowingRecords()
+    {
+        // A TXT record declaring RDLENGTH=1 but a character-string length byte of 8 must not consume the next record.
+        var message = new List<byte>
+        {
+            0x12, 0x34, 0x81, 0x80,
+            0x00, 0x00, // QDCOUNT
+            0x00, 0x02, // ANCOUNT
+            0x00, 0x00,
+            0x00, 0x00,
+        };
+
+        message.AddRange([0x00, 0x00, 0x10, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x01, 0x08]); // TXT, RDLENGTH=1
+        message.AddRange([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x04, 192, 0, 2, 1]); // A 192.0.2.1
+
+        var exception = Record.Exception(() => DnsMessageEncoder.DecodeResponse([.. message]));
+        if (exception is not null)
+        {
+            Assert.IsType<DnsProtocolException>(exception);
+            return;
+        }
+
+        // If it parses, the second record must still be the A record it actually is.
+        var response = DnsMessageEncoder.DecodeResponse([.. message]);
+        Assert.Equal(DnsQueryType.A, response.Answers[1].RecordType);
+        Assert.Equal(IPAddress.Parse("192.0.2.1"), Assert.IsType<DnsARecord>(response.Answers[1]).Address);
+    }
+
+    [Fact]
+    public void ReadDomainName_ForwardPointer_ThrowsDnsProtocolException()
+    {
+        // A pointer must refer to an earlier position; a forward pointer is how compression loops are built.
+        byte[] data = [0xC0, 0x04, 0x00, 0x00, 1, (byte)'a', 0];
+        Assert.Throws<DnsProtocolException>(() =>
+        {
+            var reader = new DnsWireReader(data);
+            return reader.ReadDomainName();
+        });
+    }
+
+    [Fact]
+    public void ReadDomainName_SelfReferentialPointer_ThrowsDnsProtocolException()
+    {
+        byte[] data = [1, (byte)'a', 0xC0, 0x02];
+        Assert.Throws<DnsProtocolException>(() =>
+        {
+            var reader = new DnsWireReader(data);
+            return reader.ReadDomainName();
+        });
+    }
+
+    [Fact]
+    public void ReadDomainName_PointerBeyondMessage_ThrowsDnsProtocolException()
+    {
+        // Must not silently truncate the name to whatever was read before the bad pointer.
+        byte[] data = [1, (byte)'a', 0xC0, 0xFF, 0, 0, 0, 0];
+        Assert.Throws<DnsProtocolException>(() =>
+        {
+            var reader = new DnsWireReader(data);
+            return reader.ReadDomainName();
+        });
+    }
+
+    [Fact]
+    public void ReadDomainName_ExceedingMaximumLength_ThrowsDnsProtocolException()
+    {
+        var data = new List<byte>();
+        for (var i = 0; i < 10; i++)
+        {
+            data.Add(63);
+            data.AddRange(Enumerable.Repeat((byte)'a', 63));
+        }
+
+        data.Add(0);
+
+        // 10 x 64 bytes is well past the RFC 1035 255-byte limit.
+        Assert.Throws<DnsProtocolException>(() =>
+        {
+            var reader = new DnsWireReader([.. data]);
+            return reader.ReadDomainName();
+        });
+    }
+
+    [Fact]
+    public void ReadDomainName_EscapesDotsAndNonPrintableOctetsSoDistinctNamesStayDistinct()
+    {
+        // One label containing a dot must not be confused with two labels.
+        byte[] oneLabel = [8, (byte)'e', (byte)'v', (byte)'i', (byte)'l', (byte)'.', (byte)'c', (byte)'o', (byte)'m', 0];
+        var reader = new DnsWireReader(oneLabel);
+        Assert.Equal(@"evil\.com", reader.ReadDomainName());
+
+        byte[] twoLabels = [4, (byte)'e', (byte)'v', (byte)'i', (byte)'l', 3, (byte)'c', (byte)'o', (byte)'m', 0];
+        var otherReader = new DnsWireReader(twoLabels);
+        Assert.Equal("evil.com", otherReader.ReadDomainName());
+
+        byte[] binary = [3, (byte)'a', 0xFF, (byte)'b', 0];
+        var binaryReader = new DnsWireReader(binary);
+        Assert.Equal(@"a\255b", binaryReader.ReadDomainName());
+    }
+
+    [Fact]
+    public void WriteDomainName_RoundTripsEscapedLabels()
+    {
+        var writer = new DnsWireWriter();
+        writer.WriteDomainName(@"evil\.com");
+        var bytes = writer.ToArray();
+
+        Assert.Equal(8, bytes[0]);
+        var reader = new DnsWireReader(bytes);
+        Assert.Equal(@"evil\.com", reader.ReadDomainName());
+    }
+
+    [Fact]
+    public void WriteDomainName_NameLongerThanTheMaximum_ThrowsDnsProtocolException()
+    {
+        var name = string.Join('.', Enumerable.Repeat(new string('a', 63), 10));
+
+        Assert.Throws<DnsProtocolException>(() =>
+        {
+            var writer = new DnsWireWriter();
+            writer.WriteDomainName(name);
+        });
+    }
+
+    [Fact]
+    public void WriteDomainName_NonAsciiName_ThrowsDnsProtocolException()
+    {
+        // Silently substituting '?' would query a different name than the caller asked for.
+        Assert.Throws<DnsProtocolException>(() =>
+        {
+            var writer = new DnsWireWriter();
+            writer.WriteDomainName("münchen.de");
+        });
+    }
+
+    [Fact]
+    public void DecodeResponse_TruncatedAtEveryOffset_ThrowsDnsProtocolExceptionOrSucceeds()
+    {
+        var full = BuildSingleAnswerMessage(DnsQueryType.A, rdLength: 4, rdata: [192, 0, 2, 1], trailing: []);
+
+        for (var length = 0; length < full.Length; length++)
+        {
+            var truncated = full.AsSpan(0, length).ToArray();
+            var exception = Record.Exception(() => DnsMessageEncoder.DecodeResponse(truncated));
+
+            // Whatever happens, it must be the documented exception type - never an ArgumentException or a hang.
+            if (exception is not null)
+            {
+                Assert.IsType<DnsProtocolException>(exception);
+            }
+        }
+    }
+
+    [Fact]
+    public void DecodeResponse_AnswerCountLargerThanTheMessage_ThrowsDnsProtocolException()
+    {
+        byte[] message = [0x12, 0x34, 0x81, 0x80, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00];
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeResponse(message));
+    }
+
+    [Fact]
+    public void DecodeResponse_NsecBitmapWindowLongerThanAllowed_ThrowsDnsProtocolException()
+    {
+        // RFC 4034 4.1.2 caps a bitmap window at 32 bytes; a larger one produces type codes above 65535.
+        var rdata = new List<byte> { 0x00 }; // NEXT = root
+        rdata.AddRange([0x00, 0xFF]); // window 0, bitmap length 255
+        rdata.AddRange(Enumerable.Repeat((byte)0xFF, 255));
+
+        var message = BuildSingleAnswerMessage(DnsQueryType.NSEC, (ushort)rdata.Count, [.. rdata], trailing: []);
+
+        Assert.Throws<DnsProtocolException>(() => DnsMessageEncoder.DecodeResponse(message));
+    }
+
+    private static byte[] BuildSingleAnswerMessage(DnsQueryType type, ushort rdLength, byte[] rdata, byte[] trailing)
+    {
+        var bytes = new List<byte>
+        {
+            0x12, 0x34,
+            0x81, 0x80,
+            0x00, 0x00, // QDCOUNT
+            0x00, 0x01, // ANCOUNT
+            0x00, 0x00,
+            0x00, 0x00,
+            0x00, // NAME = root
+        };
+
+        bytes.AddRange([(byte)((ushort)type >> 8), (byte)(ushort)type]);
+        bytes.AddRange([0x00, 0x01]); // CLASS IN
+        bytes.AddRange([0x00, 0x00, 0x00, 0x3C]); // TTL
+        bytes.AddRange([(byte)(rdLength >> 8), (byte)rdLength]);
+        bytes.AddRange(rdata);
+        bytes.AddRange(trailing);
+        return [.. bytes];
+    }
+
+    [Fact]
+    public void ParseSrvRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsSrvRecord>(DnsQueryType.SRV, [
+            0x00, 0x0A, // priority 10
+            0x00, 0x14, // weight 20
+            0x1F, 0x90, // port 8080
+            4, (byte)'h', (byte)'o', (byte)'s', (byte)'t', 0,
+        ]);
+
+        Assert.Equal(10, record.Priority);
+        Assert.Equal(20, record.Weight);
+        Assert.Equal(8080, record.Port);
+        Assert.Equal("host", record.Target);
+    }
+
+    [Fact]
+    public void ParseNaptrRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsNaptrRecord>(DnsQueryType.NAPTR, [
+            0x00, 0x64, // order 100
+            0x00, 0x0A, // preference 10
+            1, (byte)'u',
+            7, (byte)'E', (byte)'2', (byte)'U', (byte)'+', (byte)'s', (byte)'i', (byte)'p',
+            3, (byte)'!', (byte)'^', (byte)'!',
+            4, (byte)'h', (byte)'o', (byte)'s', (byte)'t', 0,
+        ]);
+
+        Assert.Equal(100, record.Order);
+        Assert.Equal(10, record.Preference);
+        Assert.Equal("u", record.Flags);
+        Assert.Equal("E2U+sip", record.Services);
+        Assert.Equal("!^!", record.Regexp);
+        Assert.Equal("host", record.Replacement);
+    }
+
+    [Fact]
+    public void ParseTlsaRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsTlsaRecord>(DnsQueryType.TLSA, [3, 1, 1, 0xAA, 0xBB]);
+
+        Assert.Equal(3, record.CertificateUsage);
+        Assert.Equal(1, record.Selector);
+        Assert.Equal(1, record.MatchingType);
+        Assert.Equal<byte>([0xAA, 0xBB], record.CertificateAssociationData);
+    }
+
+    [Fact]
+    public void ParseSshfpRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsSshfpRecord>(DnsQueryType.SSHFP, [4, 2, 0x01, 0x02, 0x03]);
+
+        Assert.Equal(4, record.Algorithm);
+        Assert.Equal(2, record.FingerprintType);
+        Assert.Equal<byte>([0x01, 0x02, 0x03], record.Fingerprint);
+    }
+
+    [Fact]
+    public void ParseUriRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsUriRecord>(DnsQueryType.URI, [
+            0x00, 0x0A, 0x00, 0x01,
+            (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)'s', (byte)':', (byte)'/', (byte)'/', (byte)'a',
+        ]);
+
+        Assert.Equal(10, record.Priority);
+        Assert.Equal(1, record.Weight);
+        Assert.Equal("https://a", record.Target);
+    }
+
+    [Fact]
+    public void ParseHinfoRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsHinfoRecord>(DnsQueryType.HINFO, [
+            3, (byte)'a', (byte)'r', (byte)'m',
+            5, (byte)'l', (byte)'i', (byte)'n', (byte)'u', (byte)'x',
+        ]);
+
+        Assert.Equal("arm", record.Cpu);
+        Assert.Equal("linux", record.Os);
+    }
+
+    [Fact]
+    public void ParseRpRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsRpRecord>(DnsQueryType.RP, [
+            2, (byte)'m', (byte)'e', 0,
+            3, (byte)'t', (byte)'x', (byte)'t', 0,
+        ]);
+
+        Assert.Equal("me", record.Mailbox);
+        Assert.Equal("txt", record.TxtDomainName);
+    }
+
+    [Fact]
+    public void ParseDnameRecord_ReadsTarget()
+    {
+        var record = ParseSingleAnswer<DnsDnameRecord>(DnsQueryType.DNAME, [6, (byte)'t', (byte)'a', (byte)'r', (byte)'g', (byte)'e', (byte)'t', 0]);
+
+        Assert.Equal("target", record.Target);
+    }
+
+    [Fact]
+    public void ParseNsec3ParamRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsNsec3ParamRecord>(DnsQueryType.NSEC3PARAM, [1, 0, 0x00, 0x0A, 2, 0xAB, 0xCD]);
+
+        Assert.Equal(1, record.HashAlgorithm);
+        Assert.Equal(0, record.Flags);
+        Assert.Equal(10, record.Iterations);
+        Assert.Equal<byte>([0xAB, 0xCD], record.Salt);
+    }
+
+    [Fact]
+    public void ParseNsecRecord_ReadsTypeBitmapWindows()
+    {
+        // Window 0, one bitmap byte with bits for A (1) and NS (2); then window 1 with bit for type 256+1.
+        var record = ParseSingleAnswer<DnsNsecRecord>(DnsQueryType.NSEC, [
+            4, (byte)'n', (byte)'e', (byte)'x', (byte)'t', 0,
+            0x00, 0x01, 0b0110_0000,
+            0x01, 0x01, 0b0100_0000,
+        ]);
+
+        Assert.Equal("next", record.NextDomainName);
+        Assert.Contains(DnsQueryType.A, record.TypeBitMaps);
+        Assert.Contains(DnsQueryType.NS, record.TypeBitMaps);
+        Assert.Contains((DnsQueryType)257, record.TypeBitMaps);
+    }
+
+    [Fact]
+    public void ParseLocRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsLocRecord>(DnsQueryType.LOC, [
+            0, 0x12, 0x16, 0x13,
+            0x80, 0x00, 0x00, 0x01,
+            0x80, 0x00, 0x00, 0x02,
+            0x00, 0x98, 0x96, 0x80,
+        ]);
+
+        Assert.Equal(0, record.Version);
+        Assert.Equal(0x12, record.Size);
+        Assert.Equal(0x16, record.HorizontalPrecision);
+        Assert.Equal(0x13, record.VerticalPrecision);
+        Assert.Equal(0x80000001u, record.Latitude);
+        Assert.Equal(0x80000002u, record.Longitude);
+        Assert.Equal(10000000u, record.Altitude);
+    }
+
+    [Fact]
+    public void ParseSvcbRecord_ReadsPriorityTargetAndParameters()
+    {
+        var record = ParseSingleAnswer<DnsSvcbRecord>(DnsQueryType.HTTPS, [
+            0x00, 0x01,
+            0x00, // target = root
+            0x00, 0x01, 0x00, 0x03, (byte)'h', (byte)'2', (byte)'!',
+        ]);
+
+        Assert.Equal(1, record.Priority);
+        Assert.Empty(record.TargetName);
+        var parameter = Assert.Single(record.Parameters);
+        Assert.Equal(1, parameter.Key);
+        Assert.Equal<byte>([(byte)'h', (byte)'2', (byte)'!'], parameter.Value);
+    }
+
+    [Fact]
+    public void ParseUnknownRecordType_KeepsRawData()
+    {
+        var record = ParseSingleAnswer<DnsUnknownRecord>((DnsQueryType)64999, [0xDE, 0xAD, 0xBE, 0xEF]);
+
+        Assert.Equal<byte>([0xDE, 0xAD, 0xBE, 0xEF], record.Data);
+    }
+
+    [Fact]
+    public void ParseAaaaRecord_ReadsAddress()
+    {
+        var address = IPAddress.Parse("2001:db8::1");
+        var record = ParseSingleAnswer<DnsAaaaRecord>(DnsQueryType.AAAA, address.GetAddressBytes());
+
+        Assert.Equal(address, record.Address);
+    }
+
+    [Fact]
+    public void ParseCaaRecord_ReadsFieldsInOrder()
+    {
+        var record = ParseSingleAnswer<DnsCaaRecord>(DnsQueryType.CAA, [
+            0,
+            5, (byte)'i', (byte)'s', (byte)'s', (byte)'u', (byte)'e',
+            (byte)'c', (byte)'a', (byte)'.', (byte)'x',
+        ]);
+
+        Assert.Equal(0, record.Flags);
+        Assert.Equal("issue", record.Tag);
+        Assert.Equal("ca.x", record.Value);
+    }
+
+    private static T ParseSingleAnswer<T>(DnsQueryType type, byte[] rdata)
+        where T : DnsRecord
+    {
+        var message = BuildSingleAnswerMessage(type, (ushort)rdata.Length, rdata, trailing: []);
+        var response = DnsMessageEncoder.DecodeResponse(message);
+        return Assert.IsType<T>(Assert.Single(response.Answers));
     }
 }

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnssecValidatorTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnssecValidatorTests.cs
@@ -39,6 +39,86 @@ public sealed class DnssecValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_BogusNxDomain_WhenWildcardDenialIsMissing()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.NxDomainMissingWildcardDenialResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.InvalidDenialProof);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusNxDomain_WhenDenialComesFromAnUnrelatedZone()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.CrossZoneDenialResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.InvalidDenialProof);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenSignatureBytesAreTampered()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.TamperedSignatureResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.SignatureVerificationFailed);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenSignatureIsNotYetValid()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.NotYetValidSignatureResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.SignatureNotYetValid);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenKeyTagDoesNotMatchAnyDnskey()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.WrongKeyTagResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.MissingDnskey);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenRrsigIsStrippedFromASignedZone()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.StrippedSignatureResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.MissingRrsig);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenWildcardAnswerHasNoDenialOfTheQueriedName()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.WildcardWithoutDenialResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.InvalidDenialProof);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenAnswerDoesNotCorrespondToTheQuestion()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.UnrelatedAnswerResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.InvalidData);
+    }
+
+    [Fact]
     public async Task ValidateAsync_SecureNoData()
     {
         var fixture = DnssecTestFixture.Create();
@@ -179,7 +259,15 @@ public sealed class DnssecValidatorTests
             DnsResponseMessage insecureUnsignedResponse,
             DnsResponseMessage expiredSignatureResponse,
             DnsResponseMessage crossZoneSignedResponse,
-            DnsResponseMessage unsupportedAlgorithmResponse)
+            DnsResponseMessage unsupportedAlgorithmResponse,
+            DnsResponseMessage nxDomainMissingWildcardDenialResponse,
+            DnsResponseMessage crossZoneDenialResponse,
+            DnsResponseMessage tamperedSignatureResponse,
+            DnsResponseMessage notYetValidSignatureResponse,
+            DnsResponseMessage wrongKeyTagResponse,
+            DnsResponseMessage strippedSignatureResponse,
+            DnsResponseMessage wildcardWithoutDenialResponse,
+            DnsResponseMessage unrelatedAnswerResponse)
         {
             Responses = responses;
             TrustAnchors = trustAnchors;
@@ -192,6 +280,14 @@ public sealed class DnssecValidatorTests
             ExpiredSignatureResponse = expiredSignatureResponse;
             CrossZoneSignedResponse = crossZoneSignedResponse;
             UnsupportedAlgorithmResponse = unsupportedAlgorithmResponse;
+            NxDomainMissingWildcardDenialResponse = nxDomainMissingWildcardDenialResponse;
+            CrossZoneDenialResponse = crossZoneDenialResponse;
+            TamperedSignatureResponse = tamperedSignatureResponse;
+            NotYetValidSignatureResponse = notYetValidSignatureResponse;
+            WrongKeyTagResponse = wrongKeyTagResponse;
+            StrippedSignatureResponse = strippedSignatureResponse;
+            WildcardWithoutDenialResponse = wildcardWithoutDenialResponse;
+            UnrelatedAnswerResponse = unrelatedAnswerResponse;
         }
 
         private IReadOnlyDictionary<QueryKey, DnsResponseMessage> Responses { get; }
@@ -215,6 +311,22 @@ public sealed class DnssecValidatorTests
         public DnsResponseMessage CrossZoneSignedResponse { get; }
 
         public DnsResponseMessage UnsupportedAlgorithmResponse { get; }
+
+        public DnsResponseMessage NxDomainMissingWildcardDenialResponse { get; }
+
+        public DnsResponseMessage CrossZoneDenialResponse { get; }
+
+        public DnsResponseMessage TamperedSignatureResponse { get; }
+
+        public DnsResponseMessage NotYetValidSignatureResponse { get; }
+
+        public DnsResponseMessage WrongKeyTagResponse { get; }
+
+        public DnsResponseMessage StrippedSignatureResponse { get; }
+
+        public DnsResponseMessage WildcardWithoutDenialResponse { get; }
+
+        public DnsResponseMessage UnrelatedAnswerResponse { get; }
 
         public static DnssecTestFixture Create(bool dsMismatch = false, ushort? exampleKeyFlags = null)
         {
@@ -281,9 +393,21 @@ public sealed class DnssecValidatorTests
             var aliasSignature = CreateSignature([alias], DnsQueryType.CNAME, "example.com", exampleKey, exampleRsa, now);
             var cnameResponse = CreateMessage("alias.example.com", DnsQueryType.A, [alias, aliasSignature, a, aSignature]);
 
+            // A complete RFC 4035 5.4 NXDOMAIN proof needs two NSECs: one covering the queried name, and one showing
+            // that no wildcard at the closest encloser could have answered it.
             var nxDomainNsec = CreateNsec("a.example.com", "z.example.com", [DnsQueryType.NSEC, DnsQueryType.RRSIG]);
             var nxDomainNsecSignature = CreateSignature([nxDomainNsec], DnsQueryType.NSEC, "example.com", exampleKey, exampleRsa, now);
-            var nxDomainResponse = CreateMessage("missing.example.com", DnsQueryType.A, [], [nxDomainNsec, nxDomainNsecSignature], DnsResponseCode.NameError);
+            var nxDomainWildcardNsec = CreateNsec("example.com", "a.example.com", [DnsQueryType.SOA, DnsQueryType.NS, DnsQueryType.DNSKEY, DnsQueryType.NSEC, DnsQueryType.RRSIG]);
+            var nxDomainWildcardNsecSignature = CreateSignature([nxDomainWildcardNsec], DnsQueryType.NSEC, "example.com", exampleKey, exampleRsa, now);
+            var nxDomainResponse = CreateMessage("missing.example.com", DnsQueryType.A, [], [nxDomainNsec, nxDomainNsecSignature, nxDomainWildcardNsec, nxDomainWildcardNsecSignature], DnsResponseCode.NameError);
+
+            // The same response without the wildcard denial: signed, covering, but not a complete proof.
+            var nxDomainMissingWildcardDenialResponse = CreateMessage("missing.example.com", DnsQueryType.A, [], [nxDomainNsec, nxDomainNsecSignature], DnsResponseCode.NameError);
+
+            // A genuine, correctly signed NSEC from a zone the attacker controls, replayed to deny a name in another zone.
+            var attackerNsec = CreateNsec("a.attacker.example.com", "z.attacker.example.com", [DnsQueryType.NSEC, DnsQueryType.RRSIG]);
+            var attackerNsecSignature = CreateSignature([attackerNsec], DnsQueryType.NSEC, "attacker.example.com", attackerKey, attackerRsa, now);
+            var crossZoneDenialResponse = CreateMessage("missing.example.com", DnsQueryType.A, [], [attackerNsec, attackerNsecSignature], DnsResponseCode.NameError);
 
             var noDataNsec = CreateNsec("www.example.com", "z.example.com", [DnsQueryType.A, DnsQueryType.NSEC, DnsQueryType.RRSIG]);
             var noDataNsecSignature = CreateSignature([noDataNsec], DnsQueryType.NSEC, "example.com", exampleKey, exampleRsa, now);
@@ -298,12 +422,36 @@ public sealed class DnssecValidatorTests
             var unsupportedSignature = CreateUnsupportedSignature(a, exampleKey, now);
             var unsupportedAlgorithmResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, unsupportedSignature]);
 
-            return new(responses, [trustAnchor], timeProvider, positiveAResponse, cnameResponse, nxDomainResponse, noDataResponse, insecureUnsignedResponse, expiredSignatureResponse, crossZoneSignedResponse, unsupportedAlgorithmResponse);
+            // A signature whose bytes were altered must not verify.
+            var tamperedSignature = CloneSignature(aSignature);
+            tamperedSignature.Signature[0] ^= 0xFF;
+            var tamperedSignatureResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, tamperedSignature]);
+
+            var notYetValidSignature = CreateSignature([a], DnsQueryType.A, "example.com", exampleKey, exampleRsa, now, TimeSpan.FromHours(2), TimeSpan.FromHours(3));
+            var notYetValidSignatureResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, notYetValidSignature]);
+
+            var wrongKeyTagSignature = CloneSignature(aSignature);
+            wrongKeyTagSignature.KeyTag = unchecked((ushort)(wrongKeyTagSignature.KeyTag + 1));
+            var wrongKeyTagResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, wrongKeyTagSignature]);
+
+            // The zone is signed, so an answer with the RRSIG removed must be Bogus rather than treated as unsigned.
+            var strippedSignatureResponse = CreateMessage("www.example.com", DnsQueryType.A, [a]);
+
+            // A genuine wildcard signature (Labels = 2, i.e. "*.example.com") replayed for a name that has real data,
+            // with no NSEC proving the queried name is absent.
+            var wildcardA = CreateRecord(new DnsARecord { Address = IPAddress.Parse("192.0.2.99") }, "shadowed.example.com", DnsQueryType.A);
+            var wildcardSignature = CreateSignature([wildcardA], DnsQueryType.A, "example.com", exampleKey, exampleRsa, now, inceptionOffset: null, expirationOffset: null, labels: 2);
+            var wildcardWithoutDenialResponse = CreateMessage("shadowed.example.com", DnsQueryType.A, [wildcardA, wildcardSignature]);
+
+            // A correctly signed RRset for a name nobody asked about.
+            var unrelatedAnswerResponse = CreateMessage("bank.example.com", DnsQueryType.A, [a, aSignature]);
+
+            return new(responses, [trustAnchor], timeProvider, positiveAResponse, cnameResponse, nxDomainResponse, noDataResponse, insecureUnsignedResponse, expiredSignatureResponse, crossZoneSignedResponse, unsupportedAlgorithmResponse, nxDomainMissingWildcardDenialResponse, crossZoneDenialResponse, tamperedSignatureResponse, notYetValidSignatureResponse, wrongKeyTagResponse, strippedSignatureResponse, wildcardWithoutDenialResponse, unrelatedAnswerResponse);
         }
 
         public async Task<DnssecValidationResult> ValidateAsync(DnsResponseMessage response)
         {
-            var validator = new DnssecValidator(ResolveAsync, TrustAnchors, TimeProvider);
+            var validator = new DnssecValidator(ResolveAsync, TrustAnchors, TimeProvider, ednsUdpPayloadSize: 1232);
             return await validator.ValidateAsync(response, CancellationToken.None);
         }
 
@@ -392,14 +540,15 @@ public sealed class DnssecValidatorTests
         RSA signerRsa,
         DateTimeOffset now,
         TimeSpan? inceptionOffset = null,
-        TimeSpan? expirationOffset = null)
+        TimeSpan? expirationOffset = null,
+        byte? labels = null)
     {
         var signature = CreateRecord(
             new DnsRrsigRecord
             {
                 TypeCovered = typeCovered,
                 Algorithm = signerKey.Algorithm,
-                Labels = (byte)DnssecCanonicalizer.CountLabels(rrset[0].Name),
+                Labels = labels ?? (byte)DnssecCanonicalizer.CountLabels(rrset[0].Name),
                 OriginalTtl = rrset[0].TimeToLive,
                 SignatureExpiration = checked((uint)now.Add(expirationOffset ?? TimeSpan.FromHours(1)).ToUnixTimeSeconds()),
                 SignatureInception = checked((uint)now.Add(inceptionOffset ?? TimeSpan.FromHours(-1)).ToUnixTimeSeconds()),
@@ -411,6 +560,26 @@ public sealed class DnssecValidatorTests
 
         signature.Signature = signerRsa.SignData(DnssecCanonicalizer.GetSignedData(rrset, signature), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         return signature;
+    }
+
+    /// <summary>Copies an RRSIG so a test can corrupt one field without disturbing the fixture's other responses.</summary>
+    private static DnsRrsigRecord CloneSignature(DnsRrsigRecord signature)
+    {
+        return CreateRecord(
+            new DnsRrsigRecord
+            {
+                TypeCovered = signature.TypeCovered,
+                Algorithm = signature.Algorithm,
+                Labels = signature.Labels,
+                OriginalTtl = signature.OriginalTtl,
+                SignatureExpiration = signature.SignatureExpiration,
+                SignatureInception = signature.SignatureInception,
+                KeyTag = signature.KeyTag,
+                SignerName = signature.SignerName,
+                Signature = signature.Signature.ToArray(),
+            },
+            signature.Name,
+            DnsQueryType.RRSIG);
     }
 
     private static DnsRrsigRecord CreateUnsupportedSignature(DnsRecord record, DnsDnskeyRecord signerKey, DateTimeOffset now)


### PR DESCRIPTION
An audit of `Meziantou.Framework.DnsClient` turned up three critical defects and several high-severity ones. This fixes them, with tests.

## The three critical ones

**Responses were accepted without being checked against the query.** The transaction ID was generated inside `EncodeQuery` and immediately discarded, the echoed question was never compared to the one sent, and the QR bit was never inspected — `grep` for `Header.Id` found zero read sites. Confirmed end to end: a response carrying `attacker.test A 6.6.6.6` came back as the answer to a query for `example.com`. On top of that, `DnsUdpTransport` never called `Connect`, so the kernel applied no source filter either. Over `DnsClientProtocol.Udp` that is off-path cache poisoning with no ID to guess.

`EncodeQuery` now returns the identifier, `SendCoreAsync` rejects any response whose ID, QR bit, opcode or question does not match, the UDP socket is connected, and the ID comes from `RandomNumberGenerator`.

**`DnssecValidationMode.Local` threw on ordinary zones.** `ByteArrayComparer` delegated to `StructuralComparisons.StructuralComparer`, which throws when two arrays differ in length, so canonical ordering failed for any RRset whose records were not all the same size. Live against Cloudflare DoH, `cloudflare.com TXT` threw `InvalidOperationException: Failed to compare two elements in the array` straight out of `QueryAsync`. `A`/`NS`/`DNSKEY` passed only because their records happen to be equal-length — which is why the existing suite, whose DNSSEC fixtures all sign single-record RRsets, never noticed.

**The negative-answer half of DNSSEC could be forged.** Nothing required an NSEC/NSEC3 record to come from a zone related to the queried name, so anyone owning one signed NSEC3 zone could compute hashes bracketing any target name under their own salt and mint an authenticated `NXDOMAIN` for it. Denial proofs are now bound to the queried zone, `NXDOMAIN` requires the wildcard proof as well as the covering proof (RFC 4035 §5.4), wildcard-expanded answers require a denial of the queried name (§5.3.4), and opt-out NSEC3 no longer proves a name does not exist (RFC 5155 §6).

## Two bugs the audit missed, found while fixing

- **The RRset sort key was wrong.** `GetSignedData` sorted whole canonical RRs, which orders by RDLENGTH before RDATA; RFC 4034 §6.3 sorts by RDATA alone. This was masked by the comparer throwing — once that was fixed, `cloudflare.com MX` verified as `Bogus`.
- **Closest-encloser derivation has to tolerate synthesized names.** Requiring an exact NSEC owner/next match broke RFC 4470 minimally-covering zones (`nlnetlabs.nl`). It is now derived by longest common suffix.

## Also fixed

**DNSSEC** — answers are matched to the question through the CNAME/DNAME chain, so a signed RRset from an unrelated zone no longer yields `Secure`; canonical label ordering compares downcased octets (`OrdinalIgnoreCase` folds to uppercase and put `_` on the wrong side of the letters, breaking NSEC ranges for `_dmarc`, `_domainkey`, `_tcp` and DANE names); chain-walk failures become `Indeterminate` instead of throwing out of the caller's query, with a query budget so a hostile response cannot fan out into a walk to the root per bogus signer name; the ancestry check runs before any network I/O; canonical RDATA uses the preserved wire bytes except for the types RFC 4034 §6.2 (as amended by RFC 6840 §5.1) actually requires downcasing; RRSIG validity uses RFC 1982 serial arithmetic; `ComputeNsec3Hash` no longer sizes a `stackalloc` from parsed input.

**Wire parsing** — negative computed RDATA lengths threw `ArgumentOutOfRangeException` out of the library and now throw `DnsProtocolException`; each record is parsed through a reader bounded to its own RDATA, so an inner length field can no longer read into the next record and silently desynchronize the rest of the message; names are capped at 255 bytes and pointers must point strictly backwards, removing a ~1000x memory amplification (a 14 KB response allocated 14.3 MB) and making pointer loops unrepresentable; a pointer past the end of the message is an error rather than a silently truncated name; labels are escaped in RFC 1035 presentation format so a single label `evil.com` is no longer indistinguishable from the two-label name; the EDNS extended RCODE is combined with the header RCODE, so BADVERS no longer decodes as `NoError`.

**Client and transports** — truncated (TC) UDP answers are re-issued over TCP; a timeout throws `TimeoutException`, distinguishable from caller cancellation; `SendAsync` no longer mutates the caller's message, applies IDN conversion, and agrees with `QueryAsync` on whether EDNS is advertised; `Dispose` is idempotent and use-after-dispose throws; `DnsClientProtocol.Https` rejects cleartext `http://`; DoH bounds the response body to 65535 bytes; QUIC support is checked at construction so callers can fall back; bracketed IPv6 addresses keep their port (`IPAddress.TryParse` accepts `[::1]:5353` and silently discards it).

## Behaviour and API changes worth a look

- `EdnsUdpPayloadSize` defaults to **1232** (RFC 9715 / DNS Flag Day 2020) instead of 4096.
- `HttpVersion` defaults to **HTTP/2** instead of HTTP/3.
- **Breaking:** `DnssecTrustAnchor.Digest` is `ReadOnlyMemory<byte>` rather than `byte[]` — the root anchors are a process-wide singleton and the array was writable. Visible in the `ref/` diff.
- New `DnsClientOptions.RetryTruncatedOverTcp`, and the `ChainQueryFailed` / `QueryBudgetExceeded` issue codes.
- CDS and CDNSKEY are parsed.

## Testing

52 → 135 tests per target framework. Adds hostile-input coverage for the parser, eight DNSSEC *rejection* tests (tampered signature, not-yet-valid, wrong key tag, stripped RRSIG, cross-zone denial, missing wildcard denial, unrelated answer), round-trip tests for the record parsers that had none, and response-validation tests. The NXDOMAIN fixture is now a complete RFC 4035 §5.4 proof rather than a single covering NSEC.

Network tests are gated on a per-endpoint reachability probe and skip rather than fail — reachability is tracked per `(server, protocol)` because a network that allows 443 may still block 53/853. `Query_DoQ` previously did a bare `return` when QUIC was unavailable, reporting a pass having asserted nothing; it now skips.

**Verified:** 270 tests pass across net10.0 and net11.0 (2 skipped — QUIC unsupported on the dev machine), the dependent `DnsServer` (90) and `DnsProxy` (84) suites pass, the solution builds with `-p:TreatWarningsAsErrors=true`, `eng/update-all.cs` was run and `ref/` regenerated.

Live against real resolvers, every signed zone tested validates `Secure` — NSEC3 (`nic.cz`, `verisign.com`), minimally-covering NSEC (`nlnetlabs.nl`), underscore names (`_dmarc`, `_25._tcp` TLSA) and NXDOMAIN proofs — while `dnssec-failed.org` reports `Bogus` and unsigned zones report `Insecure`.

## Deliberately not included

Flagged in the audit as design changes rather than defects, each needing a call that is yours: connection pooling for DoT/DoQ (a handshake per query, and a client-side port exhaustion ceiling under load); hoisting the DNSSEC key cache across queries (a validated lookup still costs ~6 round trips — doing it properly needs a TTL and negative-caching policy); lazy async server resolution (the constructor still resolves hostnames synchronously and pins the first address); and the v3-scale items — making `IDnsTransport` public and extracting the protocol enums duplicated with `DnsServer`.