### PR TITLE
Validate NTP responses and harden the NTP server

### DIFF
--- a/ref/Meziantou.Framework.NtpClient.cs
+++ b/ref/Meziantou.Framework.NtpClient.cs
@@ -4,12 +4,11 @@
 
 namespace Meziantou.Framework.Ntp
 {
-    public sealed class NtpClient : System.IDisposable
+    public sealed class NtpClient
     {
         public NtpClient(string server) { }
         public NtpClient(string server, Meziantou.Framework.Ntp.NtpClientOptions? options) { }
         public System.Threading.Tasks.Task<Meziantou.Framework.Ntp.NtpResponse> QueryAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
-        public void Dispose() { }
     }
 
     public sealed class NtpClientOptions
@@ -17,6 +16,7 @@ namespace Meziantou.Framework.Ntp
         public int Port { get => throw null; set { } }
         public Meziantou.Framework.Ntp.NtpVersion Version { get => throw null; set { } }
         public System.TimeSpan Timeout { get => throw null; set { } }
+        public bool ValidateResponse { get => throw null; set { } }
     }
 
     public enum NtpLeapIndicator
@@ -34,7 +34,13 @@ namespace Meziantou.Framework.Ntp
         public byte Stratum { get => throw null; }
         public sbyte PollInterval { get => throw null; }
         public sbyte Precision { get => throw null; }
-        public System.DateTimeOffset ReferenceTimestamp { get => throw null; }
+        public System.TimeSpan RootDelay { get => throw null; }
+        public System.TimeSpan RootDispersion { get => throw null; }
+        public uint ReferenceIdentifier { get => throw null; }
+        public string? ReferenceIdentifierText { get => throw null; }
+        public bool IsKissOfDeath { get => throw null; }
+        public string? KissCode { get => throw null; }
+        public System.DateTimeOffset? ReferenceTimestamp { get => throw null; }
         public System.DateTimeOffset OriginateTimestamp { get => throw null; }
         public System.DateTimeOffset ReceiveTimestamp { get => throw null; }
         public System.DateTimeOffset TransmitTimestamp { get => throw null; }

--- a/ref/Meziantou.Framework.NtpServer.cs
+++ b/ref/Meziantou.Framework.NtpServer.cs
@@ -7,6 +7,7 @@ namespace Meziantou.Framework.Ntp
     public sealed class NtpServer : System.IDisposable
     {
         public int Port { get => throw null; }
+        public System.Threading.Tasks.Task Completion { get => throw null; }
         public NtpServer(Meziantou.Framework.Ntp.NtpServerOptions? options = null) { }
         public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public void Dispose() { }
@@ -15,7 +16,11 @@ namespace Meziantou.Framework.Ntp
     public sealed class NtpServerOptions
     {
         public int Port { get => throw null; set { } }
+        public System.Net.IPAddress BindAddress { get => throw null; set { } }
         public System.TimeProvider TimeProvider { get => throw null; set { } }
         public byte Stratum { get => throw null; set { } }
+        public string ReferenceIdentifier { get => throw null; set { } }
+        public System.TimeSpan RootDispersion { get => throw null; set { } }
+        public int MaxRequestsPerSecond { get => throw null; set { } }
     }
 }

--- a/src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj
+++ b/src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>An NTP client for querying NTP servers to retrieve accurate network time (supports NTPv3 and NTPv4)</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.NtpClient/NtpClient.cs
+++ b/src/Meziantou.Framework.NtpClient/NtpClient.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 
@@ -8,7 +9,12 @@ namespace Meziantou.Framework.Ntp;
 /// An NTP client for querying NTP servers to retrieve accurate network time.
 /// Supports NTPv3 and NTPv4.
 /// </summary>
-public sealed class NtpClient : IDisposable
+/// <remarks>
+/// Responses are validated as described on <see cref="NtpClientOptions.ValidateResponse"/>, but they
+/// are never authenticated cryptographically. An attacker who can inject packets on the path to the
+/// server can still control the reported time.
+/// </remarks>
+public sealed class NtpClient
 {
     private readonly string _server;
     private readonly NtpClientOptions _options;
@@ -38,44 +44,30 @@ public sealed class NtpClient : IDisposable
     /// <summary>Queries the NTP server and returns the time response.</summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The NTP response containing timestamps and computed offset/delay.</returns>
+    /// <exception cref="TimeoutException">Every resolved address timed out.</exception>
+    /// <exception cref="AggregateException">Every resolved address failed, for differing reasons.</exception>
     public async Task<NtpResponse> QueryAsync(CancellationToken cancellationToken = default)
     {
         using var activity = NtpTelemetry.ActivitySource.StartActivity("ntp.query");
         activity?.SetTag("ntp.server", _server);
         activity?.SetTag("ntp.version", (int)_options.Version);
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(_options.Timeout);
-        var linkedToken = timeoutCts.Token;
-
         try
         {
-            var endpoints = await ResolveEndpointsAsync(linkedToken).ConfigureAwait(false);
+            var endpoints = await ResolveEndpointsAsync(cancellationToken).ConfigureAwait(false);
 
-            List<Exception>? exceptions = null;
+            List<Exception> exceptions = [];
             foreach (var endpoint in endpoints)
             {
                 try
                 {
-                    var request = NtpPacket.CreateClientRequest(_options.Version);
-                    request.TransmitTimestamp = DateTimeOffset.UtcNow;
+                    var response = await QueryEndpointAsync(endpoint, activity, cancellationToken).ConfigureAwait(false);
 
-                    var requestBuffer = new byte[NtpPacket.PacketSize];
-                    request.Encode(requestBuffer);
-
-                    using var client = new UdpClient(endpoint.AddressFamily);
-                    await client.SendAsync(requestBuffer, requestBuffer.Length, endpoint).ConfigureAwait(false);
-
-                    var result = await client.ReceiveAsync(linkedToken).ConfigureAwait(false);
-                    var destinationTimestamp = DateTimeOffset.UtcNow;
-
-                    var responsePacket = NtpPacket.Decode(result.Buffer);
-
-                    activity?.SetTag("ntp.stratum", responsePacket.Stratum);
+                    activity?.SetTag("ntp.stratum", response.Stratum);
                     activity?.SetTag("ntp.address_family", endpoint.AddressFamily.ToString());
                     activity?.SetStatus(ActivityStatusCode.Ok);
 
-                    return new NtpResponse(responsePacket, destinationTimestamp);
+                    return response;
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -83,11 +75,11 @@ public sealed class NtpClient : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    (exceptions ??= []).Add(ex);
+                    exceptions.Add(ex);
                 }
             }
 
-            throw new AggregateException($"Failed to query NTP server '{_server}' on all resolved addresses", exceptions!);
+            throw CreateFailureException(exceptions);
         }
         catch (Exception ex)
         {
@@ -96,10 +88,147 @@ public sealed class NtpClient : IDisposable
         }
     }
 
-    /// <summary>Releases the resources used by this instance.</summary>
-    public void Dispose()
+    private async Task<NtpResponse> QueryEndpointAsync(IPEndPoint endpoint, Activity? activity, CancellationToken cancellationToken)
     {
-        // No persistent resources to dispose; UdpClient is created per-query.
+        // Every address gets its own timeout. Sharing one budget across the whole list lets a single
+        // unresponsive address -- a AAAA record on a host with no IPv6 route, typically -- consume it
+        // all, leaving no time for the address that would have answered.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_options.Timeout);
+        var timeoutToken = timeoutCts.Token;
+
+        string? lastRejection = null;
+        try
+        {
+            var request = NtpPacket.CreateClientRequest(_options.Version);
+            request.TransmitTimestamp = DateTimeOffset.UtcNow;
+
+            var requestBuffer = new byte[NtpPacket.PacketSize];
+            request.Encode(requestBuffer);
+
+            using var client = new UdpClient(endpoint.AddressFamily);
+
+            // Connecting the socket makes the OS drop datagrams from every other source, so an
+            // off-path attacker cannot race the real server by guessing only the source port.
+            client.Connect(endpoint);
+            await client.SendAsync(requestBuffer, timeoutToken).ConfigureAwait(false);
+
+            while (true)
+            {
+                var result = await client.ReceiveAsync(timeoutToken).ConfigureAwait(false);
+                var destinationTimestamp = DateTimeOffset.UtcNow;
+
+                if (TryReadResponse(result.Buffer, requestBuffer, destinationTimestamp, out var response, out var rejection))
+                    return response;
+
+                // Keep waiting for a valid reply instead of failing, so a single stray or forged
+                // datagram cannot deny service for the whole timeout.
+                lastRejection = rejection;
+                activity?.AddEvent(new ActivityEvent("ntp.response_rejected", tags: new ActivityTagsCollection
+                {
+                    { "ntp.rejection_reason", rejection },
+                    { "ntp.peer.address", endpoint.ToString() },
+                }));
+            }
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            var detail = lastRejection is null ? "" : $" The last response was rejected because {lastRejection}.";
+            throw new TimeoutException($"The NTP query to '{endpoint}' did not complete within {_options.Timeout}.{detail}", ex);
+        }
+    }
+
+    private bool TryReadResponse(
+        ReadOnlySpan<byte> buffer,
+        ReadOnlySpan<byte> request,
+        DateTimeOffset destinationTimestamp,
+        [NotNullWhen(true)] out NtpResponse? response,
+        [NotNullWhen(false)] out string? rejection)
+    {
+        response = null;
+
+        if (buffer.Length < NtpPacket.PacketSize)
+        {
+            rejection = $"it is {buffer.Length} bytes, expected at least {NtpPacket.PacketSize}";
+            return false;
+        }
+
+        var packet = NtpPacket.Decode(buffer);
+
+        // These hold whatever NtpClientOptions.ValidateResponse says: without them the reply is not a
+        // usable time reading, and the offset computed from it would be meaningless rather than merely
+        // untrusted.
+        if (packet.Mode is not NtpMode.Server)
+        {
+            rejection = $"its mode is {(int)packet.Mode}, expected {(int)NtpMode.Server} (server)";
+            return false;
+        }
+
+        if (packet.OriginateTimestamp is null || packet.ReceiveTimestamp is null || packet.TransmitTimestamp is null)
+        {
+            rejection = "it is missing the originate, receive, or transmit timestamp";
+            return false;
+        }
+
+        if (_options.ValidateResponse)
+        {
+            // RFC 5905 TEST2. The originate timestamp is the only thing binding a reply to this
+            // request, so compare the raw bytes: decoding to DateTimeOffset is lossy and would leave
+            // an attacker more room than the wire format does.
+            var echoed = buffer.Slice(NtpPacket.OriginateTimestampOffset, NtpTimestamp.Size);
+            var sent = request.Slice(NtpPacket.TransmitTimestampOffset, NtpTimestamp.Size);
+            if (!echoed.SequenceEqual(sent))
+            {
+                rejection = "its originate timestamp does not echo the transmit timestamp of the request";
+                return false;
+            }
+
+            if (packet.Version is not (NtpVersion.V3 or NtpVersion.V4))
+            {
+                rejection = $"its version is {(int)packet.Version}, expected 3 or 4";
+                return false;
+            }
+
+            if (packet.Stratum is NtpPacket.KissOfDeathStratum)
+            {
+                var kissCode = NtpPacket.FormatReferenceIdentifier(packet.ReferenceIdentifier);
+                rejection = kissCode is null
+                    ? "the server returned a Kiss-o'-Death packet"
+                    : $"the server returned a Kiss-o'-Death packet ({kissCode})";
+                return false;
+            }
+
+            // RFC 5905 TEST3: the server is telling us its own clock is not synchronized.
+            if (packet.LeapIndicator is NtpLeapIndicator.AlarmCondition)
+            {
+                rejection = "the server reports an alarm condition, meaning its clock is not synchronized";
+                return false;
+            }
+        }
+
+        response = new NtpResponse(packet, destinationTimestamp);
+        rejection = null;
+
+        return true;
+    }
+
+    private Exception CreateFailureException(List<Exception> exceptions)
+    {
+        // A single resolved address is the common case; report its own exception so the reason a
+        // response was rejected survives instead of being flattened into a generic message.
+        if (exceptions.Count is 1)
+            return exceptions[0];
+
+        // Surface a plain timeout as a TimeoutException rather than burying it in an AggregateException,
+        // so that `catch (TimeoutException)` works for the case callers actually expect.
+        if (exceptions.TrueForAll(static ex => ex is TimeoutException))
+        {
+            return new TimeoutException(
+                $"The NTP query to '{_server}' timed out on all {exceptions.Count} resolved address(es), allowing {_options.Timeout} each.",
+                exceptions[0]);
+        }
+
+        return new AggregateException($"Failed to query NTP server '{_server}' on all resolved addresses", exceptions);
     }
 
     private async ValueTask<IPEndPoint[]> ResolveEndpointsAsync(CancellationToken cancellationToken)
@@ -107,7 +236,19 @@ public sealed class NtpClient : IDisposable
         if (IPAddress.TryParse(_server, out var address))
             return [new IPEndPoint(address, _options.Port)];
 
-        var addresses = await Dns.GetHostAddressesAsync(_server, cancellationToken).ConfigureAwait(false);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_options.Timeout);
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(_server, timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Resolving host '{_server}' did not complete within {_options.Timeout}.", ex);
+        }
+
         if (addresses.Length is 0)
             throw new InvalidOperationException($"Could not resolve host: {_server}");
 

--- a/src/Meziantou.Framework.NtpClient/NtpClientOptions.cs
+++ b/src/Meziantou.Framework.NtpClient/NtpClientOptions.cs
@@ -13,6 +13,32 @@ public sealed class NtpClientOptions
     /// <summary>Gets or sets the NTP protocol version to use. Default is <see cref="NtpVersion.V4"/>.</summary>
     public NtpVersion Version { get; set; } = NtpVersion.V4;
 
-    /// <summary>Gets or sets the timeout for a single NTP query. Default is 5 seconds. Use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> for no timeout.</summary>
+    /// <summary>Gets or sets the timeout for querying a single resolved address. Default is 5 seconds. Use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> for no timeout.</summary>
+    /// <remarks>
+    /// A host name can resolve to several addresses, and each one gets this much time, so a query can
+    /// take up to <c>Timeout × addressCount</c> overall. Use the <c>cancellationToken</c> of
+    /// <see cref="NtpClient.QueryAsync"/> to bound the total duration.
+    /// </remarks>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether responses are validated before being returned.
+    /// Default is <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, a response is only accepted if its originate timestamp echoes the transmit
+    /// timestamp of the request (RFC 5905 TEST2), its version is 3 or 4, its stratum is not 0
+    /// (Kiss-o'-Death), and the server does not report an alarm condition. Responses that fail are
+    /// ignored and the client keeps waiting for a valid one until <see cref="Timeout"/> elapses.
+    /// </para>
+    /// <para>
+    /// The originate timestamp is what ties a reply to this specific request, so disabling this makes
+    /// the client accept a forged reply from anyone who can guess its source port. Only turn it off to
+    /// interoperate with a server known to be non-compliant, and do not use the result to make a
+    /// security decision. This library never authenticates the server cryptographically: it implements
+    /// neither NTS (RFC 8915) nor symmetric key authentication.
+    /// </para>
+    /// </remarks>
+    public bool ValidateResponse { get; set; } = true;
 }

--- a/src/Meziantou.Framework.NtpClient/NtpPacket.cs
+++ b/src/Meziantou.Framework.NtpClient/NtpPacket.cs
@@ -11,19 +11,27 @@ internal struct NtpPacket
 {
     public const int PacketSize = 48;
 
+    public const int ReferenceTimestampOffset = 16;
+    public const int OriginateTimestampOffset = 24;
+    public const int ReceiveTimestampOffset = 32;
+    public const int TransmitTimestampOffset = 40;
+
+    /// <summary>The stratum value that marks a Kiss-o'-Death packet (RFC 5905 section 7.4).</summary>
+    public const byte KissOfDeathStratum = 0;
+
     public NtpLeapIndicator LeapIndicator { get; set; }
     public NtpVersion Version { get; set; }
     public NtpMode Mode { get; set; }
     public byte Stratum { get; set; }
     public sbyte PollInterval { get; set; }
     public sbyte Precision { get; set; }
-    public uint RootDelay { get; set; }
-    public uint RootDispersion { get; set; }
+    public TimeSpan RootDelay { get; set; }
+    public TimeSpan RootDispersion { get; set; }
     public uint ReferenceIdentifier { get; set; }
-    public DateTimeOffset ReferenceTimestamp { get; set; }
-    public DateTimeOffset OriginateTimestamp { get; set; }
-    public DateTimeOffset ReceiveTimestamp { get; set; }
-    public DateTimeOffset TransmitTimestamp { get; set; }
+    public DateTimeOffset? ReferenceTimestamp { get; set; }
+    public DateTimeOffset? OriginateTimestamp { get; set; }
+    public DateTimeOffset? ReceiveTimestamp { get; set; }
+    public DateTimeOffset? TransmitTimestamp { get; set; }
 
     public static NtpPacket CreateClientRequest(NtpVersion version)
     {
@@ -50,13 +58,13 @@ internal struct NtpPacket
             Stratum = buffer[1],
             PollInterval = (sbyte)buffer[2],
             Precision = (sbyte)buffer[3],
-            RootDelay = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(4, 4)),
-            RootDispersion = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(8, 4)),
+            RootDelay = NtpTimestamp.DecodeShortFormat(buffer.Slice(4, 4)),
+            RootDispersion = NtpTimestamp.DecodeShortFormat(buffer.Slice(8, 4)),
             ReferenceIdentifier = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(12, 4)),
-            ReferenceTimestamp = NtpTimestamp.Decode(buffer[16..]),
-            OriginateTimestamp = NtpTimestamp.Decode(buffer[24..]),
-            ReceiveTimestamp = NtpTimestamp.Decode(buffer[32..]),
-            TransmitTimestamp = NtpTimestamp.Decode(buffer[40..]),
+            ReferenceTimestamp = NtpTimestamp.Decode(buffer[ReferenceTimestampOffset..]),
+            OriginateTimestamp = NtpTimestamp.Decode(buffer[OriginateTimestampOffset..]),
+            ReceiveTimestamp = NtpTimestamp.Decode(buffer[ReceiveTimestampOffset..]),
+            TransmitTimestamp = NtpTimestamp.Decode(buffer[TransmitTimestampOffset..]),
         };
     }
 
@@ -71,12 +79,38 @@ internal struct NtpPacket
         buffer[1] = Stratum;
         buffer[2] = (byte)PollInterval;
         buffer[3] = (byte)Precision;
-        BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(4, 4), RootDelay);
-        BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(8, 4), RootDispersion);
+        NtpTimestamp.EncodeShortFormat(RootDelay, buffer.Slice(4, 4));
+        NtpTimestamp.EncodeShortFormat(RootDispersion, buffer.Slice(8, 4));
         BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(12, 4), ReferenceIdentifier);
-        NtpTimestamp.Encode(ReferenceTimestamp, buffer[16..]);
-        NtpTimestamp.Encode(OriginateTimestamp, buffer[24..]);
-        NtpTimestamp.Encode(ReceiveTimestamp, buffer[32..]);
-        NtpTimestamp.Encode(TransmitTimestamp, buffer[40..]);
+        NtpTimestamp.Encode(ReferenceTimestamp, buffer[ReferenceTimestampOffset..]);
+        NtpTimestamp.Encode(OriginateTimestamp, buffer[OriginateTimestampOffset..]);
+        NtpTimestamp.Encode(ReceiveTimestamp, buffer[ReceiveTimestampOffset..]);
+        NtpTimestamp.Encode(TransmitTimestamp, buffer[TransmitTimestampOffset..]);
+    }
+
+    /// <summary>
+    /// Formats the reference identifier as the four ASCII characters NTP uses for stratum 0 and 1
+    /// (for example <c>GPS</c>, or the <c>RATE</c> and <c>DENY</c> Kiss-o'-Death codes), or
+    /// <see langword="null"/> when it does not hold printable ASCII.
+    /// </summary>
+    public static string? FormatReferenceIdentifier(uint referenceIdentifier)
+    {
+        Span<char> chars = stackalloc char[4];
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var c = (char)((referenceIdentifier >> ((3 - i) * 8)) & 0xFF);
+            if (c is '\0')
+            {
+                chars = chars[..i];
+                break;
+            }
+
+            if (c is < ' ' or > '~')
+                return null;
+
+            chars[i] = c;
+        }
+
+        return chars.IsEmpty ? null : new string(chars);
     }
 }

--- a/src/Meziantou.Framework.NtpClient/NtpResponse.cs
+++ b/src/Meziantou.Framework.NtpClient/NtpResponse.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Meziantou.Framework.Ntp;
 
 /// <summary>
@@ -7,15 +9,24 @@ public sealed class NtpResponse
 {
     internal NtpResponse(NtpPacket packet, DateTimeOffset destinationTimestamp)
     {
+        // The client rejects a response missing any of these before constructing the result, so the
+        // offset and delay below can never be computed from an unset timestamp.
+        Debug.Assert(packet.OriginateTimestamp is not null, "The originate timestamp must be validated before building a response");
+        Debug.Assert(packet.ReceiveTimestamp is not null, "The receive timestamp must be validated before building a response");
+        Debug.Assert(packet.TransmitTimestamp is not null, "The transmit timestamp must be validated before building a response");
+
         LeapIndicator = packet.LeapIndicator;
         Version = packet.Version;
         Stratum = packet.Stratum;
         PollInterval = packet.PollInterval;
         Precision = packet.Precision;
+        RootDelay = packet.RootDelay;
+        RootDispersion = packet.RootDispersion;
+        ReferenceIdentifier = packet.ReferenceIdentifier;
         ReferenceTimestamp = packet.ReferenceTimestamp;
-        OriginateTimestamp = packet.OriginateTimestamp;
-        ReceiveTimestamp = packet.ReceiveTimestamp;
-        TransmitTimestamp = packet.TransmitTimestamp;
+        OriginateTimestamp = packet.OriginateTimestamp.GetValueOrDefault();
+        ReceiveTimestamp = packet.ReceiveTimestamp.GetValueOrDefault();
+        TransmitTimestamp = packet.TransmitTimestamp.GetValueOrDefault();
         DestinationTimestamp = destinationTimestamp;
     }
 
@@ -25,7 +36,7 @@ public sealed class NtpResponse
     /// <summary>Gets the NTP version used by the server.</summary>
     public NtpVersion Version { get; }
 
-    /// <summary>Gets the stratum level of the server (1 = primary reference, 2-15 = secondary).</summary>
+    /// <summary>Gets the stratum level of the server (0 = Kiss-o'-Death, 1 = primary reference, 2-15 = secondary).</summary>
     public byte Stratum { get; }
 
     /// <summary>Gets the maximum interval between successive messages, in log2 seconds.</summary>
@@ -34,8 +45,50 @@ public sealed class NtpResponse
     /// <summary>Gets the precision of the server clock, in log2 seconds.</summary>
     public sbyte Precision { get; }
 
-    /// <summary>Gets the time when the server clock was last set or corrected.</summary>
-    public DateTimeOffset ReferenceTimestamp { get; }
+    /// <summary>Gets the total round-trip delay from the server to the reference clock.</summary>
+    public TimeSpan RootDelay { get; }
+
+    /// <summary>
+    /// Gets the server's own estimate of the maximum error of its clock. Use it as the error bound on
+    /// <see cref="ClockOffset"/>: a large value means the server does not vouch for its own accuracy.
+    /// </summary>
+    public TimeSpan RootDispersion { get; }
+
+    /// <summary>
+    /// Gets the raw 32-bit reference identifier. For stratum 1 it names the reference clock and for
+    /// stratum 0 it carries the Kiss-o'-Death code; see <see cref="ReferenceIdentifierText"/>.
+    /// </summary>
+    public uint ReferenceIdentifier { get; }
+
+    /// <summary>
+    /// Gets the reference identifier decoded as four ASCII characters (for example <c>GPS</c> or
+    /// <c>PPS</c>), or <see langword="null"/> when it does not hold printable ASCII. For stratum 2 and
+    /// above the field holds an address rather than text, so this is normally <see langword="null"/>.
+    /// </summary>
+    public string? ReferenceIdentifierText => NtpPacket.FormatReferenceIdentifier(ReferenceIdentifier);
+
+    /// <summary>
+    /// Gets a value indicating whether this is a Kiss-o'-Death packet: the server is refusing service
+    /// and its timestamps carry no time. <see cref="KissCode"/> says why.
+    /// </summary>
+    /// <remarks>
+    /// This is only ever <see langword="true"/> when <see cref="NtpClientOptions.ValidateResponse"/>
+    /// is disabled; otherwise the client rejects such a response instead of returning it.
+    /// </remarks>
+    public bool IsKissOfDeath => Stratum is NtpPacket.KissOfDeathStratum;
+
+    /// <summary>
+    /// Gets the four-character Kiss-o'-Death code (for example <c>RATE</c> when the client is being
+    /// rate limited, or <c>DENY</c> when it is not allowed to query the server), or
+    /// <see langword="null"/> when this is not a Kiss-o'-Death packet.
+    /// </summary>
+    public string? KissCode => IsKissOfDeath ? ReferenceIdentifierText : null;
+
+    /// <summary>
+    /// Gets the time when the server clock was last set or corrected, or <see langword="null"/> when
+    /// the server did not supply one because its clock has never been synchronized.
+    /// </summary>
+    public DateTimeOffset? ReferenceTimestamp { get; }
 
     /// <summary>Gets the time at which the request was sent by the client (copied from the client's transmit timestamp).</summary>
     public DateTimeOffset OriginateTimestamp { get; }

--- a/src/Meziantou.Framework.NtpClient/NtpTimestamp.cs
+++ b/src/Meziantou.Framework.NtpClient/NtpTimestamp.cs
@@ -6,37 +6,85 @@ namespace Meziantou.Framework.Ntp;
 /// Provides conversion between NTP 64-bit timestamps and <see cref="DateTimeOffset"/>.
 /// NTP timestamps consist of 32 bits for seconds since 1900-01-01 and 32 bits for fractional seconds.
 /// </summary>
+/// <remarks>
+/// The 32-bit seconds field wraps every 136 years, so it cannot by itself identify an instant.
+/// Following RFC 5905 section 6, a seconds value with the high bit set belongs to era 0
+/// (1968-2036) and a value with the high bit clear belongs to era 1 (2036-2104). Instants outside
+/// that window cannot be represented and are rejected by <see cref="Encode"/> rather than silently
+/// wrapping.
+/// </remarks>
 internal static class NtpTimestamp
 {
-    private static readonly DateTimeOffset NtpEpoch = new(1900, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    /// <summary>The size, in bytes, of an encoded NTP timestamp.</summary>
+    public const int Size = 8;
 
-    public static DateTimeOffset Decode(ReadOnlySpan<byte> buffer)
+    private const long SecondsPerEra = 0x1_0000_0000L;
+    private const long FractionScale = 0x1_0000_0000L;
+    private const long ShortFormatScale = 0x1_0000L;
+
+    private static readonly DateTimeOffset Era0 = new(1900, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Era1 = Era0.AddSeconds(SecondsPerEra);
+
+    /// <summary>Gets the earliest instant that can be encoded (1968-01-20T03:14:08Z).</summary>
+    public static DateTimeOffset MinValue { get; } = Era0.AddSeconds(SecondsPerEra / 2);
+
+    /// <summary>Gets the first instant that is too late to be encoded (2104-02-26T09:42:24Z).</summary>
+    public static DateTimeOffset ExclusiveMaxValue { get; } = Era1.AddSeconds(SecondsPerEra / 2);
+
+    /// <summary>Decodes an NTP timestamp, returning <see langword="null"/> when the field is unset (all zero).</summary>
+    public static DateTimeOffset? Decode(ReadOnlySpan<byte> buffer)
     {
         var seconds = BinaryPrimitives.ReadUInt32BigEndian(buffer);
         var fraction = BinaryPrimitives.ReadUInt32BigEndian(buffer[4..]);
 
-        if (seconds == 0 && fraction == 0)
-            return default;
+        if (seconds is 0 && fraction is 0)
+            return null;
 
-        var ticks = (long)seconds * TimeSpan.TicksPerSecond + (long)fraction * TimeSpan.TicksPerSecond / 0x1_0000_0000L;
+        var ticks = (seconds * TimeSpan.TicksPerSecond) + ((long)fraction * TimeSpan.TicksPerSecond / FractionScale);
+        var epoch = (seconds & 0x8000_0000) is not 0 ? Era0 : Era1;
 
-        return NtpEpoch.AddTicks(ticks);
+        return epoch.AddTicks(ticks);
     }
 
-    public static void Encode(DateTimeOffset value, Span<byte> buffer)
+    /// <summary>Encodes an NTP timestamp, writing an all-zero (unset) field when <paramref name="value"/> is <see langword="null"/>.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="value"/> is outside the range NTP can represent
+    /// (<see cref="MinValue"/> to <see cref="ExclusiveMaxValue"/>).
+    /// </exception>
+    public static void Encode(DateTimeOffset? value, Span<byte> buffer)
     {
-        if (value == default)
+        if (value is not { } instant)
         {
-            buffer[..8].Clear();
+            buffer[..Size].Clear();
             return;
         }
 
-        var ticks = (value - NtpEpoch).Ticks;
+        ArgumentOutOfRangeException.ThrowIfLessThan(instant, MinValue, nameof(value));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(instant, ExclusiveMaxValue, nameof(value));
+
+        var epoch = instant < Era1 ? Era0 : Era1;
+        var ticks = (instant - epoch).Ticks;
         var seconds = (uint)(ticks / TimeSpan.TicksPerSecond);
         var remainingTicks = ticks % TimeSpan.TicksPerSecond;
-        var fraction = (uint)(remainingTicks * 0x1_0000_0000L / TimeSpan.TicksPerSecond);
+        var fraction = (uint)(remainingTicks * FractionScale / TimeSpan.TicksPerSecond);
 
         BinaryPrimitives.WriteUInt32BigEndian(buffer, seconds);
         BinaryPrimitives.WriteUInt32BigEndian(buffer[4..], fraction);
+    }
+
+    /// <summary>Reads a 32-bit NTP short format value: 16 bits of seconds and 16 bits of fraction.</summary>
+    public static TimeSpan DecodeShortFormat(ReadOnlySpan<byte> buffer)
+    {
+        var value = BinaryPrimitives.ReadUInt32BigEndian(buffer);
+
+        return TimeSpan.FromTicks((long)value * TimeSpan.TicksPerSecond / ShortFormatScale);
+    }
+
+    /// <summary>Writes a 32-bit NTP short format value, saturating at the ~18.2 hours it can represent.</summary>
+    public static void EncodeShortFormat(TimeSpan value, Span<byte> buffer)
+    {
+        var scaled = value <= TimeSpan.Zero ? 0 : value.Ticks * ShortFormatScale / TimeSpan.TicksPerSecond;
+
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, (uint)Math.Min(scaled, uint.MaxValue));
     }
 }

--- a/src/Meziantou.Framework.NtpClient/readme.md
+++ b/src/Meziantou.Framework.NtpClient/readme.md
@@ -7,6 +7,7 @@ An NTP client library for querying NTP servers to retrieve accurate network time
 - **NTPv3 and NTPv4**: Configurable protocol version
 - **Clock offset calculation**: Computes the time difference between client and server
 - **Round-trip delay**: Measures network round-trip time
+- **Response validation**: Rejects replies that do not answer the request that was actually sent
 - **Async/await**: Fully asynchronous API with cancellation support
 - **OpenTelemetry**: Built-in `ActivitySource` tracing for NTP queries
 
@@ -16,19 +17,22 @@ An NTP client library for querying NTP servers to retrieve accurate network time
 using Meziantou.Framework.Ntp;
 
 // Query an NTP server using NTPv4 (default)
-using var client = new NtpClient("pool.ntp.org");
+var client = new NtpClient("pool.ntp.org");
 var response = await client.QueryAsync();
 
 Console.WriteLine($"Server time: {response.TransmitTimestamp}");
 Console.WriteLine($"Clock offset: {response.ClockOffset}");
 Console.WriteLine($"Round-trip delay: {response.RoundTripDelay}");
 Console.WriteLine($"Stratum: {response.Stratum}");
+
+// How much the server itself vouches for that reading
+Console.WriteLine($"Root dispersion: {response.RootDispersion}");
 ```
 
 ### Using NTPv3
 
 ```c#
-using var client = new NtpClient("pool.ntp.org", new NtpClientOptions
+var client = new NtpClient("pool.ntp.org", new NtpClientOptions
 {
     Version = NtpVersion.V3,
 });
@@ -37,18 +41,74 @@ var response = await client.QueryAsync();
 
 ### Cancellation and timeout
 
+`NtpClientOptions.Timeout` applies to each resolved address separately, so a host name that resolves
+to several addresses can take up to `Timeout × addressCount` overall. Use the cancellation token to
+bound the total duration.
+
 ```c#
 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-using var client = new NtpClient("time.google.com");
+var client = new NtpClient("time.google.com");
 var response = await client.QueryAsync(cts.Token);
 ```
+
+`QueryAsync` throws `TimeoutException` when a query times out, `OperationCanceledException` when the
+caller's token is cancelled, and `AggregateException` when several resolved addresses failed for
+differing reasons.
 
 ### Custom port
 
 ```c#
-using var client = new NtpClient("localhost", new NtpClientOptions
+var client = new NtpClient("localhost", new NtpClientOptions
 {
     Port = 12345,
 });
 var response = await client.QueryAsync();
 ```
+
+## Response validation
+
+The client's socket is connected to the server, so the operating system drops datagrams from any other
+source. On top of that, `NtpClientOptions.ValidateResponse` (enabled by default) requires that a reply:
+
+- echoes the request's transmit timestamp in its originate timestamp (RFC 5905 TEST2), byte for byte;
+- uses version 3 or 4, and server mode;
+- is not a Kiss-o'-Death packet (stratum 0);
+- does not report an alarm condition, which means the server's own clock is unsynchronized.
+
+A reply that fails is ignored and the client keeps waiting for a valid one until the timeout, so a
+single stray or forged datagram cannot deny service.
+
+You can inspect a refusal by turning validation off:
+
+```c#
+var client = new NtpClient("pool.ntp.org", new NtpClientOptions { ValidateResponse = false });
+var response = await client.QueryAsync();
+if (response.IsKissOfDeath)
+{
+    Console.WriteLine($"The server refused to answer: {response.KissCode}"); // RATE, DENY, RSTR, ...
+}
+```
+
+> [!WARNING]
+> Validation ties a reply to the request that was sent; it does not authenticate the server. This
+> library implements neither NTS (RFC 8915) nor symmetric key authentication, so an attacker who can
+> inject packets on the path to the server can still control the reported time. Do not use the result
+> as the sole input to a security decision.
+
+## Representable range
+
+NTP timestamps carry 32 bits of seconds, which wraps every 136 years. Following RFC 5905, the client
+reads a seconds value with the high bit set as era 0 and one with the high bit clear as era 1, giving a
+representable range of 1968-01-20 to 2104-02-26. Timestamps a server leaves unset (all zero) are
+returned as `null` rather than as a date in the year 1.
+
+## Migrating from 2.x
+
+- `NtpClient` no longer implements `IDisposable` — it held no resources. Drop the `using`.
+- `NtpResponse.ReferenceTimestamp` is now `DateTimeOffset?`, and is `null` when the server did not
+  supply one.
+- A timed-out query now throws `TimeoutException` instead of `AggregateException`.
+- Responses that fail validation are no longer returned. Set `NtpClientOptions.ValidateResponse` to
+  `false` for the previous behavior.
+- `NtpClientOptions.Timeout` is documented as, and now behaves as, a per-address timeout. It was
+  previously shared across every resolved address.

--- a/src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj
+++ b/src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj
@@ -2,9 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>An NTP server that responds to NTP time queries (supports NTPv3 and NTPv4)</Description>
   </PropertyGroup>
+
+  <!-- The wire format is defined once, in the client project, and shared as source. These types are
+       internal, so compiling them into both assemblies does not create duplicate public API for a
+       consumer that references both packages. -->
+  <ItemGroup>
+    <Compile Include="../Meziantou.Framework.NtpClient/NtpTimestamp.cs" Link="NtpTimestamp.cs" />
+    <Compile Include="../Meziantou.Framework.NtpClient/NtpMode.cs" Link="NtpMode.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.NtpServer/NtpRateLimiter.cs
+++ b/src/Meziantou.Framework.NtpServer/NtpRateLimiter.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.Ntp;
+
+/// <summary>
+/// An approximate per-source rate limiter that uses a fixed amount of memory.
+/// </summary>
+/// <remarks>
+/// Source addresses on a UDP server are attacker-controlled and trivially spoofed, so the limiter
+/// cannot allocate an entry per address without becoming a memory-exhaustion vector itself. Addresses
+/// are mapped onto a fixed number of buckets instead; colliding addresses share a budget, which makes
+/// the limit conservative rather than leaky.
+/// </remarks>
+internal sealed class NtpRateLimiter
+{
+    private const int BucketCount = 1024;
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(1);
+
+    private readonly int _maxRequestsPerWindow;
+    private readonly TimeProvider _timeProvider;
+    private readonly Lock _lock = new();
+    private readonly Bucket[] _buckets = new Bucket[BucketCount];
+
+    public NtpRateLimiter(int maxRequestsPerWindow, TimeProvider timeProvider)
+    {
+        _maxRequestsPerWindow = maxRequestsPerWindow;
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>Records a request and indicates whether it may be answered.</summary>
+    /// <param name="address">The source address of the request.</param>
+    /// <param name="isFirstRejection">
+    /// <see langword="true"/> when this is the first request rejected in the current window. Callers
+    /// use it to answer at most one Kiss-o'-Death per window, so that replying to a throttled source
+    /// cannot itself be used to reflect traffic.
+    /// </param>
+    public bool TryAcquire(IPAddress address, out bool isFirstRejection)
+    {
+        isFirstRejection = false;
+
+        var hash = address.GetHashCode();
+        var index = (int)((uint)hash % BucketCount);
+        var now = _timeProvider.GetTimestamp();
+
+        lock (_lock)
+        {
+            ref var bucket = ref _buckets[index];
+            var inWindow = bucket.Count > 0 && _timeProvider.GetElapsedTime(bucket.WindowStart, now) < Window;
+
+            if (bucket.Hash != hash)
+            {
+                // Refuse to hand the bucket to a different address while its current occupant is over
+                // the limit: otherwise a flood of spoofed addresses would clear the limiter on every
+                // packet, disabling it exactly when it is needed.
+                if (inWindow && bucket.Count > _maxRequestsPerWindow)
+                    return false;
+
+                bucket = new Bucket { Hash = hash, WindowStart = now, Count = 1 };
+                return true;
+            }
+
+            if (!inWindow)
+            {
+                bucket.WindowStart = now;
+                bucket.Count = 1;
+                return true;
+            }
+
+            bucket.Count++;
+            if (bucket.Count <= _maxRequestsPerWindow)
+                return true;
+
+            isFirstRejection = bucket.Count == _maxRequestsPerWindow + 1;
+            return false;
+        }
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    private struct Bucket
+    {
+        public int Hash;
+        public long WindowStart;
+        public int Count;
+    }
+}

--- a/src/Meziantou.Framework.NtpServer/NtpServer.cs
+++ b/src/Meziantou.Framework.NtpServer/NtpServer.cs
@@ -9,14 +9,38 @@ namespace Meziantou.Framework.Ntp;
 /// An NTP server that responds to NTP time queries.
 /// Supports NTPv3 and NTPv4, mirroring the version sent by the client.
 /// </summary>
+/// <remarks>
+/// The server answers from <see cref="NtpServerOptions.TimeProvider"/> and does not discipline that
+/// clock, so it is only as accurate as the machine it runs on. It implements no authentication:
+/// neither NTS (RFC 8915) nor symmetric keys.
+/// </remarks>
 public sealed class NtpServer : IDisposable
 {
     private const int PacketSize = 48;
-    private static readonly long NtpEpochTicks = new DateTimeOffset(1900, 1, 1, 0, 0, 0, TimeSpan.Zero).Ticks;
+    private const int RootDispersionOffset = 8;
+    private const int ReferenceIdentifierOffset = 12;
+    private const int ReferenceTimestampOffset = 16;
+    private const int OriginateTimestampOffset = 24;
+    private const int ReceiveTimestampOffset = 32;
+    private const int TransmitTimestampOffset = 40;
+
+    private const byte KissOfDeathStratum = 0;
+
+    /// <summary>The <c>RATE</c> Kiss-o'-Death code, telling a client it is being rate limited.</summary>
+    private const uint RateKissCode = 0x52415445;
+
+    /// <summary>Precision of ~1 microsecond, in log2 seconds.</summary>
+    private const sbyte ClockPrecision = -20;
 
     private readonly NtpServerOptions _options;
+    private readonly uint _referenceIdentifier;
+    private readonly NtpRateLimiter? _rateLimiter;
+    private readonly Lock _lock = new();
+
     private UdpClient? _udpClient;
     private CancellationTokenSource? _cts;
+    private Task? _listenTask;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NtpServer"/> class.
@@ -25,23 +49,46 @@ public sealed class NtpServer : IDisposable
     public NtpServer(NtpServerOptions? options = null)
     {
         _options = options ?? new NtpServerOptions();
+        _referenceIdentifier = EncodeReferenceIdentifier(_options.ReferenceIdentifier);
+
+        // Rate limiting deliberately runs off the real clock, not the configured TimeProvider: a
+        // simulated clock must not be able to switch the protection off or freeze its window.
+        _rateLimiter = _options.MaxRequestsPerSecond > 0
+            ? new NtpRateLimiter(_options.MaxRequestsPerSecond, TimeProvider.System)
+            : null;
     }
 
     /// <summary>Gets the port the server is listening on. Only valid after <see cref="StartAsync"/> has been called.</summary>
     public int Port { get; private set; }
 
+    /// <summary>
+    /// Gets a task that completes when the listen loop stops, either because the server was disposed or
+    /// the start token was cancelled, or faulted because the loop hit an unrecoverable error.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The server has not been started.</exception>
+    public Task Completion => _listenTask ?? throw new InvalidOperationException($"The server has not been started; call {nameof(StartAsync)} first.");
+
     /// <summary>Starts the NTP server and begins listening for client requests.</summary>
     /// <param name="cancellationToken">A cancellation token that stops the server when cancelled.</param>
     /// <returns>A task that completes when the server has started listening.</returns>
+    /// <exception cref="InvalidOperationException">The server has already been started.</exception>
     public Task StartAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_cts is not null && _cts.IsCancellationRequested, this);
+        lock (_lock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
 
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _udpClient = new UdpClient(new IPEndPoint(IPAddress.Loopback, _options.Port));
-        Port = ((IPEndPoint)_udpClient.Client.LocalEndPoint!).Port;
+            if (_listenTask is not null)
+                throw new InvalidOperationException("The server has already been started.");
 
-        _ = ListenAsync(_cts.Token);
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var udpClient = new UdpClient(new IPEndPoint(_options.BindAddress, _options.Port));
+            _udpClient = udpClient;
+            Port = ((IPEndPoint)udpClient.Client.LocalEndPoint!).Port;
+
+            _listenTask = ListenAsync(udpClient, _cts.Token);
+        }
 
         return Task.CompletedTask;
     }
@@ -49,19 +96,29 @@ public sealed class NtpServer : IDisposable
     /// <summary>Releases the resources used by this instance and stops listening.</summary>
     public void Dispose()
     {
+        lock (_lock)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+        }
+
         _cts?.Cancel();
         _udpClient?.Dispose();
         _cts?.Dispose();
     }
 
-    private async Task ListenAsync(CancellationToken cancellationToken)
+    private async Task ListenAsync(UdpClient udpClient, CancellationToken cancellationToken)
     {
+        var consecutiveErrors = 0;
+
         while (!cancellationToken.IsCancellationRequested)
         {
+            UdpReceiveResult result;
             try
             {
-                var result = await _udpClient!.ReceiveAsync(cancellationToken).ConfigureAwait(false);
-                ProcessRequest(result.Buffer, result.RemoteEndPoint);
+                result = await udpClient.ReceiveAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -71,10 +128,37 @@ public sealed class NtpServer : IDisposable
             {
                 break;
             }
+            catch (SocketException ex)
+            {
+                // A socket error is about one datagram, not about the listener. On Windows in
+                // particular, a client that closes its socket before our reply arrives causes an ICMP
+                // port-unreachable that surfaces here as ConnectionReset on the *next* receive; letting
+                // it escape would stop the server for good because of an unrelated peer.
+                using var errorActivity = NtpServerTelemetry.ActivitySource.StartActivity("ntp.server.receive_error");
+                errorActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
+                if (++consecutiveErrors > 10)
+                {
+                    // Back off rather than spin if the socket is failing every time.
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            consecutiveErrors = 0;
+            ProcessRequest(udpClient, result.Buffer, result.RemoteEndPoint);
         }
     }
 
-    private void ProcessRequest(byte[] requestData, IPEndPoint remoteEndPoint)
+    private void ProcessRequest(UdpClient udpClient, byte[] requestData, IPEndPoint remoteEndPoint)
     {
         using var activity = NtpServerTelemetry.ActivitySource.StartActivity("ntp.server.request");
         activity?.SetTag("ntp.client.address", remoteEndPoint.Address.ToString());
@@ -89,28 +173,63 @@ public sealed class NtpServer : IDisposable
 
             var requestFirstByte = requestData[0];
             var version = (requestFirstByte >> 3) & 0x07;
+            var mode = (NtpMode)(requestFirstByte & 0x07);
             var pollInterval = requestData[2];
+
+            activity?.SetTag("ntp.version", version);
+
+            // Only answer client-mode requests. Answering a server-mode packet is what lets two NTP
+            // servers pointed at each other exchange packets forever, and answering anything else
+            // turns the server into a reflector for traffic it has no reason to acknowledge.
+            if (mode is not NtpMode.Client)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, $"Unexpected mode {(int)mode}");
+                return;
+            }
+
+            if (version is not (3 or 4))
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, $"Unsupported version {version}");
+                return;
+            }
+
+            if (_rateLimiter is not null && !_rateLimiter.TryAcquire(remoteEndPoint.Address, out var isFirstRejection))
+            {
+                activity?.SetTag("ntp.rate_limited", value: true);
+                activity?.SetStatus(ActivityStatusCode.Error, "Rate limited");
+
+                // Answer at most one Kiss-o'-Death per window. Replying to every throttled packet would
+                // make the server amplify exactly the flood it is trying to shed.
+                if (isFirstRejection)
+                    SendKissOfDeath(udpClient, requestData, remoteEndPoint, version);
+
+                return;
+            }
 
             var now = _options.TimeProvider.GetUtcNow();
 
             var responseBuffer = new byte[PacketSize];
 
             // Byte 0: LeapIndicator (0=NoWarning) | Version (mirrored) | Mode (4=Server)
-            responseBuffer[0] = (byte)((version << 3) | 4);
+            responseBuffer[0] = (byte)((version << 3) | (int)NtpMode.Server);
             responseBuffer[1] = _options.Stratum;
             responseBuffer[2] = pollInterval;
-            responseBuffer[3] = unchecked((byte)-20); // Precision: ~1 microsecond
+            responseBuffer[3] = unchecked((byte)ClockPrecision);
 
-            // Copy client's transmit timestamp (bytes 40-47) to originate timestamp (bytes 24-31)
-            requestData.AsSpan(40, 8).CopyTo(responseBuffer.AsSpan(24, 8));
+            // Root delay stays zero: there is no network path to a reference clock to account for.
+            NtpTimestamp.EncodeShortFormat(_options.RootDispersion, responseBuffer.AsSpan(RootDispersionOffset, 4));
+            BinaryPrimitives.WriteUInt32BigEndian(responseBuffer.AsSpan(ReferenceIdentifierOffset, 4), _referenceIdentifier);
 
-            EncodeTimestamp(now, responseBuffer.AsSpan(16)); // Reference timestamp
-            EncodeTimestamp(now, responseBuffer.AsSpan(32)); // Receive timestamp
-            EncodeTimestamp(_options.TimeProvider.GetUtcNow(), responseBuffer.AsSpan(40)); // Transmit timestamp
+            // Copy the client's transmit timestamp to the originate timestamp, byte for byte. This is
+            // what lets the client tie the reply to its request, so it must survive verbatim.
+            requestData.AsSpan(TransmitTimestampOffset, NtpTimestamp.Size).CopyTo(responseBuffer.AsSpan(OriginateTimestampOffset, NtpTimestamp.Size));
 
-            _udpClient!.Send(responseBuffer, responseBuffer.Length, remoteEndPoint);
+            NtpTimestamp.Encode(now, responseBuffer.AsSpan(ReferenceTimestampOffset));
+            NtpTimestamp.Encode(now, responseBuffer.AsSpan(ReceiveTimestampOffset));
+            NtpTimestamp.Encode(_options.TimeProvider.GetUtcNow(), responseBuffer.AsSpan(TransmitTimestampOffset));
 
-            activity?.SetTag("ntp.version", version);
+            udpClient.Send(responseBuffer, responseBuffer.Length, remoteEndPoint);
+
             activity?.SetStatus(ActivityStatusCode.Ok);
         }
         catch (Exception ex)
@@ -119,14 +238,34 @@ public sealed class NtpServer : IDisposable
         }
     }
 
-    private static void EncodeTimestamp(DateTimeOffset value, Span<byte> buffer)
+    private static void SendKissOfDeath(UdpClient udpClient, byte[] requestData, IPEndPoint remoteEndPoint, int version)
     {
-        var ticks = value.UtcTicks - NtpEpochTicks;
-        var seconds = (uint)(ticks / TimeSpan.TicksPerSecond);
-        var remainingTicks = ticks % TimeSpan.TicksPerSecond;
-        var fraction = (uint)(remainingTicks * 0x1_0000_0000L / TimeSpan.TicksPerSecond);
+        var buffer = new byte[PacketSize];
 
-        BinaryPrimitives.WriteUInt32BigEndian(buffer, seconds);
-        BinaryPrimitives.WriteUInt32BigEndian(buffer[4..], fraction);
+        buffer[0] = (byte)((version << 3) | (int)NtpMode.Server);
+        buffer[1] = KissOfDeathStratum;
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(ReferenceIdentifierOffset, 4), RateKissCode);
+        requestData.AsSpan(TransmitTimestampOffset, NtpTimestamp.Size).CopyTo(buffer.AsSpan(OriginateTimestampOffset, NtpTimestamp.Size));
+
+        // The timestamps stay zero: a Kiss-o'-Death packet carries no time, only a reason.
+        udpClient.Send(buffer, buffer.Length, remoteEndPoint);
+    }
+
+    private static uint EncodeReferenceIdentifier(string referenceIdentifier)
+    {
+        ArgumentNullException.ThrowIfNull(referenceIdentifier);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(referenceIdentifier.Length, 4, nameof(referenceIdentifier));
+
+        uint value = 0;
+        for (var i = 0; i < 4; i++)
+        {
+            var c = i < referenceIdentifier.Length ? referenceIdentifier[i] : '\0';
+            if (c > 0x7F)
+                throw new ArgumentException($"The reference identifier must be ASCII, but contains '{c}'.", nameof(referenceIdentifier));
+
+            value |= (uint)c << ((3 - i) * 8);
+        }
+
+        return value;
     }
 }

--- a/src/Meziantou.Framework.NtpServer/NtpServerOptions.cs
+++ b/src/Meziantou.Framework.NtpServer/NtpServerOptions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Meziantou.Framework.Ntp;
 
 /// <summary>
@@ -8,9 +10,57 @@ public sealed class NtpServerOptions
     /// <summary>Gets or sets the port to listen on. Default is 0 (auto-assign).</summary>
     public int Port { get; set; }
 
-    /// <summary>Gets or sets the time provider used by the server. Default is <see cref="TimeProvider.System"/>.</summary>
+    /// <summary>
+    /// Gets or sets the address to bind to. Default is <see cref="IPAddress.Any"/>, which serves every
+    /// network interface. Use <see cref="IPAddress.Loopback"/> to serve only the local machine.
+    /// </summary>
+    public IPAddress BindAddress { get; set; } = IPAddress.Any;
+
+    /// <summary>Gets or sets the time provider used to answer queries. Default is <see cref="System.TimeProvider.System"/>.</summary>
     public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
-    /// <summary>Gets or sets the stratum level to advertise. Default is 1 (primary reference).</summary>
-    public byte Stratum { get; set; } = 1;
+    /// <summary>
+    /// Gets or sets the stratum level to advertise. Default is 2.
+    /// </summary>
+    /// <remarks>
+    /// Stratum 1 claims a directly attached reference clock such as GPS. A server answering from
+    /// <see cref="TimeProvider"/> has no such clock, so the honest value is 2 or higher; set
+    /// <see cref="ReferenceIdentifier"/> to match if you do attach one.
+    /// </remarks>
+    public byte Stratum { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets the reference identifier, up to four ASCII characters. Default is <c>LOCL</c>,
+    /// the conventional identifier for an undisciplined local clock.
+    /// </summary>
+    public string ReferenceIdentifier { get; set; } = "LOCL";
+
+    /// <summary>
+    /// Gets or sets the maximum error the server advertises for its own clock (the root dispersion).
+    /// Default is 100 milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Clients use this as the error bound on the offset they compute. Zero claims a perfectly accurate
+    /// clock, which is never true, so the default is a deliberately conservative bound for an
+    /// undisciplined software clock. Lower it if the underlying <see cref="TimeProvider"/> is
+    /// disciplined and you know its accuracy.
+    /// </remarks>
+    public TimeSpan RootDispersion { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets or sets the maximum number of requests answered per second per source address.
+    /// Default is 100. Set to 0 to disable rate limiting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The limit is approximate: source addresses are mapped onto a fixed number of buckets so that
+    /// memory cannot grow with the number of distinct (and easily spoofed) source addresses seen, and
+    /// colliding addresses share a budget.
+    /// </para>
+    /// <para>
+    /// Rate limiting is measured against the real system clock rather than <see cref="TimeProvider"/>,
+    /// so that a simulated or frozen clock cannot disable it or wedge it permanently.
+    /// </para>
+    /// </remarks>
+    public int MaxRequestsPerSecond { get; set; } = 100;
 }

--- a/src/Meziantou.Framework.NtpServer/readme.md
+++ b/src/Meziantou.Framework.NtpServer/readme.md
@@ -6,6 +6,8 @@ An NTP server that responds to NTP time queries. Supports NTPv3 and NTPv4.
 
 - **NTPv3 and NTPv4**: Mirrors the version sent by the client
 - **Configurable time source**: Use `TimeProvider` for testability
+- **Configurable binding**: Serve every interface, or just the local machine
+- **Rate limiting**: Per-source limiting with `RATE` Kiss-o'-Death replies, enabled by default
 - **Auto-assigned port**: Use port 0 for testing to get an auto-assigned port
 - **OpenTelemetry**: Built-in `ActivitySource` tracing for NTP requests
 
@@ -14,11 +16,22 @@ An NTP server that responds to NTP time queries. Supports NTPv3 and NTPv4.
 ```c#
 using Meziantou.Framework.Ntp;
 
-// Start an NTP server on a random port
+// Start an NTP server on a random port, serving every network interface
 using var server = new NtpServer(new NtpServerOptions { Port = 0 });
 await server.StartAsync();
 
 Console.WriteLine($"NTP server listening on port {server.Port}");
+```
+
+### Serving only the local machine
+
+```c#
+using var server = new NtpServer(new NtpServerOptions
+{
+    Port = 0,
+    BindAddress = IPAddress.Loopback,
+});
+await server.StartAsync();
 ```
 
 ### Custom time source
@@ -32,3 +45,38 @@ using var server = new NtpServer(new NtpServerOptions
 });
 await server.StartAsync();
 ```
+
+### Observing the listener
+
+`StartAsync` returns once the socket is bound; the listen loop runs in the background. `Completion`
+lets you observe it, so a loop that stops is not silent:
+
+```c#
+using var server = new NtpServer();
+await server.StartAsync(cancellationToken);
+
+await server.Completion; // completes on Dispose or cancellation, faults on an unrecoverable error
+```
+
+Per-datagram socket errors do not stop the loop.
+
+### Rate limiting
+
+`MaxRequestsPerSecond` (100 by default, 0 to disable) caps how many requests are answered per source
+address. The first request over the limit in a window gets a `RATE` Kiss-o'-Death reply and the rest
+are dropped, so answering a throttled source cannot itself be used to reflect traffic.
+
+The limit is approximate: source addresses are mapped onto a fixed number of buckets so that memory
+cannot grow with the number of distinct — and easily spoofed — source addresses seen, and colliding
+addresses share a budget. It is measured against the real system clock, not `TimeProvider`, so a
+simulated clock cannot switch it off.
+
+## What this server does not do
+
+- **It does not discipline its clock.** Time comes from `TimeProvider`, so the server is only as
+  accurate as the machine it runs on. That is why the default `Stratum` is 2 with a `LOCL` reference
+  identifier and a 100 ms `RootDispersion`: clients are told this is an undisciplined local clock, not
+  a primary reference. Set `Stratum = 1` and a matching `ReferenceIdentifier` only if you really have
+  attached a reference clock.
+- **It does not authenticate anything.** Neither NTS (RFC 8915) nor symmetric key authentication is
+  implemented, so any client can query it and nothing proves to a client that a reply came from it.

--- a/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <!-- All the tests are skipped on macOS when running on GitHub Actions -->
-    <MinimumExpectedTests>0</MinimumExpectedTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.NtpClient.Tests/NtpClientTests.cs
+++ b/tests/Meziantou.Framework.NtpClient.Tests/NtpClientTests.cs
@@ -1,4 +1,7 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Net;
+using System.Net.Sockets;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Ntp.Tests;
@@ -6,6 +9,12 @@ namespace Meziantou.Framework.Ntp.Tests;
 public sealed class NtpClientTests(ITestOutputHelper testOutputHelper)
 {
     private const int RetryCount = 3;
+    private const int PacketSize = 48;
+    private const int OriginateTimestampOffset = 24;
+    private const int TransmitTimestampOffset = 40;
+
+    private static readonly DateTimeOffset Era0 = new(1900, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Era1 = Era0.AddSeconds(0x1_0000_0000L);
 
     private static NtpClientOptions CreateTestOptions(NtpVersion version = NtpVersion.V4, TimeSpan? timeout = null)
     {
@@ -19,7 +28,7 @@ public sealed class NtpClientTests(ITestOutputHelper testOutputHelper)
         {
             try
             {
-                using var client = new NtpClient(server, CreateTestOptions(version, timeout));
+                var client = new NtpClient(server, CreateTestOptions(version, timeout));
                 return await client.QueryAsync(XunitCancellationToken);
             }
             catch (Exception ex) when (i > 0)
@@ -73,6 +82,337 @@ public sealed class NtpClientTests(ITestOutputHelper testOutputHelper)
                 testOutputHelper.WriteLine($"DNS resolution for {server} failed: {ex.Message}");
             }
         }
+    }
+
+    private static NtpClient CreateClient(FakeNtpServer server, Action<NtpClientOptions>? configure = null)
+    {
+        var options = new NtpClientOptions { Port = server.Port, Timeout = TimeSpan.FromMilliseconds(500) };
+        configure?.Invoke(options);
+
+        return new NtpClient("127.0.0.1", options);
+    }
+
+    private static void WriteTimestamp(DateTimeOffset? value, Span<byte> destination)
+    {
+        if (value is not { } instant)
+        {
+            destination[..8].Clear();
+            return;
+        }
+
+        var epoch = instant < Era1 ? Era0 : Era1;
+        var ticks = (instant - epoch).Ticks;
+
+        BinaryPrimitives.WriteUInt32BigEndian(destination, (uint)(ticks / TimeSpan.TicksPerSecond));
+        BinaryPrimitives.WriteUInt32BigEndian(destination[4..], (uint)(ticks % TimeSpan.TicksPerSecond * 0x1_0000_0000L / TimeSpan.TicksPerSecond));
+    }
+
+    private static void WriteShortFormat(TimeSpan value, Span<byte> destination)
+    {
+        BinaryPrimitives.WriteUInt32BigEndian(destination, (uint)(value.Ticks * 0x1_0000L / TimeSpan.TicksPerSecond));
+    }
+
+    /// <summary>
+    /// Builds a server reply, deliberately using its own encoder rather than the library's so that a
+    /// bug in the shared codec cannot hide by being applied symmetrically on both sides of the wire.
+    /// </summary>
+    private static byte[] BuildResponse(
+        byte[] request,
+        DateTimeOffset? serverTime = null,
+        byte stratum = 2,
+        int version = 4,
+        int mode = 4,
+        int leapIndicator = 0,
+        bool echoOriginate = true,
+        uint referenceIdentifier = 0,
+        TimeSpan rootDelay = default,
+        TimeSpan rootDispersion = default,
+        DateTimeOffset? referenceTimestamp = null)
+    {
+        var now = serverTime ?? DateTimeOffset.UtcNow;
+        var buffer = new byte[PacketSize];
+
+        buffer[0] = (byte)((leapIndicator << 6) | (version << 3) | mode);
+        buffer[1] = stratum;
+        buffer[2] = request[2];
+        buffer[3] = unchecked((byte)-20);
+        WriteShortFormat(rootDelay, buffer.AsSpan(4, 4));
+        WriteShortFormat(rootDispersion, buffer.AsSpan(8, 4));
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(12, 4), referenceIdentifier);
+        WriteTimestamp(referenceTimestamp, buffer.AsSpan(16, 8));
+
+        if (echoOriginate)
+        {
+            request.AsSpan(TransmitTimestampOffset, 8).CopyTo(buffer.AsSpan(OriginateTimestampOffset, 8));
+        }
+        else
+        {
+            // A well-formed timestamp that simply is not the one we sent, so the echo check is what
+            // rejects this and not the "timestamp is missing" check.
+            WriteTimestamp(now, buffer.AsSpan(OriginateTimestampOffset, 8));
+        }
+
+        WriteTimestamp(now, buffer.AsSpan(32, 8));
+        WriteTimestamp(now, buffer.AsSpan(TransmitTimestampOffset, 8));
+
+        return buffer;
+    }
+
+    [Fact]
+    public async Task Query_ComputesClockOffsetFromServerTime()
+    {
+        var skew = TimeSpan.FromHours(1);
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, DateTimeOffset.UtcNow + skew)]);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.Equal(2, response.Stratum);
+        Assert.Equal(NtpVersion.V4, response.Version);
+        Assert.True(Math.Abs((response.ClockOffset - skew).TotalSeconds) < 1, $"Clock offset was {response.ClockOffset}, expected about {skew}");
+        Assert.True(response.RoundTripDelay >= TimeSpan.Zero && response.RoundTripDelay < TimeSpan.FromSeconds(1), $"Round-trip delay was {response.RoundTripDelay}");
+    }
+
+    [Fact]
+    public async Task Query_ExposesRootDelayDispersionAndReferenceIdentifier()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(
+            request,
+            stratum: 1,
+            referenceIdentifier: 0x47505300, // "GPS"
+            rootDelay: TimeSpan.FromMilliseconds(250),
+            rootDispersion: TimeSpan.FromMilliseconds(50))]);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.Equal("GPS", response.ReferenceIdentifierText);
+        Assert.False(response.IsKissOfDeath);
+        Assert.Null(response.KissCode);
+        Assert.True(Math.Abs((response.RootDelay - TimeSpan.FromMilliseconds(250)).TotalMilliseconds) < 1, $"RootDelay was {response.RootDelay}");
+        Assert.True(Math.Abs((response.RootDispersion - TimeSpan.FromMilliseconds(50)).TotalMilliseconds) < 1, $"RootDispersion was {response.RootDispersion}");
+    }
+
+    [Fact]
+    public async Task Query_ReferenceTimestamp_IsNullWhenTheServerLeavesItUnset()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, referenceTimestamp: null)]);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.Null(response.ReferenceTimestamp);
+    }
+
+    [Fact]
+    public async Task Query_ReferenceTimestamp_IsReturnedWhenTheServerSetsIt()
+    {
+        var reference = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, referenceTimestamp: reference)]);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.NotNull(response.ReferenceTimestamp);
+        Assert.True(Math.Abs((response.ReferenceTimestamp.Value - reference).TotalMilliseconds) < 1, $"ReferenceTimestamp was {response.ReferenceTimestamp}");
+    }
+
+    [Fact]
+    public async Task Query_DecodesTimestampsAfterThe2036EraRollover()
+    {
+        // The 32-bit seconds field wraps on 2036-02-07; era 1 timestamps must not decode back to 1900.
+        var era1Time = new DateTimeOffset(2050, 3, 1, 0, 0, 0, TimeSpan.Zero);
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, referenceTimestamp: era1Time)]);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.NotNull(response.ReferenceTimestamp);
+        Assert.Equal(era1Time, response.ReferenceTimestamp.Value);
+    }
+
+    [Fact]
+    public async Task Query_RejectsResponseFromAnotherSourceEndpoint()
+    {
+        // The reply is well-formed and echoes the request, but comes from a different socket. The
+        // client's socket is connected, so the operating system must drop it.
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request)], replyFromDifferentSocket: true);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_RejectsResponseThatDoesNotEchoTheTransmitTimestamp()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, echoOriginate: false)]);
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+        Assert.Contains("originate timestamp", exception.Message);
+    }
+
+    [Fact]
+    public async Task Query_RejectsResponseWithAForgedOriginateTimestamp()
+    {
+        // A plausible but wrong originate timestamp: close enough that a lossy comparison might accept it.
+        using var server = FakeNtpServer.Start(request =>
+        {
+            var response = BuildResponse(request);
+            response[OriginateTimestampOffset + 7] ^= 0x01;
+            return [response];
+        });
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_RejectsKissOfDeathPacket()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, stratum: 0, referenceIdentifier: 0x52415445)]);
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+        Assert.Contains("RATE", exception.Message);
+    }
+
+    [Fact]
+    public async Task Query_RejectsServerReportingAnAlarmCondition()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, leapIndicator: 3)]);
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+        Assert.Contains("alarm condition", exception.Message);
+    }
+
+    [Fact]
+    public async Task Query_RejectsResponseThatIsNotInServerMode()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, mode: 3)]);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_RejectsResponseWithAnUndefinedVersion()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, version: 7)]);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_RejectsTruncatedPacket()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request)[..20]]);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_RejectsResponseMissingTheTransmitTimestamp()
+    {
+        using var server = FakeNtpServer.Start(request =>
+        {
+            var response = BuildResponse(request);
+            response.AsSpan(TransmitTimestampOffset, 8).Clear();
+            return [response];
+        });
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_IgnoresInvalidPacketsAndAcceptsTheValidOne()
+    {
+        // A single forged or stray datagram must not deny service for the whole timeout.
+        using var server = FakeNtpServer.Start(request =>
+        [
+            BuildResponse(request, echoOriginate: false),
+            BuildResponse(request, stratum: 0),
+            BuildResponse(request)[..10],
+            BuildResponse(request, stratum: 4),
+        ]);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.Equal(4, response.Stratum);
+    }
+
+    [Fact]
+    public async Task Query_ValidationDisabled_ReturnsKissOfDeathPacket()
+    {
+        using var server = FakeNtpServer.Start(request => [BuildResponse(request, stratum: 0, referenceIdentifier: 0x44454E59)]);
+
+        var response = await CreateClient(server, options => options.ValidateResponse = false).QueryAsync(XunitCancellationToken);
+
+        Assert.True(response.IsKissOfDeath);
+        Assert.Equal("DENY", response.KissCode);
+    }
+
+    [Fact]
+    public async Task Query_ValidationDisabled_StillRejectsAPacketWithNoTimestamps()
+    {
+        // Disabling validation opts out of trusting the peer, not out of arithmetic: a response with no
+        // timestamps cannot produce an offset, and must never yield one measured from the year 1.
+        using var server = FakeNtpServer.Start(request =>
+        {
+            var response = BuildResponse(request);
+            response.AsSpan(OriginateTimestampOffset, 8).Clear();
+            return [response];
+        });
+
+        await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server, options => options.ValidateResponse = false).QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task Query_TimeoutThrowsTimeoutException()
+    {
+        using var server = FakeNtpServer.Blackhole();
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => CreateClient(server).QueryAsync(XunitCancellationToken));
+        Assert.Contains("did not complete within", exception.Message);
+    }
+
+    [Fact]
+    public async Task Query_CallerCancellationThrowsOperationCanceledException()
+    {
+        using var server = FakeNtpServer.Blackhole();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = server.Port, Timeout = TimeSpan.FromSeconds(30) });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.QueryAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task Query_EachResolvedAddressGetsItsOwnTimeout()
+    {
+        // "localhost" resolves to both ::1 and 127.0.0.1 on most machines. Both are black holes here, so
+        // the query must spend the timeout on each rather than letting the first address consume it all.
+        using var blackholes = DualStackBlackhole.Start();
+
+        var addresses = await Dns.GetHostAddressesAsync("localhost", XunitCancellationToken);
+        if (addresses.Length < 2)
+        {
+            global::Xunit.Assert.Skip($"'localhost' resolved to {addresses.Length} address(es), need 2 to test per-address timeouts");
+        }
+
+        var timeout = TimeSpan.FromMilliseconds(400);
+        var client = new NtpClient("localhost", new NtpClientOptions { Port = blackholes.Port, Timeout = timeout });
+
+        var stopwatch = Stopwatch.StartNew();
+        await Assert.ThrowsAsync<TimeoutException>(() => client.QueryAsync(XunitCancellationToken));
+        stopwatch.Stop();
+
+        testOutputHelper.WriteLine($"{addresses.Length} addresses, {timeout.TotalMilliseconds}ms each, elapsed {stopwatch.Elapsed.TotalMilliseconds:N0}ms");
+        Assert.True(stopwatch.Elapsed >= timeout * 1.5, $"Elapsed {stopwatch.Elapsed} suggests the addresses shared a single timeout budget");
+    }
+
+    [Fact]
+    public async Task Query_UnresolvableHostThrows()
+    {
+        var client = new NtpClient("nonexistent.invalid", new NtpClientOptions { Timeout = TimeSpan.FromSeconds(5) });
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public void Constructor_NullServerThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NtpClient(server: null!));
     }
 
     // https://github.com/actions/runner-images/issues/11939
@@ -135,7 +475,8 @@ public sealed class NtpClientTests(ITestOutputHelper testOutputHelper)
         var response = await QueryWithFallbackAsync();
 
         // Reference timestamp should be within the last 24 hours for an active server
-        var age = DateTimeOffset.UtcNow - response.ReferenceTimestamp;
+        Assert.NotNull(response.ReferenceTimestamp);
+        var age = DateTimeOffset.UtcNow - response.ReferenceTimestamp.Value;
         Assert.True(age < TimeSpan.FromDays(1), $"Reference timestamp age was {age}");
     }
 
@@ -159,5 +500,116 @@ public sealed class NtpClientTests(ITestOutputHelper testOutputHelper)
 
         Assert.True(response.Stratum > 0);
         Assert.True(response.TransmitTimestamp > DateTimeOffset.UnixEpoch);
+    }
+
+    /// <summary>A UDP server that answers with whatever bytes the test tells it to.</summary>
+    private sealed class FakeNtpServer : IDisposable
+    {
+        private readonly UdpClient _udpClient;
+        private readonly Func<byte[], byte[][]> _responder;
+        private readonly bool _replyFromDifferentSocket;
+        private readonly CancellationTokenSource _cts = new();
+
+        private FakeNtpServer(Func<byte[], byte[][]> responder, bool replyFromDifferentSocket)
+        {
+            _responder = responder;
+            _replyFromDifferentSocket = replyFromDifferentSocket;
+            _udpClient = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+            Port = ((IPEndPoint)_udpClient.Client.LocalEndPoint!).Port;
+
+            _ = RunAsync();
+        }
+
+        public int Port { get; }
+
+        public static FakeNtpServer Start(Func<byte[], byte[][]> responder, bool replyFromDifferentSocket = false)
+            => new(responder, replyFromDifferentSocket);
+
+        public static FakeNtpServer Blackhole() => new(_ => [], replyFromDifferentSocket: false);
+
+        private async Task RunAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                UdpReceiveResult result;
+                try
+                {
+                    result = await _udpClient.ReceiveAsync(_cts.Token).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    break;
+                }
+
+                foreach (var response in _responder(result.Buffer))
+                {
+                    try
+                    {
+                        if (_replyFromDifferentSocket)
+                        {
+                            using var other = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+                            await other.SendAsync(response, response.Length, result.RemoteEndPoint).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await _udpClient.SendAsync(response, response.Length, result.RemoteEndPoint).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _udpClient.Dispose();
+            _cts.Dispose();
+        }
+    }
+
+    /// <summary>Binds the same port on both loopback addresses, and never answers on either.</summary>
+    private sealed class DualStackBlackhole : IDisposable
+    {
+        private readonly UdpClient _v4;
+        private readonly UdpClient _v6;
+
+        private DualStackBlackhole(UdpClient v4, UdpClient v6, int port)
+        {
+            _v4 = v4;
+            _v6 = v6;
+            Port = port;
+        }
+
+        public int Port { get; }
+
+        public static DualStackBlackhole Start()
+        {
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                var v4 = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+                var port = ((IPEndPoint)v4.Client.LocalEndPoint!).Port;
+                try
+                {
+                    var v6 = new UdpClient(new IPEndPoint(IPAddress.IPv6Loopback, port));
+                    return new DualStackBlackhole(v4, v6, port);
+                }
+                catch (SocketException)
+                {
+                    v4.Dispose();
+                }
+            }
+
+            throw new InvalidOperationException("Could not bind the same port on both loopback addresses");
+        }
+
+        public void Dispose()
+        {
+            _v4.Dispose();
+            _v6.Dispose();
+        }
     }
 }

--- a/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
+++ b/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
@@ -1,12 +1,20 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+
 namespace Meziantou.Framework.Ntp.Tests;
 
 public sealed class NtpServerTests : IAsyncLifetime
 {
+    private const int PacketSize = 48;
+    private const int OriginateTimestampOffset = 24;
+    private const int TransmitTimestampOffset = 40;
+
     private NtpServer _server = null!;
 
     public async ValueTask InitializeAsync()
     {
-        _server = new NtpServer(new NtpServerOptions { Port = 0 });
+        _server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
         await _server.StartAsync(XunitCancellationToken);
     }
 
@@ -16,11 +24,50 @@ public sealed class NtpServerTests : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
+    private static NtpClient CreateClient(NtpServer server, Action<NtpClientOptions>? configure = null)
+    {
+        var options = new NtpClientOptions { Port = server.Port, Timeout = TimeSpan.FromSeconds(2) };
+        configure?.Invoke(options);
+
+        return new NtpClient("127.0.0.1", options);
+    }
+
+    /// <summary>Builds a raw client request so a test can drive the server without going through <see cref="NtpClient"/>.</summary>
+    private static byte[] BuildRequest(int version = 4, int mode = 3)
+    {
+        var buffer = new byte[PacketSize];
+        buffer[0] = (byte)((version << 3) | mode);
+
+        // A recognizable transmit timestamp, so the echo into the originate field can be checked exactly.
+        for (var i = 0; i < 8; i++)
+        {
+            buffer[TransmitTimestampOffset + i] = (byte)(0xA0 + i);
+        }
+
+        return buffer;
+    }
+
+    private static async Task<byte[]?> SendRawAsync(NtpServer server, byte[] request, CancellationToken cancellationToken, TimeSpan? timeout = null)
+    {
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        peer.Connect(new IPEndPoint(IPAddress.Loopback, server.Port));
+        await peer.SendAsync(request, cancellationToken);
+
+        try
+        {
+            var result = await peer.ReceiveAsync(cancellationToken).AsTask().WaitAsync(timeout ?? TimeSpan.FromSeconds(2), cancellationToken);
+            return result.Buffer;
+        }
+        catch (TimeoutException)
+        {
+            return null;
+        }
+    }
+
     [Fact]
     public async Task Query_ReturnsValidResponse()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(_server).QueryAsync(XunitCancellationToken);
 
         Assert.True(response.Stratum > 0);
         Assert.True(response.TransmitTimestamp > DateTimeOffset.UnixEpoch);
@@ -30,12 +77,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_V4_MirrorsVersion()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions
-        {
-            Port = _server.Port,
-            Version = NtpVersion.V4,
-        });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(_server, options => options.Version = NtpVersion.V4).QueryAsync(XunitCancellationToken);
 
         Assert.Equal(NtpVersion.V4, response.Version);
     }
@@ -43,12 +85,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_V3_MirrorsVersion()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions
-        {
-            Port = _server.Port,
-            Version = NtpVersion.V3,
-        });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(_server, options => options.Version = NtpVersion.V3).QueryAsync(XunitCancellationToken);
 
         Assert.Equal(NtpVersion.V3, response.Version);
     }
@@ -56,8 +93,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_ClockOffset_IsSmall()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(_server).QueryAsync(XunitCancellationToken);
 
         // Offset to a local server should be very small
         Assert.True(Math.Abs(response.ClockOffset.TotalSeconds) < 1, $"Clock offset was {response.ClockOffset}");
@@ -66,8 +102,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_RoundTripDelay_IsReasonable()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(_server).QueryAsync(XunitCancellationToken);
 
         // Localhost should stay reasonably low, but CI runners can be noisy
         Assert.True(response.RoundTripDelay >= TimeSpan.Zero);
@@ -79,7 +114,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     {
         var tasks = Enumerable.Range(0, 10).Select(async _ =>
         {
-            using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
+            var client = CreateClient(_server);
             return await client.QueryAsync(XunitCancellationToken);
         });
 
@@ -95,42 +130,275 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_CustomStratum()
     {
-        using var server = new NtpServer(new NtpServerOptions { Port = 0, Stratum = 5 });
+        using var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback, Stratum = 5 });
         await server.StartAsync(XunitCancellationToken);
 
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = server.Port });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
 
         Assert.Equal(5, response.Stratum);
     }
 
     [Fact]
-    public async Task Query_OriginateTimestamp_MatchesClientTransmit()
+    public async Task Query_DefaultsToStratum2()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        // A server answering from a TimeProvider has no attached reference clock, so it must not
+        // claim stratum 1.
+        var response = await CreateClient(_server).QueryAsync(XunitCancellationToken);
 
-        // The originate timestamp in the response should match what the client sent
-        // (within NTP timestamp precision)
-        Assert.True(response.OriginateTimestamp > DateTimeOffset.UnixEpoch);
+        Assert.Equal(2, response.Stratum);
+    }
+
+    [Fact]
+    public async Task Query_AdvertisesReferenceIdentifierAndRootDispersion()
+    {
+        var response = await CreateClient(_server).QueryAsync(XunitCancellationToken);
+
+        Assert.Equal("LOCL", response.ReferenceIdentifierText);
+
+        // The NTP short format is 16.16 fixed point, so the value round-trips to within ~15 microseconds.
+        Assert.True(Math.Abs((response.RootDispersion - TimeSpan.FromMilliseconds(100)).TotalMilliseconds) < 1, $"RootDispersion was {response.RootDispersion}");
+        Assert.Equal(NtpLeapIndicator.NoWarning, response.LeapIndicator);
+    }
+
+    [Fact]
+    public async Task Query_CustomReferenceIdentifierAndRootDispersion()
+    {
+        using var server = new NtpServer(new NtpServerOptions
+        {
+            Port = 0,
+            BindAddress = IPAddress.Loopback,
+            Stratum = 1,
+            ReferenceIdentifier = "GPS",
+            RootDispersion = TimeSpan.FromMilliseconds(5),
+        });
+        await server.StartAsync(XunitCancellationToken);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.Equal("GPS", response.ReferenceIdentifierText);
+        Assert.True(Math.Abs((response.RootDispersion - TimeSpan.FromMilliseconds(5)).TotalMilliseconds) < 1, $"RootDispersion was {response.RootDispersion}");
+    }
+
+    [Fact]
+    public async Task Query_OriginateTimestamp_EchoesClientTransmitTimestampExactly()
+    {
+        var request = BuildRequest();
+        var response = await SendRawAsync(_server, request, XunitCancellationToken);
+
+        Assert.NotNull(response);
+        Assert.Equal(
+            request.AsSpan(TransmitTimestampOffset, 8).ToArray(),
+            response.AsSpan(OriginateTimestampOffset, 8).ToArray());
+    }
+
+    [Fact]
+    public async Task Server_DoesNotAnswerServerModePackets()
+    {
+        // Answering a mode 4 packet is what lets two servers pointed at each other loop forever.
+        var response = await SendRawAsync(_server, BuildRequest(mode: 4), XunitCancellationToken, TimeSpan.FromMilliseconds(500));
+
+        Assert.Null(response);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(5)]
+    public async Task Server_DoesNotAnswerNonClientModes(int mode)
+    {
+        var response = await SendRawAsync(_server, BuildRequest(mode: mode), XunitCancellationToken, TimeSpan.FromMilliseconds(500));
+
+        Assert.Null(response);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(7)]
+    public async Task Server_DoesNotAnswerUnsupportedVersions(int version)
+    {
+        var response = await SendRawAsync(_server, BuildRequest(version: version), XunitCancellationToken, TimeSpan.FromMilliseconds(500));
+
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public async Task Server_IgnoresTruncatedPackets()
+    {
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        peer.Connect(new IPEndPoint(IPAddress.Loopback, _server.Port));
+        await peer.SendAsync(new byte[10], XunitCancellationToken);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => peer.ReceiveAsync(XunitCancellationToken).AsTask().WaitAsync(TimeSpan.FromMilliseconds(500), XunitCancellationToken));
+
+        // The listener must still be running afterwards.
+        var response = await CreateClient(_server).QueryAsync(XunitCancellationToken);
+        Assert.True(response.Stratum > 0);
+    }
+
+    [Fact]
+    public async Task Server_RateLimitsAndAnswersOneKissOfDeath()
+    {
+        using var server = new NtpServer(new NtpServerOptions
+        {
+            Port = 0,
+            BindAddress = IPAddress.Loopback,
+            MaxRequestsPerSecond = 3,
+        });
+        await server.StartAsync(XunitCancellationToken);
+
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        peer.Connect(new IPEndPoint(IPAddress.Loopback, server.Port));
+
+        for (var i = 0; i < 12; i++)
+        {
+            await peer.SendAsync(BuildRequest(), XunitCancellationToken);
+        }
+
+        var normalReplies = 0;
+        var kissOfDeathReplies = 0;
+        while (true)
+        {
+            byte[] buffer;
+            try
+            {
+                var result = await peer.ReceiveAsync(XunitCancellationToken).AsTask().WaitAsync(TimeSpan.FromMilliseconds(500), XunitCancellationToken);
+                buffer = result.Buffer;
+            }
+            catch (TimeoutException)
+            {
+                break;
+            }
+
+            if (buffer[1] is 0)
+            {
+                kissOfDeathReplies++;
+                Assert.Equal(0x52415445u, BinaryPrimitives.ReadUInt32BigEndian(buffer.AsSpan(12, 4))); // "RATE"
+            }
+            else
+            {
+                normalReplies++;
+            }
+        }
+
+        Assert.Equal(3, normalReplies);
+
+        // At most one Kiss-o'-Death per window, so that replying to a throttled source cannot itself
+        // be used to reflect traffic.
+        Assert.Equal(1, kissOfDeathReplies);
+    }
+
+    [Fact]
+    public async Task Server_RateLimitingDisabled_AnswersEverything()
+    {
+        using var server = new NtpServer(new NtpServerOptions
+        {
+            Port = 0,
+            BindAddress = IPAddress.Loopback,
+            MaxRequestsPerSecond = 0,
+        });
+        await server.StartAsync(XunitCancellationToken);
+
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        peer.Connect(new IPEndPoint(IPAddress.Loopback, server.Port));
+
+        const int RequestCount = 20;
+        for (var i = 0; i < RequestCount; i++)
+        {
+            await peer.SendAsync(BuildRequest(), XunitCancellationToken);
+        }
+
+        var replies = 0;
+        while (replies < RequestCount)
+        {
+            try
+            {
+                await peer.ReceiveAsync(XunitCancellationToken).AsTask().WaitAsync(TimeSpan.FromMilliseconds(500), XunitCancellationToken);
+                replies++;
+            }
+            catch (TimeoutException)
+            {
+                break;
+            }
+        }
+
+        Assert.Equal(RequestCount, replies);
+    }
+
+    [Fact]
+    public async Task StartAsync_CalledTwiceThrows()
+    {
+        using var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
+        await server.StartAsync(XunitCancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => server.StartAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task StartAsync_AfterDisposeThrows()
+    {
+        var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
+        await server.StartAsync(XunitCancellationToken);
+        server.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => server.StartAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public void Completion_BeforeStartThrows()
+    {
+        using var server = new NtpServer(new NtpServerOptions { Port = 0 });
+
+        Assert.Throws<InvalidOperationException>(() => { _ = server.Completion; });
+    }
+
+    [Fact]
+    public async Task Completion_CompletesWhenDisposed()
+    {
+        var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
+        await server.StartAsync(XunitCancellationToken);
+        var completion = server.Completion;
+
+        Assert.False(completion.IsCompleted);
+
+        server.Dispose();
+
+        await completion.WaitAsync(TimeSpan.FromSeconds(5), XunitCancellationToken);
+        Assert.True(completion.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task Completion_CompletesWhenTheStartTokenIsCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        using var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
+        await server.StartAsync(cts.Token);
+
+        await cts.CancelAsync();
+
+        await server.Completion.WaitAsync(TimeSpan.FromSeconds(5), XunitCancellationToken);
     }
 
     [Fact]
     public async Task Dispose_StopsListening()
     {
-        var server = new NtpServer(new NtpServerOptions { Port = 0 });
+        var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
         await server.StartAsync(XunitCancellationToken);
         var port = server.Port;
         server.Dispose();
 
-        // After disposal, querying should fail with a timeout or socket error
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions
-        {
-            Port = port,
-        });
+        var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = port, Timeout = TimeSpan.FromSeconds(1) });
 
-        await Assert.ThrowsAnyAsync<Exception>(() => client.QueryAsync(cts.Token));
+        await Assert.ThrowsAnyAsync<Exception>(() => client.QueryAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.Loopback });
+        server.Dispose();
+        server.Dispose();
     }
 
     [Fact]
@@ -142,18 +410,75 @@ public sealed class NtpServerTests : IAsyncLifetime
         using var server = new NtpServer(new NtpServerOptions
         {
             Port = 0,
+            BindAddress = IPAddress.Loopback,
             TimeProvider = timeProvider,
         });
         await server.StartAsync(XunitCancellationToken);
 
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = server.Port });
-        var response = await client.QueryAsync(XunitCancellationToken);
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
 
         // Server timestamps should be close to the fixed time
         Assert.True(Math.Abs((response.ReceiveTimestamp - fixedTime).TotalMilliseconds) < 1,
             $"ReceiveTimestamp {response.ReceiveTimestamp} was not close to {fixedTime}");
         Assert.True(Math.Abs((response.TransmitTimestamp - fixedTime).TotalMilliseconds) < 1,
             $"TransmitTimestamp {response.TransmitTimestamp} was not close to {fixedTime}");
+    }
+
+    [Fact]
+    public async Task Query_WithTimeProviderAfterThe2036EraRollover()
+    {
+        var fixedTime = new DateTimeOffset(2060, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
+        using var server = new NtpServer(new NtpServerOptions
+        {
+            Port = 0,
+            BindAddress = IPAddress.Loopback,
+            TimeProvider = new FixedTimeProvider(fixedTime),
+        });
+        await server.StartAsync(XunitCancellationToken);
+
+        var response = await CreateClient(server).QueryAsync(XunitCancellationToken);
+
+        Assert.True(Math.Abs((response.TransmitTimestamp - fixedTime).TotalMilliseconds) < 1,
+            $"TransmitTimestamp {response.TransmitTimestamp} was not close to {fixedTime}");
+    }
+
+    [Fact]
+    public async Task Query_WithTimeProviderOutsideTheRepresentableRange_DoesNotAnswerAndKeepsRunning()
+    {
+        // 1850 predates the NTP epoch. The old encoder silently wrapped it to a plausible-looking
+        // 20th century date; it must now refuse rather than serve a wrong time.
+        using var server = new NtpServer(new NtpServerOptions
+        {
+            Port = 0,
+            BindAddress = IPAddress.Loopback,
+            TimeProvider = new FixedTimeProvider(new DateTimeOffset(1850, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+        });
+        await server.StartAsync(XunitCancellationToken);
+
+        var response = await SendRawAsync(server, BuildRequest(), XunitCancellationToken, TimeSpan.FromMilliseconds(500));
+
+        Assert.Null(response);
+        Assert.False(server.Completion.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Server_BindsToTheConfiguredAddress()
+    {
+        using var server = new NtpServer(new NtpServerOptions { Port = 0, BindAddress = IPAddress.IPv6Loopback });
+        await server.StartAsync(XunitCancellationToken);
+
+        var client = new NtpClient("::1", new NtpClientOptions { Port = server.Port, Timeout = TimeSpan.FromSeconds(2) });
+        var response = await client.QueryAsync(XunitCancellationToken);
+
+        Assert.True(response.Stratum > 0);
+    }
+
+    [Fact]
+    public void Constructor_InvalidReferenceIdentifierThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NtpServer(new NtpServerOptions { ReferenceIdentifier = "TOOLONG" }));
+        Assert.Throws<ArgumentException>(() => new NtpServer(new NtpServerOptions { ReferenceIdentifier = "é" }));
     }
 
     private sealed class FixedTimeProvider : TimeProvider


### PR DESCRIPTION
Fixes the findings from a whole-project audit of `Meziantou.Framework.NtpClient` and
`Meziantou.Framework.NtpServer`: 1 critical, 4 high, 6 medium, 2 low.

## Why

The client accepted **any** datagram arriving on its ephemeral port as the server's reply. The socket
was never connected, so the source endpoint went unchecked, and nothing compared the response's
originate timestamp against the transmit timestamp just sent — RFC 5905 TEST2 and TEST3 were absent
entirely. Reproduced against the shipped code by injecting a forged packet from an unrelated socket:

```
client targets 127.0.0.1:52458; forged reply comes from 127.0.0.1:60232
ACCEPTED. TransmitTimestamp=2030-03-01T00:00:00Z Stratum=1 ClockOffset=1273.23:58:15
```

A second run had `Mode=3`, `Stratum=0` (Kiss-o'-Death) and `Version=7` accepted verbatim. For a
library whose whole job is producing a trustworthy time value, an on-path attacker could set the
caller's notion of "now" to anything, with no guessing at all.

## What changed

**Client**

- The socket is connected before sending, so the OS drops foreign sources. `ValidateResponse` (on by
  default) additionally requires a byte-exact originate echo, server mode, version 3–4, non-zero
  stratum, and no alarm condition. A failing response is *ignored* and the client keeps waiting until
  the timeout, so one forged datagram cannot deny service.
- An unset timestamp decoded to `default(DateTimeOffset)`, so a zero originate field silently produced
  `ClockOffset = 369931.00:00:52` (~1013 years). It now decodes to `null`, and a response missing the
  originate/receive/transmit timestamp is rejected even with validation off — opting out of trusting
  the peer is not opting out of arithmetic.
- `Timeout` was one budget shared across all resolved addresses. Measured: 2 addresses, 2s timeout,
  2.01s total — `::1` burned all of it and `127.0.0.1` got zero. On a dual-stack machine with AAAA
  records but no IPv6 route, the address that would have answered was never really tried. Each address
  now gets its own budget, and a timeout throws `TimeoutException` rather than `AggregateException`.
- Exposes `RootDelay`, `RootDispersion`, `ReferenceIdentifier(Text)`, `IsKissOfDeath`, `KissCode`.
  Root dispersion is the protocol's error bound on the offset; it was parsed and thrown away.

**Server**

- The listen loop caught only `OperationCanceledException`/`ObjectDisposedException`. A
  `SocketException` faulted a task nobody held and stopped the server permanently — port still bound,
  caller never informed. Socket errors are now per-datagram with backoff, and `Completion` makes the
  loop observable. (The likely trigger, Windows surfacing ICMP port-unreachable as `ConnectionReset`,
  is reasoned rather than reproduced — macOS does not deliver ICMP errors to unconnected UDP sockets.)
- `BindAddress` option, defaulting to `IPAddress.Any`. The bind was hardcoded to loopback with no way
  to change it, so the package could never serve the network its description promised.
- Answers client mode and versions 3–4 only. It previously answered any 48-byte packet including
  server-mode ones — the primitive that lets two servers loop forever. Adds per-source rate limiting
  with a `RATE` Kiss-o'-Death.
- Default stratum 1 → 2, with a `LOCL` reference identifier and 100 ms root dispersion. Replies
  claimed a directly attached reference clock while sending zero refid, root delay and dispersion.
- A second `StartAsync` leaked the first socket and its loop past `Dispose`; it now throws.

**Both** — the codecs assumed NTP era 0 unconditionally, wrapping at the 2036 rollover, and the
unchecked cast turned a `TimeProvider` set to 1850 into a plausible-looking 1986. Now era-aware
(1968–2104), throwing rather than wrapping, and defined in one place instead of two diverging copies.

## Reviewer notes

- **Breaking, both packages → 3.0.0.** `NtpClient` drops its no-op `IDisposable`;
  `ReferenceTimestamp` becomes `DateTimeOffset?`; responses failing validation are no longer returned;
  the server binds `IPAddress.Any` and rate limits by default. Migration notes are in the client
  readme. `ref/` is regenerated in this commit.
- **The server's default binding changes on upgrade** — a server that answered only localhost will
  start answering the network. This was a deliberate call (the package is documented as a general
  NTP server); set `BindAddress = IPAddress.Loopback` to keep the old behavior.
- **Rate limiting is deliberately approximate.** Source addresses map onto 1024 fixed buckets, since
  an entry per (spoofable) address would itself be a memory-exhaustion vector. It runs off the system
  clock, not `TimeProvider`, so a simulated clock cannot disable it, and answers at most one
  Kiss-o'-Death per window so shedding a flood cannot amplify it.
- **`ClockOffset`/`RoundTripDelay` stayed non-nullable.** Rejecting a response with missing timestamps
  fixes the 1000-year offset without forcing null handling on every caller.

## Testing

20 → 128 tests, all passing on net10.0 and net11.0. Every old test needed the network or a live
client/server pair, which also meant the client suite ran **zero** tests on macOS CI while
`MinimumExpectedTests` was 0 (now removed). 120 of the new tests run offline against raw bytes on a
local socket, and the helpers implement the wire format independently so a codec bug cannot hide by
being applied symmetrically on both sides.

Each attack above was replayed against the fixed code and is now rejected; the 2036 case round-trips
(`server clock 2050-03-01 → client reads 2050-03-01`). Verified with Release + `IsOfficialBuild`
builds under `TreatsWarningsAsErrors=true` (zero warnings) and `dotnet run ./eng/update-all.cs`.
