### PR TITLE
Fix matching and lifecycle defects in Meziantou.Framework.Http.Recording

### DIFF
--- a/ref/Meziantou.Framework.Http.Recording.cs
+++ b/ref/Meziantou.Framework.Http.Recording.cs
@@ -7,6 +7,9 @@ namespace Meziantou.Framework.Http.Recording
     public sealed class DefaultHttpRequestMatcher : Meziantou.Framework.Http.Recording.IHttpRequestMatcher
     {
         public static Meziantou.Framework.Http.Recording.DefaultHttpRequestMatcher Instance { get => throw null; }
+        public static Meziantou.Framework.Http.Recording.DefaultHttpRequestMatcher IgnoringRequestBody { get => throw null; }
+        public bool MatchRequestBody { get => throw null; }
+        public DefaultHttpRequestMatcher(bool matchRequestBody = true) { }
         public string ComputeFingerprint(Meziantou.Framework.Http.Recording.HttpRecordingEntry entry) => throw null;
     }
 
@@ -35,6 +38,10 @@ namespace Meziantou.Framework.Http.Recording
         public byte[]? RequestBody { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("statusCode")]
         public required int StatusCode { get => throw null; set { } }
+        [System.Text.Json.Serialization.JsonPropertyName("reasonPhrase")]
+        public string? ReasonPhrase { get => throw null; set { } }
+        [System.Text.Json.Serialization.JsonPropertyName("httpVersion")]
+        public string? HttpVersion { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("responseHeaders")]
         public System.Collections.Generic.Dictionary<string, string[]>? ResponseHeaders { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("responseBody")]
@@ -43,13 +50,14 @@ namespace Meziantou.Framework.Http.Recording
         public System.DateTimeOffset RecordedAt { get => throw null; set { } }
     }
 
-    public sealed class HttpRecordingHandler : System.Net.Http.DelegatingHandler
+    public sealed class HttpRecordingHandler : System.IAsyncDisposable, System.Net.Http.DelegatingHandler
     {
         public HttpRecordingHandler(Meziantou.Framework.Http.Recording.IHttpRecordingStore store, Meziantou.Framework.Http.Recording.HttpRecordingOptions? options = null) { }
         public HttpRecordingHandler(System.Net.Http.HttpMessageHandler innerHandler, Meziantou.Framework.Http.Recording.IHttpRecordingStore store, Meziantou.Framework.Http.Recording.HttpRecordingOptions? options = null) { }
         public System.Threading.Tasks.Task InitializeAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.Task SaveAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) => throw null;
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
         protected override void Dispose(bool disposing) { }
     }
 
@@ -77,9 +85,10 @@ namespace Meziantou.Framework.Http.Recording
     public sealed class HttpRecordingOptions
     {
         public Meziantou.Framework.Http.Recording.HttpRecordingMode Mode { get => throw null; set { } }
-        public Meziantou.Framework.Http.Recording.HttpRecordingMissBehavior MissBehavior { get => throw null; set { } }
+        public Meziantou.Framework.Http.Recording.HttpRecordingMissBehavior? MissBehavior { get => throw null; set { } }
         public Meziantou.Framework.Http.Recording.IHttpRequestMatcher? RequestMatcher { get => throw null; set { } }
-        public Meziantou.Framework.Http.Recording.IHttpRecordingSanitizer? Sanitizer { get => throw null; set { } }
+        public System.Collections.Generic.IList<Meziantou.Framework.Http.Recording.IHttpRecordingSanitizer> Sanitizers { get => throw null; }
+        public bool AutoSave { get => throw null; set { } }
     }
 
     public interface IHttpRecordingSanitizer
@@ -103,5 +112,11 @@ namespace Meziantou.Framework.Http.Recording
         public JsonHttpRecordingStore(string filePath) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Http.Recording.HttpRecordingEntry>> LoadAsync(System.Threading.CancellationToken cancellationToken) => throw null;
         public System.Threading.Tasks.ValueTask SaveAsync(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Http.Recording.HttpRecordingEntry> entries, System.Threading.CancellationToken cancellationToken) => throw null;
+    }
+
+    public sealed class UriQueryParameterSanitizer : Meziantou.Framework.Http.Recording.IHttpRecordingSanitizer
+    {
+        public UriQueryParameterSanitizer(params string[] parameterNames) { }
+        public void Sanitize(Meziantou.Framework.Http.Recording.HttpRecordingEntry entry) { }
     }
 }

--- a/src/Meziantou.Framework.Http.Recording/DefaultHttpRequestMatcher.cs
+++ b/src/Meziantou.Framework.Http.Recording/DefaultHttpRequestMatcher.cs
@@ -1,31 +1,46 @@
+using System.Security.Cryptography;
+
 namespace Meziantou.Framework.Http.Recording;
 
-/// <summary>Matches requests based on HTTP method and URL with sorted query parameters.</summary>
+/// <summary>Matches requests based on HTTP method, URL with sorted query parameters, and request body.</summary>
 public sealed class DefaultHttpRequestMatcher : IHttpRequestMatcher
 {
-    /// <summary>Gets the default instance.</summary>
+    /// <summary>Gets the default instance, which includes the request body in the fingerprint.</summary>
     public static DefaultHttpRequestMatcher Instance { get; } = new();
+
+    /// <summary>Gets an instance that matches on method and URL only, ignoring the request body.</summary>
+    public static DefaultHttpRequestMatcher IgnoringRequestBody { get; } = new(matchRequestBody: false);
+
+    /// <summary>Initializes a new instance of the <see cref="DefaultHttpRequestMatcher"/> class.</summary>
+    /// <param name="matchRequestBody">
+    /// When <see langword="true"/> (the default), the request body is part of the fingerprint, so two requests to the
+    /// same URL that carry different payloads do not match each other. Set it to <see langword="false"/> for endpoints
+    /// whose body varies between runs (a nonce or a timestamp) and should not affect matching.
+    /// </param>
+    public DefaultHttpRequestMatcher(bool matchRequestBody = true)
+    {
+        MatchRequestBody = matchRequestBody;
+    }
+
+    /// <summary>Gets a value indicating whether the request body is part of the fingerprint.</summary>
+    public bool MatchRequestBody { get; }
 
     /// <inheritdoc />
     [SuppressMessage("Design", "CA1055:URI-like return values should not be strings")]
     public string ComputeFingerprint(HttpRecordingEntry entry)
     {
+        ArgumentNullException.ThrowIfNull(entry);
+
         var sb = new StringBuilder();
         sb.Append(entry.Method.ToUpperInvariant());
         sb.Append(' ');
 
         if (Uri.TryCreate(entry.RequestUri, UriKind.Absolute, out var uri))
         {
-            // Scheme + host + path (normalized)
+            // Scheme + host + path (normalized). Userinfo is deliberately excluded: it is stripped when the request is
+            // captured, so including it here would make a hand-written recording that still carries it unmatchable.
             sb.Append(uri.Scheme.ToLowerInvariant());
             sb.Append("://");
-
-            if (!string.IsNullOrEmpty(uri.UserInfo))
-            {
-                sb.Append(uri.UserInfo);
-                sb.Append('@');
-            }
-
             sb.Append(uri.Host.ToLowerInvariant());
             if (!uri.IsDefaultPort)
             {
@@ -62,13 +77,20 @@ public sealed class DefaultHttpRequestMatcher : IHttpRequestMatcher
             sb.Append(entry.RequestUri);
         }
 
+        if (MatchRequestBody && entry.RequestBody is { Length: > 0 } body)
+        {
+            // Hash rather than embed: bodies can be large, and the fingerprint is used as a dictionary key.
+            sb.Append(" body:");
+            sb.Append(Convert.ToHexString(SHA256.HashData(body)));
+        }
+
         return sb.ToString();
     }
 
     private static KeyValuePair<string, string>[] ParseAndSortQueryString(string query)
     {
         // Remove leading '?'
-        var queryString = query.Substring(1);
+        var queryString = query[1..];
         var parts = queryString.Split('&');
         var pairs = new List<KeyValuePair<string, string>>(parts.Length);
 

--- a/src/Meziantou.Framework.Http.Recording/HarHttpRecordingStore.cs
+++ b/src/Meziantou.Framework.Http.Recording/HarHttpRecordingStore.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Text.Json;
 using Meziantou.Framework.HttpArchive;
 
 namespace Meziantou.Framework.Http.Recording;
@@ -5,7 +7,13 @@ namespace Meziantou.Framework.Http.Recording;
 /// <summary>Stores recorded HTTP entries in HAR (HTTP Archive) 1.2 format.</summary>
 public sealed class HarHttpRecordingStore : IHttpRecordingStore
 {
-    private static readonly System.Text.UTF8Encoding Utf8EncodingThrowOnInvalid = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    /// <summary>HAR 1.2 uses -1 for "information not available". 0 is a factual claim that tooling will plot.</summary>
+    private const long UnknownSize = -1;
+
+    private static readonly UTF8Encoding Utf8EncodingThrowOnInvalid = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly JsonElement Base64EncodingValue = CreateBase64EncodingValue();
+    private static readonly string CreatorVersion = GetCreatorVersion();
+
     private readonly string _filePath;
 
     public HarHttpRecordingStore(string filePath)
@@ -22,11 +30,22 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             return [];
         }
 
-        await using var stream = File.OpenRead(_filePath);
-        var doc = await HarDocument.ParseAsync(stream, cancellationToken).ConfigureAwait(false);
+        HarDocument doc;
+        await using (var stream = File.OpenRead(_filePath))
+        {
+            try
+            {
+                doc = await HarDocument.ParseAsync(stream, cancellationToken).ConfigureAwait(false);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidDataException($"The recording file '{_filePath}' is not a valid HAR document. It may have been truncated by an interrupted save.", ex);
+            }
+        }
+
         if (doc.Log?.Entries is not { } harEntries)
         {
-            return [];
+            throw new InvalidDataException($"The recording file '{_filePath}' has no 'log.entries' array. Delete it to start a new recording.");
         }
 
         var entries = new List<HttpRecordingEntry>(harEntries.Count);
@@ -35,17 +54,14 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             entries.Add(ConvertFromHarEntry(harEntry));
         }
 
+        HttpRecordingStoreHelpers.ValidateEntries(entries, _filePath);
         return entries;
     }
 
     /// <inheritdoc />
-    public async ValueTask SaveAsync(IReadOnlyList<HttpRecordingEntry> entries, CancellationToken cancellationToken)
+    public ValueTask SaveAsync(IReadOnlyList<HttpRecordingEntry> entries, CancellationToken cancellationToken)
     {
-        var directory = Path.GetDirectoryName(_filePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        ArgumentNullException.ThrowIfNull(entries);
 
         var harEntries = new List<HarEntry>(entries.Count);
         foreach (var entry in entries)
@@ -58,13 +74,15 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             Log = new HarLog
             {
                 Version = "1.2",
-                Creator = new HarCreator { Name = "Meziantou.Framework.Http.Recording", Version = "1.0.0" },
+                Creator = new HarCreator { Name = "Meziantou.Framework.Http.Recording", Version = CreatorVersion },
                 Entries = harEntries,
             },
         };
 
-        await using var stream = File.Create(_filePath);
-        await doc.WriteToAsync(stream, indented: true, cancellationToken).ConfigureAwait(false);
+        return HttpRecordingStoreHelpers.WriteAtomicallyAsync(
+            _filePath,
+            async (stream, token) => await doc.WriteToAsync(stream, indented: true, token).ConfigureAwait(false),
+            cancellationToken);
     }
 
     private static HttpRecordingEntry ConvertFromHarEntry(HarEntry harEntry)
@@ -77,6 +95,8 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             Method = request?.Method ?? "",
             RequestUri = request?.Url ?? "",
             StatusCode = response?.Status ?? 0,
+            ReasonPhrase = string.IsNullOrEmpty(response?.StatusText) ? null : response.StatusText,
+            HttpVersion = ParseHttpVersion(response?.HttpVersion),
             RecordedAt = harEntry.StartedDateTime,
             RequestHeaders = ConvertFromHarHeaders(request?.Headers),
             ResponseHeaders = ConvertFromHarHeaders(response?.Headers),
@@ -88,12 +108,11 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             entry.RequestBody = requestBody;
         }
 
-        // Response body
-        if (response?.Content?.Text is { } responseText)
+        // Response body. Uses the same helper as the request side: it reports an unrecognized encoding or malformed
+        // base64 as "no body" instead of throwing or silently returning the undecoded text as bytes.
+        if (response?.Content.TryGetRawData(out var responseBody) is true)
         {
-            entry.ResponseBody = string.Equals(response.Content.Encoding, "base64", StringComparison.OrdinalIgnoreCase)
-                ? Convert.FromBase64String(responseText)
-                : System.Text.Encoding.UTF8.GetBytes(responseText);
+            entry.ResponseBody = responseBody;
         }
 
         return entry;
@@ -125,13 +144,18 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             Method = entry.Method,
             Url = entry.RequestUri,
             Headers = ConvertToHarHeaders(entry.RequestHeaders),
+            HeadersSize = UnknownSize,
+            BodySize = entry.RequestBody?.Length ?? UnknownSize,
         };
 
         var response = new HarResponse
         {
             Status = entry.StatusCode,
-            StatusText = "",
+            StatusText = entry.ReasonPhrase ?? "",
+            HttpVersion = entry.HttpVersion is { } version ? "HTTP/" + version : "",
             Headers = ConvertToHarHeaders(entry.ResponseHeaders),
+            HeadersSize = UnknownSize,
+            BodySize = entry.ResponseBody?.Length ?? UnknownSize,
         };
 
         // Request body
@@ -151,9 +175,9 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             else
             {
                 postData.Text = Convert.ToBase64String(entry.RequestBody);
-                postData.ExtensionData = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal)
+                postData.ExtensionData = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
                 {
-                    [HarPostDataExtensions.DefaultEncodingExtensionName] = System.Text.Json.JsonDocument.Parse("\"base64\"").RootElement.Clone(),
+                    [HarPostDataExtensions.DefaultEncodingExtensionName] = Base64EncodingValue,
                 };
             }
 
@@ -187,6 +211,7 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
         return new HarEntry
         {
             StartedDateTime = entry.RecordedAt,
+            Time = UnknownSize,
             Request = request,
             Response = response,
         };
@@ -244,11 +269,40 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             text = Utf8EncodingThrowOnInvalid.GetString(bytes);
             return true;
         }
-        catch (System.Text.DecoderFallbackException)
+        catch (DecoderFallbackException)
         {
             text = null;
             return false;
         }
     }
 
+    /// <summary>Converts the HAR <c>httpVersion</c> field (e.g. <c>HTTP/1.1</c>) to the version string used by <see cref="HttpRecordingEntry.HttpVersion"/>.</summary>
+    private static string? ParseHttpVersion(string? httpVersion)
+    {
+        if (string.IsNullOrEmpty(httpVersion))
+            return null;
+
+        const string Prefix = "HTTP/";
+        var value = httpVersion.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase) ? httpVersion[Prefix.Length..] : httpVersion;
+        return Version.TryParse(value, out _) ? value : null;
+    }
+
+    private static JsonElement CreateBase64EncodingValue()
+    {
+        using var document = JsonDocument.Parse("\"base64\"");
+        return document.RootElement.Clone();
+    }
+
+    private static string GetCreatorVersion()
+    {
+        var informationalVersion = typeof(HarHttpRecordingStore).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(informationalVersion))
+        {
+            // Strip the source-revision suffix that the SDK appends (1.2.3+abcdef).
+            var separatorIndex = informationalVersion.IndexOf('+', StringComparison.Ordinal);
+            return separatorIndex >= 0 ? informationalVersion[..separatorIndex] : informationalVersion;
+        }
+
+        return typeof(HarHttpRecordingStore).Assembly.GetName().Version?.ToString() ?? "";
+    }
 }

--- a/src/Meziantou.Framework.Http.Recording/HeaderRemovalSanitizer.cs
+++ b/src/Meziantou.Framework.Http.Recording/HeaderRemovalSanitizer.cs
@@ -1,18 +1,27 @@
 namespace Meziantou.Framework.Http.Recording;
 
-/// <summary>Removes specified headers from recorded entries before persistence.</summary>
+/// <summary>Removes the specified headers from recorded entries.</summary>
+/// <remarks>
+/// This sanitizer only reaches headers. Secrets carried in the request URI or in a body are not affected:
+/// use <see cref="UriQueryParameterSanitizer"/> for query string parameters, or a custom
+/// <see cref="IHttpRecordingSanitizer"/> to rewrite <see cref="HttpRecordingEntry.RequestBody"/> and
+/// <see cref="HttpRecordingEntry.ResponseBody"/>.
+/// </remarks>
 public sealed class HeaderRemovalSanitizer : IHttpRecordingSanitizer
 {
     private readonly HashSet<string> _headerNames;
 
     public HeaderRemovalSanitizer(params string[] headerNames)
     {
+        ArgumentNullException.ThrowIfNull(headerNames);
         _headerNames = new HashSet<string>(headerNames, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
     public void Sanitize(HttpRecordingEntry entry)
     {
+        ArgumentNullException.ThrowIfNull(entry);
+
         RemoveHeaders(entry.RequestHeaders);
         RemoveHeaders(entry.ResponseHeaders);
     }
@@ -20,9 +29,7 @@ public sealed class HeaderRemovalSanitizer : IHttpRecordingSanitizer
     private void RemoveHeaders(Dictionary<string, string[]>? headers)
     {
         if (headers is null)
-        {
             return;
-        }
 
         foreach (var name in _headerNames)
         {

--- a/src/Meziantou.Framework.Http.Recording/HttpMessageConverter.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpMessageConverter.cs
@@ -26,8 +26,10 @@ internal static class HttpMessageConverter
         var entry = new HttpRecordingEntry
         {
             Method = request.Method.Method,
-            RequestUri = request.RequestUri?.AbsoluteUri ?? "",
+            RequestUri = GetRequestUri(request),
             StatusCode = (int)response.StatusCode,
+            ReasonPhrase = response.ReasonPhrase,
+            HttpVersion = response.Version.ToString(),
             RecordedAt = DateTimeOffset.UtcNow,
         };
 
@@ -49,30 +51,47 @@ internal static class HttpMessageConverter
         return entry;
     }
 
-    public static HttpRecordingEntry CreateFromRequest(HttpRequestMessage request)
+    /// <summary>Builds the entry used to look up a recording. It carries everything a matcher may read: method, URI, headers and body.</summary>
+    /// <remarks>The caller must have buffered <see cref="HttpRequestMessage.Content"/> so the body can be read without consuming it.</remarks>
+    public static async Task<HttpRecordingEntry> CreateFromRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        return new HttpRecordingEntry
+        var entry = new HttpRecordingEntry
         {
             Method = request.Method.Method,
-            RequestUri = request.RequestUri?.AbsoluteUri ?? "",
+            RequestUri = GetRequestUri(request),
             RequestHeaders = CaptureHeaders(request.Headers, request.Content?.Headers),
             StatusCode = 0,
         };
+
+        if (request.Content is not null)
+        {
+            entry.RequestBody = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return entry;
     }
 
-    public static HttpResponseMessage ToHttpResponseMessage(HttpRecordingEntry entry)
+    public static HttpResponseMessage ToHttpResponseMessage(HttpRecordingEntry entry, HttpRequestMessage request)
     {
-        var response = new HttpResponseMessage((HttpStatusCode)entry.StatusCode);
+        if (entry.StatusCode is < 0 or > 999)
+        {
+            throw new InvalidOperationException($"The recorded entry for {entry.Method} {HttpRecordingUri.Redact(entry.RequestUri)} has an out-of-range status code ({entry.StatusCode}). Valid values are between 0 and 999.");
+        }
 
-        HttpContent content;
-        if (entry.ResponseBody is { Length: > 0 })
+        var response = new HttpResponseMessage((HttpStatusCode)entry.StatusCode)
         {
-            content = new ByteArrayContent(entry.ResponseBody);
-        }
-        else
+            RequestMessage = request,
+            ReasonPhrase = entry.ReasonPhrase,
+        };
+
+        if (entry.HttpVersion is { } version && Version.TryParse(version, out var parsedVersion))
         {
-            content = new ByteArrayContent([]);
+            response.Version = parsedVersion;
         }
+
+        HttpContent content = entry.ResponseBody is { Length: > 0 } body
+            ? new ByteArrayContent(body)
+            : new ByteArrayContent([]);
 
         response.Content = content;
 
@@ -80,6 +99,14 @@ internal static class HttpMessageConverter
         {
             foreach (var (name, values) in entry.ResponseHeaders)
             {
+                // Content-Length is recomputed from the body we actually have. A recorded value can disagree with it
+                // (a hand-edited recording, a sanitized body, a browser-exported HAR holding a decompressed payload),
+                // and a wrong Content-Length makes consumers read past the data or wait for bytes that never arrive.
+                if (string.Equals(name, "Content-Length", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 if (ContentHeaderNames.Contains(name))
                 {
                     content.Headers.TryAddWithoutValidation(name, values);
@@ -92,6 +119,13 @@ internal static class HttpMessageConverter
         }
 
         return response;
+    }
+
+    private static string GetRequestUri(HttpRequestMessage request)
+    {
+        // Credentials in the userinfo component would otherwise be written to a recording file that is meant to be
+        // committed. Stripping them on both the record and the lookup path keeps matching symmetric.
+        return HttpRecordingUri.RemoveUserInfo(request.RequestUri?.AbsoluteUri ?? "");
     }
 
     private static Dictionary<string, string[]> CaptureHeaders(

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingEntry.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingEntry.cs
@@ -27,6 +27,14 @@ public sealed class HttpRecordingEntry
     [JsonPropertyName("statusCode")]
     public required int StatusCode { get; set; }
 
+    /// <summary>Gets or sets the reason phrase returned with the status code, when the server sent one.</summary>
+    [JsonPropertyName("reasonPhrase")]
+    public string? ReasonPhrase { get; set; }
+
+    /// <summary>Gets or sets the HTTP version of the response (e.g., 1.1, 2.0). When <see langword="null"/>, the default version is used on replay.</summary>
+    [JsonPropertyName("httpVersion")]
+    public string? HttpVersion { get; set; }
+
     /// <summary>Gets or sets the response headers.</summary>
     [JsonPropertyName("responseHeaders")]
     public Dictionary<string, string[]>? ResponseHeaders { get; set; }

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingHandler.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingHandler.cs
@@ -3,31 +3,31 @@ using System.Net;
 namespace Meziantou.Framework.Http.Recording;
 
 /// <summary>A delegating handler that records and replays HTTP interactions for testing.</summary>
-public sealed class HttpRecordingHandler : DelegatingHandler
+public sealed class HttpRecordingHandler : DelegatingHandler, IAsyncDisposable
 {
-    private readonly IHttpRecordingStore _store;
-    private readonly HttpRecordingMode _mode;
-    private readonly HttpRecordingMissBehavior _missBehavior;
-    private readonly IHttpRecordingSanitizer? _sanitizer;
-    private readonly RecordingSession _session;
+    [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposing it would race in-flight requests that are about to release it, throwing ObjectDisposedException from a finally block and replacing the real exception. It never hands out a wait handle, so it holds no unmanaged resource. See Dispose(bool).")]
     private readonly SemaphoreSlim _ioLock = new(1, 1);
-    private volatile bool _initialized;
+    private readonly Lock _pendingLock = new();
 
-    /// <summary>Initializes a new instance of the <see cref="HttpRecordingHandler"/> class.</summary>
+    private IHttpRecordingStore _store = null!;
+    private HttpRecordingMode _mode;
+    private HttpRecordingMissBehavior _missBehavior;
+    private IHttpRecordingSanitizer[] _sanitizers = [];
+    private bool _autoSave;
+    private RecordingSession _session = null!;
+
+    private volatile bool _initialized;
+    private volatile bool _disposed;
+    private volatile bool _autoSaved;
+    private int _pendingRecordings;
+    private TaskCompletionSource? _recordingsDrained;
+
+    /// <summary>Initializes a new instance of the <see cref="HttpRecordingHandler"/> class without an inner handler.</summary>
     /// <param name="store">The store used to load and save recorded entries.</param>
-    /// <param name="options">The recording options.</param>
+    /// <param name="options">The recording options. Because there is no inner handler, no real HTTP call can be made, so the mode must be <see cref="HttpRecordingMode.Replay"/> and the miss behavior must not be <see cref="HttpRecordingMissBehavior.Passthrough"/>.</param>
     public HttpRecordingHandler(IHttpRecordingStore store, HttpRecordingOptions? options = null)
     {
-        ArgumentNullException.ThrowIfNull(store);
-        _store = store;
-
-        var resolvedOptions = options ?? new HttpRecordingOptions();
-        _mode = resolvedOptions.Mode;
-        _missBehavior = resolvedOptions.MissBehavior;
-        _sanitizer = resolvedOptions.Sanitizer;
-
-        var matcher = resolvedOptions.RequestMatcher ?? DefaultHttpRequestMatcher.Instance;
-        _session = new RecordingSession(matcher);
+        Initialize(store, options, hasInnerHandler: false);
     }
 
     /// <summary>Initializes a new instance of the <see cref="HttpRecordingHandler"/> class with an inner handler.</summary>
@@ -37,19 +37,43 @@ public sealed class HttpRecordingHandler : DelegatingHandler
     public HttpRecordingHandler(HttpMessageHandler innerHandler, IHttpRecordingStore store, HttpRecordingOptions? options = null)
         : base(innerHandler)
     {
+        Initialize(store, options, hasInnerHandler: true);
+    }
+
+    private void Initialize(IHttpRecordingStore store, HttpRecordingOptions? options, bool hasInnerHandler)
+    {
         ArgumentNullException.ThrowIfNull(store);
         _store = store;
 
         var resolvedOptions = options ?? new HttpRecordingOptions();
         _mode = resolvedOptions.Mode;
-        _missBehavior = resolvedOptions.MissBehavior;
-        _sanitizer = resolvedOptions.Sanitizer;
+        _missBehavior = resolvedOptions.MissBehavior ?? (_mode is HttpRecordingMode.Auto
+            ? HttpRecordingMissBehavior.Passthrough
+            : HttpRecordingMissBehavior.Throw);
+        _sanitizers = [.. resolvedOptions.Sanitizers];
+        _autoSave = resolvedOptions.AutoSave;
+
+        if (!hasInnerHandler)
+        {
+            // Without an inner handler every path that reaches the network throws a DelegatingHandler error that says
+            // nothing about the misconfiguration. Reject it here instead, while the caller can still see why.
+            if (_mode is not HttpRecordingMode.Replay)
+            {
+                throw new ArgumentException($"{nameof(HttpRecordingOptions)}.{nameof(HttpRecordingOptions.Mode)} must be {nameof(HttpRecordingMode.Replay)} when no inner handler is provided, because {_mode} performs real HTTP calls. Use the constructor that takes an inner handler.", nameof(options));
+            }
+
+            if (_missBehavior is HttpRecordingMissBehavior.Passthrough)
+            {
+                throw new ArgumentException($"{nameof(HttpRecordingOptions)}.{nameof(HttpRecordingOptions.MissBehavior)} cannot be {nameof(HttpRecordingMissBehavior.Passthrough)} when no inner handler is provided, because there is nothing to forward the request to. Use the constructor that takes an inner handler.", nameof(options));
+            }
+        }
 
         var matcher = resolvedOptions.RequestMatcher ?? DefaultHttpRequestMatcher.Instance;
         _session = new RecordingSession(matcher);
     }
 
     /// <summary>Loads existing recordings from the store. If not called explicitly, the first <see cref="SendAsync"/> call will call it automatically.</summary>
+    /// <remarks>Nothing is loaded in <see cref="HttpRecordingMode.Record"/> mode: saving there replaces the store's content instead of appending to it.</remarks>
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         if (_initialized)
@@ -65,8 +89,12 @@ public sealed class HttpRecordingHandler : DelegatingHandler
                 return;
             }
 
-            var entries = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
-            _session.LoadEntries(entries);
+            if (_mode is not HttpRecordingMode.Record)
+            {
+                var entries = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
+                _session.LoadEntries(entries);
+            }
+
             _initialized = true;
         }
         finally
@@ -75,13 +103,23 @@ public sealed class HttpRecordingHandler : DelegatingHandler
         }
     }
 
-    /// <summary>Saves all recorded entries to the store.</summary>
-    public async Task SaveAsync(CancellationToken cancellationToken = default)
+    /// <summary>Saves all recorded entries to the store, waiting for any in-flight recording to complete first.</summary>
+    public Task SaveAsync(CancellationToken cancellationToken = default)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return SaveCoreAsync(cancellationToken);
+    }
+
+    private async Task SaveCoreAsync(CancellationToken cancellationToken)
+    {
+        // A request that is still being recorded would otherwise be missing from the snapshot, and the store has
+        // already replaced the previous content by the time it completes.
+        await WaitForPendingRecordingsAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+
         await _ioLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var entries = _session.GetAllEntries();
+            var entries = _session.GetEntriesToPersist();
             await _store.SaveAsync(entries, cancellationToken).ConfigureAwait(false);
         }
         finally
@@ -91,15 +129,27 @@ public sealed class HttpRecordingHandler : DelegatingHandler
     }
 
     /// <inheritdoc />
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        await InitializeAsync(cancellationToken).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Loading the store is local I/O that has nothing to do with the remote endpoint. Billing it to the request's
+        // token would surface a slow or large recording file as an HttpClient.Timeout against a server never contacted.
+        await InitializeAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // Buffer the request body up front so it can be fingerprinted and recorded. Reading it after the inner handler
+        // has written it to the wire fails for any content that can only be consumed once.
+        if (request.Content is not null)
+        {
+            await request.Content.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
+        }
 
         return _mode switch
         {
             HttpRecordingMode.Record => await RecordAsync(request, cancellationToken).ConfigureAwait(false),
-            HttpRecordingMode.Replay => Replay(request),
+            HttpRecordingMode.Replay => await ReplayAsync(request, cancellationToken).ConfigureAwait(false),
             HttpRecordingMode.Auto => await AutoAsync(request, cancellationToken).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unknown recording mode: {_mode}"),
         };
@@ -107,18 +157,44 @@ public sealed class HttpRecordingHandler : DelegatingHandler
 
     private async Task<HttpResponseMessage> RecordAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        await RecordEntryAsync(request, response, cancellationToken).ConfigureAwait(false);
-        return response;
+        // Counted for the whole exchange, not just the part after the response arrives, so that SaveAsync cannot
+        // snapshot the session while this request is still on its way to being recorded.
+        BeginRecording();
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await RecordEntryAsync(request, response, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // The response never reaches the caller, so nobody else can dispose it. Leaving it alive would hold its
+                // pooled connection until finalization.
+                response.Dispose();
+                throw;
+            }
+
+            return response;
+        }
+        finally
+        {
+            EndRecording();
+        }
     }
 
-    private HttpResponseMessage Replay(HttpRequestMessage request)
+    private async Task<HttpResponseMessage> ReplayAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var requestEntry = HttpMessageConverter.CreateFromRequest(request);
+        var requestEntry = await CreateLookupEntryAsync(request, cancellationToken).ConfigureAwait(false);
 
         if (_session.TryGetRecordedResponse(requestEntry, out var match) && match is not null)
         {
-            return HttpMessageConverter.ToHttpResponseMessage(match);
+            return HttpMessageConverter.ToHttpResponseMessage(match, request);
+        }
+
+        if (_missBehavior is HttpRecordingMissBehavior.Passthrough)
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         return HandleMiss(request, requestEntry);
@@ -126,28 +202,51 @@ public sealed class HttpRecordingHandler : DelegatingHandler
 
     private async Task<HttpResponseMessage> AutoAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var requestEntry = HttpMessageConverter.CreateFromRequest(request);
+        var requestEntry = await CreateLookupEntryAsync(request, cancellationToken).ConfigureAwait(false);
 
         if (_session.TryGetRecordedResponse(requestEntry, out var match) && match is not null)
         {
-            return HttpMessageConverter.ToHttpResponseMessage(match);
+            return HttpMessageConverter.ToHttpResponseMessage(match, request);
+        }
+
+        if (_missBehavior is not HttpRecordingMissBehavior.Passthrough)
+        {
+            return HandleMiss(request, requestEntry);
         }
 
         // No match — record the real call
-        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        await RecordEntryAsync(request, response, cancellationToken).ConfigureAwait(false);
-        return response;
+        return await RecordAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<HttpRecordingEntry> CreateLookupEntryAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var entry = await HttpMessageConverter.CreateFromRequestAsync(request, cancellationToken).ConfigureAwait(false);
+
+        // Stored entries were sanitized before being persisted, so the lookup entry must go through the same
+        // transformation or a sanitized field the matcher reads could never match again.
+        Sanitize(entry);
+        return entry;
     }
 
     private async Task RecordEntryAsync(HttpRequestMessage request, HttpResponseMessage response, CancellationToken cancellationToken)
     {
+        // Buffering here is what keeps the response the caller receives readable after we have consumed it.
         await response.Content.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
 
         var entry = await HttpMessageConverter.CreateFromRequestResponseAsync(request, response, cancellationToken).ConfigureAwait(false);
-        _sanitizer?.Sanitize(entry);
+        Sanitize(entry);
         _session.AddRecordedEntry(entry);
     }
 
+    private void Sanitize(HttpRecordingEntry entry)
+    {
+        foreach (var sanitizer in _sanitizers)
+        {
+            sanitizer.Sanitize(entry);
+        }
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The response is returned to the caller, which owns it.")]
     private HttpResponseMessage HandleMiss(HttpRequestMessage request, HttpRecordingEntry requestEntry)
     {
         return _missBehavior switch
@@ -156,15 +255,68 @@ public sealed class HttpRecordingHandler : DelegatingHandler
             HttpRecordingMissBehavior.ReturnDefault => new HttpResponseMessage(HttpStatusCode.InternalServerError)
             {
                 Content = new StringContent(
-                    $"No recorded response found for {requestEntry.Method} {requestEntry.RequestUri}.",
+                    $"No recorded response found for {requestEntry.Method} {HttpRecordingUri.Redact(requestEntry.RequestUri)}.",
                     Encoding.UTF8,
                     "text/plain"),
                 RequestMessage = request,
             },
-            HttpRecordingMissBehavior.Passthrough => throw new InvalidOperationException(
-                "Passthrough miss behavior is not supported in Replay mode. Use Auto mode instead."),
             _ => throw new InvalidOperationException($"Unknown miss behavior: {_missBehavior}"),
         };
+    }
+
+    private void BeginRecording()
+    {
+        lock (_pendingLock)
+        {
+            _pendingRecordings++;
+        }
+    }
+
+    private void EndRecording()
+    {
+        TaskCompletionSource? drained = null;
+        lock (_pendingLock)
+        {
+            if (--_pendingRecordings is 0)
+            {
+                drained = _recordingsDrained;
+                _recordingsDrained = null;
+            }
+        }
+
+        drained?.TrySetResult();
+    }
+
+    private Task WaitForPendingRecordingsAsync()
+    {
+        lock (_pendingLock)
+        {
+            if (_pendingRecordings is 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            _recordingsDrained ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return _recordingsDrained.Task;
+        }
+    }
+
+    /// <summary>Saves the recordings when <see cref="HttpRecordingOptions.AutoSave"/> is enabled, then disposes the handler.</summary>
+    /// <remarks>
+    /// The save is not skipped when the handler has already been disposed synchronously: an <see cref="HttpClient"/>
+    /// owns its handler by default and disposes it first, so by the time this runs the handler is usually disposed
+    /// already. The recorded entries are still in memory and are what needs persisting.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_autoSave && !_autoSaved)
+        {
+            _autoSaved = true;
+            await SaveCoreAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        Dispose();
+        GC.SuppressFinalize(this);
     }
 
     /// <inheritdoc />
@@ -172,7 +324,12 @@ public sealed class HttpRecordingHandler : DelegatingHandler
     {
         if (disposing)
         {
-            _ioLock.Dispose();
+            _disposed = true;
+
+            // _ioLock is deliberately not disposed. A request that is still in flight may be about to release it, and
+            // SemaphoreSlim.Dispose racing Release throws ObjectDisposedException from a finally block, which replaces
+            // the exception the caller actually needs to see. A SemaphoreSlim that never handed out a wait handle holds
+            // no unmanaged resource.
         }
 
         base.Dispose(disposing);

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingMissBehavior.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingMissBehavior.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.Http.Recording;
 
-/// <summary>Specifies what happens when no recorded response matches an incoming request during replay.</summary>
+/// <summary>Specifies what happens when no recorded response matches an incoming request.</summary>
 public enum HttpRecordingMissBehavior
 {
     /// <summary>Throw an <see cref="HttpRecordingMissException"/>.</summary>
@@ -9,6 +9,10 @@ public enum HttpRecordingMissBehavior
     /// <summary>Return a default HTTP 500 response with a diagnostic body.</summary>
     ReturnDefault,
 
-    /// <summary>Forward the request to the inner handler (make a real HTTP call).</summary>
+    /// <summary>
+    /// Forward the request to the inner handler (make a real HTTP call).
+    /// In <see cref="HttpRecordingMode.Auto"/> the response is also recorded; in <see cref="HttpRecordingMode.Replay"/> it is not.
+    /// Requires an inner handler.
+    /// </summary>
     Passthrough,
 }

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingMissException.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingMissException.cs
@@ -6,7 +6,7 @@ public sealed class HttpRecordingMissException : InvalidOperationException
 {
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public HttpRecordingMissException(string method, string requestUri)
-        : base($"No recorded response found for {method} {requestUri}.")
+        : base($"No recorded response found for {method} {HttpRecordingUri.Redact(requestUri)}.")
     {
         Method = method;
         RequestUri = requestUri;
@@ -15,7 +15,7 @@ public sealed class HttpRecordingMissException : InvalidOperationException
     /// <summary>Gets the HTTP method of the unmatched request.</summary>
     public string Method { get; }
 
-    /// <summary>Gets the request URI of the unmatched request.</summary>
+    /// <summary>Gets the request URI of the unmatched request. Unlike the exception message, this value is not redacted.</summary>
     [SuppressMessage("Design", "CA1056:URI-like properties should not be strings")]
     public string RequestUri { get; }
 }

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingMode.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingMode.cs
@@ -3,12 +3,18 @@ namespace Meziantou.Framework.Http.Recording;
 /// <summary>Specifies the operating mode for the recording handler.</summary>
 public enum HttpRecordingMode
 {
-    /// <summary>Execute real HTTP calls, record request/response pairs, and persist to storage.</summary>
+    /// <summary>
+    /// Execute real HTTP calls, record request/response pairs, and persist to storage.
+    /// Existing recordings are not loaded, so saving replaces the previous content of the store rather than appending to it.
+    /// </summary>
     Record,
 
-    /// <summary>Intercept HTTP calls and return recorded responses. No external HTTP calls are made.</summary>
+    /// <summary>Intercept HTTP calls and return recorded responses. No external HTTP calls are made unless <see cref="HttpRecordingMissBehavior.Passthrough"/> is configured.</summary>
     Replay,
 
-    /// <summary>Replay if a match exists; otherwise, execute real call and record it.</summary>
+    /// <summary>
+    /// Replay if a match exists among the previously stored recordings; otherwise apply <see cref="HttpRecordingOptions.MissBehavior"/>.
+    /// Entries recorded during the current session are persisted but are not replayed within that same session.
+    /// </summary>
     Auto,
 }

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingOptions.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingOptions.cs
@@ -6,12 +6,24 @@ public sealed class HttpRecordingOptions
     /// <summary>Gets or sets the operating mode. Default is <see cref="HttpRecordingMode.Auto"/>.</summary>
     public HttpRecordingMode Mode { get; set; } = HttpRecordingMode.Auto;
 
-    /// <summary>Gets or sets the behavior when no recorded response matches during replay. Default is <see cref="HttpRecordingMissBehavior.Throw"/>.</summary>
-    public HttpRecordingMissBehavior MissBehavior { get; set; } = HttpRecordingMissBehavior.Throw;
+    /// <summary>Gets or sets the behavior when no recorded response matches an incoming request.</summary>
+    /// <remarks>
+    /// When <see langword="null"/> (the default), the behavior depends on <see cref="Mode"/>:
+    /// <see cref="HttpRecordingMissBehavior.Throw"/> for <see cref="HttpRecordingMode.Replay"/>, and
+    /// <see cref="HttpRecordingMissBehavior.Passthrough"/> for <see cref="HttpRecordingMode.Auto"/> so that a missing
+    /// recording is created. Setting it explicitly overrides that default in both modes: in particular,
+    /// <see cref="HttpRecordingMode.Auto"/> combined with <see cref="HttpRecordingMissBehavior.Throw"/> never performs
+    /// a real HTTP call. This option is not used in <see cref="HttpRecordingMode.Record"/>.
+    /// </remarks>
+    public HttpRecordingMissBehavior? MissBehavior { get; set; }
 
     /// <summary>Gets or sets the request matcher used for fingerprinting. When <see langword="null"/>, the <see cref="DefaultHttpRequestMatcher"/> is used.</summary>
     public IHttpRequestMatcher? RequestMatcher { get; set; }
 
-    /// <summary>Gets or sets the sanitizer applied to entries before persistence. When <see langword="null"/>, no sanitization is applied.</summary>
-    public IHttpRecordingSanitizer? Sanitizer { get; set; }
+    /// <summary>Gets the sanitizers applied to entries before persistence, and to incoming requests before matching. Empty by default, meaning no sanitization.</summary>
+    public IList<IHttpRecordingSanitizer> Sanitizers { get; } = [];
+
+    /// <summary>Gets or sets a value indicating whether recordings are saved when the handler is disposed asynchronously. Default is <see langword="false"/>.</summary>
+    /// <remarks>Auto-saving requires disposing the handler with <see cref="IAsyncDisposable.DisposeAsync"/>; a synchronous <see cref="IDisposable.Dispose"/> cannot save.</remarks>
+    public bool AutoSave { get; set; }
 }

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingStoreHelpers.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingStoreHelpers.cs
@@ -1,0 +1,71 @@
+namespace Meziantou.Framework.Http.Recording;
+
+/// <summary>Shared behavior for the file-backed <see cref="IHttpRecordingStore"/> implementations.</summary>
+internal static class HttpRecordingStoreHelpers
+{
+    /// <summary>
+    /// Writes to a temporary file next to the destination and moves it into place once the write has fully succeeded.
+    /// </summary>
+    /// <remarks>
+    /// Opening the destination directly would truncate it before the first byte is produced, so a cancelled save, a
+    /// serialization error, or a process kill would destroy a recording file that is often the only copy of the
+    /// responses it holds.
+    /// </remarks>
+    public static async ValueTask WriteAtomicallyAsync(string filePath, Func<Stream, CancellationToken, ValueTask> writeAsync, CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var temporaryPath = $"{filePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await using (var stream = File.Create(temporaryPath))
+            {
+                await writeAsync(stream, cancellationToken).ConfigureAwait(false);
+            }
+
+            File.Move(temporaryPath, filePath, overwrite: true);
+        }
+        catch
+        {
+            TryDelete(temporaryPath);
+            throw;
+        }
+    }
+
+    /// <summary>Rejects entries that cannot be matched, naming the file and the index so the developer knows what to repair.</summary>
+    public static void ValidateEntries(IReadOnlyList<HttpRecordingEntry> entries, string filePath)
+    {
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            if (entry is null)
+            {
+                throw new InvalidDataException($"The recording file '{filePath}' contains a null entry at index {i}.");
+            }
+
+            // 'required' is not a null check: a JSON document can set these to null and deserialization accepts it.
+            if (string.IsNullOrEmpty(entry.Method))
+            {
+                throw new InvalidDataException($"The entry at index {i} in the recording file '{filePath}' has no HTTP method.");
+            }
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingUri.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingUri.cs
@@ -1,0 +1,62 @@
+namespace Meziantou.Framework.Http.Recording;
+
+/// <summary>Helpers to rewrite recorded request URIs so credentials do not reach recordings or diagnostics.</summary>
+internal static class HttpRecordingUri
+{
+    public const string RedactedValue = "***";
+
+    /// <summary>Removes the userinfo component (<c>https://user:password@host/</c>) from an absolute URI.</summary>
+    public static string RemoveUserInfo(string requestUri)
+    {
+        if (!Uri.TryCreate(requestUri, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.UserInfo))
+            return requestUri;
+
+        var builder = new UriBuilder(uri) { UserName = "", Password = "" };
+        return builder.Uri.AbsoluteUri;
+    }
+
+    /// <summary>Replaces the value of every query parameter whose name is in <paramref name="parameterNames"/> with <see cref="RedactedValue"/>.</summary>
+    public static string MaskQueryParameters(string requestUri, HashSet<string> parameterNames)
+    {
+        return RewriteQuery(requestUri, name => parameterNames.Contains(name));
+    }
+
+    /// <summary>Produces a form of the URI that is safe to put in an exception message or a log: no userinfo and no query values.</summary>
+    public static string Redact(string requestUri)
+    {
+        return RewriteQuery(RemoveUserInfo(requestUri), static _ => true);
+    }
+
+    private static string RewriteQuery(string requestUri, Func<string, bool> shouldMask)
+    {
+        if (!Uri.TryCreate(requestUri, UriKind.Absolute, out var uri))
+            return requestUri;
+
+        var query = uri.Query;
+        if (query.Length <= 1)
+            return requestUri;
+
+        var masked = false;
+        var parts = query[1..].Split('&');
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var part = parts[i];
+            var separatorIndex = part.IndexOf('=', StringComparison.Ordinal);
+            if (separatorIndex < 0)
+                continue;
+
+            var name = part[..separatorIndex];
+            if (!shouldMask(Uri.UnescapeDataString(name)))
+                continue;
+
+            parts[i] = name + "=" + RedactedValue;
+            masked = true;
+        }
+
+        if (!masked)
+            return requestUri;
+
+        var builder = new UriBuilder(uri) { Query = string.Join('&', parts) };
+        return builder.Uri.AbsoluteUri;
+    }
+}

--- a/src/Meziantou.Framework.Http.Recording/IHttpRecordingSanitizer.cs
+++ b/src/Meziantou.Framework.Http.Recording/IHttpRecordingSanitizer.cs
@@ -1,8 +1,13 @@
 namespace Meziantou.Framework.Http.Recording;
 
-/// <summary>Defines the contract for sanitizing recorded HTTP entries before persistence.</summary>
+/// <summary>Defines the contract for sanitizing recorded HTTP entries.</summary>
+/// <remarks>
+/// Sanitizers run on both sides of matching: on entries before they are persisted, and on the entry built from an
+/// incoming request before its fingerprint is computed. Applying the same transformation to both sides is what allows
+/// a value to be redacted without breaking replay. A sanitizer must therefore be deterministic.
+/// </remarks>
 public interface IHttpRecordingSanitizer
 {
-    /// <summary>Sanitizes the entry in-place to redact sensitive data before it is persisted.</summary>
+    /// <summary>Sanitizes the entry in-place to redact sensitive data.</summary>
     void Sanitize(HttpRecordingEntry entry);
 }

--- a/src/Meziantou.Framework.Http.Recording/JsonHttpRecordingStore.cs
+++ b/src/Meziantou.Framework.Http.Recording/JsonHttpRecordingStore.cs
@@ -21,23 +21,37 @@ public sealed class JsonHttpRecordingStore : IHttpRecordingStore
             return [];
         }
 
-        await using var stream = File.OpenRead(_filePath);
-        var entries = await JsonSerializer.DeserializeAsync(stream, HttpRecordingSerializerContext.Default.ListHttpRecordingEntry, cancellationToken).ConfigureAwait(false);
-        return entries ?? [];
+        List<HttpRecordingEntry>? entries;
+        await using (var stream = File.OpenRead(_filePath))
+        {
+            try
+            {
+                entries = await JsonSerializer.DeserializeAsync(stream, HttpRecordingSerializerContext.Default.ListHttpRecordingEntry, cancellationToken).ConfigureAwait(false);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidDataException($"The recording file '{_filePath}' is not valid JSON. It may have been truncated by an interrupted save.", ex);
+            }
+        }
+
+        if (entries is null)
+        {
+            throw new InvalidDataException($"The recording file '{_filePath}' does not contain a list of recordings. Delete it to start a new recording.");
+        }
+
+        HttpRecordingStoreHelpers.ValidateEntries(entries, _filePath);
+        return entries;
     }
 
     /// <inheritdoc />
-    public async ValueTask SaveAsync(IReadOnlyList<HttpRecordingEntry> entries, CancellationToken cancellationToken)
+    public ValueTask SaveAsync(IReadOnlyList<HttpRecordingEntry> entries, CancellationToken cancellationToken)
     {
-        var directory = Path.GetDirectoryName(_filePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        ArgumentNullException.ThrowIfNull(entries);
 
         var list = entries as List<HttpRecordingEntry> ?? new List<HttpRecordingEntry>(entries);
-
-        await using var stream = File.Create(_filePath);
-        await JsonSerializer.SerializeAsync(stream, list, HttpRecordingSerializerContext.Default.ListHttpRecordingEntry, cancellationToken).ConfigureAwait(false);
+        return HttpRecordingStoreHelpers.WriteAtomicallyAsync(
+            _filePath,
+            async (stream, token) => await JsonSerializer.SerializeAsync(stream, list, HttpRecordingSerializerContext.Default.ListHttpRecordingEntry, token).ConfigureAwait(false),
+            cancellationToken);
     }
 }

--- a/src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj
+++ b/src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.2</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>HTTP record and replay for testing, using DelegatingHandler with HAR format support</Description>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Http.Recording/RecordingSession.cs
+++ b/src/Meziantou.Framework.Http.Recording/RecordingSession.cs
@@ -2,10 +2,19 @@ using System.Collections.Concurrent;
 
 namespace Meziantou.Framework.Http.Recording;
 
+/// <summary>
+/// Holds the recordings for one handler instance.
+/// </summary>
+/// <remarks>
+/// Loaded entries and entries recorded during the session are tracked separately. Only loaded entries are replayable,
+/// so a freshly recorded response is never handed back to a later request in the same session — that would consume the
+/// recording the session is in the middle of producing, and the resulting file could not replay its own scenario.
+/// </remarks>
 internal sealed class RecordingSession
 {
-    private readonly ConcurrentDictionary<string, ConcurrentQueue<HttpRecordingEntry>> _entriesByFingerprint = new(StringComparer.Ordinal);
-    private readonly ConcurrentQueue<HttpRecordingEntry> _allEntries = new();
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<HttpRecordingEntry>> _replayQueues = new(StringComparer.Ordinal);
+    private readonly ConcurrentQueue<HttpRecordingEntry> _loadedEntries = new();
+    private readonly ConcurrentQueue<HttpRecordingEntry> _recordedEntries = new();
     private readonly IHttpRequestMatcher _matcher;
 
     public RecordingSession(IHttpRequestMatcher matcher)
@@ -15,12 +24,19 @@ internal sealed class RecordingSession
 
     public void LoadEntries(IReadOnlyList<HttpRecordingEntry> entries)
     {
+        // Fingerprint everything first: if the matcher throws on one entry, the session must be left untouched rather
+        // than half-populated, because initialization is retried and would otherwise duplicate the prefix.
+        var fingerprinted = new List<(string Fingerprint, HttpRecordingEntry Entry)>(entries.Count);
         foreach (var entry in entries)
         {
-            var fingerprint = _matcher.ComputeFingerprint(entry);
-            var queue = _entriesByFingerprint.GetOrAdd(fingerprint, static _ => new ConcurrentQueue<HttpRecordingEntry>());
+            fingerprinted.Add((_matcher.ComputeFingerprint(entry), entry));
+        }
+
+        foreach (var (fingerprint, entry) in fingerprinted)
+        {
+            var queue = _replayQueues.GetOrAdd(fingerprint, static _ => new ConcurrentQueue<HttpRecordingEntry>());
             queue.Enqueue(entry);
-            _allEntries.Enqueue(entry);
+            _loadedEntries.Enqueue(entry);
         }
     }
 
@@ -28,7 +44,7 @@ internal sealed class RecordingSession
     {
         var fingerprint = _matcher.ComputeFingerprint(requestEntry);
 
-        if (_entriesByFingerprint.TryGetValue(fingerprint, out var queue) && queue.TryDequeue(out match))
+        if (_replayQueues.TryGetValue(fingerprint, out var queue) && queue.TryDequeue(out match))
         {
             return true;
         }
@@ -39,14 +55,23 @@ internal sealed class RecordingSession
 
     public void AddRecordedEntry(HttpRecordingEntry entry)
     {
-        var fingerprint = _matcher.ComputeFingerprint(entry);
-        var queue = _entriesByFingerprint.GetOrAdd(fingerprint, static _ => new ConcurrentQueue<HttpRecordingEntry>());
-        queue.Enqueue(entry);
-        _allEntries.Enqueue(entry);
+        _recordedEntries.Enqueue(entry);
     }
 
-    public IReadOnlyList<HttpRecordingEntry> GetAllEntries()
+    /// <summary>Gets the entries to persist: everything that was loaded, plus everything recorded during this session.</summary>
+    public IReadOnlyList<HttpRecordingEntry> GetEntriesToPersist()
     {
-        return _allEntries.ToArray();
+        var loaded = _loadedEntries.ToArray();
+        var recorded = _recordedEntries.ToArray();
+        if (recorded.Length is 0)
+            return loaded;
+
+        if (loaded.Length is 0)
+            return recorded;
+
+        var result = new HttpRecordingEntry[loaded.Length + recorded.Length];
+        loaded.CopyTo(result, 0);
+        recorded.CopyTo(result, loaded.Length);
+        return result;
     }
 }

--- a/src/Meziantou.Framework.Http.Recording/UriQueryParameterSanitizer.cs
+++ b/src/Meziantou.Framework.Http.Recording/UriQueryParameterSanitizer.cs
@@ -1,0 +1,29 @@
+namespace Meziantou.Framework.Http.Recording;
+
+/// <summary>Replaces the value of the specified query string parameters in the recorded request URI.</summary>
+/// <remarks>
+/// <see cref="HeaderRemovalSanitizer"/> only reaches headers. Secrets frequently travel in the query string
+/// (<c>api_key</c>, <c>sig</c>, <c>token</c>), which this sanitizer redacts. Credentials in the userinfo component
+/// (<c>https://user:password@host/</c>) are removed unconditionally when the request is captured.
+/// </remarks>
+public sealed class UriQueryParameterSanitizer : IHttpRecordingSanitizer
+{
+    private readonly HashSet<string> _parameterNames;
+
+    public UriQueryParameterSanitizer(params string[] parameterNames)
+    {
+        ArgumentNullException.ThrowIfNull(parameterNames);
+        _parameterNames = new HashSet<string>(parameterNames, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public void Sanitize(HttpRecordingEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (_parameterNames.Count is 0)
+            return;
+
+        entry.RequestUri = HttpRecordingUri.MaskQueryParameters(entry.RequestUri, _parameterNames);
+    }
+}

--- a/src/Meziantou.Framework.Http.Recording/readme.md
+++ b/src/Meziantou.Framework.Http.Recording/readme.md
@@ -27,23 +27,21 @@ var store = new HarHttpRecordingStore("http-recordings.har");
 var options = new HttpRecordingOptions
 {
     Mode = HttpRecordingMode.Auto,
-    MissBehavior = HttpRecordingMissBehavior.Throw,
-    Sanitizer = new HeaderRemovalSanitizer("Authorization", "Cookie"),
+    Sanitizers = { new HeaderRemovalSanitizer("Authorization", "Cookie") },
 };
 
 using var innerHandler = new SocketsHttpHandler();
-using var recordingHandler = new HttpRecordingHandler(innerHandler, store, options);
+await using var recordingHandler = new HttpRecordingHandler(innerHandler, store, options);
 using var httpClient = new HttpClient(recordingHandler);
 
-// First run calls the real endpoint and records the response.
+// The first run calls the real endpoint and records the response.
 var response1 = await httpClient.GetAsync("https://api.example.com/data");
-
-// Later calls are replayed when a matching recording exists.
-var response2 = await httpClient.GetAsync("https://api.example.com/data");
 
 // Persist all recordings at the end of the test/session.
 await recordingHandler.SaveAsync();
 ```
+
+On a later run, the recorded response is replayed instead of calling the real endpoint.
 
 ## Replay-only mode
 
@@ -63,11 +61,91 @@ using var httpClient = new HttpClient(recordingHandler);
 var response = await httpClient.GetAsync("https://api.example.com/data");
 ```
 
+The constructor without an inner handler can only be used with `HttpRecordingMode.Replay` and a miss behavior other
+than `Passthrough`: there is nothing to forward a request to. Any other combination throws an `ArgumentException`.
+
+## Matching
+
+A recording is matched by a fingerprint. `DefaultHttpRequestMatcher` uses the HTTP method, the URL with its query
+parameters sorted, and **the request body**. Two `POST`s to the same URL carrying different payloads therefore do not
+match each other, which matters for GraphQL, JSON-RPC, SOAP and batch endpoints.
+
+If the body varies between runs in a way that should not affect matching (a nonce, a timestamp), match on the URL only:
+
+```c#
+var options = new HttpRecordingOptions
+{
+    RequestMatcher = DefaultHttpRequestMatcher.IgnoringRequestBody,
+};
+```
+
+Implement `IHttpRequestMatcher` for anything else. The entry passed to `ComputeFingerprint` carries the method, URI,
+headers and body on both the record and the replay path, so a matcher may read any of them.
+
+**Recordings are consumed in order.** Each stored entry replays at most once, so a request issued three times needs
+three recordings. This is what makes it possible to record an endpoint that returns something different on each call.
+
 ## Miss behavior
 
-When no recorded response matches in replay mode:
+`MissBehavior` controls what happens when no recorded response matches. When it is left unset, the default depends on
+the mode: `Throw` in `Replay` mode, and `Passthrough` in `Auto` mode so that a missing recording gets created.
 
 - `Throw`: throws `HttpRecordingMissException`
 - `ReturnDefault`: returns HTTP 500 with a diagnostic message
-- `Passthrough`: valid in `Auto` mode, not in `Replay` mode
+- `Passthrough`: forwards the request to the inner handler. In `Auto` mode the response is also recorded; in `Replay`
+  mode it is not.
 
+Setting it explicitly applies to `Auto` as well. `Mode = Auto` with `MissBehavior = Throw` replays what has been
+recorded and fails on anything else, without ever performing a real HTTP call:
+
+```c#
+var options = new HttpRecordingOptions
+{
+    Mode = HttpRecordingMode.Auto,
+    MissBehavior = HttpRecordingMissBehavior.Throw,
+};
+```
+
+## Recording modes and the store
+
+- `Record` does not load the existing recordings, so saving **replaces** the content of the store. Use it to refresh
+  recordings against the live API.
+- `Auto` loads the existing recordings and saves them together with whatever was recorded during the session, so the
+  store grows as new interactions are encountered. Entries recorded during a session are not replayed within that same
+  session.
+- `Replay` never writes.
+
+Nothing is written until `SaveAsync` is called. Set `AutoSave = true` and dispose the handler with `await using` to
+save automatically:
+
+```c#
+var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Auto, AutoSave = true };
+await using var recordingHandler = new HttpRecordingHandler(innerHandler, store, options);
+```
+
+Saving is atomic: the file is written next to the destination and moved into place, so an interrupted save cannot
+destroy an existing recording.
+
+## Sanitizing secrets
+
+Recording files are usually committed, so anything secret in a request or response ends up in the repository.
+
+```c#
+var options = new HttpRecordingOptions
+{
+    Sanitizers =
+    {
+        new HeaderRemovalSanitizer("Authorization", "Cookie"),
+        new UriQueryParameterSanitizer("api_key", "sig"),
+    },
+};
+```
+
+- `HeaderRemovalSanitizer` removes headers. It does **not** touch the URL or the bodies.
+- `UriQueryParameterSanitizer` masks the value of the named query string parameters.
+- Credentials in the userinfo component (`https://user:password@host/`) are removed unconditionally when a request is
+  captured.
+- To redact a body, implement `IHttpRecordingSanitizer` and rewrite `entry.RequestBody` / `entry.ResponseBody`.
+
+Sanitizers run on entries before they are persisted **and** on incoming requests before matching, so redacting a value
+the matcher reads (such as a query parameter) does not prevent replay. A sanitizer must therefore be deterministic.

--- a/src/Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj
+++ b/src/Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>HAR 1.2 (HTTP Archive) format parser and writer</Description>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Http.Recording.Tests/DefaultHttpRequestMatcherTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/DefaultHttpRequestMatcherTests.cs
@@ -88,20 +88,59 @@ public sealed class DefaultHttpRequestMatcherTests
     }
 
     [Fact]
-    public void UserInfo_IsIncludedInFingerprint()
+    public void UserInfo_IsIgnoredInFingerprint()
     {
+        // Credentials are stripped when a request is captured, so a hand-written recording that still carries them
+        // must match the same request coming through the handler.
         var entry1 = new HttpRecordingEntry { Method = "GET", RequestUri = "https://example.com/api", StatusCode = 200 };
         var entry2 = new HttpRecordingEntry { Method = "GET", RequestUri = "https://user:password@example.com/api", StatusCode = 200 };
+
+        Assert.Equal(_matcher.ComputeFingerprint(entry1), _matcher.ComputeFingerprint(entry2));
+    }
+
+    [Fact]
+    public void DifferentUserInfo_SameFingerprint()
+    {
+        var entry1 = new HttpRecordingEntry { Method = "GET", RequestUri = "https://user:password1@example.com/api", StatusCode = 200 };
+        var entry2 = new HttpRecordingEntry { Method = "GET", RequestUri = "https://user:password2@example.com/api", StatusCode = 200 };
+
+        Assert.Equal(_matcher.ComputeFingerprint(entry1), _matcher.ComputeFingerprint(entry2));
+    }
+
+    [Fact]
+    public void DifferentRequestBody_DifferentFingerprint()
+    {
+        var entry1 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/graphql", StatusCode = 200, RequestBody = """{"query":"getUser"}"""u8.ToArray() };
+        var entry2 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/graphql", StatusCode = 200, RequestBody = """{"query":"deleteAll"}"""u8.ToArray() };
 
         Assert.NotEqual(_matcher.ComputeFingerprint(entry1), _matcher.ComputeFingerprint(entry2));
     }
 
     [Fact]
-    public void DifferentUserInfo_DifferentFingerprint()
+    public void SameRequestBody_SameFingerprint()
     {
-        var entry1 = new HttpRecordingEntry { Method = "GET", RequestUri = "https://user:password1@example.com/api", StatusCode = 200 };
-        var entry2 = new HttpRecordingEntry { Method = "GET", RequestUri = "https://user:password2@example.com/api", StatusCode = 200 };
+        var entry1 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/graphql", StatusCode = 200, RequestBody = "payload"u8.ToArray() };
+        var entry2 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/graphql", StatusCode = 200, RequestBody = "payload"u8.ToArray() };
 
-        Assert.NotEqual(_matcher.ComputeFingerprint(entry1), _matcher.ComputeFingerprint(entry2));
+        Assert.Equal(_matcher.ComputeFingerprint(entry1), _matcher.ComputeFingerprint(entry2));
+    }
+
+    [Fact]
+    public void EmptyAndMissingRequestBody_SameFingerprint()
+    {
+        var entry1 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/api", StatusCode = 200, RequestBody = [] };
+        var entry2 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/api", StatusCode = 200 };
+
+        Assert.Equal(_matcher.ComputeFingerprint(entry1), _matcher.ComputeFingerprint(entry2));
+    }
+
+    [Fact]
+    public void IgnoringRequestBody_DifferentBodies_SameFingerprint()
+    {
+        var matcher = DefaultHttpRequestMatcher.IgnoringRequestBody;
+        var entry1 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/api", StatusCode = 200, RequestBody = "a"u8.ToArray() };
+        var entry2 = new HttpRecordingEntry { Method = "POST", RequestUri = "https://example.com/api", StatusCode = 200, RequestBody = "b"u8.ToArray() };
+
+        Assert.Equal(matcher.ComputeFingerprint(entry1), matcher.ComputeFingerprint(entry2));
     }
 }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Meziantou.Framework.HttpArchive;
 
 namespace Meziantou.Framework.Http.Recording.Tests;
@@ -177,5 +178,176 @@ public sealed class HarHttpRecordingStoreTests
         var loaded = await store.LoadAsync(CancellationToken.None);
         var loadedEntry = Assert.Single(loaded);
         Assert.Equal(requestBody, loadedEntry.RequestBody);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Canceled_DoesNotDestroyTheExistingFile()
+    {
+        using var temporaryFile = TemporaryFile.Create("recordings.har");
+        var filePath = (string)temporaryFile;
+        var store = new HarHttpRecordingStore(filePath);
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api", StatusCode = 200, ResponseBody = "hi"u8.ToArray() },
+        };
+        await store.SaveAsync(entries, CancellationToken.None);
+        var original = await File.ReadAllTextAsync(filePath);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await store.SaveAsync(entries, cts.Token));
+
+        Assert.Equal(original, await File.ReadAllTextAsync(filePath));
+        Assert.Single(await store.LoadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullLog_ThrowsInsteadOfReportingNoRecordings()
+    {
+        using var temporaryFile = TemporaryFile.Create("no-log.har");
+        var filePath = (string)temporaryFile;
+        await File.WriteAllTextAsync(filePath, "{\"log\":null}");
+
+        var store = new HarHttpRecordingStore(filePath);
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(async () => await store.LoadAsync(CancellationToken.None));
+        Assert.Contains("no-log.har", exception.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyLog_ReturnsNoRecordings()
+    {
+        using var temporaryFile = TemporaryFile.Create("empty-log.har");
+        var filePath = (string)temporaryFile;
+        await File.WriteAllTextAsync(filePath, "{}");
+
+        // An empty entries list is a legitimately empty recording, not a damaged file.
+        var store = new HarHttpRecordingStore(filePath);
+        Assert.Empty(await store.LoadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task LoadAsync_MalformedBase64ResponseBody_ReportsNoBodyInsteadOfThrowing()
+    {
+        using var temporaryFile = TemporaryFile.Create("bad-base64.har");
+        var filePath = (string)temporaryFile;
+        await File.WriteAllTextAsync(filePath, """
+            {"log":{"version":"1.2","entries":[{"startedDateTime":"2024-01-01T00:00:00Z",
+            "request":{"method":"GET","url":"https://example.com/api"},
+            "response":{"status":200,"content":{"size":3,"mimeType":"application/octet-stream","encoding":"base64","text":"not valid base64 !!"}}}]}}
+            """);
+
+        var store = new HarHttpRecordingStore(filePath);
+        var entry = Assert.Single(await store.LoadAsync(CancellationToken.None));
+        Assert.Null(entry.ResponseBody);
+    }
+
+    [Fact]
+    public async Task LoadAsync_UnknownContentEncoding_ReportsNoBodyInsteadOfCorruptingIt()
+    {
+        using var temporaryFile = TemporaryFile.Create("gzip-encoding.har");
+        var filePath = (string)temporaryFile;
+        await File.WriteAllTextAsync(filePath, """
+            {"log":{"version":"1.2","entries":[{"startedDateTime":"2024-01-01T00:00:00Z",
+            "request":{"method":"GET","url":"https://example.com/api"},
+            "response":{"status":200,"content":{"size":3,"mimeType":"application/json","encoding":"gzip","text":"H4sIAAAA"}}}]}}
+            """);
+
+        var store = new HarHttpRecordingStore(filePath);
+        var entry = Assert.Single(await store.LoadAsync(CancellationToken.None));
+        Assert.Null(entry.ResponseBody);
+    }
+
+    [Fact]
+    public async Task RoundTrip_BinaryResponseBody()
+    {
+        using var temporaryFile = TemporaryFile.Create("binary.har");
+        var filePath = (string)temporaryFile;
+        var store = new HarHttpRecordingStore(filePath);
+        var body = new byte[] { 0x00, 0xFF, 0x10, 0x80, 0x7F };
+        var entries = new List<HttpRecordingEntry>
+        {
+            new()
+            {
+                Method = "GET",
+                RequestUri = "https://example.com/image",
+                StatusCode = 200,
+                ResponseHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase) { ["Content-Type"] = ["image/png"] },
+                ResponseBody = body,
+            },
+        };
+
+        await store.SaveAsync(entries, CancellationToken.None);
+        var loaded = Assert.Single(await store.LoadAsync(CancellationToken.None));
+
+        Assert.Equal(body, loaded.ResponseBody);
+    }
+
+    [Fact]
+    public async Task RoundTrip_PreservesReasonPhraseAndHttpVersion()
+    {
+        using var temporaryFile = TemporaryFile.Create("metadata.har");
+        var filePath = (string)temporaryFile;
+        var store = new HarHttpRecordingStore(filePath);
+        var entries = new List<HttpRecordingEntry>
+        {
+            new()
+            {
+                Method = "GET",
+                RequestUri = "https://example.com/api",
+                StatusCode = 599,
+                ReasonPhrase = "Vendor Failure",
+                HttpVersion = "2.0",
+            },
+        };
+
+        await store.SaveAsync(entries, CancellationToken.None);
+        var loaded = Assert.Single(await store.LoadAsync(CancellationToken.None));
+
+        Assert.Equal("Vendor Failure", loaded.ReasonPhrase);
+        Assert.Equal("2.0", loaded.HttpVersion);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesUnknownSizesAsMinusOne()
+    {
+        using var temporaryFile = TemporaryFile.Create("sizes.har");
+        var filePath = (string)temporaryFile;
+        var store = new HarHttpRecordingStore(filePath);
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api", StatusCode = 200, ResponseBody = "hello"u8.ToArray() },
+        };
+
+        await store.SaveAsync(entries, CancellationToken.None);
+
+        await using var stream = File.OpenRead(filePath);
+        var doc = await HarDocument.ParseAsync(stream, CancellationToken.None);
+        var harEntry = Assert.Single(doc.Log!.Entries!);
+
+        // HAR 1.2 uses -1 for "not available"; 0 would be a factual claim that tooling plots.
+        Assert.Equal(-1, harEntry.Request!.HeadersSize);
+        Assert.Equal(-1, harEntry.Request.BodySize);
+        Assert.Equal(-1, harEntry.Response!.HeadersSize);
+        Assert.Equal(5, harEntry.Response.BodySize);
+        Assert.Equal(-1, harEntry.Time);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesTheAssemblyVersionAsCreatorVersion()
+    {
+        using var temporaryFile = TemporaryFile.Create("creator.har");
+        var filePath = (string)temporaryFile;
+        var store = new HarHttpRecordingStore(filePath);
+        await store.SaveAsync([new() { Method = "GET", RequestUri = "https://example.com/api", StatusCode = 200 }], CancellationToken.None);
+
+        await using var stream = File.OpenRead(filePath);
+        var doc = await HarDocument.ParseAsync(stream, CancellationToken.None);
+
+        var informationalVersion = typeof(HarHttpRecordingStore).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+            .InformationalVersion;
+        var expected = informationalVersion.Split('+')[0];
+
+        Assert.Equal(expected, doc.Log!.Creator!.Version);
     }
 }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HttpRecordingHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HttpRecordingHandlerTests.cs
@@ -169,7 +169,7 @@ public sealed class HttpRecordingHandlerTests
         var options = new HttpRecordingOptions
         {
             Mode = HttpRecordingMode.Record,
-            Sanitizer = new HeaderRemovalSanitizer("Authorization"),
+            Sanitizers = { new HeaderRemovalSanitizer("Authorization") },
         };
 
         using var handler = CreateHandler(innerHandler, store, options);
@@ -438,6 +438,633 @@ public sealed class HttpRecordingHandlerTests
         return (app, new Uri(address));
     }
 
+    [Fact]
+    public async Task AutoMode_MissBehaviorThrow_DoesNotCallInnerHandler()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Auto,
+            MissBehavior = HttpRecordingMissBehavior.Throw,
+        };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        await Assert.ThrowsAsync<HttpRecordingMissException>(() => client.GetAsync("/api/data"));
+        Assert.Equal(0, innerHandler.CallCount);
+    }
+
+    [Fact]
+    public async Task AutoMode_MissBehaviorReturnDefault_DoesNotCallInnerHandler()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Auto,
+            MissBehavior = HttpRecordingMissBehavior.ReturnDefault,
+        };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal(0, innerHandler.CallCount);
+    }
+
+    [Fact]
+    public async Task AutoMode_DefaultMissBehavior_RecordsRealCall()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Auto };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, innerHandler.CallCount);
+
+        await handler.SaveAsync();
+        Assert.Single(store.SavedEntries);
+    }
+
+    [Fact]
+    public async Task AutoMode_TwoIdenticalRequests_RecordBothAndReplayLater()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Auto };
+
+        using (var handler = CreateHandler(innerHandler, store, options))
+        {
+            using var client = CreateClient(handler);
+            using var response1 = await client.GetAsync("/api/poll");
+            using var response2 = await client.GetAsync("/api/poll");
+            await handler.SaveAsync();
+        }
+
+        // A recorded entry must not be replayed within the session that produced it, otherwise the second request
+        // consumes the first one's recording and the file cannot replay its own scenario.
+        Assert.Equal(2, innerHandler.CallCount);
+        Assert.HasCount(2, store.SavedEntries);
+
+        var replayStore = new InMemoryRecordingStore(store.SavedEntries);
+        using var replayInner = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var replayHandler = CreateHandler(replayInner, replayStore, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var replayClient = CreateClient(replayHandler);
+
+        using var replayed1 = await replayClient.GetAsync("/api/poll");
+        using var replayed2 = await replayClient.GetAsync("/api/poll");
+        Assert.Equal(HttpStatusCode.OK, replayed1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, replayed2.StatusCode);
+        Assert.Equal(0, replayInner.CallCount);
+    }
+
+    [Fact]
+    public async Task RecordMode_ReplacesExistingEntries_DoesNotAppend()
+    {
+        var existing = new List<HttpRecordingEntry>
+        {
+            new()
+            {
+                Method = "GET",
+                RequestUri = "https://example.com/api/data",
+                StatusCode = 200,
+                ResponseBody = "stale"u8.ToArray(),
+            },
+        };
+        var store = new InMemoryRecordingStore(existing);
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "fresh");
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Record };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+        await handler.SaveAsync();
+
+        var entry = Assert.Single(store.SavedEntries);
+        Assert.Equal("fresh", System.Text.Encoding.UTF8.GetString(entry.ResponseBody!));
+    }
+
+    [Fact]
+    public async Task ReplayMode_DifferentPostBodies_ReturnTheirOwnResponse()
+    {
+        var store = new InMemoryRecordingStore();
+        using (var recordInner = new EchoHttpHandler())
+        using (var recordHandler = CreateHandler(recordInner, store, new HttpRecordingOptions { Mode = HttpRecordingMode.Record }))
+        {
+            using var recordClient = CreateClient(recordHandler);
+            using var recordGetUser = new StringContent("{getUser}");
+            using var first = await recordClient.PostAsync("/graphql", recordGetUser);
+            using var recordDeleteAll = new StringContent("{deleteAll}");
+            using var second = await recordClient.PostAsync("/graphql", recordDeleteAll);
+            await recordHandler.SaveAsync();
+        }
+
+        var replayStore = new InMemoryRecordingStore(store.SavedEntries);
+        using var replayInner = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(replayInner, replayStore, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var client = CreateClient(handler);
+
+        // Requested in the opposite order: matching on the body must not hand back the other query's response.
+        using var deleteAllContent = new StringContent("{deleteAll}");
+        using var deleteAll = await client.PostAsync("/graphql", deleteAllContent);
+        using var getUserContent = new StringContent("{getUser}");
+        using var getUser = await client.PostAsync("/graphql", getUserContent);
+
+        Assert.Equal("echo:{deleteAll}", await deleteAll.Content.ReadAsStringAsync());
+        Assert.Equal("echo:{getUser}", await getUser.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task CustomMatcher_CanMatchOnRequestBody()
+    {
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Record,
+            RequestMatcher = new RequestBodyMatcher(),
+        };
+
+        using (var recordInner = new EchoHttpHandler())
+        using (var recordHandler = CreateHandler(recordInner, store, options))
+        {
+            using var recordClient = CreateClient(recordHandler);
+            using var recordContent = new StringContent("{getUser}");
+            using var recorded = await recordClient.PostAsync("/graphql", recordContent);
+            await recordHandler.SaveAsync();
+        }
+
+        var replayStore = new InMemoryRecordingStore(store.SavedEntries);
+        using var replayInner = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(replayInner, replayStore, new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Replay,
+            RequestMatcher = new RequestBodyMatcher(),
+        });
+        using var client = CreateClient(handler);
+
+        using var replayContent = new StringContent("{getUser}");
+        using var response = await client.PostAsync("/graphql", replayContent);
+        Assert.Equal("echo:{getUser}", await response.Content.ReadAsStringAsync());
+        Assert.Equal(0, replayInner.CallCount);
+    }
+
+    [Fact]
+    public async Task Sanitizer_IsAppliedToLookupEntry_SoCustomMatcherStillMatches()
+    {
+        var store = new InMemoryRecordingStore();
+        var recordOptions = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Record,
+            RequestMatcher = new AuthorizationHeaderMatcher(),
+            Sanitizers = { new HeaderRemovalSanitizer("Authorization") },
+        };
+
+        using (var recordInner = new FakeHttpHandler(HttpStatusCode.OK, "recorded"))
+        using (var recordHandler = CreateHandler(recordInner, store, recordOptions))
+        {
+            using var recordClient = CreateClient(recordHandler);
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/api/data");
+            request.Headers.Add("Authorization", "Bearer secret");
+            using var recorded = await recordClient.SendAsync(request);
+            await recordHandler.SaveAsync();
+        }
+
+        var replayStore = new InMemoryRecordingStore(store.SavedEntries);
+        using var replayInner = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(replayInner, replayStore, new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Replay,
+            RequestMatcher = new AuthorizationHeaderMatcher(),
+            Sanitizers = { new HeaderRemovalSanitizer("Authorization") },
+        });
+        using var client = CreateClient(handler);
+
+        using var replayRequest = new HttpRequestMessage(HttpMethod.Get, "/api/data");
+        replayRequest.Headers.Add("Authorization", "Bearer secret");
+        using var response = await client.SendAsync(replayRequest);
+
+        Assert.Equal("recorded", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task UriQueryParameterSanitizer_RedactsSecretAndStillReplays()
+    {
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Record,
+            Sanitizers = { new UriQueryParameterSanitizer("api_key") },
+        };
+
+        using (var recordInner = new FakeHttpHandler(HttpStatusCode.OK, "recorded"))
+        using (var recordHandler = CreateHandler(recordInner, store, options))
+        {
+            using var recordClient = CreateClient(recordHandler);
+            using var recorded = await recordClient.GetAsync("/api/data?api_key=SUPERSECRET&page=1");
+            await recordHandler.SaveAsync();
+        }
+
+        var entry = Assert.Single(store.SavedEntries);
+        Assert.DoesNotContain("SUPERSECRET", entry.RequestUri);
+        Assert.Contains("page=1", entry.RequestUri);
+
+        var replayStore = new InMemoryRecordingStore(store.SavedEntries);
+        using var replayInner = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(replayInner, replayStore, new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Replay,
+            Sanitizers = { new UriQueryParameterSanitizer("api_key") },
+        });
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data?api_key=SUPERSECRET&page=1");
+        Assert.Equal("recorded", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task RecordMode_StripsCredentialsFromRequestUri()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK);
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Record };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("https://user:password@example.com/api/data");
+        await handler.SaveAsync();
+
+        var entry = Assert.Single(store.SavedEntries);
+        Assert.DoesNotContain("password", entry.RequestUri);
+    }
+
+    [Fact]
+    public async Task RecordMode_NonSeekableStreamContent_IsRecorded()
+    {
+        using var innerHandler = new ConsumingHttpHandler();
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Record };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        using var content = new StreamContent(new NonSeekableStream("payload-bytes"u8.ToArray()));
+        using var response = await client.PostAsync("/api/upload", content);
+
+        await handler.SaveAsync();
+        var entry = Assert.Single(store.SavedEntries);
+        Assert.Equal("payload-bytes", System.Text.Encoding.UTF8.GetString(entry.RequestBody!));
+    }
+
+    [Fact]
+    public async Task RecordMode_WhenRecordingFails_DisposesTheResponse()
+    {
+        using var content = new DisposeTrackingContent("body");
+        using var innerHandler = new FakeHttpHandler(() => new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Record,
+            Sanitizers = { new ThrowingSanitizer() },
+        };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetAsync("/api/data"));
+
+        // The response never reaches the caller, so the handler must dispose it rather than leak its connection.
+        Assert.True(content.IsDisposed);
+    }
+
+    [Fact]
+    public async Task ReplayMode_ResponseCarriesTheRequestMessage()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api/data", StatusCode = 200 },
+        };
+        var store = new InMemoryRecordingStore(entries);
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(innerHandler, store, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+
+        Assert.NotNull(response.RequestMessage);
+        Assert.Equal(new Uri("https://example.com/api/data"), response.RequestMessage.RequestUri);
+    }
+
+    [Fact]
+    public async Task ReplayMode_RoundTripsReasonPhraseAndVersion()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new()
+            {
+                Method = "GET",
+                RequestUri = "https://example.com/api/data",
+                StatusCode = 599,
+                ReasonPhrase = "Vendor Failure",
+                HttpVersion = "2.0",
+            },
+        };
+        var store = new InMemoryRecordingStore(entries);
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(innerHandler, store, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+
+        Assert.Equal(599, (int)response.StatusCode);
+        Assert.Equal("Vendor Failure", response.ReasonPhrase);
+        Assert.Equal(new Version(2, 0), response.Version);
+    }
+
+    [Fact]
+    public async Task ReplayMode_IgnoresRecordedContentLength()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new()
+            {
+                Method = "GET",
+                RequestUri = "https://example.com/api/data",
+                StatusCode = 200,
+                ResponseHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Content-Type"] = ["application/json; charset=utf-8"],
+                    ["Content-Length"] = ["99999"],
+                },
+                ResponseBody = "hello"u8.ToArray(),
+            },
+        };
+        var store = new InMemoryRecordingStore(entries);
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(innerHandler, store, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+
+        Assert.Equal(5, response.Content.Headers.ContentLength);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("utf-8", response.Content.Headers.ContentType?.CharSet);
+        Assert.Equal("hello", await response.Content.ReadAsStringAsync());
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1000)]
+    public async Task ReplayMode_OutOfRangeStatusCode_ThrowsDiagnosableError(int statusCode)
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api/data", StatusCode = statusCode },
+        };
+        var store = new InMemoryRecordingStore(entries);
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(innerHandler, store, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var client = CreateClient(handler);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetAsync("/api/data"));
+        Assert.Contains("out-of-range status code", exception.Message);
+    }
+
+    [Fact]
+    public async Task ReplayMode_CanceledToken_Throws()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api/data", StatusCode = 200 },
+        };
+        var store = new InMemoryRecordingStore(entries);
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.InternalServerError);
+        using var handler = CreateHandler(innerHandler, store, new HttpRecordingOptions { Mode = HttpRecordingMode.Replay });
+        using var client = CreateClient(handler);
+        await handler.InitializeAsync();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync("/api/data", cts.Token));
+    }
+
+    [Fact]
+    public async Task ReplayMode_Passthrough_CallsInnerHandlerWithoutRecording()
+    {
+        var store = new InMemoryRecordingStore();
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Replay,
+            MissBehavior = HttpRecordingMissBehavior.Passthrough,
+        };
+
+        using var handler = CreateHandler(innerHandler, store, options);
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+        Assert.Equal("live", await response.Content.ReadAsStringAsync());
+        Assert.Equal(1, innerHandler.CallCount);
+
+        await handler.SaveAsync();
+        Assert.Empty(store.SavedEntries);
+    }
+
+    [Theory]
+    [InlineData(HttpRecordingMode.Record)]
+    [InlineData(HttpRecordingMode.Auto)]
+    public void Constructor_WithoutInnerHandler_RequiresReplayMode(HttpRecordingMode mode)
+    {
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = mode };
+
+        var exception = Assert.Throws<ArgumentException>(() => new HttpRecordingHandler(store, options));
+        Assert.Contains(nameof(HttpRecordingMode.Replay), exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithoutInnerHandler_RejectsPassthrough()
+    {
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions
+        {
+            Mode = HttpRecordingMode.Replay,
+            MissBehavior = HttpRecordingMissBehavior.Passthrough,
+        };
+
+        Assert.Throws<ArgumentException>(() => new HttpRecordingHandler(store, options));
+    }
+
+    [Fact]
+    public async Task Constructor_WithoutInnerHandler_ReplaysWithoutTouchingTheNetwork()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api/data", StatusCode = 204 },
+        };
+        var store = new InMemoryRecordingStore(entries);
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Replay };
+
+        using var handler = new HttpRecordingHandler(store, options);
+        using var client = CreateClient(handler);
+
+        using var response = await client.GetAsync("/api/data");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AutoSave_SavesOnAsyncDispose()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Auto, AutoSave = true };
+
+        await using (var handler = CreateHandler(innerHandler, store, options))
+        {
+            using var client = CreateClient(handler);
+            using var response = await client.GetAsync("/api/data");
+        }
+
+        Assert.Single(store.SavedEntries);
+    }
+
+    [Fact]
+    public async Task WithoutAutoSave_AsyncDisposeSavesNothing()
+    {
+        using var innerHandler = new FakeHttpHandler(HttpStatusCode.OK, "live");
+        var store = new InMemoryRecordingStore();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Auto };
+
+        await using (var handler = CreateHandler(innerHandler, store, options))
+        {
+            using var client = CreateClient(handler);
+            using var response = await client.GetAsync("/api/data");
+        }
+
+        Assert.Empty(store.SavedEntries);
+    }
+
+    private sealed class EchoHttpHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("echo:" + body) };
+        }
+    }
+
+    /// <summary>An inner handler that consumes the request body the way a real transport does, instead of buffering it.</summary>
+    private sealed class ConsumingHttpHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            if (request.Content is not null)
+            {
+                await request.Content.CopyToAsync(Stream.Null, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+        }
+    }
+
+    private sealed class NonSeekableStream(byte[] data) : Stream
+    {
+        private readonly MemoryStream _inner = new(data);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class DisposeTrackingContent : HttpContent
+    {
+        private readonly byte[] _data;
+
+        public DisposeTrackingContent(string text)
+        {
+            _data = System.Text.Encoding.UTF8.GetBytes(text);
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => stream.WriteAsync(_data, 0, _data.Length);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _data.Length;
+            return true;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                IsDisposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class ThrowingSanitizer : IHttpRecordingSanitizer
+    {
+        public void Sanitize(HttpRecordingEntry entry) => throw new InvalidOperationException("Sanitizer failed");
+    }
+
+    private sealed class RequestBodyMatcher : IHttpRequestMatcher
+    {
+        public string ComputeFingerprint(HttpRecordingEntry entry)
+        {
+            var body = entry.RequestBody is null ? "<none>" : Convert.ToBase64String(entry.RequestBody);
+            return $"{entry.Method} {entry.RequestUri} body={body}";
+        }
+    }
+
+    private sealed class AuthorizationHeaderMatcher : IHttpRequestMatcher
+    {
+        public string ComputeFingerprint(HttpRecordingEntry entry)
+        {
+            var authorization = entry.RequestHeaders is not null && entry.RequestHeaders.TryGetValue("Authorization", out var values)
+                ? string.Join(",", values)
+                : "<none>";
+            return $"{entry.Method} {entry.RequestUri} auth={authorization}";
+        }
+    }
+
     private sealed class FakeHttpHandler : HttpMessageHandler
     {
         private readonly Func<HttpResponseMessage> _responseFactory;
@@ -452,7 +1079,7 @@ public sealed class HttpRecordingHandlerTests
         {
         }
 
-        private FakeHttpHandler(Func<HttpResponseMessage> responseFactory)
+        public FakeHttpHandler(Func<HttpResponseMessage> responseFactory)
         {
             _responseFactory = responseFactory;
         }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/JsonHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/JsonHttpRecordingStoreTests.cs
@@ -111,4 +111,90 @@ public sealed class JsonHttpRecordingStoreTests : IDisposable
         Assert.Single(loaded);
         Assert.Equal("POST", loaded[0].Method);
     }
+
+    [Fact]
+    public async Task SaveAsync_Canceled_DoesNotDestroyTheExistingFile()
+    {
+        var filePath = Path.Combine(_tempDir, "recordings.json");
+        var store = new JsonHttpRecordingStore(filePath);
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api", StatusCode = 200, ResponseBody = "hi"u8.ToArray() },
+        };
+        await store.SaveAsync(entries, CancellationToken.None);
+        var original = await File.ReadAllTextAsync(filePath);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await store.SaveAsync(entries, cts.Token));
+
+        Assert.Equal(original, await File.ReadAllTextAsync(filePath));
+        Assert.Single(await store.LoadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SaveAsync_LeavesNoTemporaryFileBehind()
+    {
+        var filePath = Path.Combine(_tempDir, "recordings.json");
+        var store = new JsonHttpRecordingStore(filePath);
+        await store.SaveAsync([new() { Method = "GET", RequestUri = "https://example.com/api", StatusCode = 200 }], CancellationToken.None);
+
+        Assert.Single(Directory.GetFiles(_tempDir));
+    }
+
+    [Fact]
+    public async Task LoadAsync_MalformedJson_ThrowsNamingTheFile()
+    {
+        var filePath = Path.Combine(_tempDir, "broken.json");
+        await File.WriteAllTextAsync(filePath, "[{\"method\": \"GET\"");
+        var store = new JsonHttpRecordingStore(filePath);
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(async () => await store.LoadAsync(CancellationToken.None));
+        Assert.Contains("broken.json", exception.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullDocument_ThrowsInsteadOfReportingNoRecordings()
+    {
+        var filePath = Path.Combine(_tempDir, "null.json");
+        await File.WriteAllTextAsync(filePath, "null");
+        var store = new JsonHttpRecordingStore(filePath);
+
+        await Assert.ThrowsAsync<InvalidDataException>(async () => await store.LoadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task LoadAsync_EntryWithoutMethod_ThrowsNamingTheIndex()
+    {
+        var filePath = Path.Combine(_tempDir, "bad-entry.json");
+        await File.WriteAllTextAsync(filePath, "[{\"method\": null, \"requestUri\": \"https://example.com/api\", \"statusCode\": 200}]");
+        var store = new JsonHttpRecordingStore(filePath);
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(async () => await store.LoadAsync(CancellationToken.None));
+        Assert.Contains("index 0", exception.Message);
+    }
+
+    [Fact]
+    public async Task RoundTrip_PreservesReasonPhraseAndHttpVersion()
+    {
+        var filePath = Path.Combine(_tempDir, "recordings.json");
+        var store = new JsonHttpRecordingStore(filePath);
+        var entries = new List<HttpRecordingEntry>
+        {
+            new()
+            {
+                Method = "GET",
+                RequestUri = "https://example.com/api",
+                StatusCode = 599,
+                ReasonPhrase = "Vendor Failure",
+                HttpVersion = "2.0",
+            },
+        };
+
+        await store.SaveAsync(entries, CancellationToken.None);
+        var loaded = Assert.Single(await store.LoadAsync(CancellationToken.None));
+
+        Assert.Equal("Vendor Failure", loaded.ReasonPhrase);
+        Assert.Equal("2.0", loaded.HttpVersion);
+    }
 }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/ThreadSafetyTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/ThreadSafetyTests.cs
@@ -57,7 +57,7 @@ public sealed class ThreadSafetyTests
     }
 
     [Fact]
-    public async Task ConcurrentReplay_FIFO_IdenticalRequests()
+    public async Task ConcurrentReplay_EachRecordingHandedOutExactlyOnce()
     {
         const int RequestCount = 10;
 
@@ -80,18 +80,129 @@ public sealed class ThreadSafetyTests
         using var handler = new HttpRecordingHandler(innerHandler, store, options);
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        // Make requests sequentially to verify FIFO order
-        var bodies = new List<string>();
-        for (var i = 0; i < RequestCount; i++)
+        // Contend on the single queue that backs this fingerprint: every recording must be handed out exactly once,
+        // with none duplicated and none lost.
+        var bodies = new ConcurrentBag<string>();
+        await Parallel.ForAsync(0, RequestCount, async (_, token) =>
         {
-            using var response = await client.GetAsync("/api/same");
-            bodies.Add(await response.Content.ReadAsStringAsync());
+            using var response = await client.GetAsync("/api/same", token);
+            bodies.Add(await response.Content.ReadAsStringAsync(token));
+        });
+
+        var expected = Enumerable.Range(0, RequestCount).Select(i => $"response-{i}").Order(StringComparer.Ordinal);
+        Assert.Equal(expected, bodies.Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task ConcurrentReplay_ExhaustedRecordings_ThrowMiss()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api/same", StatusCode = 200 },
+        };
+
+        var store = new InMemoryStore(entries);
+        using var innerHandler = new FakeHandler();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Replay };
+
+        using var handler = new HttpRecordingHandler(innerHandler, store, options);
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+
+        var successes = 0;
+        var misses = 0;
+        await Parallel.ForAsync(0, 8, async (_, token) =>
+        {
+            try
+            {
+                using var response = await client.GetAsync("/api/same", token);
+                Interlocked.Increment(ref successes);
+            }
+            catch (HttpRecordingMissException)
+            {
+                Interlocked.Increment(ref misses);
+            }
+        });
+
+        Assert.Equal(1, successes);
+        Assert.Equal(7, misses);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WaitsForInFlightRecording()
+    {
+        var store = new InMemoryStore([]);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var innerHandler = new BlockingHandler(entered, release);
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Record };
+
+        using var handler = new HttpRecordingHandler(innerHandler, store, options);
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+
+        var requestTask = client.GetAsync("/api/slow");
+        await entered.Task;
+
+        var saveTask = handler.SaveAsync();
+        release.SetResult();
+
+        using var response = await requestTask;
+        await saveTask;
+
+        // Saving while a request was still being recorded must not persist a snapshot that omits it, because the
+        // store has already replaced whatever it held before.
+        Assert.Single(store.SavedEntries);
+    }
+
+    [Fact]
+    public async Task DisposeDuringInFlightRequest_DoesNotMaskTheResult()
+    {
+        var entries = new List<HttpRecordingEntry>
+        {
+            new() { Method = "GET", RequestUri = "https://example.com/api/data", StatusCode = 204 },
+        };
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new BlockingLoadStore(entries, entered, release);
+
+        using var innerHandler = new FakeHandler();
+        var options = new HttpRecordingOptions { Mode = HttpRecordingMode.Replay };
+
+        var handler = new HttpRecordingHandler(innerHandler, store, options);
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+
+        var requestTask = client.GetAsync("/api/data");
+        await entered.Task;
+
+        // Disposing while a request holds the initialization lock must not turn the result into an
+        // ObjectDisposedException raised from a finally block.
+        handler.Dispose();
+        release.SetResult();
+
+        using var response = await requestTask;
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private sealed class BlockingHandler(TaskCompletionSource entered, TaskCompletionSource release) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            entered.TrySetResult();
+            await release.Task;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+        }
+    }
+
+    private sealed class BlockingLoadStore(List<HttpRecordingEntry> entries, TaskCompletionSource entered, TaskCompletionSource release) : IHttpRecordingStore
+    {
+        public async ValueTask<IReadOnlyList<HttpRecordingEntry>> LoadAsync(CancellationToken cancellationToken)
+        {
+            entered.TrySetResult();
+            await release.Task;
+            return entries;
         }
 
-        for (var i = 0; i < RequestCount; i++)
-        {
-            Assert.Equal($"response-{i}", bodies[i]);
-        }
+        public ValueTask SaveAsync(IReadOnlyList<HttpRecordingEntry> entries, CancellationToken cancellationToken) => default;
     }
 
     [Fact]


### PR DESCRIPTION
An audit of `Meziantou.Framework.Http.Recording` found that the recorder could silently return the **wrong** recorded response, silently perform **real HTTP calls** from tests meant to be hermetic, and **destroy an existing recording file**. This fixes those and the remaining findings.

Every behavior below was reproduced against the compiled library before the fix and re-verified after.

## The three that matter most

**Request bodies were invisible to matching.** `DefaultHttpRequestMatcher` keyed on method + URL only, so two POSTs to the same URL were interchangeable — a recording made for `{getUser}` was returned, with no error, as the response to `{deleteAll}`. The documented escape hatch was broken too: the entry handed to a custom `IHttpRequestMatcher` never carried `RequestBody`, so a body-aware matcher missed 100% of the time. GraphQL, JSON-RPC, SOAP and batch endpoints were unusable, with no workaround.

**The session never distinguished loaded / recorded / replayed entries.** One root cause behind four user-visible bugs: Auto mode consumed the entry it had just recorded (two identical calls recorded one interaction, and the resulting file could not replay its own scenario), `MissBehavior` was unreachable in Auto so `Mode = Auto, MissBehavior = Throw` — the old readme's headline example — silently called the live endpoint, Record mode appended instead of replacing, and the stale entry won on replay.

**A cancelled or failed `SaveAsync` destroyed the cassette.** Both stores opened the destination with `File.Create`, truncating it before serializing anything. A test timeout turned a valid 94-byte recording into 0 bytes.

## Before / after

| Behavior | Before | After |
|---|---|---|
| POSTs differing only in body | wrong response, no error | correct response |
| Custom body-aware matcher | misses every time | replays |
| `Auto` + `Throw` | real network call | 0 network hits |
| 2 identical calls in Auto | 1 entry, unreplayable | 2 entries, replays |
| Re-recording 3× | 1 → 2 → 3 entries | 1, 1, 1 |
| Sanitizer + custom matcher | permanent miss | replays |
| `api_key` in the URL | written to the file | redacted, still replays |
| Non-seekable `StreamContent` | threw after the request was sent | recorded |
| Cancelled save | file truncated to 0 bytes | file intact |
| `"method": null` in a file | `NullReferenceException` | `InvalidDataException` naming file and index |

## Also fixed

- Sanitizers now run on the lookup entry too, so redacting a value the matcher reads no longer breaks replay permanently.
- Userinfo is stripped at capture, so credentials never reach a recording.
- A failure while recording disposes the response instead of leaking it and its pooled connection.
- `SaveAsync` waits for in-flight recordings before snapshotting.
- The handler no longer disposes its semaphore, which could replace a real exception with `ObjectDisposedException` thrown from a `finally`.
- Loading is all-or-nothing; cancellation is observed on replay; store loading is no longer billed to `HttpClient.Timeout`.
- Reason phrase and HTTP version round-trip; a recorded `Content-Length` no longer overrides the real body length; out-of-range status codes get a diagnosable message.
- HAR: response bodies use the shared decoding helper (malformed base64 and unknown encodings report no body instead of throwing or corrupting), `-1` for unknown sizes per the spec, real assembly version as creator version.
- `Passthrough` is implemented in Replay mode instead of throwing; the store-only constructor validates its options up front.

## Breaking changes — version moves to 3.0.0

1. **`HttpRecordingOptions.MissBehavior` is now `HttpRecordingMissBehavior?`.** Honoring `Throw` in Auto while keeping `Throw` the default would have made Auto unable to record anything. Unset means `Passthrough` in Auto and `Throw` in Replay; setting it explicitly applies in both, so `Auto` + `Throw` is now genuinely hermetic.
2. **`Sanitizer` → `Sanitizers` collection**, plus a new `UriQueryParameterSanitizer`. Header-only redaction was the root of the secret-leak finding, and a single-sanitizer property could not compose.
3. **`DefaultHttpRequestMatcher` includes the request body by default.** `DefaultHttpRequestMatcher.IgnoringRequestBody` opts out where the body carries a nonce or timestamp.

## Reviewer notes

- **Two existing tests were inverted deliberately.** `UserInfo_IsIncludedInFingerprint` and `DifferentUserInfo_DifferentFingerprint` now assert userinfo is *ignored*. Since credentials are stripped at capture, keeping them in the fingerprint would make a hand-written recording that still carries them unmatchable.
- **`_ioLock` is intentionally not disposed** (`CA2213` suppressed with justification). Disposing it races in-flight requests about to release it, throwing `ObjectDisposedException` from a `finally` and replacing the real exception; it never hands out a wait handle, so it holds no unmanaged resource.
- **`AutoSave` deliberately saves even after a synchronous `Dispose`.** `HttpClient` owns its handler and disposes it first, so by the time `DisposeAsync` runs the handler is normally already disposed while the entries still need persisting.
- **One finding is not addressed:** the HAR save path materializes a UTF-16 base64 string per binary body (~2.7× its size). This only matters when recording multi-MB binaries; the real fix means changing the HAR model to expose bytes so `Utf8JsonWriter.WriteBase64String` is used, which is a larger change to `Meziantou.Framework.HttpArchive`. Happy to do it separately.
- **One finding is partial:** a HAR with a missing `log` key cannot be distinguished from an empty recording, because `HarLog.Entries` defaults to `[]`. Only an explicit `"log": null` is detected. Both behaviors are pinned by tests.

## Validation

- `Meziantou.Framework.Http.Recording.Tests`: **170 passed** (85 per TFM, up from 38), 0 failed.
- `Meziantou.Framework.HttpArchive.Tests`: 150 passed, 0 failed.
- Release + `IsOfficialBuild=true` + `TreatsWarningsAsErrors=true`: clean, 0 warnings. `IsAotCompatible` newly declared on both packages and analyzer-clean.
- `ref/Meziantou.Framework.Http.Recording.cs` regenerated; `dotnet run ./eng/update-all.cs` produces no further changes.
