### PR TITLE
Fix silent fail-open defects in DnsFilter parsing and matching

### DIFF
--- a/ref/Meziantou.Framework.DnsFilter.cs
+++ b/ref/Meziantou.Framework.DnsFilter.cs
@@ -13,8 +13,10 @@ namespace Meziantou.Framework.DnsFilter
 
     public enum DnsFilterAction
     {
-        Block = 0,
-        Allow = 1
+        None = 0,
+        Block = 1,
+        Allow = 2,
+        Rewrite = 3
     }
 
     public sealed class DnsFilterEngine
@@ -36,6 +38,32 @@ namespace Meziantou.Framework.DnsFilter
     {
         public static System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterRule> Parse(System.IO.TextReader reader, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) => throw null;
         public static System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterRule> Parse(string text, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) => throw null;
+        public static Meziantou.Framework.DnsFilter.DnsFilterParseResult ParseWithDiagnostics(System.IO.TextReader reader, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) => throw null;
+        public static Meziantou.Framework.DnsFilter.DnsFilterParseResult ParseWithDiagnostics(string text, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) => throw null;
+    }
+
+    public sealed class DnsFilterParseDiagnostic
+    {
+        public int LineNumber { get => throw null; }
+        public string Line { get => throw null; }
+        public Meziantou.Framework.DnsFilter.DnsFilterParseError Error { get => throw null; }
+        public string? Detail { get => throw null; }
+        public override string ToString() => throw null;
+    }
+
+    public enum DnsFilterParseError
+    {
+        UnsupportedModifier = 0,
+        InvalidModifierValue = 1,
+        InvalidRegex = 2,
+        InvalidPattern = 3
+    }
+
+    public sealed class DnsFilterParseResult
+    {
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterRule> Rules { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterParseDiagnostic> Diagnostics { get => throw null; }
+        public Meziantou.Framework.DnsFilter.DnsFilterListFormat Format { get => throw null; }
     }
 
     public enum DnsFilterQueryType
@@ -45,12 +73,28 @@ namespace Meziantou.Framework.DnsFilter
         CNAME = 5,
         SOA = 6,
         PTR = 12,
+        HINFO = 13,
         MX = 15,
         TXT = 16,
         AAAA = 28,
+        LOC = 29,
         SRV = 33,
+        NAPTR = 35,
+        CERT = 37,
+        DNAME = 39,
+        DS = 43,
+        SSHFP = 44,
+        RRSIG = 46,
+        NSEC = 47,
+        DNSKEY = 48,
+        NSEC3 = 50,
+        TLSA = 52,
+        SVCB = 64,
         HTTPS = 65,
-        ANY = 255
+        SPF = 99,
+        ANY = 255,
+        URI = 256,
+        CAA = 257
     }
 
     public sealed class DnsFilterResult
@@ -66,7 +110,8 @@ namespace Meziantou.Framework.DnsFilter
     {
         NoError = 0,
         NameError = 1,
-        Refused = 2
+        Refused = 2,
+        ServerFailure = 3
     }
 
     public sealed class DnsFilterRewriteRule
@@ -82,19 +127,25 @@ namespace Meziantou.Framework.DnsFilter
         public required Meziantou.Framework.DnsFilter.DnsFilterAction Action { get => throw null; init { } }
         public bool IsImportant { get => throw null; init { } }
         public bool IsBadFilter { get => throw null; init { } }
+        public string? ExactDomain { get => throw null; init { } }
+        public string? DomainSuffix { get => throw null; init { } }
+        public string? PatternText { get => throw null; }
         public System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.DnsFilter.DnsFilterQueryType>? AllowedDnsTypes { get => throw null; init { } }
         public System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.DnsFilter.DnsFilterQueryType>? ExcludedDnsTypes { get => throw null; init { } }
         public System.Collections.Generic.IReadOnlyCollection<string>? DenyAllowDomains { get => throw null; init { } }
         public Meziantou.Framework.DnsFilter.DnsFilterRewriteRule? Rewrite { get => throw null; init { } }
+        public static Meziantou.Framework.DnsFilter.DnsFilterRule CreateBlock(string domain, bool includeSubdomains = false) => throw null;
+        public static Meziantou.Framework.DnsFilter.DnsFilterRule CreateAllow(string domain, bool includeSubdomains = false) => throw null;
     }
 
     public sealed class DnsFilterRuleSet
     {
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterRule> Rules { get => throw null; }
+        public int Count { get => throw null; }
         public void Add(Meziantou.Framework.DnsFilter.DnsFilterRule rule) { }
         public void AddRange(System.Collections.Generic.IEnumerable<Meziantou.Framework.DnsFilter.DnsFilterRule> rules) { }
-        public void AddFromList(System.IO.TextReader reader, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) { }
-        public void AddFromList(string text, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) { }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterParseDiagnostic> AddFromList(System.IO.TextReader reader, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) => throw null;
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsFilter.DnsFilterParseDiagnostic> AddFromList(string text, Meziantou.Framework.DnsFilter.DnsFilterListFormat format = 0) => throw null;
         public void Clear() { }
     }
 }

--- a/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
+++ b/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
@@ -23,7 +23,7 @@ internal sealed class FilterEngineProvider
         var initialRuleSet = new DnsFilterRuleSet();
         AddCachedFilterLists(initialRuleSet, options.Value);
         _engine = new DnsFilterEngine(initialRuleSet);
-        _ruleCount = initialRuleSet.Rules.Count;
+        _ruleCount = initialRuleSet.Count;
     }
 
     public DnsFilterEngine Engine => Volatile.Read(ref _engine);
@@ -61,7 +61,7 @@ internal sealed class FilterEngineProvider
         activity?.SetTag("dns_proxy.filter.count", filterCount);
         activity?.SetTag("dns_proxy.filter.loaded_count", loadedFilterCount);
         activity?.SetTag("dns_proxy.filter.failed_count", failedFilterCount);
-        activity?.SetTag("dns_proxy.rule.count", ruleSet.Rules.Count);
+        activity?.SetTag("dns_proxy.rule.count", ruleSet.Count);
 
         if (failedFilterCount == 0)
         {
@@ -72,7 +72,7 @@ internal sealed class FilterEngineProvider
             activity?.SetStatus(ActivityStatusCode.Error, $"{failedFilterCount} filter lists failed to load");
         }
 
-        Volatile.Write(ref _ruleCount, ruleSet.Rules.Count);
+        Volatile.Write(ref _ruleCount, ruleSet.Count);
         Volatile.Write(ref _engine, new DnsFilterEngine(ruleSet));
     }
 
@@ -88,11 +88,13 @@ internal sealed class FilterEngineProvider
                 : DnsFilterListFormat.AutoDetect;
             activity?.SetTag("dns_proxy.filter.format", format.ToString());
 
-            var ruleCount = ruleSet.Rules.Count;
+            var ruleCount = ruleSet.Count;
             var listText = await httpClient.GetStringAsync(filter.Url, cancellationToken).ConfigureAwait(false);
-            ruleSet.AddFromList(listText, format);
+            var diagnostics = ruleSet.AddFromList(listText, format);
             await WriteFilterListToCacheAsync(options, filter, listText, cancellationToken).ConfigureAwait(false);
-            activity?.SetTag("dns_proxy.filter.rule_count", ruleSet.Rules.Count - ruleCount);
+            activity?.SetTag("dns_proxy.filter.rule_count", ruleSet.Count - ruleCount);
+            activity?.SetTag("dns_proxy.filter.skipped_line_count", diagnostics.Count);
+            LogSkippedLines(filter, diagnostics);
             activity?.SetStatus(ActivityStatusCode.Ok);
 
             return true;
@@ -135,7 +137,7 @@ internal sealed class FilterEngineProvider
             }
 
             var listText = File.ReadAllText(cacheFilePath);
-            AddFilterList(ruleSet, filter, listText);
+            LogSkippedLines(filter, AddFilterList(ruleSet, filter, listText));
         }
         catch (Exception ex)
         {
@@ -186,12 +188,30 @@ internal sealed class FilterEngineProvider
         }
     }
 
-    private static void AddFilterList(DnsFilterRuleSet ruleSet, FilterListOption filter, string listText)
+    private static IReadOnlyList<DnsFilterParseDiagnostic> AddFilterList(DnsFilterRuleSet ruleSet, FilterListOption filter, string listText)
     {
         var format = Enum.TryParse<DnsFilterListFormat>(filter.Format, ignoreCase: true, out var parsedFormat)
             ? parsedFormat
             : DnsFilterListFormat.AutoDetect;
-        ruleSet.AddFromList(listText, format);
+
+        return ruleSet.AddFromList(listText, format);
+    }
+
+    /// <summary>
+    /// A list whose lines were mostly discarded is indistinguishable from a healthy one if only the
+    /// rule count is reported, so say how many lines were skipped and give a few examples.
+    /// </summary>
+    private void LogSkippedLines(FilterListOption filter, IReadOnlyList<DnsFilterParseDiagnostic> diagnostics)
+    {
+        if (diagnostics.Count is 0)
+            return;
+
+        var examples = string.Join(" | ", diagnostics.Take(3).Select(d => d.ToString()));
+        _logger.LogWarning(
+            "Skipped {SkippedLineCount} unparsable line(s) in filter list {FilterUrl}. First: {Examples}",
+            diagnostics.Count,
+            filter.Url,
+            examples);
     }
 
     private static string GetCacheFilePath(DnsProxyOptions options, FilterListOption filter)

--- a/src/Meziantou.DnsProxy/Proxy/CustomDnsRecordProvider.cs
+++ b/src/Meziantou.DnsProxy/Proxy/CustomDnsRecordProvider.cs
@@ -103,7 +103,7 @@ internal sealed class CustomDnsRecordProvider
         }
     }
 
-    private static bool TryCreateRecordData(DnsQueryType type, string value, [NotNullWhen(true)] out DnsResourceRecordData? data)
+    internal static bool TryCreateRecordData(DnsQueryType type, string value, [NotNullWhen(true)] out DnsResourceRecordData? data)
     {
         data = type switch
         {

--- a/src/Meziantou.DnsProxy/Proxy/DnsProxyHandler.cs
+++ b/src/Meziantou.DnsProxy/Proxy/DnsProxyHandler.cs
@@ -13,6 +13,8 @@ namespace Meziantou.DnsProxy.Proxy;
 
 internal sealed class DnsProxyHandler
 {
+    private const uint RewriteTimeToLive = 60;
+
     private readonly FilterEngineProvider _filterEngineProvider;
     private readonly FilteringPauseState _filteringPauseState;
     private readonly CustomDnsRecordProvider _customDnsRecordProvider;
@@ -82,7 +84,16 @@ internal sealed class DnsProxyHandler
                         Address = clientAddress,
                     });
 
-                if (filterResult.IsMatched && filterResult.Action == DnsFilterAction.Block)
+                if (filterResult.Action is DnsFilterAction.Rewrite && TryApplyRewrite(filterResult.Rewrite!, question, response))
+                {
+                    ApplyQueryEdnsOptions(context, response);
+                    historyEntryBuilder.Result = "Rewritten";
+                    historyEntryBuilder.ResponseCode = response.ResponseCode.ToString();
+                    _requestHistoryStore.Add(historyEntryBuilder.Build(response));
+                    continue;
+                }
+
+                if (filterResult.Action is DnsFilterAction.Block or DnsFilterAction.Rewrite)
                 {
                     response.ResponseCode = DnsResponseCode.NameError;
                     historyEntryBuilder.Result = "Blocked";
@@ -195,9 +206,50 @@ internal sealed class DnsProxyHandler
 
     private static DnsFilterQueryType ConvertToFilterQueryType(DnsQueryType queryType)
     {
-        return Enum.IsDefined((DnsFilterQueryType)queryType)
-            ? (DnsFilterQueryType)queryType
-            : DnsFilterQueryType.ANY;
+        // DnsFilterQueryType is an open set of QTYPE codes. Substituting ANY for an unnamed type
+        // would make $dnstype=ANY rules fire on it and $dnstype=~ANY rules spare it.
+        return (DnsFilterQueryType)queryType;
+    }
+
+    /// <summary>
+    /// Applies a <c>$dnsrewrite</c> directive to the response. Returns <see langword="false"/> when
+    /// the directive cannot be represented, in which case the caller falls back to blocking.
+    /// </summary>
+    private static bool TryApplyRewrite(DnsFilterRewriteRule rewrite, DnsQuestion question, DnsMessage response)
+    {
+        response.ResponseCode = rewrite.ResponseCode switch
+        {
+            DnsFilterRewriteResponseCode.NoError => DnsResponseCode.NoError,
+            DnsFilterRewriteResponseCode.NameError => DnsResponseCode.NameError,
+            DnsFilterRewriteResponseCode.Refused => DnsResponseCode.Refused,
+            DnsFilterRewriteResponseCode.ServerFailure => DnsResponseCode.ServerFailure,
+            _ => DnsResponseCode.NameError,
+        };
+
+        if (rewrite.RecordType is not { } recordType || rewrite.Value is not { } value)
+            return true;
+
+        var answerType = (DnsQueryType)recordType;
+        if (question.Type is not DnsQueryType.ANY && question.Type != answerType)
+        {
+            // The rewrite targets a different record type than the one asked for; answer the
+            // question with an empty NOERROR rather than a record the client did not request.
+            return true;
+        }
+
+        if (!CustomDnsRecordProvider.TryCreateRecordData(answerType, value, out var data))
+            return false;
+
+        response.Answers.Add(new DnsResourceRecord
+        {
+            Name = question.Name,
+            Type = answerType,
+            Class = DnsQueryClass.IN,
+            TimeToLive = RewriteTimeToLive,
+            Data = data,
+        });
+
+        return true;
     }
 
     private async Task<ForwardResult> ForwardToUpstreamAsync(Meziantou.Framework.DnsServer.Protocol.DnsQuestion question, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.DnsFilter/DnsDomainName.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsDomainName.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+
+namespace Meziantou.Framework.DnsFilter;
+
+/// <summary>
+/// The single definition of how a domain name is normalized, used for both rule patterns and
+/// queried names so the two can never drift apart.
+/// </summary>
+internal static class DnsDomainName
+{
+    private const int MaxLabelLength = 63;
+    private const int MaxNameLength = 253;
+
+    private static readonly IdnMapping IdnMapping = new() { AllowUnassigned = true, UseStd3AsciiRules = false };
+
+    /// <summary>
+    /// Trims, strips the root label, lowercases, and converts internationalized names to their
+    /// A-label (punycode) form, which is what DNS actually carries on the wire.
+    /// </summary>
+    /// <returns><see langword="false"/> when the value is not usable as a domain name.</returns>
+    public static bool TryNormalize(string value, [NotNullWhen(true)] out string? normalized)
+    {
+        normalized = null;
+
+        var trimmed = value.AsSpan().Trim().TrimEnd('.');
+        if (trimmed.IsEmpty)
+            return false;
+
+        var candidate = trimmed.ToString();
+        if (!Ascii.IsValid(candidate))
+        {
+            try
+            {
+                candidate = IdnMapping.GetAscii(candidate);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        candidate = candidate.ToLowerInvariant();
+        if (!IsValid(candidate))
+            return false;
+
+        normalized = candidate;
+        return true;
+    }
+
+    /// <summary>
+    /// Checks that a normalized value is shaped like a domain name. This is deliberately permissive
+    /// about characters real blocklists use (underscores, digits) and strict about the ones that
+    /// indicate the value is not a domain at all — most importantly whitespace, which is what a
+    /// mis-detected hosts line (<c>0.0.0.0 ads.example.com</c>) would carry.
+    /// </summary>
+    private static bool IsValid(string value)
+    {
+        if (value.Length is 0 or > MaxNameLength)
+            return false;
+
+        var labelLength = 0;
+        foreach (var c in value)
+        {
+            if (c is '.')
+            {
+                if (labelLength is 0)
+                    return false;
+
+                labelLength = 0;
+                continue;
+            }
+
+            if (!IsAllowedInLabel(c))
+                return false;
+
+            if (++labelLength > MaxLabelLength)
+                return false;
+        }
+
+        return labelLength is not 0;
+    }
+
+    private static bool IsAllowedInLabel(char c)
+    {
+        return char.IsAsciiLetterOrDigit(c) || c is '-' or '_';
+    }
+}

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterAction.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterAction.cs
@@ -1,10 +1,16 @@
 namespace Meziantou.Framework.DnsFilter;
 
 /// <summary>
-/// Specifies the action a DNS filter rule performs when matched.
+/// Specifies the action determined by DNS filter evaluation.
 /// </summary>
 public enum DnsFilterAction
 {
+    /// <summary>
+    /// No rule matched the query. This is the default value, so an unmatched
+    /// result never appears to request blocking.
+    /// </summary>
+    None = 0,
+
     /// <summary>
     /// The rule blocks the matching DNS query.
     /// </summary>
@@ -14,4 +20,14 @@ public enum DnsFilterAction
     /// The rule explicitly allows the matching DNS query (exception/allowlist rule).
     /// </summary>
     Allow,
+
+    /// <summary>
+    /// The matching rule replaces the DNS response instead of simply refusing it.
+    /// The directive is available on <see cref="DnsFilterResult.Rewrite"/>.
+    /// </summary>
+    /// <remarks>
+    /// This value is only ever produced on a <see cref="DnsFilterResult"/>.
+    /// <see cref="DnsFilterRule.Action"/> is always <see cref="Block"/> or <see cref="Allow"/>.
+    /// </remarks>
+    Rewrite,
 }

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterEngine.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterEngine.cs
@@ -1,10 +1,17 @@
+using System.Text.RegularExpressions;
+
 namespace Meziantou.Framework.DnsFilter;
 
 /// <summary>
 /// A DNS filter matching engine that evaluates DNS queries against a set of filter rules.
 /// Supports efficient exact domain matching, subdomain matching, wildcard, and regex patterns.
-/// Thread-safe for concurrent query evaluation; supports atomic rule-set replacement via <see cref="Reload"/>.
 /// </summary>
+/// <remarks>
+/// <see cref="Evaluate"/> is safe to call concurrently, and <see cref="Reload"/> swaps the rule set
+/// atomically. <see cref="DnsFilterRuleSet"/> itself is not thread-safe for concurrent mutation;
+/// the engine takes a snapshot when it builds, so mutating a rule set afterwards never affects an
+/// engine already built from it.
+/// </remarks>
 public sealed class DnsFilterEngine
 {
     private volatile FilterData _data;
@@ -20,7 +27,8 @@ public sealed class DnsFilterEngine
     }
 
     /// <summary>
-    /// Atomically replaces the current rule set with a new one. Thread-safe.
+    /// Atomically replaces the current rule set with a new one. Thread-safe with respect to
+    /// concurrent <see cref="Evaluate"/> calls.
     /// </summary>
     /// <param name="ruleSet">The new rule set.</param>
     public void Reload(DnsFilterRuleSet ruleSet)
@@ -32,158 +40,184 @@ public sealed class DnsFilterEngine
     /// <summary>
     /// Evaluates a DNS query against the filter rules.
     /// </summary>
-    /// <param name="domain">The queried domain name.</param>
-    /// <param name="queryType">The DNS query type.</param>
-    /// <param name="client">Optional client information for <c>$client</c> and <c>$ctag</c> matching.</param>
-    /// <returns>A <see cref="DnsFilterResult"/> indicating whether the query is blocked, allowed, or unmatched.</returns>
+    /// <param name="domain">The queried domain name. Internationalized names are converted to their
+    /// punycode form before matching.</param>
+    /// <param name="queryType">The DNS query type. Pass the raw QTYPE cast to
+    /// <see cref="DnsFilterQueryType"/> even when it is not a named member.</param>
+    /// <param name="client">Optional client information for <c>$client</c> and <c>$ctag</c> matching.
+    /// When a dimension is not supplied, rules scoped on it do not match.</param>
+    /// <returns>A <see cref="DnsFilterResult"/> indicating whether the query is blocked, allowed,
+    /// rewritten, or unmatched. This method does not throw for malformed or hostile input.</returns>
     public DnsFilterResult Evaluate(string domain, DnsFilterQueryType queryType = DnsFilterQueryType.A, DnsClientInfo client = default)
     {
         ArgumentNullException.ThrowIfNull(domain);
 
-        domain = domain.Trim().TrimEnd('.').ToLowerInvariant();
-        if (domain.Length == 0)
-        {
+        if (!DnsDomainName.TryNormalize(domain, out var name))
             return DnsFilterResult.NotMatched;
-        }
 
         var data = _data;
-        var candidates = FindCandidateRules(data, domain);
+        var state = default(MatchState);
 
-        // Apply filtering pipeline and resolve priority
-        DnsFilterRule? bestBlock = null;
-        DnsFilterRule? bestAllow = null;
-        DnsFilterRule? bestImportantBlock = null;
-        DnsFilterRule? bestImportantAllow = null;
-
-        foreach (var rule in candidates)
+        // 1. Exact domain match.
+        if (data.ExactDomainRules.Count > 0 && data.ExactDomainRules.TryGetValue(name, out var exact))
         {
-            // Skip $badfilter rules (they only disable other rules)
-            if (rule.IsBadFilter)
-                continue;
+            ConsiderBucket(exact, ref state, name, queryType, client, requirePatternMatch: false);
+        }
 
-            // Check if this rule is disabled by a $badfilter
-            if (IsDisabledByBadFilter(data, rule))
-                continue;
+        // 2. Suffix (subdomain) match: the name itself and each of its parents.
+        if (data.SuffixDomainRules.Count > 0 || data.SuffixPatternRules.Count > 0)
+        {
+            var suffixLookup = data.SuffixDomainRules.GetAlternateLookup<ReadOnlySpan<char>>();
+            var patternLookup = data.SuffixPatternRules.GetAlternateLookup<ReadOnlySpan<char>>();
 
-            // Filter by $dnstype
-            if (!MatchesDnsType(rule, queryType))
-                continue;
-
-            // Filter by $denyallow
-            if (IsExcludedByDenyAllow(rule, domain))
-                continue;
-
-            // Filter by $client
-            if (!MatchesClient(rule, client))
-                continue;
-
-            // Filter by $ctag
-            if (!MatchesCtag(rule, client))
-                continue;
-
-            // Categorize by priority
-            if (rule.IsImportant)
+            var current = name.AsSpan();
+            while (true)
             {
-                if (rule.Action == DnsFilterAction.Block)
+                if (suffixLookup.TryGetValue(current, out var suffixRules))
                 {
-                    bestImportantBlock ??= rule;
+                    ConsiderBucket(suffixRules, ref state, name, queryType, client, requirePatternMatch: false);
                 }
-                else
+
+                if (patternLookup.TryGetValue(current, out var patternRules))
                 {
-                    bestImportantAllow ??= rule;
+                    ConsiderBucket(patternRules, ref state, name, queryType, client, requirePatternMatch: true);
                 }
-            }
-            else
-            {
-                if (rule.Action == DnsFilterAction.Block)
-                {
-                    bestBlock ??= rule;
-                }
-                else
-                {
-                    bestAllow ??= rule;
-                }
+
+                var dotIndex = current.IndexOf('.');
+                if (dotIndex < 0)
+                    break;
+
+                current = current[(dotIndex + 1)..];
             }
         }
 
-        // Priority resolution:
-        // 1. $important block rules beat everything
-        // 2. $important allow rules beat normal rules
-        // 3. Normal allow (@@) rules beat normal block rules
-        // 4. Normal block rules
-        if (bestImportantBlock is not null)
-        {
-            return DnsFilterResult.Blocked(bestImportantBlock);
-        }
-
-        if (bestImportantAllow is not null)
-        {
-            return DnsFilterResult.Allowed(bestImportantAllow);
-        }
-
-        if (bestAllow is not null)
-        {
-            return DnsFilterResult.Allowed(bestAllow);
-        }
-
-        if (bestBlock is not null)
-        {
-            return DnsFilterResult.Blocked(bestBlock);
-        }
-
-        return DnsFilterResult.NotMatched;
-    }
-
-    private static List<DnsFilterRule> FindCandidateRules(FilterData data, string domain)
-    {
-        var candidates = new List<DnsFilterRule>();
-
-        // 1. Exact domain match
-        if (data.ExactDomainRules.TryGetValue(domain, out var exactRules))
-        {
-            candidates.AddRange(exactRules);
-        }
-
-        // 2. Suffix (subdomain) match: check domain itself and all parent domains
-        // For "sub.ads.example.com", check: "sub.ads.example.com", "ads.example.com", "example.com", "com"
-        var current = domain;
-        while (true)
-        {
-            if (data.SuffixDomainRules.TryGetValue(current, out var suffixRules))
-            {
-                candidates.AddRange(suffixRules);
-            }
-
-            var dotIndex = current.IndexOf('.', StringComparison.Ordinal);
-            if (dotIndex < 0)
-                break;
-
-            current = current[(dotIndex + 1)..];
-        }
-
-        // 3. Regex/wildcard pattern rules
+        // 3. Pattern rules with no indexable suffix, gated by a literal prefilter.
         foreach (var rule in data.PatternRules)
         {
-            if (rule.Pattern!.IsMatch(domain))
+            Consider(rule, ref state, name, queryType, client, requirePatternMatch: true);
+        }
+
+        if (state.Best is null)
+            return DnsFilterResult.NotMatched;
+
+        return state.Best.Action is DnsFilterAction.Allow
+            ? DnsFilterResult.Allowed(state.Best)
+            : DnsFilterResult.Blocked(state.Best);
+    }
+
+    private static void ConsiderBucket(object bucket, ref MatchState state, string name, DnsFilterQueryType queryType, in DnsClientInfo client, bool requirePatternMatch)
+    {
+        if (bucket is DnsFilterRule single)
+        {
+            Consider(single, ref state, name, queryType, client, requirePatternMatch);
+            return;
+        }
+
+        foreach (var rule in (List<DnsFilterRule>)bucket)
+        {
+            Consider(rule, ref state, name, queryType, client, requirePatternMatch);
+        }
+    }
+
+    private static void Consider(DnsFilterRule rule, ref MatchState state, string name, DnsFilterQueryType queryType, in DnsClientInfo client, bool requirePatternMatch)
+    {
+        // Cheap ordering checks first: a rule that cannot beat the incumbent needs no matching work.
+        var rank = GetRank(rule);
+        if (rank < state.Rank)
+            return;
+
+        var specificity = GetSpecificity(rule);
+        if (rank == state.Rank && specificity <= state.Specificity)
+            return;
+
+        if (requirePatternMatch && !MatchesPattern(rule, name))
+            return;
+
+        if (!MatchesDnsType(rule, queryType))
+            return;
+
+        if (IsExcludedByDenyAllow(rule, name))
+            return;
+
+        if (!MatchesClient(rule, client))
+            return;
+
+        if (!MatchesCtag(rule, client))
+            return;
+
+        state.Best = rule;
+        state.Rank = rank;
+        state.Specificity = specificity;
+    }
+
+    private struct MatchState
+    {
+        public DnsFilterRule? Best;
+        public int Rank;
+        public int Specificity;
+    }
+
+    /// <summary>
+    /// Priority of a rule, highest wins. An <c>$important</c> exception outranks an
+    /// <c>$important</c> block, which is what makes <c>@@…$important</c> usable as an override
+    /// against a blocklist the operator does not control.
+    /// </summary>
+    private static int GetRank(DnsFilterRule rule) => (rule.IsImportant, rule.Action) switch
+    {
+        (true, DnsFilterAction.Allow) => 4,
+        (true, _) => 3,
+        (false, DnsFilterAction.Allow) => 2,
+        _ => 1,
+    };
+
+    /// <summary>
+    /// Tie-break within a priority level: a rewrite beats a plain block, then the more specific
+    /// rule wins. Without this the winner would be whichever rule the index happened to yield first.
+    /// </summary>
+    private static int GetSpecificity(DnsFilterRule rule)
+    {
+        var score = rule.ExactDomain is not null ? 1_000_000
+            : rule.DomainSuffix is not null ? 1_000 + rule.DomainSuffix.Length
+            : 1;
+
+        if (rule.Rewrite is not null)
+        {
+            score += 10_000_000;
+        }
+
+        return score;
+    }
+
+    private static bool MatchesPattern(DnsFilterRule rule, string domain)
+    {
+        if (rule.RequiredLiterals is { } literals)
+        {
+            foreach (var literal in literals)
             {
-                candidates.Add(rule);
+                if (!domain.Contains(literal, StringComparison.Ordinal))
+                    return false;
             }
         }
 
-        return candidates;
+        try
+        {
+            return rule.Pattern!.IsMatch(domain);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // A pathological pattern in a third-party list must not take the resolver down. Treat it
+            // as a non-match; the rule is effectively inert for this query.
+            return false;
+        }
     }
 
     private static bool MatchesDnsType(DnsFilterRule rule, DnsFilterQueryType queryType)
     {
-        if (rule.AllowedDnsTypes is not null)
-        {
-            return rule.AllowedDnsTypes.Contains(queryType);
-        }
+        if (rule.AllowedDnsTypes is not null && !rule.AllowedDnsTypes.Contains(queryType))
+            return false;
 
-        if (rule.ExcludedDnsTypes is not null)
-        {
-            return !rule.ExcludedDnsTypes.Contains(queryType);
-        }
+        if (rule.ExcludedDnsTypes is not null && rule.ExcludedDnsTypes.Contains(queryType))
+            return false;
 
         return true;
     }
@@ -195,8 +229,10 @@ public sealed class DnsFilterEngine
 
         foreach (var allowed in rule.DenyAllowDomains)
         {
-            if (domain.Equals(allowed, StringComparison.OrdinalIgnoreCase) ||
-                domain.EndsWith("." + allowed, StringComparison.OrdinalIgnoreCase))
+            if (domain.Equals(allowed, StringComparison.Ordinal) ||
+                (domain.Length > allowed.Length &&
+                 domain[domain.Length - allowed.Length - 1] is '.' &&
+                 domain.EndsWith(allowed, StringComparison.Ordinal)))
             {
                 return true;
             }
@@ -210,58 +246,49 @@ public sealed class DnsFilterEngine
         if (rule.ClientSpecs is null)
             return true;
 
-        // If there are only exclusion specs, the rule matches unless the client matches an exclusion
         var hasInclusions = false;
         var matchedInclusion = false;
 
         foreach (var spec in rule.ClientSpecs)
         {
-            var matches = MatchesClientSpec(spec, client);
-
             if (spec.IsExclusion)
             {
-                if (matches)
-                {
-                    return false; // Excluded client
-                }
+                // The caller may not have supplied the dimension this spec is written against. An
+                // exclusion that cannot be evaluated must not be assumed satisfied, or a
+                // "block for everyone except X" rule would end up applying to X itself.
+                if (!CanEvaluate(spec, client) || MatchesClientSpec(spec, client))
+                    return false;
             }
             else
             {
                 hasInclusions = true;
-                if (matches)
+                if (CanEvaluate(spec, client) && MatchesClientSpec(spec, client))
                 {
                     matchedInclusion = true;
                 }
             }
         }
 
-        // If there are inclusion specs, at least one must match
-        if (hasInclusions)
-        {
-            return matchedInclusion;
-        }
+        return !hasInclusions || matchedInclusion;
+    }
 
-        return true;
+    private static bool CanEvaluate(DnsFilterClientSpec spec, DnsClientInfo client)
+    {
+        if (spec.Address is not null || spec.Network is not null)
+            return client.Address is not null;
+
+        return client.Name is not null;
     }
 
     private static bool MatchesClientSpec(DnsFilterClientSpec spec, DnsClientInfo client)
     {
-        if (spec.Address is not null && client.Address is not null)
-        {
+        if (spec.Address is not null)
             return spec.Address.Equals(client.Address);
-        }
 
-        if (spec.Network is not null && client.Address is not null)
-        {
-            return spec.Network.Value.Contains(client.Address);
-        }
+        if (spec.Network is not null)
+            return spec.Network.Value.Contains(client.Address!);
 
-        if (spec.Name is not null && client.Name is not null)
-        {
-            return spec.Name.Equals(client.Name, StringComparison.OrdinalIgnoreCase);
-        }
-
-        return false;
+        return spec.Name is not null && spec.Name.Equals(client.Name, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool MatchesCtag(DnsFilterRule rule, DnsClientInfo client)
@@ -269,31 +296,25 @@ public sealed class DnsFilterEngine
         if (rule.TagSpec is null)
             return true;
 
-        // If no tags provided by caller, rules with $ctag never match
-        if (client.Tags is null || client.Tags.Count == 0)
+        if (client.Tags is null || client.Tags.Count is 0)
             return false;
 
+        // Exclusions and inclusions are both requirements, not alternatives.
         if (rule.TagSpec.ExcludedTags is not null)
         {
             foreach (var tag in rule.TagSpec.ExcludedTags)
             {
-                if (client.Tags.Any(t => t.Equals(tag, StringComparison.OrdinalIgnoreCase)))
-                {
+                if (ContainsTag(client.Tags, tag))
                     return false;
-                }
             }
-
-            return true;
         }
 
         if (rule.TagSpec.IncludedTags is not null)
         {
             foreach (var tag in rule.TagSpec.IncludedTags)
             {
-                if (client.Tags.Any(t => t.Equals(tag, StringComparison.OrdinalIgnoreCase)))
-                {
+                if (ContainsTag(client.Tags, tag))
                     return true;
-                }
             }
 
             return false;
@@ -302,105 +323,106 @@ public sealed class DnsFilterEngine
         return true;
     }
 
-    private static bool IsDisabledByBadFilter(FilterData data, DnsFilterRule rule)
+    private static bool ContainsTag(IReadOnlyList<string> tags, string tag)
     {
-        if (data.BadFilterTexts.Count == 0)
-            return false;
+        foreach (var candidate in tags)
+        {
+            if (candidate.Equals(tag, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
 
-        // A $badfilter rule disables a rule whose text matches (minus the $badfilter modifier)
-        return data.BadFilterTexts.Contains(rule.OriginalText);
+        return false;
     }
 
     private static FilterData BuildFilterData(DnsFilterRuleSet ruleSet)
     {
-        var exactDomainRules = new Dictionary<string, List<DnsFilterRule>>(StringComparer.OrdinalIgnoreCase);
-        var suffixDomainRules = new Dictionary<string, List<DnsFilterRule>>(StringComparer.OrdinalIgnoreCase);
-        var patternRules = new List<DnsFilterRule>();
-        var badFilterTexts = new HashSet<string>(StringComparer.Ordinal);
+        var rules = ruleSet.ToArray();
 
-        foreach (var rule in ruleSet.Rules)
+        // Pass 1: collect the identities disabled by $badfilter, so disabled rules are never
+        // indexed at all and the query path does not have to check for them.
+        HashSet<string>? badFilterKeys = null;
+        foreach (var rule in rules)
+        {
+            if (rule.IsBadFilter && rule.BadFilterKey is not null)
+            {
+                badFilterKeys ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                badFilterKeys.Add(rule.BadFilterKey);
+            }
+        }
+
+        var exactDomainRules = new Dictionary<string, object>(rules.Length, StringComparer.OrdinalIgnoreCase);
+        var suffixDomainRules = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        var suffixPatternRules = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        var patternRules = new List<DnsFilterRule>();
+
+        foreach (var rule in rules)
         {
             if (rule.IsBadFilter)
-            {
-                // Compute what the original rule text would be (strip $badfilter from the original)
-                var originalText = ComputeBadFilterTarget(rule.OriginalText);
-                badFilterTexts.Add(originalText);
                 continue;
-            }
+
+            if (badFilterKeys is not null && rule.BadFilterKey is not null && badFilterKeys.Contains(rule.BadFilterKey))
+                continue;
 
             if (rule.ExactDomain is not null)
             {
-                if (!exactDomainRules.TryGetValue(rule.ExactDomain, out var list))
-                {
-                    list = [];
-                    exactDomainRules[rule.ExactDomain] = list;
-                }
-
-                list.Add(rule);
+                AddToIndex(exactDomainRules, rule.ExactDomain, rule);
             }
             else if (rule.DomainSuffix is not null)
             {
-                if (!suffixDomainRules.TryGetValue(rule.DomainSuffix, out var list))
-                {
-                    list = [];
-                    suffixDomainRules[rule.DomainSuffix] = list;
-                }
-
-                list.Add(rule);
+                AddToIndex(suffixDomainRules, rule.DomainSuffix, rule);
             }
             else if (rule.Pattern is not null)
             {
-                patternRules.Add(rule);
+                // A wildcard rule anchored on a concrete multi-label suffix can be reached through
+                // the parent-domain walk instead of being tested against every single query.
+                if (rule.PatternSuffix is not null)
+                {
+                    AddToIndex(suffixPatternRules, rule.PatternSuffix, rule);
+                }
+                else
+                {
+                    patternRules.Add(rule);
+                }
             }
         }
+
+        exactDomainRules.TrimExcess();
 
         return new FilterData
         {
             ExactDomainRules = exactDomainRules,
             SuffixDomainRules = suffixDomainRules,
+            SuffixPatternRules = suffixPatternRules,
             PatternRules = patternRules,
-            BadFilterTexts = badFilterTexts,
         };
     }
 
-    private static string ComputeBadFilterTarget(string originalText)
+    /// <summary>
+    /// Stores the rule directly for the ~76% of keys that hold exactly one, promoting to a list
+    /// only on the second insert.
+    /// </summary>
+    private static void AddToIndex(Dictionary<string, object> index, string key, DnsFilterRule rule)
     {
-        // Remove $badfilter from the original rule text to find what it targets
-        // e.g., "||example.com^$badfilter" → "||example.com^"
-        // e.g., "||example.com^$important,badfilter" → "||example.com^$important"
-        const string BadfilterStr = "badfilter";
-        var idx = originalText.LastIndexOf(BadfilterStr, StringComparison.OrdinalIgnoreCase);
-        if (idx < 0)
-            return originalText;
-
-        var before = originalText[..idx];
-        var after = originalText[(idx + BadfilterStr.Length)..];
-
-        // Remove trailing/leading comma
-        if (before.EndsWith(',', StringComparison.Ordinal))
+        if (!index.TryGetValue(key, out var existing))
         {
-            before = before[..^1];
-        }
-        else if (after.StartsWith(',', StringComparison.Ordinal))
-        {
-            after = after[1..];
+            index[key] = rule;
+            return;
         }
 
-        // If the $ sign is now trailing with nothing after, remove it
-        var result = before + after;
-        if (result.EndsWith('$', StringComparison.Ordinal))
+        if (existing is List<DnsFilterRule> list)
         {
-            result = result[..^1];
+            list.Add(rule);
+            return;
         }
 
-        return result;
+        index[key] = new List<DnsFilterRule> { (DnsFilterRule)existing, rule };
     }
 
     private sealed class FilterData
     {
-        public required Dictionary<string, List<DnsFilterRule>> ExactDomainRules { get; init; }
-        public required Dictionary<string, List<DnsFilterRule>> SuffixDomainRules { get; init; }
+        public required Dictionary<string, object> ExactDomainRules { get; init; }
+        public required Dictionary<string, object> SuffixDomainRules { get; init; }
+        public required Dictionary<string, object> SuffixPatternRules { get; init; }
         public required List<DnsFilterRule> PatternRules { get; init; }
-        public required HashSet<string> BadFilterTexts { get; init; }
     }
 }

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterListReader.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterListReader.cs
@@ -7,49 +7,84 @@ namespace Meziantou.Framework.DnsFilter;
 /// Reads DNS filter lists in various formats and produces <see cref="DnsFilterRule"/> instances.
 /// Supports hosts files, domains-only lists, and AdGuard/Adblock DNS filtering syntax.
 /// </summary>
+/// <remarks>
+/// Parsing is strict: a rule carrying a modifier this library does not implement, or a modifier
+/// whose value cannot be parsed, is discarded rather than applied without it. Ignoring an
+/// unrecognized modifier would silently widen the rule — turning <c>@@||x^$script</c> into a
+/// blanket allow, or <c>||x^$dnstype=SVCB</c> into a block of every record type. Use
+/// <see cref="ParseWithDiagnostics(string, DnsFilterListFormat)"/> to see what was discarded.
+/// </remarks>
 public static class DnsFilterListReader
 {
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
+
+    private static readonly string[] LocalhostNames =
+    [
+        "localhost", "localhost.localdomain", "local", "broadcasthost",
+        "ip6-localhost", "ip6-loopback", "ip6-localnet", "ip6-mcastprefix",
+        "ip6-allnodes", "ip6-allrouters", "ip6-allhosts",
+    ];
+
     /// <summary>
     /// Parses all rules from the specified <see cref="TextReader"/>.
     /// </summary>
     /// <param name="reader">The text reader containing the filter list.</param>
     /// <param name="format">The format of the filter list. Defaults to <see cref="DnsFilterListFormat.AutoDetect"/>.</param>
-    /// <returns>A list of parsed filter rules.</returns>
+    /// <returns>A list of parsed filter rules. Lines that could not be parsed are skipped silently;
+    /// use <see cref="ParseWithDiagnostics(TextReader, DnsFilterListFormat)"/> to observe them.</returns>
     public static IReadOnlyList<DnsFilterRule> Parse(TextReader reader, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
-    {
-        ArgumentNullException.ThrowIfNull(reader);
-
-        var lines = ReadAllLines(reader);
-        if (lines.Count == 0)
-        {
-            return [];
-        }
-
-        if (format == DnsFilterListFormat.AutoDetect)
-        {
-            format = DetectFormat(lines);
-        }
-
-        return format switch
-        {
-            DnsFilterListFormat.Hosts => ParseHostsFormat(lines),
-            DnsFilterListFormat.DomainsOnly => ParseDomainsOnlyFormat(lines),
-            DnsFilterListFormat.AdBlock => ParseAdBlockFormat(lines),
-            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown filter list format."),
-        };
-    }
+        => ParseWithDiagnostics(reader, format).Rules;
 
     /// <summary>
     /// Parses all rules from the specified string.
     /// </summary>
     /// <param name="text">The filter list text.</param>
     /// <param name="format">The format of the filter list. Defaults to <see cref="DnsFilterListFormat.AutoDetect"/>.</param>
-    /// <returns>A list of parsed filter rules.</returns>
+    /// <returns>A list of parsed filter rules. Lines that could not be parsed are skipped silently;
+    /// use <see cref="ParseWithDiagnostics(string, DnsFilterListFormat)"/> to observe them.</returns>
     public static IReadOnlyList<DnsFilterRule> Parse(string text, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
+        => ParseWithDiagnostics(text, format).Rules;
+
+    /// <summary>
+    /// Parses a filter list, reporting every line that did not produce a rule.
+    /// </summary>
+    /// <param name="reader">The text reader containing the filter list.</param>
+    /// <param name="format">The format of the filter list.</param>
+    public static DnsFilterParseResult ParseWithDiagnostics(TextReader reader, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var lines = ReadAllLines(reader);
+        if (lines.Count is 0)
+            return new DnsFilterParseResult([], []) { Format = format is DnsFilterListFormat.AutoDetect ? DnsFilterListFormat.DomainsOnly : format };
+
+        if (format is DnsFilterListFormat.AutoDetect)
+        {
+            format = DetectFormat(lines);
+        }
+
+        var diagnostics = new List<DnsFilterParseDiagnostic>();
+        var rules = format switch
+        {
+            DnsFilterListFormat.Hosts => ParseHostsFormat(lines, diagnostics),
+            DnsFilterListFormat.DomainsOnly => ParseDomainsOnlyFormat(lines, diagnostics),
+            DnsFilterListFormat.AdBlock => ParseAdBlockFormat(lines, diagnostics),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown filter list format."),
+        };
+
+        return new DnsFilterParseResult(rules, diagnostics) { Format = format };
+    }
+
+    /// <summary>
+    /// Parses a filter list, reporting every line that did not produce a rule.
+    /// </summary>
+    /// <param name="text">The filter list text.</param>
+    /// <param name="format">The format of the filter list.</param>
+    public static DnsFilterParseResult ParseWithDiagnostics(string text, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
     {
         ArgumentNullException.ThrowIfNull(text);
         using var reader = new StringReader(text);
-        return Parse(reader, format);
+        return ParseWithDiagnostics(reader, format);
     }
 
     private static List<string> ReadAllLines(TextReader reader)
@@ -64,57 +99,90 @@ public static class DnsFilterListReader
         return lines;
     }
 
+    /// <summary>
+    /// Classifies a line for format detection and for the per-format parsers, so that "what is a
+    /// comment" is defined exactly once.
+    /// </summary>
+    private static LineKind Classify(string line, out string content)
+    {
+        content = "";
+
+        var trimmed = line.Trim();
+        if (trimmed.Length is 0)
+            return LineKind.Empty;
+
+        // Adblock list header, e.g. "[Adblock Plus 2.0]"
+        if (trimmed.StartsWith('[', StringComparison.Ordinal))
+            return LineKind.AdBlockComment;
+
+        // '!' introduces an Adblock comment; '#' a hosts/domains comment. A '##' or '#?#' line is a
+        // cosmetic Adblock rule, which is meaningless for DNS either way.
+        if (trimmed.StartsWith('!', StringComparison.Ordinal))
+            return LineKind.AdBlockComment;
+
+        if (trimmed.StartsWith('#', StringComparison.Ordinal))
+            return LineKind.Comment;
+
+        // Strip an inline comment before looking at the content. Doing this first is what keeps a
+        // '$' inside a trailing "# costs $5" from being mistaken for a modifier separator.
+        var commentIndex = trimmed.IndexOf('#', StringComparison.Ordinal);
+        if (commentIndex >= 0)
+        {
+            trimmed = trimmed[..commentIndex].TrimEnd();
+            if (trimmed.Length is 0)
+                return LineKind.Comment;
+        }
+
+        content = trimmed;
+
+        if (trimmed.StartsWith("||", StringComparison.Ordinal) ||
+            trimmed.StartsWith("@@", StringComparison.Ordinal) ||
+            trimmed.StartsWith('/', StringComparison.Ordinal) ||
+            trimmed.StartsWith('|', StringComparison.Ordinal) ||
+            trimmed.Contains('*', StringComparison.Ordinal) ||
+            trimmed.Contains('^', StringComparison.Ordinal) ||
+            trimmed.Contains('$', StringComparison.Ordinal))
+        {
+            return LineKind.AdBlockRule;
+        }
+
+        return IsHostsEntry(trimmed) ? LineKind.HostsEntry : LineKind.Domain;
+    }
+
     internal static DnsFilterListFormat DetectFormat(IReadOnlyList<string> lines)
     {
-        var hasAdBlockMarkers = false;
-        var hasHostsEntries = false;
+        // Count the evidence rather than latching onto the first marker seen: a single odd line in
+        // a 150k-entry hosts file must not reclassify the whole list, because every hosts line
+        // would then be parsed as an Adblock pattern and silently match nothing.
+        var adBlockRules = 0;
+        var hostsEntries = 0;
+        var domains = 0;
+        var adBlockComments = 0;
 
         foreach (var line in lines)
         {
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0)
-                continue;
-
-            // AdBlock-style comment header
-            if (trimmed.StartsWith('[', StringComparison.Ordinal) || trimmed.StartsWith("! ", StringComparison.Ordinal) || trimmed.StartsWith("!--", StringComparison.Ordinal))
+            switch (Classify(line, out _))
             {
-                hasAdBlockMarkers = true;
-                continue;
-            }
-
-            // Standard comment
-            if (trimmed.StartsWith('#', StringComparison.Ordinal))
-                continue;
-
-            // AdBlock-style rule patterns
-            if (trimmed.StartsWith("||", StringComparison.Ordinal) ||
-                trimmed.StartsWith("@@", StringComparison.Ordinal) ||
-                (trimmed.StartsWith('/', StringComparison.Ordinal) && trimmed.EndsWith('/', StringComparison.Ordinal) && trimmed.Length > 2) ||
-                trimmed.Contains('$', StringComparison.Ordinal))
-            {
-                hasAdBlockMarkers = true;
-                continue;
-            }
-
-            // Hosts-file entry: starts with an IP address
-            if (IsHostsEntry(trimmed))
-            {
-                hasHostsEntries = true;
-                continue;
+                case LineKind.AdBlockRule: adBlockRules++; break;
+                case LineKind.HostsEntry: hostsEntries++; break;
+                case LineKind.Domain: domains++; break;
+                case LineKind.AdBlockComment: adBlockComments++; break;
+                default: break;
             }
         }
 
-        if (hasAdBlockMarkers)
-        {
+        if (adBlockRules > 0 && adBlockRules >= hostsEntries)
             return DnsFilterListFormat.AdBlock;
-        }
 
-        if (hasHostsEntries)
-        {
+        if (hostsEntries > 0)
             return DnsFilterListFormat.Hosts;
-        }
 
-        return DnsFilterListFormat.DomainsOnly;
+        if (adBlockRules > 0)
+            return DnsFilterListFormat.AdBlock;
+
+        // A list of bare domains introduced by '!' headers is an Adblock-flavoured list, but every
+        // rule in it is a plain domain, so either parser produces the same rules.
+        return domains > 0 || adBlockComments is 0 ? DnsFilterListFormat.DomainsOnly : DnsFilterListFormat.AdBlock;
     }
 
     private static bool IsHostsEntry(string line)
@@ -123,44 +191,43 @@ public static class DnsFilterListReader
         if (spaceIndex <= 0)
             return false;
 
-        var ipPart = line.AsSpan(0, spaceIndex);
-        return IPAddress.TryParse(ipPart, out _);
+        return IPAddress.TryParse(line.AsSpan(0, spaceIndex), out _);
     }
 
-    private static List<DnsFilterRule> ParseHostsFormat(IReadOnlyList<string> lines)
+    private static List<DnsFilterRule> ParseHostsFormat(List<string> lines, List<DnsFilterParseDiagnostic> diagnostics)
     {
         var rules = new List<DnsFilterRule>();
 
-        foreach (var line in lines)
+        for (var i = 0; i < lines.Count; i++)
         {
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0 || trimmed.StartsWith('#', StringComparison.Ordinal))
+            var kind = Classify(lines[i], out var content);
+            if (kind is LineKind.Empty or LineKind.Comment or LineKind.AdBlockComment)
                 continue;
 
-            // Remove inline comments
-            var commentIndex = trimmed.IndexOf('#', StringComparison.Ordinal);
-            if (commentIndex >= 0)
+            var parts = content.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2 || !IPAddress.TryParse(parts[0], out _))
             {
-                trimmed = trimmed[..commentIndex].TrimEnd();
+                diagnostics.Add(new DnsFilterParseDiagnostic(i + 1, lines[i], DnsFilterParseError.InvalidPattern, "not a hosts entry"));
+                continue;
             }
 
-            // Split by whitespace: IP domain [aliases...]
-            var parts = trimmed.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length < 2)
-                continue;
-
-            // Skip the IP part, add each domain
-            for (var i = 1; i < parts.Length; i++)
+            for (var j = 1; j < parts.Length; j++)
             {
-                var domain = NormalizeDomain(parts[i]);
-                if (domain.Length == 0 || domain is "localhost" or "localhost.localdomain" or "local" or "broadcasthost" or "ip6-localhost" or "ip6-loopback" or "ip6-localnet" or "ip6-mcastprefix" or "ip6-allnodes" or "ip6-allrouters" or "ip6-allhosts")
+                if (!DnsDomainName.TryNormalize(parts[j], out var domain))
+                {
+                    diagnostics.Add(new DnsFilterParseDiagnostic(i + 1, lines[i], DnsFilterParseError.InvalidPattern, parts[j]));
+                    continue;
+                }
+
+                if (Array.IndexOf(LocalhostNames, domain) >= 0)
                     continue;
 
                 rules.Add(new DnsFilterRule
                 {
-                    OriginalText = line,
+                    OriginalText = content,
                     Action = DnsFilterAction.Block,
                     ExactDomain = domain,
+                    BadFilterKey = "e:" + domain,
                 });
             }
         }
@@ -168,104 +235,456 @@ public static class DnsFilterListReader
         return rules;
     }
 
-    private static List<DnsFilterRule> ParseDomainsOnlyFormat(IReadOnlyList<string> lines)
+    private static List<DnsFilterRule> ParseDomainsOnlyFormat(List<string> lines, List<DnsFilterParseDiagnostic> diagnostics)
     {
         var rules = new List<DnsFilterRule>();
 
-        foreach (var line in lines)
+        for (var i = 0; i < lines.Count; i++)
         {
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0 || trimmed.StartsWith('#', StringComparison.Ordinal))
+            var kind = Classify(lines[i], out var content);
+            if (kind is LineKind.Empty or LineKind.Comment or LineKind.AdBlockComment)
                 continue;
 
-            // Remove inline comments
-            var commentIndex = trimmed.IndexOf('#', StringComparison.Ordinal);
-            if (commentIndex >= 0)
+            if (!DnsDomainName.TryNormalize(content, out var domain))
             {
-                trimmed = trimmed[..commentIndex].TrimEnd();
+                diagnostics.Add(new DnsFilterParseDiagnostic(i + 1, lines[i], DnsFilterParseError.InvalidPattern, content));
+                continue;
             }
-
-            if (trimmed.Length == 0)
-                continue;
-
-            var domain = NormalizeDomain(trimmed);
-            if (domain.Length == 0)
-                continue;
 
             rules.Add(new DnsFilterRule
             {
-                OriginalText = line,
+                OriginalText = content,
                 Action = DnsFilterAction.Block,
                 ExactDomain = domain,
+                BadFilterKey = "e:" + domain,
             });
         }
 
         return rules;
     }
 
-    private static List<DnsFilterRule> ParseAdBlockFormat(IReadOnlyList<string> lines)
+    private static List<DnsFilterRule> ParseAdBlockFormat(List<string> lines, List<DnsFilterParseDiagnostic> diagnostics)
     {
         var rules = new List<DnsFilterRule>();
 
-        foreach (var line in lines)
+        for (var i = 0; i < lines.Count; i++)
         {
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0 || trimmed.StartsWith('!', StringComparison.Ordinal) || trimmed.StartsWith('#', StringComparison.Ordinal) || trimmed.StartsWith('[', StringComparison.Ordinal))
+            var kind = Classify(lines[i], out var content);
+            if (kind is LineKind.Empty or LineKind.Comment or LineKind.AdBlockComment)
                 continue;
 
-            if (TryParseAdBlockRule(trimmed, out var rule))
+            if (TryParseAdBlockRule(content, out var rule, out var error, out var detail))
             {
                 rules.Add(rule);
+            }
+            else
+            {
+                diagnostics.Add(new DnsFilterParseDiagnostic(i + 1, lines[i], error, detail));
             }
         }
 
         return rules;
     }
 
-    private static bool TryParseAdBlockRule(string text, [NotNullWhen(true)] out DnsFilterRule? rule)
+    internal static bool TryParseAdBlockRule(string text, [NotNullWhen(true)] out DnsFilterRule? rule)
+        => TryParseAdBlockRule(text, out rule, out _, out _);
+
+    private static bool TryParseAdBlockRule(
+        string text,
+        [NotNullWhen(true)] out DnsFilterRule? rule,
+        out DnsFilterParseError error,
+        out string? detail)
     {
         rule = null;
+        error = DnsFilterParseError.InvalidPattern;
+        detail = null;
 
         var action = DnsFilterAction.Block;
         var remaining = text.AsSpan();
 
-        // Check for exception rule (@@)
         if (remaining.StartsWith("@@", StringComparison.Ordinal))
         {
             action = DnsFilterAction.Allow;
             remaining = remaining[2..];
         }
 
-        // Split off modifiers at the $ sign (but not inside regex)
         string? modifiersPart = null;
-        var isRegex = remaining.StartsWith("/", StringComparison.Ordinal) && remaining.Length > 2;
+        string patternPart;
 
-        if (isRegex)
+        if (remaining.StartsWith("/", StringComparison.Ordinal))
         {
-            // Find the closing / for regex, then check for $
-            var closingSlash = remaining[1..].IndexOf('/');
+            // A '/regex/' rule. The closing delimiter must be found without being fooled by an
+            // escaped slash inside the expression.
+            var closingSlash = FindRegexEnd(remaining);
             if (closingSlash < 0)
+            {
+                error = DnsFilterParseError.InvalidRegex;
+                detail = "missing closing '/'";
                 return false;
+            }
 
-            var afterRegex = remaining[(closingSlash + 2)..];
+            var afterRegex = remaining[(closingSlash + 1)..];
             if (afterRegex.StartsWith("$", StringComparison.Ordinal))
             {
                 modifiersPart = afterRegex[1..].ToString();
             }
-
-            remaining = remaining[1..(closingSlash + 1)];
-        }
-        else
-        {
-            var dollarIndex = remaining.IndexOf('$');
-            if (dollarIndex >= 0)
+            else if (!afterRegex.IsEmpty)
             {
-                modifiersPart = remaining[(dollarIndex + 1)..].ToString();
-                remaining = remaining[..dollarIndex];
+                error = DnsFilterParseError.InvalidRegex;
+                detail = "unexpected text after closing '/'";
+                return false;
+            }
+
+            patternPart = remaining[1..closingSlash].ToString();
+            return TryBuildRegexRule(text, patternPart, action, modifiersPart, GetRegexLiteralPrefix(patternPart) is { } prefix ? [prefix] : null, patternSuffix: null, out rule, out error, out detail);
+        }
+
+        var dollarIndex = remaining.IndexOf('$');
+        if (dollarIndex >= 0)
+        {
+            modifiersPart = remaining[(dollarIndex + 1)..].ToString();
+            remaining = remaining[..dollarIndex];
+        }
+
+        patternPart = remaining.ToString();
+        return TryBuildPatternRule(text, patternPart, action, modifiersPart, out rule, out error, out detail);
+    }
+
+    /// <summary>
+    /// Finds the index of the closing '/' of a regex rule, honouring backslash escapes.
+    /// </summary>
+    private static int FindRegexEnd(ReadOnlySpan<char> value)
+    {
+        for (var i = 1; i < value.Length; i++)
+        {
+            if (value[i] is '\\')
+            {
+                i++;
+                continue;
+            }
+
+            if (value[i] is '/')
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool TryBuildPatternRule(
+        string text,
+        string patternPart,
+        DnsFilterAction action,
+        string? modifiersPart,
+        [NotNullWhen(true)] out DnsFilterRule? rule,
+        out DnsFilterParseError error,
+        out string? detail)
+    {
+        rule = null;
+        error = DnsFilterParseError.InvalidPattern;
+        detail = null;
+
+        // Strip anchors into flags first. Dispatching on them as mutually exclusive branches is what
+        // used to make '||*.example.com^' fall into the domain branch and be stored as a literal.
+        var pattern = patternPart.AsSpan();
+        var matchSubdomains = false;
+
+        if (pattern.StartsWith("||", StringComparison.Ordinal))
+        {
+            matchSubdomains = true;
+            pattern = pattern[2..];
+        }
+        else if (pattern.StartsWith("|", StringComparison.Ordinal))
+        {
+            // A leading '|' anchors to the start of the name, which for DNS is implicit.
+            pattern = pattern[1..];
+        }
+
+        if (pattern.EndsWith("|", StringComparison.Ordinal))
+        {
+            pattern = pattern[..^1];
+        }
+
+        // '^' is a separator/terminator in Adblock syntax; for DNS it only ever means end-of-name.
+        pattern = pattern.TrimEnd('^');
+
+        if (pattern.IsEmpty)
+        {
+            detail = "empty pattern";
+            return false;
+        }
+
+        var patternText = pattern.ToString();
+
+        if (patternText.Contains('*', StringComparison.Ordinal))
+        {
+            var regexPattern = BuildWildcardRegex(patternText, matchSubdomains);
+            return TryBuildRegexRule(text, regexPattern, action, modifiersPart, GetWildcardLiterals(patternText), GetPatternSuffix(patternText), out rule, out error, out detail);
+        }
+
+        if (!DnsDomainName.TryNormalize(patternText, out var domain))
+        {
+            detail = patternText;
+            return false;
+        }
+
+        if (!TryParseModifiers(modifiersPart, out var modifiers, out error, out detail))
+            return false;
+
+        var key = (action is DnsFilterAction.Allow ? "@@" : "") + (matchSubdomains ? "s:" : "e:") + domain;
+
+        rule = CreateRule(text, action, matchSubdomains ? null : domain, matchSubdomains ? domain : null, pattern: null, requiredLiterals: null, patternSuffix: null, key, modifiers);
+        return true;
+    }
+
+    private static bool TryBuildRegexRule(
+        string text,
+        string regexPattern,
+        DnsFilterAction action,
+        string? modifiersPart,
+        string[]? requiredLiterals,
+        string? patternSuffix,
+        [NotNullWhen(true)] out DnsFilterRule? rule,
+        out DnsFilterParseError error,
+        out string? detail)
+    {
+        rule = null;
+
+        if (!TryParseModifiers(modifiersPart, out var modifiers, out error, out detail))
+            return false;
+
+        var regex = TryCreateRegex(regexPattern);
+        if (regex is null)
+        {
+            error = DnsFilterParseError.InvalidRegex;
+            detail = regexPattern;
+            return false;
+        }
+
+        var key = (action is DnsFilterAction.Allow ? "@@" : "") + "r:" + regexPattern;
+        rule = CreateRule(text, action, exactDomain: null, domainSuffix: null, regex, requiredLiterals, patternSuffix, key, modifiers);
+        return true;
+    }
+
+    private static DnsFilterRule CreateRule(
+        string text,
+        DnsFilterAction action,
+        string? exactDomain,
+        string? domainSuffix,
+        Regex? pattern,
+        string[]? requiredLiterals,
+        string? patternSuffix,
+        string key,
+        ModifierSet modifiers)
+    {
+        return new DnsFilterRule
+        {
+            OriginalText = text,
+            Action = action,
+            IsImportant = modifiers.IsImportant,
+            IsBadFilter = modifiers.IsBadFilter,
+            ExactDomain = exactDomain,
+            DomainSuffix = domainSuffix,
+            Pattern = pattern,
+            RequiredLiterals = requiredLiterals,
+            PatternSuffix = patternSuffix,
+            BadFilterKey = key + modifiers.CanonicalSuffix,
+            AllowedDnsTypes = modifiers.AllowedDnsTypes,
+            ExcludedDnsTypes = modifiers.ExcludedDnsTypes,
+            DenyAllowDomains = modifiers.DenyAllowDomains,
+            Rewrite = modifiers.Rewrite,
+            ClientSpecs = modifiers.ClientSpecs,
+            TagSpec = modifiers.TagSpec,
+        };
+    }
+
+    /// <summary>
+    /// Turns an Adblock wildcard pattern into a regex that encodes its anchors, instead of escaping
+    /// them as literal characters.
+    /// </summary>
+    private static string BuildWildcardRegex(string pattern, bool matchSubdomains)
+    {
+        var escaped = Regex.Escape(pattern).Replace("\\*", ".*", StringComparison.Ordinal);
+
+        // '||X' matches X itself and anything under it; every other form is matched against the
+        // whole name, since a DNS query carries nothing but a name to anchor against.
+        return matchSubdomains
+            ? "^(?:.*\\.)?" + escaped + "$"
+            : "^" + escaped + "$";
+    }
+
+    /// <summary>
+    /// Returns every literal run of a wildcard pattern that is long enough to be selective. All of
+    /// them must appear in a name for the pattern to have any chance of matching, so checking them
+    /// up front skips the regex for almost every query.
+    /// </summary>
+    private static string[]? GetWildcardLiterals(string pattern)
+    {
+        List<string>? literals = null;
+        foreach (var part in pattern.Split('*', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (part.Length >= 3)
+            {
+                literals ??= [];
+                literals.Add(part.ToLowerInvariant());
             }
         }
 
-        // Parse modifiers
+        return literals?.ToArray();
+    }
+
+    /// <summary>
+    /// Extracts the literal prefix a regex requires, so a name that cannot possibly match is
+    /// rejected by a substring check instead of by running the expression.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> unless the prefix is genuinely mandatory: a top-level
+    /// alternation means an input could match a different branch, and a quantifier means the last
+    /// character is optional, so both end the prefix (or discard it entirely).
+    /// </remarks>
+    internal static string? GetRegexLiteralPrefix(string source)
+    {
+        if (HasTopLevelAlternation(source))
+            return null;
+
+        var index = source.StartsWith('^', StringComparison.Ordinal) ? 1 : 0;
+        var builder = new StringBuilder();
+
+        while (index < source.Length)
+        {
+            var c = source[index];
+            char literal;
+
+            if (c is '\\')
+            {
+                // Only a punctuation escape is a literal; '\d' and friends are classes.
+                if (index + 1 >= source.Length || char.IsAsciiLetterOrDigit(source[index + 1]))
+                    break;
+
+                literal = source[index + 1];
+                index += 2;
+            }
+            else if (char.IsAsciiLetterOrDigit(c) || c is '-' or '_')
+            {
+                literal = c;
+                index++;
+            }
+            else
+            {
+                break;
+            }
+
+            // A quantifier makes the character it follows optional, so it cannot be required.
+            if (index < source.Length && source[index] is '*' or '?' or '{')
+                break;
+
+            builder.Append(literal);
+        }
+
+        return builder.Length >= 3 ? builder.ToString().ToLowerInvariant() : null;
+    }
+
+    private static bool HasTopLevelAlternation(string source)
+    {
+        var depth = 0;
+        var inClass = false;
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            var c = source[i];
+            if (c is '\\')
+            {
+                i++;
+                continue;
+            }
+
+            if (inClass)
+            {
+                if (c is ']')
+                {
+                    inClass = false;
+                }
+
+                continue;
+            }
+
+            switch (c)
+            {
+                case '[': inClass = true; break;
+                case '(': depth++; break;
+                case ')': depth--; break;
+                case '|' when depth <= 0: return true;
+                default: break;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the concrete domain suffix a wildcard pattern ends with, when the text after the
+    /// last <c>*</c> begins at a label boundary and covers at least two labels. That suffix is
+    /// specific enough to index on; a single label such as <c>com</c> is not.
+    /// </summary>
+    private static string? GetPatternSuffix(string pattern)
+    {
+        var lastStar = pattern.LastIndexOf('*', StringComparison.Ordinal);
+        if (lastStar < 0)
+            return null;
+
+        var tail = pattern[(lastStar + 1)..];
+        if (!tail.StartsWith('.', StringComparison.Ordinal))
+            return null;
+
+        tail = tail[1..].TrimEnd('^');
+        if (!tail.Contains('.', StringComparison.Ordinal))
+            return null;
+
+        return DnsDomainName.TryNormalize(tail, out var normalized) ? normalized : null;
+    }
+
+    private static Regex? TryCreateRegex(string pattern)
+    {
+        // NonBacktracking guarantees linear-time matching, which is what makes a hostile pattern in
+        // a third-party list harmless. Not every construct is supported, so fall back to the
+        // backtracking engine (still bounded by the match timeout) when it is not.
+        try
+        {
+            return new Regex(pattern, RegexOptions.NonBacktracking | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+        }
+        catch (NotSupportedException)
+        {
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+
+        try
+        {
+            return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryParseModifiers(
+        string? modifiersPart,
+        out ModifierSet modifiers,
+        out DnsFilterParseError error,
+        out string? detail)
+    {
+        modifiers = default;
+        error = DnsFilterParseError.UnsupportedModifier;
+        detail = null;
+
+        if (modifiersPart is null)
+        {
+            modifiers = new ModifierSet { CanonicalSuffix = "" };
+            return true;
+        }
+
         var isImportant = false;
         var isBadFilter = false;
         IReadOnlyCollection<DnsFilterQueryType>? allowedDnsTypes = null;
@@ -274,335 +693,449 @@ public static class DnsFilterListReader
         DnsFilterRewriteRule? rewrite = null;
         IReadOnlyList<DnsFilterClientSpec>? clientSpecs = null;
         DnsFilterTagSpec? tagSpec = null;
+        var canonical = new List<string>();
 
-        if (modifiersPart is not null)
+        foreach (var mod in SplitRespectingQuotes(modifiersPart, ','))
         {
-            var modifiers = SplitModifiers(modifiersPart);
-            foreach (var mod in modifiers)
+            if (mod.Length is 0)
+                continue;
+
+            if (mod.Equals("important", StringComparison.OrdinalIgnoreCase))
             {
-                if (mod.Equals("important", StringComparison.OrdinalIgnoreCase))
-                {
-                    isImportant = true;
-                }
-                else if (mod.Equals("badfilter", StringComparison.OrdinalIgnoreCase))
-                {
-                    isBadFilter = true;
-                }
-                else if (mod.StartsWith("dnstype=", StringComparison.OrdinalIgnoreCase))
-                {
-                    var typeValue = mod["dnstype=".Length..];
-                    ParseDnsTypeModifier(typeValue, out allowedDnsTypes, out excludedDnsTypes);
-                }
-                else if (mod.StartsWith("denyallow=", StringComparison.OrdinalIgnoreCase))
-                {
-                    var domainsPart = mod["denyallow=".Length..];
-                    denyAllowDomains = domainsPart.Split('|', StringSplitOptions.RemoveEmptyEntries)
-                        .Select(d => NormalizeDomain(d))
-                        .Where(d => d.Length > 0)
-                        .ToArray();
-                }
-                else if (mod.StartsWith("dnsrewrite=", StringComparison.OrdinalIgnoreCase))
-                {
-                    var rewriteValue = mod["dnsrewrite=".Length..];
-                    rewrite = ParseDnsRewrite(rewriteValue);
-                }
-                else if (mod.StartsWith("client=", StringComparison.OrdinalIgnoreCase))
-                {
-                    var clientValue = mod["client=".Length..];
-                    clientSpecs = ParseClientSpecs(clientValue);
-                }
-                else if (mod.StartsWith("ctag=", StringComparison.OrdinalIgnoreCase))
-                {
-                    var ctagValue = mod["ctag=".Length..];
-                    tagSpec = ParseCtagModifier(ctagValue);
-                }
+                isImportant = true;
+                canonical.Add("important");
             }
-        }
-
-        // Parse the pattern
-        string? exactDomain = null;
-        string? domainSuffix = null;
-        Regex? pattern = null;
-
-        if (isRegex)
-        {
-            try
+            else if (mod.Equals("badfilter", StringComparison.OrdinalIgnoreCase))
             {
-                pattern = new Regex(remaining.ToString(), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+                // Deliberately not part of the canonical key: a $badfilter rule must produce the
+                // same key as the rule it disables.
+                isBadFilter = true;
             }
-            catch (ArgumentException)
+            else if (mod.StartsWith("dnstype=", StringComparison.OrdinalIgnoreCase))
             {
-                return false;
-            }
-        }
-        else
-        {
-            var patternStr = remaining.ToString();
-
-            // ||domain^ — matches domain and all subdomains
-            if (patternStr.StartsWith("||", StringComparison.Ordinal))
-            {
-                var domain = patternStr[2..];
-                if (domain.EndsWith('^', StringComparison.Ordinal))
+                if (!TryParseDnsTypeModifier(mod["dnstype=".Length..], out allowedDnsTypes, out excludedDnsTypes, out var bad))
                 {
-                    domain = domain[..^1];
-                }
-
-                domain = NormalizeDomain(domain);
-                if (domain.Length == 0)
-                    return false;
-
-                domainSuffix = domain;
-            }
-            // |domain| — exact match with anchors
-            else if (patternStr.StartsWith('|', StringComparison.Ordinal) && patternStr.EndsWith('|', StringComparison.Ordinal))
-            {
-                var domain = NormalizeDomain(patternStr[1..^1]);
-                if (domain.Length == 0)
-                    return false;
-
-                exactDomain = domain;
-            }
-            // Wildcard patterns (contain *)
-            else if (patternStr.Contains('*', StringComparison.Ordinal))
-            {
-                var regexPattern = "^" + Regex.Escape(patternStr.TrimEnd('^')).Replace("\\*", ".*", StringComparison.Ordinal) + "$";
-                try
-                {
-                    pattern = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
-                }
-                catch (ArgumentException)
-                {
+                    error = DnsFilterParseError.InvalidModifierValue;
+                    detail = "dnstype=" + bad;
                     return false;
                 }
+
+                canonical.Add("dnstype=" + Canonicalize(allowedDnsTypes, excludedDnsTypes));
+            }
+            else if (mod.StartsWith("denyallow=", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!TryParseDenyAllow(mod["denyallow=".Length..], out denyAllowDomains, out var bad))
+                {
+                    error = DnsFilterParseError.InvalidModifierValue;
+                    detail = "denyallow=" + bad;
+                    return false;
+                }
+
+                canonical.Add("denyallow=" + string.Join('|', denyAllowDomains.Order(StringComparer.Ordinal)));
+            }
+            else if (mod.StartsWith("dnsrewrite=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = mod["dnsrewrite=".Length..];
+                rewrite = ParseDnsRewrite(value);
+                if (rewrite is null)
+                {
+                    error = DnsFilterParseError.InvalidModifierValue;
+                    detail = "dnsrewrite=" + value;
+                    return false;
+                }
+
+                canonical.Add("dnsrewrite=" + value.ToLowerInvariant());
+            }
+            else if (mod.StartsWith("client=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = mod["client=".Length..];
+                clientSpecs = ParseClientSpecs(value);
+                if (clientSpecs is null)
+                {
+                    error = DnsFilterParseError.InvalidModifierValue;
+                    detail = "client=" + value;
+                    return false;
+                }
+
+                canonical.Add("client=" + value.ToLowerInvariant());
+            }
+            else if (mod.StartsWith("ctag=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = mod["ctag=".Length..];
+                tagSpec = ParseCtagModifier(value);
+                if (tagSpec is null)
+                {
+                    error = DnsFilterParseError.InvalidModifierValue;
+                    detail = "ctag=" + value;
+                    return false;
+                }
+
+                canonical.Add("ctag=" + value.ToLowerInvariant());
             }
             else
             {
-                // Plain domain rule
-                var domain = patternStr.TrimEnd('^');
-                domain = NormalizeDomain(domain);
-                if (domain.Length == 0)
-                    return false;
-
-                exactDomain = domain;
+                // Unknown modifier: discard the rule rather than silently applying it unscoped.
+                error = DnsFilterParseError.UnsupportedModifier;
+                detail = mod;
+                return false;
             }
         }
 
-        rule = new DnsFilterRule
+        canonical.Sort(StringComparer.Ordinal);
+
+        modifiers = new ModifierSet
         {
-            OriginalText = text,
-            Action = action,
             IsImportant = isImportant,
             IsBadFilter = isBadFilter,
-            ExactDomain = exactDomain,
-            DomainSuffix = domainSuffix,
-            Pattern = pattern,
             AllowedDnsTypes = allowedDnsTypes,
             ExcludedDnsTypes = excludedDnsTypes,
             DenyAllowDomains = denyAllowDomains,
             Rewrite = rewrite,
             ClientSpecs = clientSpecs,
             TagSpec = tagSpec,
+            CanonicalSuffix = canonical.Count is 0 ? "" : "$" + string.Join(',', canonical),
         };
 
         return true;
     }
 
-    private static List<string> SplitModifiers(string modifiers)
+    private static string Canonicalize(IReadOnlyCollection<DnsFilterQueryType>? allowed, IReadOnlyCollection<DnsFilterQueryType>? excluded)
     {
-        // Split by comma, but respect quoted strings for client names
+        var parts = new List<string>();
+        if (allowed is not null)
+        {
+            parts.AddRange(allowed.Select(t => ((ushort)t).ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (excluded is not null)
+        {
+            parts.AddRange(excluded.Select(t => "~" + ((ushort)t).ToString(CultureInfo.InvariantCulture)));
+        }
+
+        parts.Sort(StringComparer.Ordinal);
+        return string.Join('|', parts);
+    }
+
+    /// <summary>
+    /// Splits on <paramref name="separator"/> while honouring quoted sections and backslash escapes.
+    /// An unterminated quote is treated as a literal character rather than swallowing the rest of
+    /// the value.
+    /// </summary>
+    private static List<string> SplitRespectingQuotes(string value, char separator)
+    {
         var result = new List<string>();
-        var current = 0;
+        if (!TrySplit(value, separator, respectQuotes: true, result))
+        {
+            result.Clear();
+            TrySplit(value, separator, respectQuotes: false, result);
+        }
+
+        return result;
+    }
+
+    private static bool TrySplit(string value, char separator, bool respectQuotes, List<string> result)
+    {
+        var start = 0;
         var inQuote = false;
         var quoteChar = '\0';
 
-        for (var i = 0; i < modifiers.Length; i++)
+        for (var i = 0; i < value.Length; i++)
         {
-            var c = modifiers[i];
+            var c = value[i];
             if (inQuote)
             {
-                if (c == '\\' && i + 1 < modifiers.Length)
+                if (c is '\\' && i + 1 < value.Length)
                 {
-                    i++; // skip escaped char
+                    i++;
                 }
                 else if (c == quoteChar)
                 {
                     inQuote = false;
                 }
             }
-            else if (c is '\'' or '"')
+            else if (respectQuotes && c is '\'' or '"')
             {
                 inQuote = true;
                 quoteChar = c;
             }
-            else if (c == ',')
+            else if (c is '\\' && i + 1 < value.Length)
             {
-                var segment = modifiers[current..i].Trim();
-                if (segment.Length > 0)
-                {
-                    result.Add(segment);
-                }
-
-                current = i + 1;
+                i++;
+            }
+            else if (c == separator)
+            {
+                AddSegment(result, value[start..i]);
+                start = i + 1;
             }
         }
 
-        var last = modifiers[current..].Trim();
-        if (last.Length > 0)
-        {
-            result.Add(last);
-        }
+        if (inQuote)
+            return false;
 
-        return result;
+        AddSegment(result, value[start..]);
+        return true;
     }
 
-    private static void ParseDnsTypeModifier(
+    private static void AddSegment(List<string> result, string segment)
+    {
+        var trimmed = segment.Trim();
+        if (trimmed.Length > 0)
+        {
+            result.Add(trimmed);
+        }
+    }
+
+    private static bool TryParseDnsTypeModifier(
         string value,
         out IReadOnlyCollection<DnsFilterQueryType>? allowed,
-        out IReadOnlyCollection<DnsFilterQueryType>? excluded)
+        out IReadOnlyCollection<DnsFilterQueryType>? excluded,
+        out string? invalidToken)
     {
+        allowed = null;
+        excluded = null;
+        invalidToken = null;
+
         var allowedList = new List<DnsFilterQueryType>();
         var excludedList = new List<DnsFilterQueryType>();
 
-        var parts = value.Split('|', StringSplitOptions.RemoveEmptyEntries);
+        var parts = SplitRespectingQuotes(value, '|');
+        if (parts.Count is 0)
+        {
+            invalidToken = "";
+            return false;
+        }
+
         foreach (var part in parts)
         {
-            var trimmed = part.Trim();
-            var isExclusion = trimmed.StartsWith('~', StringComparison.Ordinal);
+            var token = part;
+            var isExclusion = token.StartsWith('~', StringComparison.Ordinal);
             if (isExclusion)
             {
-                trimmed = trimmed[1..];
+                token = token[1..];
             }
 
-            if (Enum.TryParse<DnsFilterQueryType>(trimmed, ignoreCase: true, out var queryType))
+            if (!TryParseQueryType(token, out var queryType))
             {
-                if (isExclusion)
-                {
-                    excludedList.Add(queryType);
-                }
-                else
-                {
-                    allowedList.Add(queryType);
-                }
+                invalidToken = part;
+                return false;
+            }
+
+            if (isExclusion)
+            {
+                excludedList.Add(queryType);
+            }
+            else
+            {
+                allowedList.Add(queryType);
             }
         }
 
         allowed = allowedList.Count > 0 ? allowedList : null;
         excluded = excludedList.Count > 0 ? excludedList : null;
+        return allowed is not null || excluded is not null;
     }
 
-    private static DnsFilterRewriteRule ParseDnsRewrite(string value)
+    private static bool TryParseQueryType(string token, out DnsFilterQueryType queryType)
     {
-        // Shorthand: just an RCODE keyword
-        if (value.Equals("REFUSED", StringComparison.OrdinalIgnoreCase))
+        queryType = default;
+        if (token.Length is 0)
+            return false;
+
+        // Named types. Enum.TryParse also accepts numbers and comma-separated lists, neither of
+        // which is valid here, so require the token to be non-numeric before trusting it.
+        if (!char.IsAsciiDigit(token[0]) && Enum.TryParse(token, ignoreCase: true, out queryType) && !token.Contains(',', StringComparison.Ordinal))
+            return true;
+
+        // Numeric forms: '65' and 'TYPE65'. Unnamed types are legitimate; the enum is an open set.
+        var numeric = token.StartsWith("TYPE", StringComparison.OrdinalIgnoreCase) ? token[4..] : token;
+        if (ushort.TryParse(numeric, NumberStyles.None, CultureInfo.InvariantCulture, out var value) && value > 0)
         {
-            return new DnsFilterRewriteRule { ResponseCode = DnsFilterRewriteResponseCode.Refused };
+            queryType = (DnsFilterQueryType)value;
+            return true;
         }
 
-        if (value.Equals("NXDOMAIN", StringComparison.OrdinalIgnoreCase))
+        return false;
+    }
+
+    private static bool TryParseDenyAllow(string value, [NotNullWhen(true)] out IReadOnlyCollection<string>? domains, out string? invalidToken)
+    {
+        domains = null;
+        invalidToken = null;
+
+        var parts = SplitRespectingQuotes(value, '|');
+        if (parts.Count is 0)
         {
-            return new DnsFilterRewriteRule { ResponseCode = DnsFilterRewriteResponseCode.NameError };
+            invalidToken = "";
+            return false;
         }
 
-        if (value.Equals("NOERROR", StringComparison.OrdinalIgnoreCase))
+        var result = new List<string>(parts.Count);
+        foreach (var part in parts)
         {
-            return new DnsFilterRewriteRule { ResponseCode = DnsFilterRewriteResponseCode.NoError };
-        }
-
-        // Shorthand: IP address or domain name
-        if (IPAddress.TryParse(value, out _))
-        {
-            var isV6 = value.Contains(':', StringComparison.Ordinal);
-            return new DnsFilterRewriteRule
+            if (!DnsDomainName.TryNormalize(part, out var domain))
             {
-                ResponseCode = DnsFilterRewriteResponseCode.NoError,
-                RecordType = isV6 ? DnsFilterQueryType.AAAA : DnsFilterQueryType.A,
-                Value = value,
-            };
+                invalidToken = part;
+                return false;
+            }
+
+            result.Add(domain);
         }
 
-        // Full syntax: RCODE;RRTYPE;VALUE
-        var parts = value.Split(';');
+        domains = result;
+        return true;
+    }
+
+    private static DnsFilterRewriteRule? ParseDnsRewrite(string value)
+    {
+        if (value.Length is 0)
+            return null;
+
+        if (TryParseResponseCode(value, out var shorthandRcode))
+            return new DnsFilterRewriteRule { ResponseCode = shorthandRcode };
+
+        // Shorthand IP. Require a '.' or ':' first: IPAddress.TryParse otherwise accepts bare
+        // integers ("1234" becomes 0.0.4.210), which would silently produce a bogus A record.
+        if (LooksLikeIPAddress(value) && IPAddress.TryParse(value, out var address))
+            return CreateAddressRewrite(address);
+
+        var parts = value.Split(';', 3);
         if (parts.Length >= 3)
         {
-            var rcode = DnsFilterRewriteResponseCode.NoError;
-            if (parts[0].Length > 0 && Enum.TryParse<DnsFilterRewriteResponseCode>(parts[0], ignoreCase: true, out var parsedRcode))
-            {
-                rcode = parsedRcode;
-            }
-            else if (parts[0].Equals("NXDOMAIN", StringComparison.OrdinalIgnoreCase))
-            {
-                rcode = DnsFilterRewriteResponseCode.NameError;
-            }
-            else if (parts[0].Equals("REFUSED", StringComparison.OrdinalIgnoreCase))
-            {
-                rcode = DnsFilterRewriteResponseCode.Refused;
-            }
+            if (!TryParseResponseCode(parts[0], out var rcode))
+                return null;
 
-            DnsFilterQueryType? rrType = null;
-            if (parts[1].Length > 0 && Enum.TryParse<DnsFilterQueryType>(parts[1], ignoreCase: true, out var parsedType))
+            DnsFilterQueryType? recordType = null;
+            if (parts[1].Length > 0)
             {
-                rrType = parsedType;
+                if (!TryParseQueryType(parts[1], out var parsedType))
+                    return null;
+
+                recordType = parsedType;
             }
 
             var rewriteValue = parts[2].Length > 0 ? parts[2] : null;
+            if (!IsRewriteValueValid(recordType, rewriteValue))
+                return null;
 
             return new DnsFilterRewriteRule
             {
                 ResponseCode = rcode,
-                RecordType = rrType,
+                RecordType = recordType,
                 Value = rewriteValue,
             };
         }
 
-        // Fallback: treat as domain/CNAME rewrite
+        // Shorthand domain: a CNAME rewrite.
+        if (DnsDomainName.TryNormalize(value, out var target))
+        {
+            return new DnsFilterRewriteRule
+            {
+                ResponseCode = DnsFilterRewriteResponseCode.NoError,
+                RecordType = DnsFilterQueryType.CNAME,
+                Value = target,
+            };
+        }
+
+        return null;
+    }
+
+    private static DnsFilterRewriteRule CreateAddressRewrite(IPAddress address)
+    {
+        var isV6 = address.AddressFamily is System.Net.Sockets.AddressFamily.InterNetworkV6;
         return new DnsFilterRewriteRule
         {
             ResponseCode = DnsFilterRewriteResponseCode.NoError,
-            RecordType = DnsFilterQueryType.CNAME,
-            Value = value,
+            RecordType = isV6 ? DnsFilterQueryType.AAAA : DnsFilterQueryType.A,
+            Value = address.ToString(),
         };
     }
 
-    private static List<DnsFilterClientSpec> ParseClientSpecs(string value)
-    {
-        var specs = new List<DnsFilterClientSpec>();
-        var parts = value.Split('|', StringSplitOptions.RemoveEmptyEntries);
+    private static bool LooksLikeIPAddress(string value)
+        => value.Contains('.', StringComparison.Ordinal) || value.Contains(':', StringComparison.Ordinal);
 
+    private static bool TryParseResponseCode(string value, out DnsFilterRewriteResponseCode responseCode)
+    {
+        responseCode = DnsFilterRewriteResponseCode.NoError;
+        if (value.Length is 0)
+            return true;
+
+        // Only the DNS spellings are accepted. Enum.TryParse would also accept arbitrary integers
+        // and hand callers an undefined enum value.
+        if (value.Equals("NOERROR", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (value.Equals("NXDOMAIN", StringComparison.OrdinalIgnoreCase) || value.Equals(nameof(DnsFilterRewriteResponseCode.NameError), StringComparison.OrdinalIgnoreCase))
+        {
+            responseCode = DnsFilterRewriteResponseCode.NameError;
+            return true;
+        }
+
+        if (value.Equals("REFUSED", StringComparison.OrdinalIgnoreCase))
+        {
+            responseCode = DnsFilterRewriteResponseCode.Refused;
+            return true;
+        }
+
+        if (value.Equals("SERVFAIL", StringComparison.OrdinalIgnoreCase) || value.Equals(nameof(DnsFilterRewriteResponseCode.ServerFailure), StringComparison.OrdinalIgnoreCase))
+        {
+            responseCode = DnsFilterRewriteResponseCode.ServerFailure;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsRewriteValueValid(DnsFilterQueryType? recordType, string? value)
+    {
+        if (recordType is null || value is null)
+            return true;
+
+        return recordType switch
+        {
+            DnsFilterQueryType.A => IPAddress.TryParse(value, out var v4) && v4.AddressFamily is System.Net.Sockets.AddressFamily.InterNetwork,
+            DnsFilterQueryType.AAAA => IPAddress.TryParse(value, out var v6) && v6.AddressFamily is System.Net.Sockets.AddressFamily.InterNetworkV6,
+            DnsFilterQueryType.CNAME or DnsFilterQueryType.PTR or DnsFilterQueryType.NS or DnsFilterQueryType.DNAME => DnsDomainName.TryNormalize(value, out _),
+            _ => true,
+        };
+    }
+
+    private static List<DnsFilterClientSpec>? ParseClientSpecs(string value)
+    {
+        var parts = SplitRespectingQuotes(value, '|');
+        if (parts.Count is 0)
+            return null;
+
+        var specs = new List<DnsFilterClientSpec>(parts.Count);
         foreach (var part in parts)
         {
-            var trimmed = part.Trim();
-            var isExclusion = false;
-
-            if (trimmed.StartsWith('~', StringComparison.Ordinal))
+            var token = part;
+            var isExclusion = token.StartsWith('~', StringComparison.Ordinal);
+            if (isExclusion)
             {
-                isExclusion = true;
-                trimmed = trimmed[1..];
+                token = token[1..];
             }
 
-            // Remove surrounding quotes
-            trimmed = UnquoteClientName(trimmed);
+            token = UnquoteClientName(token);
+            if (token.Length is 0)
+                return null;
 
-            if (trimmed.Length == 0)
-                continue;
-
-            // Try IP address
-            if (IPAddress.TryParse(trimmed, out var ip))
+            if (IPAddress.TryParse(token, out var ip))
             {
                 specs.Add(new DnsFilterClientSpec { IsExclusion = isExclusion, Address = ip });
                 continue;
             }
 
-            // Try CIDR notation
-            var slashIndex = trimmed.IndexOf('/', StringComparison.Ordinal);
-            if (slashIndex > 0 && IPNetwork.TryParse(trimmed, out var network))
+            if (token.Contains('/', StringComparison.Ordinal))
             {
+                // A value that looks like a CIDR but does not parse is a mistake, not a client name.
+                if (!IPNetwork.TryParse(token, out var network))
+                    return null;
+
                 specs.Add(new DnsFilterClientSpec { IsExclusion = isExclusion, Network = network });
                 continue;
             }
 
-            // Client name
-            specs.Add(new DnsFilterClientSpec { IsExclusion = isExclusion, Name = trimmed });
+            specs.Add(new DnsFilterClientSpec { IsExclusion = isExclusion, Name = token });
         }
 
         return specs;
@@ -610,32 +1143,52 @@ public static class DnsFilterListReader
 
     private static string UnquoteClientName(string name)
     {
-        if (name.Length >= 2 && ((name.StartsWith('\'', StringComparison.Ordinal) && name.EndsWith('\'', StringComparison.Ordinal)) || (name.StartsWith('"', StringComparison.Ordinal) && name.EndsWith('"', StringComparison.Ordinal))))
+        var inner = name;
+        if (name.Length >= 2 &&
+            ((name.StartsWith('\'', StringComparison.Ordinal) && name.EndsWith('\'', StringComparison.Ordinal)) ||
+             (name.StartsWith('"', StringComparison.Ordinal) && name.EndsWith('"', StringComparison.Ordinal))))
         {
-            var inner = name[1..^1];
-            // Unescape
-            return inner.Replace("\\'", "'", StringComparison.Ordinal).Replace("\\\"", "\"", StringComparison.Ordinal).Replace("\\,", ",", StringComparison.Ordinal).Replace("\\|", "|", StringComparison.Ordinal);
+            inner = name[1..^1];
         }
 
-        return name;
+        if (!inner.Contains('\\', StringComparison.Ordinal))
+            return inner;
+
+        var builder = new StringBuilder(inner.Length);
+        for (var i = 0; i < inner.Length; i++)
+        {
+            if (inner[i] is '\\' && i + 1 < inner.Length && inner[i + 1] is '\'' or '"' or ',' or '|' or '\\')
+            {
+                i++;
+            }
+
+            builder.Append(inner[i]);
+        }
+
+        return builder.ToString();
     }
 
-    private static DnsFilterTagSpec ParseCtagModifier(string value)
+    private static DnsFilterTagSpec? ParseCtagModifier(string value)
     {
+        var parts = SplitRespectingQuotes(value, '|');
+        if (parts.Count is 0)
+            return null;
+
         var included = new List<string>();
         var excluded = new List<string>();
 
-        var parts = value.Split('|', StringSplitOptions.RemoveEmptyEntries);
         foreach (var part in parts)
         {
-            var trimmed = part.Trim();
-            if (trimmed.StartsWith('~', StringComparison.Ordinal))
+            if (part.StartsWith('~', StringComparison.Ordinal))
             {
-                excluded.Add(trimmed[1..]);
+                if (part.Length is 1)
+                    return null;
+
+                excluded.Add(part[1..]);
             }
             else
             {
-                included.Add(trimmed);
+                included.Add(part);
             }
         }
 
@@ -646,10 +1199,26 @@ public static class DnsFilterListReader
         };
     }
 
-    private static string NormalizeDomain(string domain)
+    private enum LineKind
     {
-        // Remove trailing dot, lowercase
-        domain = domain.Trim().TrimEnd('.').ToLowerInvariant();
-        return domain;
+        Empty,
+        Comment,
+        AdBlockComment,
+        AdBlockRule,
+        HostsEntry,
+        Domain,
+    }
+
+    private readonly struct ModifierSet
+    {
+        public bool IsImportant { get; init; }
+        public bool IsBadFilter { get; init; }
+        public IReadOnlyCollection<DnsFilterQueryType>? AllowedDnsTypes { get; init; }
+        public IReadOnlyCollection<DnsFilterQueryType>? ExcludedDnsTypes { get; init; }
+        public IReadOnlyCollection<string>? DenyAllowDomains { get; init; }
+        public DnsFilterRewriteRule? Rewrite { get; init; }
+        public IReadOnlyList<DnsFilterClientSpec>? ClientSpecs { get; init; }
+        public DnsFilterTagSpec? TagSpec { get; init; }
+        public string CanonicalSuffix { get; init; }
     }
 }

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterParseDiagnostic.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterParseDiagnostic.cs
@@ -1,0 +1,40 @@
+namespace Meziantou.Framework.DnsFilter;
+
+/// <summary>
+/// Describes a filter list line that did not produce a rule.
+/// </summary>
+public sealed class DnsFilterParseDiagnostic
+{
+    internal DnsFilterParseDiagnostic(int lineNumber, string line, DnsFilterParseError error, string? detail)
+    {
+        LineNumber = lineNumber;
+        Line = line;
+        Error = error;
+        Detail = detail;
+    }
+
+    /// <summary>
+    /// Gets the 1-based line number within the parsed list.
+    /// </summary>
+    public int LineNumber { get; }
+
+    /// <summary>
+    /// Gets the text of the offending line.
+    /// </summary>
+    public string Line { get; }
+
+    /// <summary>
+    /// Gets the reason the line was skipped.
+    /// </summary>
+    public DnsFilterParseError Error { get; }
+
+    /// <summary>
+    /// Gets additional context, such as the offending modifier name. May be <see langword="null"/>.
+    /// </summary>
+    public string? Detail { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Detail is null
+        ? $"Line {LineNumber}: {Error} ({Line})"
+        : $"Line {LineNumber}: {Error} '{Detail}' ({Line})";
+}

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterParseError.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterParseError.cs
@@ -1,0 +1,30 @@
+namespace Meziantou.Framework.DnsFilter;
+
+/// <summary>
+/// Identifies why a filter list line was not turned into a rule.
+/// </summary>
+public enum DnsFilterParseError
+{
+    /// <summary>
+    /// The line carries a modifier this library does not implement. The rule is discarded rather
+    /// than applied without that modifier, because ignoring it would widen the rule beyond
+    /// what its author wrote.
+    /// </summary>
+    UnsupportedModifier,
+
+    /// <summary>
+    /// The line carries a supported modifier whose value could not be parsed
+    /// (for example an unknown <c>$dnstype</c> record type or a malformed CIDR in <c>$client</c>).
+    /// </summary>
+    InvalidModifierValue,
+
+    /// <summary>
+    /// The regular expression of a <c>/pattern/</c> rule is not valid, or its closing delimiter is missing.
+    /// </summary>
+    InvalidRegex,
+
+    /// <summary>
+    /// The line has no usable match pattern, or the pattern is not a valid domain name.
+    /// </summary>
+    InvalidPattern,
+}

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterParseResult.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterParseResult.cs
@@ -1,0 +1,35 @@
+namespace Meziantou.Framework.DnsFilter;
+
+/// <summary>
+/// The outcome of parsing a filter list: the rules that were understood, and a diagnostic for
+/// every line that was not.
+/// </summary>
+/// <remarks>
+/// Filter lists are third-party input. A list that silently produces far fewer rules than it has
+/// lines — because it was served as an HTML error page, or uses modifiers this library does not
+/// implement — is indistinguishable from a healthy one if only the rule count is inspected.
+/// Callers that load lists unattended should log or alarm on <see cref="Diagnostics"/>.
+/// </remarks>
+public sealed class DnsFilterParseResult
+{
+    internal DnsFilterParseResult(IReadOnlyList<DnsFilterRule> rules, IReadOnlyList<DnsFilterParseDiagnostic> diagnostics)
+    {
+        Rules = rules;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>
+    /// Gets the rules parsed from the list.
+    /// </summary>
+    public IReadOnlyList<DnsFilterRule> Rules { get; }
+
+    /// <summary>
+    /// Gets a diagnostic for each line that did not produce a rule. Empty when the whole list was understood.
+    /// </summary>
+    public IReadOnlyList<DnsFilterParseDiagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// Gets the format the list was parsed as. Useful when <see cref="DnsFilterListFormat.AutoDetect"/> was requested.
+    /// </summary>
+    public DnsFilterListFormat Format { get; internal init; }
+}

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterQueryType.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterQueryType.cs
@@ -4,6 +4,14 @@ namespace Meziantou.Framework.DnsFilter;
 /// Specifies the type of DNS query for use with the <c>$dnstype</c> modifier.
 /// Values correspond to IANA DNS Parameters registry types commonly used in filter rules.
 /// </summary>
+/// <remarks>
+/// This enum is an <b>open</b> set of <see cref="ushort"/> record-type codes, not a closed list.
+/// Callers should cast the raw QTYPE from the wire straight through
+/// (<c>(DnsFilterQueryType)qtype</c>) even when it is not a named member; matching compares
+/// numeric values, so unnamed types behave correctly. Never substitute
+/// <see cref="ANY"/> for a type you do not recognize — that would make <c>$dnstype=ANY</c>
+/// rules fire on it and <c>$dnstype=~ANY</c> rules spare it.
+/// </remarks>
 [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "PTR is the standard DNS record type name")]
 public enum DnsFilterQueryType : ushort
 {
@@ -12,10 +20,26 @@ public enum DnsFilterQueryType : ushort
     CNAME = 5,
     SOA = 6,
     PTR = 12,
+    HINFO = 13,
     MX = 15,
     TXT = 16,
     AAAA = 28,
+    LOC = 29,
     SRV = 33,
+    NAPTR = 35,
+    CERT = 37,
+    DNAME = 39,
+    DS = 43,
+    SSHFP = 44,
+    RRSIG = 46,
+    NSEC = 47,
+    DNSKEY = 48,
+    NSEC3 = 50,
+    TLSA = 52,
+    SVCB = 64,
     HTTPS = 65,
+    SPF = 99,
     ANY = 255,
+    URI = 256,
+    CAA = 257,
 }

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterResult.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterResult.cs
@@ -11,17 +11,18 @@ public sealed class DnsFilterResult
 
     /// <summary>
     /// Gets a result indicating the query did not match any filter rule.
+    /// Its <see cref="Action"/> is <see cref="DnsFilterAction.None"/>.
     /// </summary>
-    public static DnsFilterResult NotMatched { get; } = new() { IsMatched = false, Action = DnsFilterAction.Block };
+    public static DnsFilterResult NotMatched { get; } = new() { Action = DnsFilterAction.None };
 
     /// <summary>
     /// Gets a value indicating whether the query matched a filter rule.
     /// </summary>
-    public bool IsMatched { get; private init; }
+    public bool IsMatched => Action is not DnsFilterAction.None;
 
     /// <summary>
-    /// Gets the action determined by the matching rule.
-    /// Only meaningful when <see cref="IsMatched"/> is <see langword="true"/>.
+    /// Gets the action determined by the matching rule, or <see cref="DnsFilterAction.None"/>
+    /// when no rule matched.
     /// </summary>
     public DnsFilterAction Action { get; private init; }
 
@@ -31,7 +32,8 @@ public sealed class DnsFilterResult
     public DnsFilterRule? MatchingRule { get; private init; }
 
     /// <summary>
-    /// Gets the rewrite directive from the matching rule, if any.
+    /// Gets the rewrite directive from the matching rule. Non-<see langword="null"/> if and only if
+    /// <see cref="Action"/> is <see cref="DnsFilterAction.Rewrite"/>.
     /// </summary>
     public DnsFilterRewriteRule? Rewrite { get; private init; }
 
@@ -39,8 +41,7 @@ public sealed class DnsFilterResult
     {
         return new DnsFilterResult
         {
-            IsMatched = true,
-            Action = DnsFilterAction.Block,
+            Action = rule.Rewrite is null ? DnsFilterAction.Block : DnsFilterAction.Rewrite,
             MatchingRule = rule,
             Rewrite = rule.Rewrite,
         };
@@ -50,7 +51,6 @@ public sealed class DnsFilterResult
     {
         return new DnsFilterResult
         {
-            IsMatched = true,
             Action = DnsFilterAction.Allow,
             MatchingRule = rule,
         };

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterRewriteResponseCode.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterRewriteResponseCode.cs
@@ -19,4 +19,9 @@ public enum DnsFilterRewriteResponseCode
     /// The server refuses to answer (REFUSED).
     /// </summary>
     Refused,
+
+    /// <summary>
+    /// The server failed to process the query (SERVFAIL).
+    /// </summary>
+    ServerFailure,
 }

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterRule.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterRule.cs
@@ -14,10 +14,16 @@ public sealed class DnsFilterRule
     /// <summary>
     /// Gets the original text of the rule as it appeared in the filter list.
     /// </summary>
+    /// <remarks>
+    /// This is provided for diagnostics only. It is not the rule's identity: use
+    /// <see cref="ExactDomain"/>, <see cref="DomainSuffix"/> or <see cref="PatternText"/> to
+    /// report what the rule actually matches.
+    /// </remarks>
     public required string OriginalText { get; init; }
 
     /// <summary>
-    /// Gets the action to perform when this rule matches.
+    /// Gets the action to perform when this rule matches. Always
+    /// <see cref="DnsFilterAction.Block"/> or <see cref="DnsFilterAction.Allow"/>.
     /// </summary>
     public required DnsFilterAction Action { get; init; }
 
@@ -29,24 +35,54 @@ public sealed class DnsFilterRule
 
     /// <summary>
     /// Gets a value indicating whether this is a <c>$badfilter</c> rule that
-    /// disables another rule matching its text.
+    /// disables another rule matching its pattern and modifiers.
     /// </summary>
     public bool IsBadFilter { get; init; }
 
     /// <summary>
-    /// Gets the exact domain to match, if the rule is an exact domain match.
+    /// Gets the exact domain this rule matches, or <see langword="null"/> if it does not match by exact domain.
     /// </summary>
-    internal string? ExactDomain { get; init; }
+    public string? ExactDomain { get; init; }
 
     /// <summary>
-    /// Gets the domain suffix to match (for <c>||domain^</c> style rules that match the domain and all subdomains).
+    /// Gets the domain suffix this rule matches (for <c>||domain^</c> style rules that match the
+    /// domain and all its subdomains), or <see langword="null"/>.
     /// </summary>
-    internal string? DomainSuffix { get; init; }
+    public string? DomainSuffix { get; init; }
 
     /// <summary>
-    /// Gets the compiled regular expression for regex-based rules.
+    /// Gets the regular expression source this rule matches with, or <see langword="null"/>.
+    /// Set for <c>/regex/</c> rules and for patterns containing <c>*</c>.
+    /// </summary>
+    public string? PatternText => Pattern?.ToString();
+
+    /// <summary>
+    /// Gets the compiled regular expression for pattern-based rules.
     /// </summary>
     internal Regex? Pattern { get; init; }
+
+    /// <summary>
+    /// Gets literal substrings that a matching domain must all contain, used to skip the regex
+    /// entirely for the overwhelming majority of queries. A substring check costs a few nanoseconds
+    /// against roughly 150ns for a non-backtracking regex, so testing several is still far cheaper
+    /// than running one. <see langword="null"/> when no useful literal could be extracted.
+    /// </summary>
+    internal string[]? RequiredLiterals { get; init; }
+
+    /// <summary>
+    /// Gets the concrete multi-label domain suffix a wildcard pattern is anchored on
+    /// (<c>aliyuncs.com</c> for <c>||ad-host-backup-*.aliyuncs.com^</c>), which lets the engine
+    /// reach the rule through the parent-domain walk instead of testing it against every query.
+    /// <see langword="null"/> when no such suffix exists.
+    /// </summary>
+    internal string? PatternSuffix { get; init; }
+
+    /// <summary>
+    /// Gets the identity of this rule for <c>$badfilter</c> purposes: its pattern and its modifier
+    /// set, normalized and order-independent. Two rules that differ only in casing, whitespace or
+    /// modifier order share a key.
+    /// </summary>
+    internal string? BadFilterKey { get; init; }
 
     /// <summary>
     /// Gets the set of DNS query types this rule applies to (from <c>$dnstype</c> modifier).
@@ -80,4 +116,40 @@ public sealed class DnsFilterRule
     /// Gets the client tags this rule applies to (from <c>$ctag</c> modifier).
     /// </summary>
     internal DnsFilterTagSpec? TagSpec { get; init; }
+
+    /// <summary>
+    /// Creates a rule blocking a single domain, and optionally all of its subdomains.
+    /// </summary>
+    /// <param name="domain">The domain to block.</param>
+    /// <param name="includeSubdomains">When <see langword="true"/>, subdomains are blocked too.</param>
+    /// <exception cref="ArgumentException"><paramref name="domain"/> is not a valid domain name.</exception>
+    public static DnsFilterRule CreateBlock(string domain, bool includeSubdomains = false)
+        => Create(domain, includeSubdomains, DnsFilterAction.Block);
+
+    /// <summary>
+    /// Creates an exception rule allowing a single domain, and optionally all of its subdomains.
+    /// </summary>
+    /// <param name="domain">The domain to allow.</param>
+    /// <param name="includeSubdomains">When <see langword="true"/>, subdomains are allowed too.</param>
+    /// <exception cref="ArgumentException"><paramref name="domain"/> is not a valid domain name.</exception>
+    public static DnsFilterRule CreateAllow(string domain, bool includeSubdomains = false)
+        => Create(domain, includeSubdomains, DnsFilterAction.Allow);
+
+    private static DnsFilterRule Create(string domain, bool includeSubdomains, DnsFilterAction action)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+        if (!DnsDomainName.TryNormalize(domain, out var normalized))
+            throw new ArgumentException($"'{domain}' is not a valid domain name.", nameof(domain));
+
+        var text = (action is DnsFilterAction.Allow ? "@@" : "") + (includeSubdomains ? "||" + normalized + "^" : normalized);
+
+        return new DnsFilterRule
+        {
+            OriginalText = text,
+            Action = action,
+            ExactDomain = includeSubdomains ? null : normalized,
+            DomainSuffix = includeSubdomains ? normalized : null,
+            BadFilterKey = text,
+        };
+    }
 }

--- a/src/Meziantou.Framework.DnsFilter/DnsFilterRuleSet.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterRuleSet.cs
@@ -3,14 +3,20 @@ namespace Meziantou.Framework.DnsFilter;
 /// <summary>
 /// An aggregated collection of DNS filter rules from one or more parsed sources.
 /// </summary>
+/// <remarks>
+/// This type is not thread-safe for concurrent mutation. It is safe to hand a rule set to
+/// <see cref="DnsFilterEngine"/> and keep mutating it afterwards: the engine snapshots the rules
+/// when it builds.
+/// </remarks>
 public sealed class DnsFilterRuleSet
 {
     private readonly List<DnsFilterRule> _rules = [];
+    private readonly Lock _lock = new();
 
     /// <summary>
-    /// Gets the rules in this rule set.
+    /// Gets a snapshot of the rules in this rule set.
     /// </summary>
-    public IReadOnlyList<DnsFilterRule> Rules => _rules;
+    public IReadOnlyList<DnsFilterRule> Rules => ToArray();
 
     /// <summary>
     /// Adds a single rule to this rule set.
@@ -19,7 +25,10 @@ public sealed class DnsFilterRuleSet
     public void Add(DnsFilterRule rule)
     {
         ArgumentNullException.ThrowIfNull(rule);
-        _rules.Add(rule);
+        lock (_lock)
+        {
+            _rules.Add(rule);
+        }
     }
 
     /// <summary>
@@ -29,7 +38,10 @@ public sealed class DnsFilterRuleSet
     public void AddRange(IEnumerable<DnsFilterRule> rules)
     {
         ArgumentNullException.ThrowIfNull(rules);
-        _rules.AddRange(rules);
+        lock (_lock)
+        {
+            _rules.AddRange(rules);
+        }
     }
 
     /// <summary>
@@ -37,10 +49,12 @@ public sealed class DnsFilterRuleSet
     /// </summary>
     /// <param name="reader">The text reader containing the filter list.</param>
     /// <param name="format">The format of the filter list.</param>
-    public void AddFromList(TextReader reader, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
+    /// <returns>A diagnostic for each line that did not produce a rule.</returns>
+    public IReadOnlyList<DnsFilterParseDiagnostic> AddFromList(TextReader reader, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
     {
-        var parsed = DnsFilterListReader.Parse(reader, format);
-        _rules.AddRange(parsed);
+        var parsed = DnsFilterListReader.ParseWithDiagnostics(reader, format);
+        AddRange(parsed.Rules);
+        return parsed.Diagnostics;
     }
 
     /// <summary>
@@ -48,14 +62,44 @@ public sealed class DnsFilterRuleSet
     /// </summary>
     /// <param name="text">The filter list text.</param>
     /// <param name="format">The format of the filter list.</param>
-    public void AddFromList(string text, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
+    /// <returns>A diagnostic for each line that did not produce a rule.</returns>
+    public IReadOnlyList<DnsFilterParseDiagnostic> AddFromList(string text, DnsFilterListFormat format = DnsFilterListFormat.AutoDetect)
     {
-        var parsed = DnsFilterListReader.Parse(text, format);
-        _rules.AddRange(parsed);
+        var parsed = DnsFilterListReader.ParseWithDiagnostics(text, format);
+        AddRange(parsed.Rules);
+        return parsed.Diagnostics;
+    }
+
+    /// <summary>
+    /// Gets the number of rules in this rule set.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _rules.Count;
+            }
+        }
     }
 
     /// <summary>
     /// Removes all rules from this rule set.
     /// </summary>
-    public void Clear() => _rules.Clear();
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _rules.Clear();
+        }
+    }
+
+    internal DnsFilterRule[] ToArray()
+    {
+        lock (_lock)
+        {
+            return [.. _rules];
+        }
+    }
 }

--- a/src/Meziantou.Framework.DnsFilter/readme.md
+++ b/src/Meziantou.Framework.DnsFilter/readme.md
@@ -7,9 +7,11 @@ A standalone DNS filter list parser and matching engine supporting hosts files, 
 - **Multiple list formats**: Hosts files (`0.0.0.0 domain`), domains-only lists, and AdGuard/Adblock DNS filtering syntax (`||domain^`)
 - **Auto-detection**: Automatically detects the filter list format when not specified
 - **AdGuard modifiers**: `$important`, `$badfilter`, `$dnstype`, `$denyallow`, `$dnsrewrite`, `$client`, `$ctag`
-- **Priority resolution**: Follows the AdGuard priority pipeline — `$important` block → `$important` allow → `@@` exception → normal block
+- **Priority resolution**: `$important` allow → `$important` block → `@@` exception → normal block. Within a level, a `$dnsrewrite` rule wins, then the more specific rule.
 - **Client-aware filtering**: Filter rules by client IP address, CIDR range, client name (`$client`), or client tags (`$ctag`)
-- **Efficient matching**: Hash-based exact domain and suffix lookups with regex fallback for wildcard and pattern rules
+- **Efficient matching**: Hash-based exact domain and suffix lookups. Wildcard rules anchored on a concrete domain suffix (`||ads-*.example.com^`) are reached through the same suffix index; only patterns with no indexable suffix are evaluated on every query, and those are gated behind a literal prefilter
+- **Strict parsing**: A rule carrying an unsupported modifier, or a modifier value that cannot be parsed, is discarded rather than silently applied without it. `ParseWithDiagnostics` reports every skipped line
+- **Punycode**: Rule patterns and queried names are both normalized to A-labels, so an internationalized domain matches the name DNS actually carries
 - **Thread-safe**: Concurrent query evaluation with atomic rule-set replacement via `Reload()`
 
 ## Usage
@@ -26,6 +28,7 @@ ruleSet.AddFromList("""
 var engine = new DnsFilterEngine(ruleSet);
 var result = engine.Evaluate("ads.example.com");
 // result.IsMatched == true, result.Action == DnsFilterAction.Block
+// An unmatched query returns DnsFilterAction.None, never Block.
 ```
 
 ### Load an AdGuard-style filter list
@@ -131,7 +134,35 @@ ruleSet.AddFromList("||example.com^$dnsrewrite=1.2.3.4", DnsFilterListFormat.AdB
 
 var engine = new DnsFilterEngine(ruleSet);
 var result = engine.Evaluate("example.com");
+// result.Action == DnsFilterAction.Rewrite  (not Block — the caller must synthesize an answer)
 // result.Rewrite.ResponseCode == DnsFilterRewriteResponseCode.NoError
 // result.Rewrite.RecordType == DnsFilterQueryType.A
 // result.Rewrite.Value == "1.2.3.4"
+```
+
+### See which lines were skipped
+
+`AddFromList` returns a diagnostic for every line that did not become a rule, so a list that
+silently fails to parse is visible instead of just producing fewer rules.
+
+```csharp
+var ruleSet = new DnsFilterRuleSet();
+var diagnostics = ruleSet.AddFromList(listText);
+
+foreach (var diagnostic in diagnostics)
+{
+    // Line 42: UnsupportedModifier 'third-party' (||example.com^$third-party)
+    Console.WriteLine(diagnostic);
+}
+```
+
+`DnsFilterListReader.ParseWithDiagnostics` exposes the same information, plus the format that
+auto-detection settled on.
+
+### Build rules without going through list text
+
+```csharp
+var ruleSet = new DnsFilterRuleSet();
+ruleSet.Add(DnsFilterRule.CreateBlock("ads.example.com", includeSubdomains: true));
+ruleSet.Add(DnsFilterRule.CreateAllow("safe.ads.example.com"));
 ```

--- a/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterEngineTests.cs
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterEngineTests.cs
@@ -466,7 +466,7 @@ public sealed class DnsFilterEngineTests
     }
 
     [Fact]
-    public void Evaluate_PriorityOrder_ImportantBlockBeatsImportantAllow()
+    public void Evaluate_PriorityOrder_ImportantAllowBeatsImportantBlock()
     {
         var ruleSet = new DnsFilterRuleSet();
         ruleSet.AddFromList("""
@@ -478,7 +478,20 @@ public sealed class DnsFilterEngineTests
         var result = engine.Evaluate("example.com");
 
         Assert.True(result.IsMatched);
-        Assert.Equal(DnsFilterAction.Block, result.Action);
+        Assert.Equal(DnsFilterAction.Allow, result.Action);
+    }
+
+    [Fact]
+    public void Evaluate_PriorityOrder_ImportantAllowBeatsImportantBlock_RegardlessOfListOrder()
+    {
+        var ruleSet = new DnsFilterRuleSet();
+        ruleSet.AddFromList("""
+            @@||example.com^$important
+            ||example.com^$important
+            """, DnsFilterListFormat.AdBlock);
+        var engine = new DnsFilterEngine(ruleSet);
+
+        Assert.Equal(DnsFilterAction.Allow, engine.Evaluate("example.com").Action);
     }
 
     [Fact]
@@ -508,5 +521,222 @@ public sealed class DnsFilterEngineTests
         var result = engine.Evaluate("example.com");
 
         Assert.False(result.IsMatched);
+    }
+
+    private static DnsFilterEngine CreateEngine(string list, DnsFilterListFormat format = DnsFilterListFormat.AdBlock)
+    {
+        var ruleSet = new DnsFilterRuleSet();
+        ruleSet.AddFromList(list, format);
+        return new DnsFilterEngine(ruleSet);
+    }
+
+    [Theory]
+    [InlineData("||*.example.com^", "sub.example.com")]
+    [InlineData("||*.example.com^", "a.b.example.com")]
+    [InlineData("||ads*.example.com^", "ads1.example.com")]
+    [InlineData("||ad-host-backup-*.aliyuncs.com^", "ad-host-backup-7.aliyuncs.com")]
+    [InlineData("|*.example.com|", "sub.example.com")]
+    public void Evaluate_WildcardInsideAnchoredPattern_Matches(string rule, string domain)
+    {
+        Assert.Equal(DnsFilterAction.Block, CreateEngine(rule).Evaluate(domain).Action);
+    }
+
+    [Theory]
+    [InlineData("||*.example.com^", "example.org")]
+    [InlineData("||ads*.example.com^", "tracker.example.com")]
+    public void Evaluate_WildcardInsideAnchoredPattern_DoesNotOverMatch(string rule, string domain)
+    {
+        Assert.False(CreateEngine(rule).Evaluate(domain).IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_WildcardExceptionRule_Allows()
+    {
+        var engine = CreateEngine("""
+            ||tracker.example.com^
+            @@||*.tracker.example.com^
+            """);
+
+        Assert.Equal(DnsFilterAction.Allow, engine.Evaluate("a.tracker.example.com").Action);
+        Assert.Equal(DnsFilterAction.Block, engine.Evaluate("tracker.example.com").Action);
+    }
+
+    [Fact]
+    public void Evaluate_NotMatched_ActionIsNone()
+    {
+        var result = CreateEngine("||example.com^").Evaluate("other.example.org");
+
+        Assert.False(result.IsMatched);
+        Assert.Equal(DnsFilterAction.None, result.Action);
+        Assert.Equal(DnsFilterAction.None, DnsFilterResult.NotMatched.Action);
+    }
+
+    [Fact]
+    public void Evaluate_PathologicalRegex_DoesNotThrowOrBlock()
+    {
+        var engine = CreateEngine("/^(a+)+$/");
+
+        var result = engine.Evaluate(new string('a', 60) + ".example.com");
+
+        Assert.False(result.IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_Ctag_MixedInclusionAndExclusion_RequiresBoth()
+    {
+        var engine = CreateEngine("||example.com^$ctag=user_child|~device_pc");
+
+        // Has neither the required tag nor the excluded one.
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Tags = ["device_phone"] }).IsMatched);
+
+        // Has the required tag and is not excluded.
+        Assert.True(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Tags = ["user_child"] }).IsMatched);
+
+        // Has the required tag but is excluded.
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Tags = ["user_child", "device_pc"] }).IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_Client_ExclusionOnlyRule_DoesNotMatchUnknownClient()
+    {
+        var engine = CreateEngine("||example.com^$client=~192.168.1.1");
+
+        Assert.False(engine.Evaluate("example.com").IsMatched);
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Address = IPAddress.Parse("192.168.1.1") }).IsMatched);
+        Assert.True(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Address = IPAddress.Parse("192.168.1.2") }).IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_Client_NameExclusion_DoesNotMatchWhenOnlyAddressIsSupplied()
+    {
+        var engine = CreateEngine("||example.com^$client=~KidsTablet");
+
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Address = IPAddress.Parse("10.0.0.5") }).IsMatched);
+        Assert.True(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Name = "Desktop" }).IsMatched);
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Name = "KidsTablet" }).IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_Client_MixedInclusionAndExclusion()
+    {
+        var engine = CreateEngine("||example.com^$client=192.168.1.0/24|~192.168.1.5");
+
+        Assert.True(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Address = IPAddress.Parse("192.168.1.6") }).IsMatched);
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Address = IPAddress.Parse("192.168.1.5") }).IsMatched);
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A, new DnsClientInfo { Address = IPAddress.Parse("10.0.0.1") }).IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_DnsRewrite_OutranksAPlainBlockForTheSameDomain()
+    {
+        foreach (var list in new[]
+        {
+            "||example.com^\n||example.com^$dnsrewrite=1.2.3.4",
+            "||example.com^$dnsrewrite=1.2.3.4\n||example.com^",
+            "example.com\n||example.com^$dnsrewrite=1.2.3.4",
+        })
+        {
+            var result = CreateEngine(list).Evaluate("example.com");
+
+            Assert.Equal(DnsFilterAction.Rewrite, result.Action);
+            Assert.Equal("1.2.3.4", result.Rewrite!.Value);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_Rewrite_IsNotReportedAsAPlainBlock()
+    {
+        var result = CreateEngine("||example.com^$dnsrewrite=1.2.3.4").Evaluate("example.com");
+
+        Assert.Equal(DnsFilterAction.Rewrite, result.Action);
+        Assert.NotEqual(DnsFilterAction.Block, result.Action);
+    }
+
+    [Theory]
+    [InlineData("||EXAMPLE.com^", "||example.com^$badfilter")]
+    [InlineData("||example.com^$dnstype=A,important", "||example.com^$important,dnstype=A,badfilter")]
+    [InlineData("||example.com^$denyallow=badfilter.org", "||example.com^$denyallow=badfilter.org,badfilter")]
+    public void Evaluate_BadFilter_IgnoresCasingAndModifierOrder(string rule, string badFilter)
+    {
+        Assert.False(CreateEngine(rule + "\n" + badFilter).Evaluate("example.com").IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_BadFilter_DisablesAHostsFormatRule()
+    {
+        var ruleSet = new DnsFilterRuleSet();
+        ruleSet.AddFromList("0.0.0.0 example.com", DnsFilterListFormat.Hosts);
+        ruleSet.AddFromList("example.com$badfilter", DnsFilterListFormat.AdBlock);
+
+        Assert.False(new DnsFilterEngine(ruleSet).Evaluate("example.com").IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_MoreSpecificRuleWinsWithinTheSamePriority()
+    {
+        var engine = CreateEngine("""
+            ||com^
+            ||sub.example.com^
+            """);
+
+        Assert.Equal("sub.example.com", engine.Evaluate("sub.example.com").MatchingRule!.DomainSuffix);
+    }
+
+    [Fact]
+    public void Evaluate_InternationalizedDomain_MatchesPunycodeQuery()
+    {
+        var engine = CreateEngine("||пример.рф^");
+
+        Assert.True(engine.Evaluate("xn--e1afmkfd.xn--p1ai").IsMatched);
+        Assert.True(engine.Evaluate("пример.рф").IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_UnknownQueryType_IsComparedNumerically()
+    {
+        var engine = CreateEngine("||example.com^$dnstype=CAA");
+
+        Assert.True(engine.Evaluate("example.com", DnsFilterQueryType.CAA).IsMatched);
+        Assert.False(engine.Evaluate("example.com", DnsFilterQueryType.A).IsMatched);
+        Assert.False(engine.Evaluate("example.com", (DnsFilterQueryType)999).IsMatched);
+    }
+
+    [Fact]
+    public void Evaluate_MalformedDomain_ReturnsNotMatched()
+    {
+        var engine = CreateEngine("||example.com^");
+
+        Assert.False(engine.Evaluate("   ").IsMatched);
+        Assert.False(engine.Evaluate("0.0.0.0 example.com").IsMatched);
+    }
+
+    [Fact]
+    public void RuleSet_MutatedAfterBuild_DoesNotAffectTheEngine()
+    {
+        var ruleSet = new DnsFilterRuleSet();
+        ruleSet.AddFromList("||example.com^", DnsFilterListFormat.AdBlock);
+        var engine = new DnsFilterEngine(ruleSet);
+
+        ruleSet.Clear();
+
+        Assert.True(engine.Evaluate("example.com").IsMatched);
+    }
+
+    [Fact]
+    public void RuleSet_CreateBlockAndAllowRulesAreUsableByTheEngine()
+    {
+        var ruleSet = new DnsFilterRuleSet();
+        ruleSet.Add(DnsFilterRule.CreateBlock("ads.example.com", includeSubdomains: true));
+        ruleSet.Add(DnsFilterRule.CreateAllow("safe.ads.example.com"));
+        var engine = new DnsFilterEngine(ruleSet);
+
+        Assert.Equal(DnsFilterAction.Block, engine.Evaluate("a.ads.example.com").Action);
+        Assert.Equal(DnsFilterAction.Allow, engine.Evaluate("safe.ads.example.com").Action);
+    }
+
+    [Fact]
+    public void RuleSet_CreateBlock_RejectsAnInvalidDomain()
+    {
+        Assert.Throws<ArgumentException>(() => DnsFilterRule.CreateBlock("not a domain"));
     }
 }

--- a/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterListReaderTests.cs
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterListReaderTests.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Text.RegularExpressions;
+
 namespace Meziantou.Framework.DnsFilter.Tests;
 
 public sealed class DnsFilterListReaderTests
@@ -294,7 +297,11 @@ public sealed class DnsFilterListReaderTests
 
         var rules = DnsFilterListReader.Parse(text, DnsFilterListFormat.AdBlock);
 
-        Assert.Single(rules);
+        var spec = Assert.Single(Assert.Single(rules).ClientSpecs!);
+        Assert.False(spec.IsExclusion);
+        Assert.Equal(IPAddress.Parse("192.168.1.1"), spec.Address);
+        Assert.Null(spec.Network);
+        Assert.Null(spec.Name);
     }
 
     [Fact]
@@ -304,7 +311,11 @@ public sealed class DnsFilterListReaderTests
 
         var rules = DnsFilterListReader.Parse(text, DnsFilterListFormat.AdBlock);
 
-        Assert.Single(rules);
+        var spec = Assert.Single(Assert.Single(rules).ClientSpecs!);
+        Assert.False(spec.IsExclusion);
+        Assert.Equal(IPNetwork.Parse("192.168.0.0/24"), spec.Network);
+        Assert.Null(spec.Address);
+        Assert.Null(spec.Name);
     }
 
     [Fact]
@@ -314,7 +325,28 @@ public sealed class DnsFilterListReaderTests
 
         var rules = DnsFilterListReader.Parse(text, DnsFilterListFormat.AdBlock);
 
-        Assert.Single(rules);
+        var spec = Assert.Single(Assert.Single(rules).ClientSpecs!);
+        Assert.False(spec.IsExclusion);
+        Assert.Equal("Frank's laptop", spec.Name);
+    }
+
+    [Fact]
+    public void ParseAdBlock_ClientModifier_Exclusion()
+    {
+        var rules = DnsFilterListReader.Parse("||example.com^$client=~192.168.1.1", DnsFilterListFormat.AdBlock);
+
+        var spec = Assert.Single(Assert.Single(rules).ClientSpecs!);
+        Assert.True(spec.IsExclusion);
+        Assert.Equal(IPAddress.Parse("192.168.1.1"), spec.Address);
+    }
+
+    [Fact]
+    public void ParseAdBlock_ClientModifier_EscapedPipeInQuotedName()
+    {
+        var rules = DnsFilterListReader.Parse(@"||example.com^$client='Bob\|s PC'", DnsFilterListFormat.AdBlock);
+
+        var spec = Assert.Single(Assert.Single(rules).ClientSpecs!);
+        Assert.Equal("Bob|s PC", spec.Name);
     }
 
     [Fact]
@@ -324,7 +356,9 @@ public sealed class DnsFilterListReaderTests
 
         var rules = DnsFilterListReader.Parse(text, DnsFilterListFormat.AdBlock);
 
-        Assert.Single(rules);
+        var tagSpec = Assert.Single(rules).TagSpec!;
+        Assert.Equal(["device_phone", "device_pc"], tagSpec.IncludedTags);
+        Assert.Null(tagSpec.ExcludedTags);
     }
 
     [Fact]
@@ -334,7 +368,19 @@ public sealed class DnsFilterListReaderTests
 
         var rules = DnsFilterListReader.Parse(text, DnsFilterListFormat.AdBlock);
 
-        Assert.Single(rules);
+        var tagSpec = Assert.Single(rules).TagSpec!;
+        Assert.Equal(["device_phone"], tagSpec.ExcludedTags);
+        Assert.Null(tagSpec.IncludedTags);
+    }
+
+    [Fact]
+    public void ParseAdBlock_CtagModifier_MixedInclusionAndExclusion()
+    {
+        var rules = DnsFilterListReader.Parse("||example.com^$ctag=user_child|~device_pc", DnsFilterListFormat.AdBlock);
+
+        var tagSpec = Assert.Single(rules).TagSpec!;
+        Assert.Equal(["user_child"], tagSpec.IncludedTags);
+        Assert.Equal(["device_pc"], tagSpec.ExcludedTags);
     }
 
     [Fact]
@@ -355,8 +401,11 @@ public sealed class DnsFilterListReaderTests
 
         var rules = DnsFilterListReader.Parse(text, DnsFilterListFormat.AdBlock);
 
-        Assert.Single(rules);
-        Assert.NotNull(rules[0].Pattern);
+        var rule = Assert.Single(rules);
+        Assert.NotNull(rule.Pattern);
+        Assert.True(rule.Pattern.IsMatch("xadsy.example.com"));
+        Assert.False(rule.Pattern.IsMatch("example.com"));
+        Assert.False(rule.Pattern.IsMatch("ads.example.org"));
     }
 
     [Fact]
@@ -464,5 +513,286 @@ public sealed class DnsFilterListReaderTests
     public void Parse_NullString_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => DnsFilterListReader.Parse((string)null!));
+    }
+
+    [Theory]
+    [InlineData("|")]
+    [InlineData("||")]
+    [InlineData("@@")]
+    [InlineData("@@|")]
+    [InlineData("@@||")]
+    [InlineData("|$important")]
+    [InlineData("@@|$important")]
+    [InlineData("||^")]
+    [InlineData("^")]
+    [InlineData("||$dnsrewrite=1.2.3.4")]
+    public void ParseAdBlock_DegeneratePattern_IsSkippedWithoutThrowing(string line)
+    {
+        var rules = DnsFilterListReader.Parse(line, DnsFilterListFormat.AdBlock);
+
+        Assert.Empty(rules);
+    }
+
+    [Fact]
+    public void ParseAdBlock_MalformedLine_DoesNotDiscardTheRestOfTheList()
+    {
+        var text = """
+            ||ads1.example.com^
+            |
+            ||ads2.example.com^
+            """;
+
+        var result = DnsFilterListReader.ParseWithDiagnostics(text, DnsFilterListFormat.AdBlock);
+
+        Assert.Equal(2, result.Rules.Count);
+        Assert.Equal(2, Assert.Single(result.Diagnostics).LineNumber);
+    }
+
+    [Theory]
+    [InlineData("||example.com^$third-party", "third-party")]
+    [InlineData("||example.com^$script,image", "script")]
+    [InlineData("||example.com^$domain=other.org", "domain=other.org")]
+    [InlineData("@@||example.com^$app=com.example", "app=com.example")]
+    [InlineData("||example.com^$importnat", "importnat")]
+    public void ParseAdBlock_UnsupportedModifier_DiscardsTheRule(string line, string expectedDetail)
+    {
+        var result = DnsFilterListReader.ParseWithDiagnostics(line, DnsFilterListFormat.AdBlock);
+
+        Assert.Empty(result.Rules);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(DnsFilterParseError.UnsupportedModifier, diagnostic.Error);
+        Assert.Equal(expectedDetail, diagnostic.Detail);
+    }
+
+    [Theory]
+    [InlineData("||example.com^$dnstype=NOTATYPE")]
+    [InlineData("||example.com^$dnstype=")]
+    [InlineData("||example.com^$client=192.168.1.0/33")]
+    [InlineData("||example.com^$client=")]
+    [InlineData("||example.com^$ctag=")]
+    [InlineData("||example.com^$denyallow=not a domain")]
+    [InlineData("||example.com^$dnsrewrite=NOERROR;A;not-an-ip")]
+    [InlineData("||example.com^$dnsrewrite=BOGUSCODE;A;1.2.3.4")]
+    public void ParseAdBlock_InvalidModifierValue_DiscardsTheRule(string line)
+    {
+        var result = DnsFilterListReader.ParseWithDiagnostics(line, DnsFilterListFormat.AdBlock);
+
+        Assert.Empty(result.Rules);
+        Assert.Equal(DnsFilterParseError.InvalidModifierValue, Assert.Single(result.Diagnostics).Error);
+    }
+
+    [Theory]
+    [InlineData("SVCB", DnsFilterQueryType.SVCB)]
+    [InlineData("CAA", DnsFilterQueryType.CAA)]
+    [InlineData("65", DnsFilterQueryType.HTTPS)]
+    [InlineData("TYPE64", DnsFilterQueryType.SVCB)]
+    public void ParseAdBlock_DnsType_AcceptsModernAndNumericTypes(string token, DnsFilterQueryType expected)
+    {
+        var rules = DnsFilterListReader.Parse($"||example.com^$dnstype={token}", DnsFilterListFormat.AdBlock);
+
+        Assert.Equal([expected], Assert.Single(rules).AllowedDnsTypes);
+    }
+
+    [Fact]
+    public void ParseAdBlock_WildcardInsideDomainAnchor_ProducesAPattern()
+    {
+        var rules = DnsFilterListReader.Parse("||*.example.com^", DnsFilterListFormat.AdBlock);
+
+        var rule = Assert.Single(rules);
+        Assert.Null(rule.DomainSuffix);
+        Assert.NotNull(rule.Pattern);
+        Assert.True(rule.Pattern.IsMatch("sub.example.com"));
+    }
+
+    [Fact]
+    public void ParseAdBlock_RegexWithEscapedSlash_IsParsed()
+    {
+        var rules = DnsFilterListReader.Parse(@"/^ads\/x.*\.example\.com$/", DnsFilterListFormat.AdBlock);
+
+        Assert.NotNull(Assert.Single(rules).Pattern);
+    }
+
+    [Theory]
+    [InlineData("/[unclosed/")]
+    [InlineData("/abc")]
+    public void ParseAdBlock_InvalidRegex_IsReported(string line)
+    {
+        var result = DnsFilterListReader.ParseWithDiagnostics(line, DnsFilterListFormat.AdBlock);
+
+        Assert.Empty(result.Rules);
+        Assert.Equal(DnsFilterParseError.InvalidRegex, Assert.Single(result.Diagnostics).Error);
+    }
+
+    [Fact]
+    public void ParseAdBlock_DoubleSeparator_IsStripped()
+    {
+        var rules = DnsFilterListReader.Parse("||example.com^^", DnsFilterListFormat.AdBlock);
+
+        Assert.Equal("example.com", Assert.Single(rules).DomainSuffix);
+    }
+
+    [Fact]
+    public void ParseAdBlock_UnbalancedQuote_DoesNotSwallowLaterModifiers()
+    {
+        var rules = DnsFilterListReader.Parse("||example.com^$client=Franks',important", DnsFilterListFormat.AdBlock);
+
+        Assert.True(Assert.Single(rules).IsImportant);
+    }
+
+    [Fact]
+    public void ParseAdBlock_QuotedValueContainingComma_IsOneModifier()
+    {
+        var rules = DnsFilterListReader.Parse("||example.com^$client='a,b',important", DnsFilterListFormat.AdBlock);
+
+        var rule = Assert.Single(rules);
+        Assert.True(rule.IsImportant);
+        Assert.Equal("a,b", Assert.Single(rule.ClientSpecs!).Name);
+    }
+
+    [Theory]
+    [InlineData("REFUSED", DnsFilterRewriteResponseCode.Refused)]
+    [InlineData("NXDOMAIN", DnsFilterRewriteResponseCode.NameError)]
+    [InlineData("SERVFAIL", DnsFilterRewriteResponseCode.ServerFailure)]
+    public void ParseAdBlock_DnsRewrite_ResponseCodeKeywords(string keyword, DnsFilterRewriteResponseCode expected)
+    {
+        var rules = DnsFilterListReader.Parse($"||example.com^$dnsrewrite={keyword}", DnsFilterListFormat.AdBlock);
+
+        Assert.Equal(expected, Assert.Single(rules).Rewrite!.ResponseCode);
+    }
+
+    [Fact]
+    public void ParseAdBlock_DnsRewrite_BareIntegerIsNotAnIPAddress()
+    {
+        // IPAddress.TryParse("1234") succeeds and yields 0.0.4.210, which would silently become a
+        // bogus A record; it must be treated as a domain-shaped value instead.
+        var result = DnsFilterListReader.ParseWithDiagnostics("||example.com^$dnsrewrite=1234", DnsFilterListFormat.AdBlock);
+
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal(DnsFilterQueryType.CNAME, rule.Rewrite!.RecordType);
+        Assert.Equal("1234", rule.Rewrite.Value);
+    }
+
+    [Fact]
+    public void ParseAdBlock_DnsRewrite_ValueKeepsSemicolons()
+    {
+        var rules = DnsFilterListReader.Parse("||example.com^$dnsrewrite=NOERROR;TXT;a;b", DnsFilterListFormat.AdBlock);
+
+        Assert.Equal("a;b", Assert.Single(rules).Rewrite!.Value);
+    }
+
+    [Fact]
+    public void DetectFormat_SingleDollarSignDoesNotFlipAHostsList()
+    {
+        var text = """
+            # Title: my hosts
+            0.0.0.0 ads.example.com
+            0.0.0.0 scam.example.com # win $1000
+            0.0.0.0 tracker.example.org
+            """;
+
+        var result = DnsFilterListReader.ParseWithDiagnostics(text);
+
+        Assert.Equal(DnsFilterListFormat.Hosts, result.Format);
+        Assert.Equal(3, result.Rules.Count);
+    }
+
+    [Fact]
+    public void DetectFormat_MinorityAdBlockLinesDoNotFlipAHostsList()
+    {
+        var text = """
+            0.0.0.0 a.example.com
+            0.0.0.0 b.example.com
+            0.0.0.0 c.example.com
+            ||d.example.com^
+            """;
+
+        var result = DnsFilterListReader.ParseWithDiagnostics(text);
+
+        Assert.Equal(DnsFilterListFormat.Hosts, result.Format);
+        Assert.Equal(3, result.Rules.Count);
+        Assert.Single(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ParseAdBlock_HostsLineIsRejectedRatherThanBecomingADeadRule()
+    {
+        var result = DnsFilterListReader.ParseWithDiagnostics("0.0.0.0 ads.example.com", DnsFilterListFormat.AdBlock);
+
+        Assert.Empty(result.Rules);
+        Assert.Equal(DnsFilterParseError.InvalidPattern, Assert.Single(result.Diagnostics).Error);
+    }
+
+    [Fact]
+    public void ParseDomainsOnly_AdBlockHeaderIsNotTreatedAsADomain()
+    {
+        var result = DnsFilterListReader.ParseWithDiagnostics("""
+            !Title: my list
+            ads.example.com
+            """);
+
+        Assert.Equal("ads.example.com", Assert.Single(result.Rules).ExactDomain);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Parse_InternationalizedDomain_IsConvertedToPunycode()
+    {
+        var rules = DnsFilterListReader.Parse("||пример.рф^", DnsFilterListFormat.AdBlock);
+
+        Assert.Equal("xn--e1afmkfd.xn--p1ai", Assert.Single(rules).DomainSuffix);
+    }
+
+    [Theory]
+    [InlineData(@"^139\.45\.197\.2(4[0-9]|5[0-4]):", "139.45.197.2")]
+    [InlineData(@"^ads\.example\.com$", "ads.example.com")]
+    [InlineData("^abc", "abc")]
+    [InlineData(@"^ab\d+", null)]
+    [InlineData("^abc|def", null)]
+    [InlineData(@"^(a|c)\.[0-9a-f]{56}\.com$", null)]
+    [InlineData("^ab", null)]
+    [InlineData("^abcd*e", "abc")]
+    public void GetRegexLiteralPrefix_ExtractsOnlyMandatoryPrefixes(string source, string? expected)
+    {
+        Assert.Equal(expected, DnsFilterListReader.GetRegexLiteralPrefix(source));
+    }
+
+    [Fact]
+    public void GetRegexLiteralPrefix_NeverRejectsANameTheRegexWouldMatch()
+    {
+        // The prefilter is only sound if every string the regex matches contains the literal.
+        string[] sources = [@"^139\.45\.197\.2(4[0-9]|5[0-4])", @"^ads\.example\.com$", "^abcd*e"];
+        string[] samples = ["139.45.197.244", "ads.example.com", "abce", "abcddde", "nope.example.org"];
+
+        foreach (var source in sources)
+        {
+            var prefix = DnsFilterListReader.GetRegexLiteralPrefix(source);
+            if (prefix is null)
+                continue;
+
+            var regex = new Regex(source, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+            foreach (var sample in samples)
+            {
+                if (regex.IsMatch(sample))
+                {
+                    Assert.Contains(prefix, sample);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void ParseWithDiagnostics_ReportsLineNumbersAndText()
+    {
+        var text = """
+            ||good.example.com^
+            ||bad.example.com^$third-party
+            """;
+
+        var result = DnsFilterListReader.ParseWithDiagnostics(text, DnsFilterListFormat.AdBlock);
+
+        Assert.Single(result.Rules);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(2, diagnostic.LineNumber);
+        Assert.Equal("||bad.example.com^$third-party", diagnostic.Line);
     }
 }


### PR DESCRIPTION
A whole-project audit of `Meziantou.Framework.DnsFilter` turned up a consistent theme: **every construct the parser did not fully understand failed in the widening direction, and none of them were reported.** An unknown modifier was dropped and the rule kept; an unknown `$dnstype` value was dropped and the rule kept; a `*` inside `||…^` was stored as a literal domain suffix. With no diagnostics channel, `Rules.Count` looked healthy in all of these cases.

The most concrete instance: **403 rules in AdGuard's own DNS filter — the list this library is modelled on — silently matched nothing.**

Every behavioural claim below was reproduced by executing the library, against constructed inputs and against four real blocklists (StevenBlack hosts, AdGuard DNS filter, oisd big, HaGeZi Pro; 752,558 rules).

## Parsing

- **Anchors are stripped into flags** (`||`, `|`, `^`) *before* choosing exact/suffix/regex, instead of being dispatched as mutually exclusive branches. Fixes `||*.example.com^`, `||ads*.example.com^`, `|*.x.com|` and `||example.com^^`, and structurally removes the `ArgumentOutOfRangeException` that a lone `|` line threw — which aborted the entire list load.
- **Strict modifiers.** A rule carrying an unsupported modifier, or a modifier value that cannot be parsed, is discarded rather than applied unscoped. `@@||x^$script` was becoming a blanket allow; `||x^$dnstype=SVCB` an unconditional block of every record type.
- **Diagnostics.** `ParseWithDiagnostics` / `AddFromList` report every skipped line, so a list that half-failed is visible instead of merely smaller.
- **Format detection** counts evidence per line and strips inline comments first, so a single `$` (e.g. `0.0.0.0 scam.example.com # win $1000`) no longer flips a hosts list to AdBlock and renders it inert.
- Backslash escapes are honoured when locating a regex delimiter and when splitting modifier / pipe-separated values; an unterminated quote no longer swallows the modifiers after it.
- `$dnsrewrite` values are validated against the record type, keep their semicolons, and no longer accept numeric response codes that map to undefined enum members.

## Matching

- **Score-based priority.** An `$important` exception now outranks an `$important` block (matching AdGuard), a `$dnsrewrite` rule outranks a plain block, and the more specific rule wins — instead of whichever the index happened to yield first.
- `$ctag` requires **both** inclusions and exclusions; the exclusion branch returned early and made the inclusion list unreachable, so `$ctag=user_child|~device_pc` applied to every non-PC client.
- `$badfilter` is keyed on a **canonical identity** (pattern + order-independent modifier set) rather than raw rule text, so casing, modifier order, the word appearing inside a modifier value, or a hosts-format target no longer make it a silent no-op.
- Client-scoped rules no longer match when the caller supplied no client information, as `DnsClientInfo` documents; exclusion-only `$client` rules matched everyone.
- `RegexMatchTimeoutException` is caught instead of escaping `Evaluate`, and list-supplied patterns compile as `NonBacktracking`, making catastrophic backtracking structurally impossible. The ReDoS case went from **1,004 ms + an exception** to **0 ms + a clean non-match**.
- Rule patterns and queried names share one normalization helper, including IDN→punycode.

## Public API — breaking

`ref/Meziantou.Framework.DnsFilter.cs` regenerated.

- **`DnsFilterAction` gains `None = 0` and `Rewrite`; `Block`/`Allow` shift by one.** An unmatched result is now `None`, so `Action == Block` can no longer block the whole internet, and a `$dnsrewrite` match no longer masquerades as a plain block. **This is binary-breaking and warrants a major version bump.**
- `DnsFilterRule` exposes `ExactDomain`, `DomainSuffix`, `PatternText`, and `CreateBlock`/`CreateAllow` factories, so rules can be built and reported on without round-tripping through list text.
- `DnsFilterQueryType` widened (SVCB, CAA, DS, DNSKEY, TLSA, …) and documented as an open `ushort` set; `DnsFilterRewriteResponseCode` gains `ServerFailure`.

## Performance

Wildcard rules are indexed by the concrete domain suffix they are anchored on (336 of 439 on the real corpus); the rest are gated behind a literal prefilter.

| | µs/query |
|---|---|
| Before (403 wildcard rules silently inert) | 0.9 |
| Naive fix of the wildcard bug | 17.4 |
| **This PR** | **3.3** (~300k q/s) |

The "before" number was only achievable because those rules did nothing. `RegexOptions.Compiled` is dropped, the indexes are pre-sized, and a single rule is stored directly rather than wrapped in a `List<>`.

I also tried a combined-alternation prefilter and **reverted it** — it made things worse (3.4 → 5.1 µs; a large `NonBacktracking` DFA costs more than 103 small matches).

## Meziantou.DnsProxy

Two consumer defects the old API shape invited:

- `$dnsrewrite` is now applied instead of discarded in favour of NXDOMAIN.
- The raw QTYPE is passed through instead of collapsing unknown types to `ANY` (which made `$dnstype=ANY` rules fire on CAA/SVCB/DS queries and `$dnstype=~ANY` rules spare them).
- Skipped filter-list lines are logged.

## Reviewer notes

- **Behaviour change worth a look:** strict parsing means blocklists derived from *browser* filter lists (EasyList and friends, full of `$third-party` / `$script` / `$domain=`) will now produce noticeably fewer rules — correctly, since those rules were previously being applied as unconditional DNS blocks. AdGuard's own DNS filter is unaffected: 34 skipped lines out of 179,794 rules.
- **`$important` ordering** was changed to match AdGuard (allow beats block). The old readme described the previous, opposite order *as* "the AdGuard priority pipeline", so this makes the documentation true; it is a behaviour change for anyone relying on deny-by-default at that level.
- Two audit findings were **deliberately left out of scope**: the ~440 B/rule footprint with its `Reload` doubling, and streaming the parser off the `TextReader`. Both are the largest and riskiest changes and are unrelated to the correctness work here.

## Verification

- 324 tests (162 per TFM, up from 76), 0 failures; `Meziantou.Framework.DnsProxy.Tests` 84/84.
- `Release` + `IsOfficialBuild=true` + `TreatsWarningsAsErrors=true` clean on all touched projects.
- `ref/` regenerated; `dotnet run ./eng/update-all.cs` produces no further changes.
- All builds and tests re-run after rebasing onto current `main`.
