### PR TITLE
Fix protocol, DoS and lifecycle defects in PostgreSqlServer

### DIFF
--- a/ref/Meziantou.Framework.PostgreSqlServer.cs
+++ b/ref/Meziantou.Framework.PostgreSqlServer.cs
@@ -4,16 +4,27 @@
 
 namespace Meziantou.Framework.PostgreSql
 {
-    public sealed class PostgreSqlServer : System.IDisposable
+    public sealed class PostgreSqlServer : System.IAsyncDisposable, System.IDisposable
     {
         public System.Collections.Generic.IReadOnlyList<int> Ports { get => throw null; }
         public PostgreSqlServer(Meziantou.Framework.PostgreSql.PostgreSqlServerOptions? options, Meziantou.Framework.PostgreSql.Handler.PostgreSqlAuthenticationDelegate authenticationHandler, Meziantou.Framework.PostgreSql.Handler.PostgreSqlQueryDelegate queryHandler) { }
+        public PostgreSqlServer(Meziantou.Framework.PostgreSql.PostgreSqlServerOptions? options, Meziantou.Framework.PostgreSql.Handler.PostgreSqlAuthenticationDelegate authenticationHandler, Meziantou.Framework.PostgreSql.Handler.PostgreSqlQueryDelegate queryHandler, Microsoft.Extensions.Logging.ILogger? logger) { }
         public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public void Dispose() { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
     }
 
     public sealed class PostgreSqlServerOptions
     {
+        public const int DefaultMaxMessageSize = 16777216;
+        public const int MaxStartupPacketSize = 10000;
+        public int MaxMessageSize { get => throw null; set { } }
+        public int MaxConcurrentConnections { get => throw null; set { } }
+        public int MaxPreparedStatementsPerConnection { get => throw null; set { } }
+        public int MaxPortalsPerConnection { get => throw null; set { } }
+        public System.TimeSpan HandshakeTimeout { get => throw null; set { } }
+        public System.TimeSpan IdleTimeout { get => throw null; set { } }
         public bool RequireEncryption { get => throw null; set { } }
         public Meziantou.Framework.PostgreSql.Handler.PostgreSqlAuthenticationMethod AuthenticationMethod { get => throw null; set { } }
         public string ServerVersion { get => throw null; set { } }
@@ -115,6 +126,9 @@ namespace Meziantou.Framework.PostgreSql.Handler
         public required string Name { get => throw null; init { } }
         public required object? Value { get => throw null; init { } }
         public required Meziantou.Framework.PostgreSql.Handler.PostgreSqlColumnType Type { get => throw null; init { } }
+        public uint TypeOid { get => throw null; init { } }
+        public int FormatCode { get => throw null; init { } }
+        public System.ReadOnlyMemory? RawValue { get => throw null; init { } }
         public bool IsNull { get => throw null; }
         public string? AsString() => throw null;
         public int? AsInt32() => throw null;
@@ -122,6 +136,9 @@ namespace Meziantou.Framework.PostgreSql.Handler
         public bool? AsBoolean() => throw null;
         public double? AsDouble() => throw null;
         public decimal? AsDecimal() => throw null;
+        public System.Guid? AsGuid() => throw null;
+        public System.DateTime? AsDateTime() => throw null;
+        public System.DateTimeOffset? AsDateTimeOffset() => throw null;
         public byte[]? AsBinary() => throw null;
         public System.Text.Json.Nodes.JsonObject? AsJson() => throw null;
     }
@@ -129,7 +146,8 @@ namespace Meziantou.Framework.PostgreSql.Handler
     public enum PostgreSqlQueryRequestType
     {
         SimpleQuery = 0,
-        ExtendedQuery = 1
+        ExtendedQuery = 1,
+        Describe = 2
     }
 
     public sealed class PostgreSqlQueryResult
@@ -138,6 +156,8 @@ namespace Meziantou.Framework.PostgreSql.Handler
         public System.Collections.ObjectModel.Collection<Meziantou.Framework.PostgreSql.Handler.PostgreSqlResultSet> ResultSets { get => throw null; }
         public string? CommandTag { get => throw null; set { } }
         public Meziantou.Framework.PostgreSql.Handler.PostgreSqlQueryError? Error { get => throw null; set { } }
+        public int? AffectedRowCount { get => throw null; set { } }
+        public Meziantou.Framework.PostgreSql.Handler.PostgreSqlTransactionStatus TransactionStatus { get => throw null; set { } }
         public static Meziantou.Framework.PostgreSql.Handler.PostgreSqlQueryResult FromError(Meziantou.Framework.PostgreSql.Handler.PostgreSqlQueryError error) => throw null;
     }
 
@@ -145,6 +165,13 @@ namespace Meziantou.Framework.PostgreSql.Handler
     {
         public System.Collections.ObjectModel.Collection<Meziantou.Framework.PostgreSql.Handler.PostgreSqlColumn> Columns { get => throw null; }
         public System.Collections.ObjectModel.Collection<System.Collections.Generic.IReadOnlyList<object?>> Rows { get => throw null; }
+    }
+
+    public enum PostgreSqlTransactionStatus
+    {
+        Idle = 0,
+        InTransaction = 1,
+        Failed = 2
     }
 }
 namespace Meziantou.Framework.PostgreSql.Hosting

--- a/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlAuthenticationContext.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlAuthenticationContext.cs
@@ -64,7 +64,13 @@ public sealed class PostgreSqlAuthenticationContext
 
     private bool ValidateClearTextPassword(string expectedPassword)
     {
-        return string.Equals(Password, expectedPassword, StringComparison.Ordinal);
+        if (Password is null)
+        {
+            return false;
+        }
+
+        // Compared in constant time: this is the only place a long-lived secret is compared directly.
+        return CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(Password), Encoding.UTF8.GetBytes(expectedPassword));
     }
 
     private bool ValidateMd5Password(string expectedPassword)

--- a/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlColumn.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlColumn.cs
@@ -20,5 +20,9 @@ public sealed class PostgreSqlColumn
     public PostgreSqlColumnType ColumnType { get; }
 
     /// <summary>Gets a value indicating whether the column can be null.</summary>
+    /// <remarks>
+    /// Informational metadata for the query callback. RowDescription has no nullability field, so this is
+    /// not sent to the client and does not affect the wire format.
+    /// </remarks>
     public bool IsNullable { get; }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlQueryParameter.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlQueryParameter.cs
@@ -14,6 +14,17 @@ public sealed class PostgreSqlQueryParameter
     /// <summary>Gets or sets the declared PostgreSQL column type.</summary>
     public required PostgreSqlColumnType Type { get; init; }
 
+    /// <summary>Gets the PostgreSQL type OID sent by the client.</summary>
+    /// <remarks>Use this when <see cref="Type"/> is not specific enough, for example for an OID the library does not model.</remarks>
+    public uint TypeOid { get; init; }
+
+    /// <summary>Gets the wire format of the value: <c>0</c> for text, <c>1</c> for binary.</summary>
+    public int FormatCode { get; init; }
+
+    /// <summary>Gets the undecoded payload exactly as it arrived, or <see langword="null"/> for a SQL NULL.</summary>
+    /// <remarks>This is the escape hatch for values the library could not decode; <see cref="Value"/> then holds the same bytes.</remarks>
+    public ReadOnlyMemory<byte>? RawValue { get; init; }
+
     /// <summary>Gets a value indicating whether the parameter value is null.</summary>
     public bool IsNull => Value is null or DBNull;
 
@@ -128,6 +139,47 @@ public sealed class PostgreSqlQueryParameter
             float value => (decimal)value,
             double value => (decimal)value,
             string text when decimal.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var value) => value,
+            _ => null,
+        };
+    }
+
+    /// <summary>Converts the value to <see cref="Guid"/> when possible.</summary>
+    public Guid? AsGuid()
+    {
+        return Value switch
+        {
+            null or DBNull => null,
+            Guid value => value,
+            string text when Guid.TryParse(text, CultureInfo.InvariantCulture, out var value) => value,
+            byte[] { Length: 16 } bytes => new Guid(bytes, bigEndian: true),
+            _ => null,
+        };
+    }
+
+    /// <summary>Converts the value to <see cref="DateTime"/> when possible.</summary>
+    public DateTime? AsDateTime()
+    {
+        return Value switch
+        {
+            null or DBNull => null,
+            DateTime value => value,
+            DateTimeOffset value => value.UtcDateTime,
+            DateOnly value => value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+            string text when DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var value) => value,
+            _ => null,
+        };
+    }
+
+    /// <summary>Converts the value to <see cref="DateTimeOffset"/> when possible.</summary>
+    public DateTimeOffset? AsDateTimeOffset()
+    {
+        return Value switch
+        {
+            null or DBNull => null,
+            DateTimeOffset value => value,
+            DateTime value => new DateTimeOffset(value.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(value, DateTimeKind.Utc) : value),
+            DateOnly value => new DateTimeOffset(value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)),
+            string text when DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var value) => value,
             _ => null,
         };
     }

--- a/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlQueryRequestType.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlQueryRequestType.cs
@@ -8,4 +8,10 @@ public enum PostgreSqlQueryRequestType
 
     /// <summary>An extended query request (<c>Parse/Bind/Execute</c> flow).</summary>
     ExtendedQuery,
+
+    /// <summary>
+    /// A request for the shape of a statement or portal (<c>Describe</c> message), issued before execution.
+    /// The handler should return the columns it will produce, without necessarily executing the command.
+    /// </summary>
+    Describe,
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlQueryResult.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlQueryResult.cs
@@ -17,6 +17,15 @@ public sealed class PostgreSqlQueryResult
     /// <summary>Gets or sets the error to return. When set, result sets are ignored.</summary>
     public PostgreSqlQueryError? Error { get; set; }
 
+    /// <summary>
+    /// Gets or sets the number of rows affected, reported in the command completion tag.
+    /// When <see langword="null"/>, the number of rows in the result set is used, or zero when there is none.
+    /// </summary>
+    public int? AffectedRowCount { get; set; }
+
+    /// <summary>Gets or sets the transaction state reported to the client after this command.</summary>
+    public PostgreSqlTransactionStatus TransactionStatus { get; set; }
+
     /// <summary>Creates an error query result.</summary>
     public static PostgreSqlQueryResult FromError(PostgreSqlQueryError error)
     {

--- a/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlTransactionStatus.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Handler/PostgreSqlTransactionStatus.cs
@@ -1,0 +1,14 @@
+namespace Meziantou.Framework.PostgreSql.Handler;
+
+/// <summary>Describes the transaction state reported to the client after a command completes.</summary>
+public enum PostgreSqlTransactionStatus
+{
+    /// <summary>Not inside a transaction block.</summary>
+    Idle,
+
+    /// <summary>Inside a transaction block.</summary>
+    InTransaction,
+
+    /// <summary>Inside a failed transaction block; commands are rejected until the block ends.</summary>
+    Failed,
+}

--- a/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlBackendSession.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlBackendSession.cs
@@ -2,30 +2,50 @@ namespace Meziantou.Framework.PostgreSql;
 
 internal sealed class PostgreSqlBackendSession
 {
+    // A CancelRequest arrives on a different connection, so CancelCurrentCommand runs on another thread than
+    // the one executing the command. The lock keeps it from calling Cancel() on a source that EndCommand
+    // has already disposed, which would throw on the cancelling connection and silently drop the cancel.
+    private readonly Lock _lock = new();
     private CancellationTokenSource? _currentCommandCancellationTokenSource;
 
     public CancellationTokenSource BeginCommand(CancellationToken connectionToken)
     {
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(connectionToken);
-        var previous = Interlocked.Exchange(ref _currentCommandCancellationTokenSource, cancellationTokenSource);
+        CancellationTokenSource? previous;
+        lock (_lock)
+        {
+            previous = _currentCommandCancellationTokenSource;
+            _currentCommandCancellationTokenSource = cancellationTokenSource;
+        }
+
         previous?.Dispose();
         return cancellationTokenSource;
     }
 
     public void EndCommand(CancellationTokenSource cancellationTokenSource)
     {
-        var previous = Interlocked.CompareExchange(ref _currentCommandCancellationTokenSource, null, cancellationTokenSource);
-        if (ReferenceEquals(previous, cancellationTokenSource))
+        lock (_lock)
         {
-            cancellationTokenSource.Dispose();
-            return;
-        }
+            if (ReferenceEquals(_currentCommandCancellationTokenSource, cancellationTokenSource))
+            {
+                _currentCommandCancellationTokenSource = null;
+            }
 
-        cancellationTokenSource.Dispose();
+            cancellationTokenSource.Dispose();
+        }
     }
 
     public void CancelCurrentCommand()
     {
-        Volatile.Read(ref _currentCommandCancellationTokenSource)?.Cancel();
+        lock (_lock)
+        {
+            try
+            {
+                _currentCommandCancellationTokenSource?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
     }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlConnectionProcessor.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlConnectionProcessor.cs
@@ -45,122 +45,120 @@ internal sealed class PostgreSqlConnectionProcessor
         var startupParameters = new Dictionary<string, string>(StringComparer.Ordinal);
         int processId = default;
         int secretKey = default;
-        PostgreSqlBackendSession? backendSession = null;
 
         try
         {
-            var startupPacket = await PostgreSqlMessageReader.ReadStartupPacketAsync(input, cancellationToken).ConfigureAwait(false);
-            if (startupPacket is null)
+            using (var handshakeCts = CreateTimeoutTokenSource(_options.HandshakeTimeout, cancellationToken))
             {
-                return;
-            }
-
-            while (startupPacket.RequestCode == PostgreSqlConstants.SslRequestCode)
-            {
-                var serverCertificate = _options.GetTlsCertificate();
-                var canUpgradeToTls = serverCertificate is not null;
-                await writer.WriteSslResponseAsync(canUpgradeToTls, cancellationToken).ConfigureAwait(false);
-                if (!canUpgradeToTls)
+                var handshakeToken = handshakeCts?.Token ?? cancellationToken;
+                var startupPacket = await PostgreSqlMessageReader.ReadStartupPacketAsync(input, handshakeToken).ConfigureAwait(false);
+                if (startupPacket is null)
                 {
-                    startupPacket = await PostgreSqlMessageReader.ReadStartupPacketAsync(input, cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                // An SSLRequest is answered at most once. Looping would let a client stack SslStreams on one connection.
+                if (startupPacket.RequestCode == PostgreSqlConstants.SslRequestCode)
+                {
+                    var serverCertificate = _options.GetTlsCertificate();
+                    var canUpgradeToTls = serverCertificate is not null;
+                    await writer.WriteSslResponseAsync(canUpgradeToTls, handshakeToken).ConfigureAwait(false);
+                    if (canUpgradeToTls)
+                    {
+                        sslStream = await UpgradeToTlsAsync(input, output, serverCertificate!, handshakeToken).ConfigureAwait(false);
+                        input = sslStream;
+                        output = sslStream;
+                        writer = new PostgreSqlMessageWriter(output);
+                    }
+
+                    startupPacket = await PostgreSqlMessageReader.ReadStartupPacketAsync(input, handshakeToken).ConfigureAwait(false);
                     if (startupPacket is null)
                     {
                         return;
                     }
 
-                    continue;
+                    if (startupPacket.RequestCode == PostgreSqlConstants.SslRequestCode)
+                    {
+                        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", PostgreSqlConstants.SqlStates.ProtocolViolation, "Duplicate SSLRequest"), handshakeToken).ConfigureAwait(false);
+                        return;
+                    }
                 }
 
-                sslStream = await UpgradeToTlsAsync(input, output, serverCertificate!, cancellationToken).ConfigureAwait(false);
-                input = sslStream;
-                output = sslStream;
-                writer = new PostgreSqlMessageWriter(output);
-                startupPacket = await PostgreSqlMessageReader.ReadStartupPacketAsync(input, cancellationToken).ConfigureAwait(false);
-                if (startupPacket is null)
+                if (_options.RequireEncryption && sslStream is null)
+                {
+                    // Checked before the CancelRequest branch so no pre-authentication path escapes the requirement.
+                    await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", PostgreSqlConstants.SqlStates.InvalidAuthorizationSpecification, "TLS is required"), handshakeToken).ConfigureAwait(false);
+                    return;
+                }
+
+                if (startupPacket.RequestCode == PostgreSqlConstants.CancelRequestCode)
+                {
+                    HandleCancelRequest(startupPacket.Payload, remoteEndPoint);
+                    return;
+                }
+
+                if (startupPacket.RequestCode != PostgreSqlConstants.ProtocolVersion3)
+                {
+                    await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", PostgreSqlConstants.SqlStates.ProtocolViolation, "Unsupported protocol version"), handshakeToken).ConfigureAwait(false);
+                    return;
+                }
+
+                startupParameters = PostgreSqlMessageReader.ParseStartupParameters(startupPacket.Payload);
+                var userName = startupParameters.TryGetValue("user", out var startupUserName) ? startupUserName : null;
+                var database = startupParameters.TryGetValue("database", out var startupDatabase) ? startupDatabase : null;
+                if (!await AuthenticateAsync(input, writer, remoteEndPoint, startupParameters, userName, database, handshakeToken).ConfigureAwait(false))
                 {
                     return;
                 }
             }
 
-            if (startupPacket.RequestCode == PostgreSqlConstants.CancelRequestCode)
-            {
-                HandleCancelRequest(startupPacket.Payload);
-                return;
-            }
-
-            if (startupPacket.RequestCode != PostgreSqlConstants.ProtocolVersion3)
-            {
-                await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", "08P01", "Unsupported protocol version"), cancellationToken).ConfigureAwait(false);
-                return;
-            }
-
-            startupParameters = PostgreSqlMessageReader.ParseStartupParameters(startupPacket.Payload);
-            if (_options.RequireEncryption && sslStream is null)
-            {
-                await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", "28000", "TLS is required"), cancellationToken).ConfigureAwait(false);
-                return;
-            }
-
-            var userName = startupParameters.TryGetValue("user", out var startupUserName) ? startupUserName : null;
-            var database = startupParameters.TryGetValue("database", out var startupDatabase) ? startupDatabase : null;
-            if (!await AuthenticateAsync(input, writer, remoteEndPoint, startupParameters, userName, database, cancellationToken).ConfigureAwait(false))
-            {
-                return;
-            }
-
-            (processId, secretKey, backendSession) = _options.RegisterBackendSession();
+            (processId, secretKey, var backendSession) = _options.RegisterBackendSession();
             await WriteSessionInitializedMessagesAsync(writer, processId, secretKey, cancellationToken).ConfigureAwait(false);
 
-            var preparedStatements = new Dictionary<string, PostgreSqlStatement>(StringComparer.Ordinal);
-            var portals = new Dictionary<string, PostgreSqlPortal>(StringComparer.Ordinal);
+            var session = new PostgreSqlSessionState(remoteEndPoint, startupParameters, backendSession);
             while (!cancellationToken.IsCancellationRequested)
             {
-                var message = await PostgreSqlMessageReader.ReadMessageAsync(input, cancellationToken).ConfigureAwait(false);
+                PostgreSqlFrontendMessage? message;
+                using (var idleCts = CreateTimeoutTokenSource(_options.IdleTimeout, cancellationToken))
+                {
+                    message = await PostgreSqlMessageReader.ReadMessageAsync(input, _options.MaxMessageSize, idleCts?.Token ?? cancellationToken).ConfigureAwait(false);
+                }
+
                 if (message is null)
                 {
                     return;
                 }
 
-                switch (message.Type)
+                if (message.Type == PostgreSqlConstants.Frontend.Terminate)
                 {
-                    case (byte)'Q':
-                        await HandleSimpleQueryAsync(writer, remoteEndPoint, startupParameters, message, backendSession, cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'P':
-                        HandleParseMessage(preparedStatements, message);
-                        await writer.WriteMessageAsync((byte)'1', PostgreSqlResponseSerializer.CreateParseComplete(), cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'B':
-                        HandleBindMessage(preparedStatements, portals, message);
-                        await writer.WriteMessageAsync((byte)'2', PostgreSqlResponseSerializer.CreateBindComplete(), cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'D':
-                        await HandleDescribeMessageAsync(writer, preparedStatements, portals, message, cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'E':
-                        await HandleExecuteMessageAsync(writer, portals, remoteEndPoint, startupParameters, message, backendSession, cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'C':
-                        HandleCloseMessage(preparedStatements, portals, message);
-                        await writer.WriteMessageAsync((byte)'3', PostgreSqlResponseSerializer.CreateCloseComplete(), cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'S':
-                        await writer.WriteMessageAsync((byte)'Z', PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
-                        break;
-                    case (byte)'H':
-                        break;
-                    case (byte)'X':
-                        return;
-                    default:
-                        await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse("ERROR", "08P01", $"Unsupported frontend message '{(char)message.Type}'"), cancellationToken).ConfigureAwait(false);
-                        await writer.WriteMessageAsync((byte)'Z', PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
-                        break;
+                    return;
+                }
+
+                // The extended query protocol requires the backend to skip messages until Sync once an error occurs.
+                if (session.InErrorState && message.Type != PostgreSqlConstants.Frontend.Sync)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await DispatchMessageAsync(writer, session, message, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (InvalidDataException ex)
+                {
+                    _logger.LogDebug(ex, "Protocol error from {RemoteEndPoint}", remoteEndPoint);
+                    session.InErrorState = true;
+                    await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("ERROR", PostgreSqlConstants.SqlStates.ProtocolViolation, ex.Message), cancellationToken).ConfigureAwait(false);
                 }
             }
         }
         catch (AuthenticationException ex)
         {
-            _logger.LogDebug(ex, "TLS authentication failed");
+            _logger.LogDebug(ex, "TLS authentication failed for {RemoteEndPoint}", remoteEndPoint);
         }
         finally
         {
@@ -176,6 +174,56 @@ internal sealed class PostgreSqlConnectionProcessor
         }
     }
 
+    private static CancellationTokenSource? CreateTimeoutTokenSource(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return null;
+        }
+
+        var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellationTokenSource.CancelAfter(timeout);
+        return cancellationTokenSource;
+    }
+
+    private async ValueTask DispatchMessageAsync(PostgreSqlMessageWriter writer, PostgreSqlSessionState session, PostgreSqlFrontendMessage message, CancellationToken cancellationToken)
+    {
+        switch (message.Type)
+        {
+            case PostgreSqlConstants.Frontend.Query:
+                await HandleSimpleQueryAsync(writer, session, message, cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Parse:
+                HandleParseMessage(session, message);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParseComplete, PostgreSqlResponseSerializer.CreateParseComplete(), cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Bind:
+                HandleBindMessage(session, message);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.BindComplete, PostgreSqlResponseSerializer.CreateBindComplete(), cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Describe:
+                await HandleDescribeMessageAsync(writer, session, message, cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Execute:
+                await HandleExecuteMessageAsync(writer, session, message, cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Close:
+                HandleCloseMessage(session, message);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.CloseComplete, PostgreSqlResponseSerializer.CreateCloseComplete(), cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Sync:
+                session.InErrorState = false;
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ReadyForQuery, PostgreSqlResponseSerializer.CreateReadyForQuery(session.TransactionStatus), cancellationToken).ConfigureAwait(false);
+                break;
+            case PostgreSqlConstants.Frontend.Flush:
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new InvalidDataException($"Unsupported frontend message '{(char)message.Type}'.");
+        }
+    }
+
+
     private async ValueTask<bool> AuthenticateAsync(
         Stream input,
         PostgreSqlMessageWriter writer,
@@ -185,6 +233,16 @@ internal sealed class PostgreSqlConnectionProcessor
         string? database,
         CancellationToken cancellationToken)
     {
+        // The per-method handlers return only the material specific to their mechanism; the context is built
+        // once here so a new shared property cannot be silently dropped from one of the three paths.
+        var material = _options.AuthenticationMethod switch
+        {
+            PostgreSqlAuthenticationMethod.ClearTextPassword => await HandleClearTextAuthenticationAsync(input, writer, cancellationToken).ConfigureAwait(false),
+            PostgreSqlAuthenticationMethod.Md5Password => await HandleMd5AuthenticationAsync(input, writer, cancellationToken).ConfigureAwait(false),
+            PostgreSqlAuthenticationMethod.ScramSha256 => await HandleScramAuthenticationAsync(input, writer, cancellationToken).ConfigureAwait(false),
+            _ => default,
+        };
+
         var context = new PostgreSqlAuthenticationContext
         {
             RemoteEndPoint = remoteEndPoint,
@@ -192,20 +250,35 @@ internal sealed class PostgreSqlConnectionProcessor
             UserName = userName,
             Database = database,
             StartupParameters = startupParameters,
+            Password = material.Password,
+            Md5Salt = material.Md5Salt,
+            Md5PasswordResponse = material.Md5PasswordResponse,
+            ScramSalt = material.ScramSalt,
+            ScramIterationCount = material.ScramIterationCount,
+            ScramClientProof = material.ScramClientProof,
+            ScramAuthMessage = material.ScramAuthMessage,
         };
 
-        context = _options.AuthenticationMethod switch
+        PostgreSqlAuthenticationResult result;
+        try
         {
-            PostgreSqlAuthenticationMethod.ClearTextPassword => await HandleClearTextAuthenticationAsync(input, writer, context, cancellationToken).ConfigureAwait(false),
-            PostgreSqlAuthenticationMethod.Md5Password => await HandleMd5AuthenticationAsync(input, writer, context, cancellationToken).ConfigureAwait(false),
-            PostgreSqlAuthenticationMethod.ScramSha256 => await HandleScramAuthenticationAsync(input, writer, context, cancellationToken).ConfigureAwait(false),
-            _ => context,
-        };
+            result = await _authenticationHandler(context, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Mirrors the query handler: a faulting callback becomes a protocol error, not a dropped connection.
+            _logger.LogError(ex, "Unhandled exception in PostgreSQL authentication handler for {RemoteEndPoint}", remoteEndPoint);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", PostgreSqlConstants.SqlStates.InternalError, "Unhandled authentication handler exception"), cancellationToken).ConfigureAwait(false);
+            return false;
+        }
 
-        var result = await _authenticationHandler(context, cancellationToken).ConfigureAwait(false);
         if (!result.IsAuthenticated)
         {
-            await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", result.ErrorCode, result.ErrorMessage ?? "Authentication failed"), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", result.ErrorCode, result.ErrorMessage ?? "Authentication failed"), cancellationToken).ConfigureAwait(false);
             return false;
         }
 
@@ -213,66 +286,63 @@ internal sealed class PostgreSqlConnectionProcessor
         {
             if (!context.TryGetScramServerFinalMessage(out var serverFinalMessage))
             {
-                await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", "28P01", "SCRAM validation did not provide server signature"), cancellationToken).ConfigureAwait(false);
+                _logger.LogError("The authentication handler for {RemoteEndPoint} reported success under SCRAM-SHA-256 without calling ValidatePassword, which is required to compute the server signature.", remoteEndPoint);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse("FATAL", PostgreSqlConstants.SqlStates.InternalError, "The authentication handler must call ValidatePassword when SCRAM-SHA-256 is used."), cancellationToken).ConfigureAwait(false);
                 return false;
             }
 
-            await writer.WriteMessageAsync((byte)'R', PostgreSqlResponseSerializer.CreateAuthenticationSaslFinal(serverFinalMessage), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.Authentication, PostgreSqlResponseSerializer.CreateAuthenticationSaslFinal(serverFinalMessage), cancellationToken).ConfigureAwait(false);
         }
 
-        await writer.WriteMessageAsync((byte)'R', PostgreSqlResponseSerializer.CreateAuthenticationOk(), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.Authentication, PostgreSqlResponseSerializer.CreateAuthenticationOk(), cancellationToken).ConfigureAwait(false);
         return true;
     }
 
-    private static async ValueTask<PostgreSqlAuthenticationContext> HandleClearTextAuthenticationAsync(
-        Stream input,
-        PostgreSqlMessageWriter writer,
-        PostgreSqlAuthenticationContext context,
-        CancellationToken cancellationToken)
+    /// <summary>The mechanism-specific material collected during the authentication exchange.</summary>
+    private readonly record struct AuthenticationMaterial
     {
-        await writer.WriteMessageAsync((byte)'R', PostgreSqlResponseSerializer.CreateAuthenticationClearTextPassword(), cancellationToken).ConfigureAwait(false);
+        public string? Password { get; init; }
+
+        public byte[]? Md5Salt { get; init; }
+
+        public string? Md5PasswordResponse { get; init; }
+
+        public byte[]? ScramSalt { get; init; }
+
+        public int ScramIterationCount { get; init; }
+
+        public byte[]? ScramClientProof { get; init; }
+
+        public string? ScramAuthMessage { get; init; }
+    }
+
+    private async ValueTask<AuthenticationMaterial> HandleClearTextAuthenticationAsync(Stream input, PostgreSqlMessageWriter writer, CancellationToken cancellationToken)
+    {
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.Authentication, PostgreSqlResponseSerializer.CreateAuthenticationClearTextPassword(), cancellationToken).ConfigureAwait(false);
         var passwordMessage = await ReadRequiredPasswordMessageAsync(input, cancellationToken).ConfigureAwait(false);
-        return new PostgreSqlAuthenticationContext
+        return new AuthenticationMaterial
         {
-            RemoteEndPoint = context.RemoteEndPoint,
-            Method = context.Method,
-            UserName = context.UserName,
-            Database = context.Database,
-            StartupParameters = context.StartupParameters,
             Password = DecodeNullTerminatedString(passwordMessage.Payload),
         };
     }
 
-    private static async ValueTask<PostgreSqlAuthenticationContext> HandleMd5AuthenticationAsync(
-        Stream input,
-        PostgreSqlMessageWriter writer,
-        PostgreSqlAuthenticationContext context,
-        CancellationToken cancellationToken)
+    private async ValueTask<AuthenticationMaterial> HandleMd5AuthenticationAsync(Stream input, PostgreSqlMessageWriter writer, CancellationToken cancellationToken)
     {
         var salt = new byte[4];
         RandomNumberGenerator.Fill(salt);
-        await writer.WriteMessageAsync((byte)'R', PostgreSqlResponseSerializer.CreateAuthenticationMd5Password(salt), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.Authentication, PostgreSqlResponseSerializer.CreateAuthenticationMd5Password(salt), cancellationToken).ConfigureAwait(false);
 
         var passwordMessage = await ReadRequiredPasswordMessageAsync(input, cancellationToken).ConfigureAwait(false);
-        return new PostgreSqlAuthenticationContext
+        return new AuthenticationMaterial
         {
-            RemoteEndPoint = context.RemoteEndPoint,
-            Method = context.Method,
-            UserName = context.UserName,
-            Database = context.Database,
-            StartupParameters = context.StartupParameters,
             Md5Salt = salt,
             Md5PasswordResponse = DecodeNullTerminatedString(passwordMessage.Payload),
         };
     }
 
-    private static async ValueTask<PostgreSqlAuthenticationContext> HandleScramAuthenticationAsync(
-        Stream input,
-        PostgreSqlMessageWriter writer,
-        PostgreSqlAuthenticationContext context,
-        CancellationToken cancellationToken)
+    private async ValueTask<AuthenticationMaterial> HandleScramAuthenticationAsync(Stream input, PostgreSqlMessageWriter writer, CancellationToken cancellationToken)
     {
-        await writer.WriteMessageAsync((byte)'R', PostgreSqlResponseSerializer.CreateAuthenticationSasl(["SCRAM-SHA-256"]), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.Authentication, PostgreSqlResponseSerializer.CreateAuthenticationSasl(["SCRAM-SHA-256"]), cancellationToken).ConfigureAwait(false);
         var initialMessage = await ReadRequiredPasswordMessageAsync(input, cancellationToken).ConfigureAwait(false);
         var (mechanism, initialResponse) = ParseSaslInitialResponse(initialMessage.Payload);
         if (!string.Equals(mechanism, "SCRAM-SHA-256", StringComparison.Ordinal))
@@ -281,7 +351,7 @@ internal sealed class PostgreSqlConnectionProcessor
         }
 
         var clientFirstMessage = Encoding.UTF8.GetString(initialResponse);
-        if (!PostgreSqlScramHelper.TryParseClientFirstMessage(clientFirstMessage, out var clientFirstMessageBare, out var clientNonce))
+        if (!PostgreSqlScramHelper.TryParseClientFirstMessage(clientFirstMessage, out var clientFirstMessageBare, out var clientNonce, out var gs2Header))
         {
             throw new InvalidDataException("Invalid SCRAM client-first message.");
         }
@@ -291,11 +361,11 @@ internal sealed class PostgreSqlConnectionProcessor
         var salt = PostgreSqlScramHelper.CreateSalt();
         const int IterationCount = 4096;
         var serverFirstMessage = PostgreSqlScramHelper.BuildServerFirstMessage(fullNonce, salt, IterationCount);
-        await writer.WriteMessageAsync((byte)'R', PostgreSqlResponseSerializer.CreateAuthenticationSaslContinue(serverFirstMessage), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.Authentication, PostgreSqlResponseSerializer.CreateAuthenticationSaslContinue(serverFirstMessage), cancellationToken).ConfigureAwait(false);
 
         var finalMessage = await ReadRequiredPasswordMessageAsync(input, cancellationToken).ConfigureAwait(false);
         var clientFinalMessage = Encoding.UTF8.GetString(finalMessage.Payload);
-        if (!PostgreSqlScramHelper.TryParseClientFinalMessage(clientFinalMessage, out var clientFinalWithoutProof, out var clientProof, out var clientFinalNonce))
+        if (!PostgreSqlScramHelper.TryParseClientFinalMessage(clientFinalMessage, out var clientFinalWithoutProof, out var clientProof, out var clientFinalNonce, out var channelBinding))
         {
             throw new InvalidDataException("Invalid SCRAM client-final message.");
         }
@@ -305,14 +375,15 @@ internal sealed class PostgreSqlConnectionProcessor
             throw new InvalidDataException("SCRAM nonce mismatch.");
         }
 
-        var authMessage = $"{clientFirstMessageBare},{serverFirstMessage},{clientFinalWithoutProof}";
-        return new PostgreSqlAuthenticationContext
+        // RFC 5802 5.1: c= must repeat the gs2 header sent in client-first, so a stripped -PLUS mechanism is detected.
+        if (!PostgreSqlScramHelper.IsExpectedChannelBinding(channelBinding, gs2Header))
         {
-            RemoteEndPoint = context.RemoteEndPoint,
-            Method = context.Method,
-            UserName = context.UserName,
-            Database = context.Database,
-            StartupParameters = context.StartupParameters,
+            throw new InvalidDataException("SCRAM channel binding mismatch.");
+        }
+
+        var authMessage = $"{clientFirstMessageBare},{serverFirstMessage},{clientFinalWithoutProof}";
+        return new AuthenticationMaterial
+        {
             ScramSalt = salt,
             ScramIterationCount = IterationCount,
             ScramClientProof = clientProof,
@@ -351,10 +422,10 @@ internal sealed class PostgreSqlConnectionProcessor
         return Encoding.UTF8.GetString(payload[..end]);
     }
 
-    private static async ValueTask<PostgreSqlFrontendMessage> ReadRequiredPasswordMessageAsync(Stream input, CancellationToken cancellationToken)
+    private async ValueTask<PostgreSqlFrontendMessage> ReadRequiredPasswordMessageAsync(Stream input, CancellationToken cancellationToken)
     {
-        var message = await PostgreSqlMessageReader.ReadMessageAsync(input, cancellationToken).ConfigureAwait(false);
-        if (message is null || message.Type != (byte)'p')
+        var message = await PostgreSqlMessageReader.ReadMessageAsync(input, _options.MaxMessageSize, cancellationToken).ConfigureAwait(false);
+        if (message is null || message.Type != PostgreSqlConstants.Frontend.PasswordMessage)
         {
             throw new InvalidDataException("Expected password message.");
         }
@@ -364,17 +435,17 @@ internal sealed class PostgreSqlConnectionProcessor
 
     private async ValueTask WriteSessionInitializedMessagesAsync(PostgreSqlMessageWriter writer, int processId, int secretKey, CancellationToken cancellationToken)
     {
-        await writer.WriteMessageAsync((byte)'S', PostgreSqlResponseSerializer.CreateParameterStatus("server_version", _options.ServerVersion), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'S', PostgreSqlResponseSerializer.CreateParameterStatus("server_encoding", "UTF8"), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'S', PostgreSqlResponseSerializer.CreateParameterStatus("client_encoding", "UTF8"), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'S', PostgreSqlResponseSerializer.CreateParameterStatus("DateStyle", "ISO, MDY"), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'S', PostgreSqlResponseSerializer.CreateParameterStatus("integer_datetimes", "on"), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'S', PostgreSqlResponseSerializer.CreateParameterStatus("standard_conforming_strings", "on"), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'K', PostgreSqlResponseSerializer.CreateBackendKeyData(processId, secretKey), cancellationToken).ConfigureAwait(false);
-        await writer.WriteMessageAsync((byte)'Z', PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterStatus, PostgreSqlResponseSerializer.CreateParameterStatus("server_version", _options.ServerVersion), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterStatus, PostgreSqlResponseSerializer.CreateParameterStatus("server_encoding", "UTF8"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterStatus, PostgreSqlResponseSerializer.CreateParameterStatus("client_encoding", "UTF8"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterStatus, PostgreSqlResponseSerializer.CreateParameterStatus("DateStyle", "ISO, MDY"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterStatus, PostgreSqlResponseSerializer.CreateParameterStatus("integer_datetimes", "on"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterStatus, PostgreSqlResponseSerializer.CreateParameterStatus("standard_conforming_strings", "on"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.BackendKeyData, PostgreSqlResponseSerializer.CreateBackendKeyData(processId, secretKey), cancellationToken).ConfigureAwait(false);
+        await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ReadyForQuery, PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
     }
 
-    private void HandleCancelRequest(byte[] payload)
+    private void HandleCancelRequest(byte[] payload, EndPoint remoteEndPoint)
     {
         if (payload.Length < 8)
         {
@@ -383,10 +454,13 @@ internal sealed class PostgreSqlConnectionProcessor
 
         var processId = BinaryPrimitives.ReadInt32BigEndian(payload.AsSpan(0, 4));
         var secretKey = BinaryPrimitives.ReadInt32BigEndian(payload.AsSpan(4, 4));
-        _ = _options.TryCancelBackendSession(processId, secretKey);
+        if (!_options.TryCancelBackendSession(processId, secretKey))
+        {
+            _logger.LogDebug("Ignored cancel request for unknown session from {RemoteEndPoint}", remoteEndPoint);
+        }
     }
 
-    private static void HandleParseMessage(Dictionary<string, PostgreSqlStatement> preparedStatements, PostgreSqlFrontendMessage message)
+    private void HandleParseMessage(PostgreSqlSessionState session, PostgreSqlFrontendMessage message)
     {
         var payload = message.Payload.AsSpan();
         var index = 0;
@@ -399,7 +473,12 @@ internal sealed class PostgreSqlConnectionProcessor
 
         var parameterTypeCount = BinaryPrimitives.ReadInt16BigEndian(payload.Slice(index, 2));
         index += 2;
-        var parameterTypeOids = new List<uint>(Math.Max((int)parameterTypeCount, 0));
+        if (parameterTypeCount < 0)
+        {
+            throw new InvalidDataException("Invalid Parse message parameter type count.");
+        }
+
+        var parameterTypeOids = new List<uint>(parameterTypeCount);
         for (var i = 0; i < parameterTypeCount; i++)
         {
             if (index + 4 > payload.Length)
@@ -411,7 +490,13 @@ internal sealed class PostgreSqlConnectionProcessor
             index += 4;
         }
 
-        preparedStatements[statementName] = new PostgreSqlStatement
+        // The name is client-supplied and entries live for the connection, so the count is bounded.
+        if (!session.PreparedStatements.ContainsKey(statementName) && session.PreparedStatements.Count >= _options.MaxPreparedStatementsPerConnection)
+        {
+            throw new InvalidDataException($"The connection reached the limit of {_options.MaxPreparedStatementsPerConnection} prepared statements.");
+        }
+
+        session.PreparedStatements[statementName] = new PostgreSqlStatement
         {
             Name = statementName,
             Query = query,
@@ -419,13 +504,13 @@ internal sealed class PostgreSqlConnectionProcessor
         };
     }
 
-    private static void HandleBindMessage(Dictionary<string, PostgreSqlStatement> preparedStatements, Dictionary<string, PostgreSqlPortal> portals, PostgreSqlFrontendMessage message)
+    private void HandleBindMessage(PostgreSqlSessionState session, PostgreSqlFrontendMessage message)
     {
         var payload = message.Payload.AsSpan();
         var index = 0;
         var portalName = PostgreSqlMessageReader.ReadNullTerminatedString(payload, ref index);
         var statementName = PostgreSqlMessageReader.ReadNullTerminatedString(payload, ref index);
-        if (!preparedStatements.TryGetValue(statementName, out var statement))
+        if (!session.PreparedStatements.TryGetValue(statementName, out var statement))
         {
             throw new InvalidDataException($"Unknown prepared statement '{statementName}'.");
         }
@@ -438,7 +523,18 @@ internal sealed class PostgreSqlConnectionProcessor
 
         var parameterCount = BinaryPrimitives.ReadInt16BigEndian(payload.Slice(index, 2));
         index += 2;
-        var parameters = new List<PostgreSqlBoundParameter>(Math.Max((int)parameterCount, 0));
+        if (parameterCount < 0)
+        {
+            throw new InvalidDataException("Invalid Bind message parameter count.");
+        }
+
+        // The spec allows 0 (all text), 1 (applies to all), or exactly one code per parameter.
+        if (parameterFormatCodes.Count > 1 && parameterFormatCodes.Count != parameterCount)
+        {
+            throw new InvalidDataException($"Bind supplied {parameterFormatCodes.Count} parameter format codes for {parameterCount} parameters.");
+        }
+
+        var parameters = new List<PostgreSqlBoundParameter>(parameterCount);
         for (var i = 0; i < parameterCount; i++)
         {
             if (index + 4 > payload.Length)
@@ -459,6 +555,10 @@ internal sealed class PostgreSqlConnectionProcessor
                 value = payload.Slice(index, valueLength).ToArray();
                 index += valueLength;
             }
+            else if (valueLength != -1)
+            {
+                throw new InvalidDataException("Invalid Bind parameter length.");
+            }
 
             var typeOid = i < statement.ParameterTypeOids.Count ? statement.ParameterTypeOids[i] : 0u;
             var formatCode = ResolveFormatCode(parameterFormatCodes, i);
@@ -471,7 +571,12 @@ internal sealed class PostgreSqlConnectionProcessor
         }
 
         var resultFormatCodes = ReadFormatCodes(payload, ref index);
-        portals[portalName] = new PostgreSqlPortal
+        if (!session.Portals.ContainsKey(portalName) && session.Portals.Count >= _options.MaxPortalsPerConnection)
+        {
+            throw new InvalidDataException($"The connection reached the limit of {_options.MaxPortalsPerConnection} portals.");
+        }
+
+        session.Portals[portalName] = new PostgreSqlPortal
         {
             Name = portalName,
             Statement = statement,
@@ -480,58 +585,97 @@ internal sealed class PostgreSqlConnectionProcessor
         };
     }
 
-    private static async ValueTask HandleDescribeMessageAsync(
-        PostgreSqlMessageWriter writer,
-        Dictionary<string, PostgreSqlStatement> preparedStatements,
-        Dictionary<string, PostgreSqlPortal> portals,
-        PostgreSqlFrontendMessage message,
-        CancellationToken cancellationToken)
+    private async ValueTask HandleDescribeMessageAsync(PostgreSqlMessageWriter writer, PostgreSqlSessionState session, PostgreSqlFrontendMessage message, CancellationToken cancellationToken)
     {
         var payload = message.Payload.AsSpan();
-        var index = 0;
-        if (index >= payload.Length)
+        if (payload.IsEmpty)
         {
             throw new InvalidDataException("Invalid Describe message.");
         }
 
+        var index = 0;
         var describeType = payload[index++];
         var name = PostgreSqlMessageReader.ReadNullTerminatedString(payload, ref index);
-        if (describeType == (byte)'S')
+
+        PostgreSqlStatement statement;
+        PostgreSqlPortal? portal = null;
+        if (describeType == PostgreSqlConstants.DescribeTarget.Statement)
         {
-            if (preparedStatements.TryGetValue(name, out var statement))
+            if (!session.PreparedStatements.TryGetValue(name, out var describedStatement))
             {
-                await writer.WriteMessageAsync((byte)'t', PostgreSqlResponseSerializer.CreateParameterDescription(statement.ParameterTypeOids), cancellationToken).ConfigureAwait(false);
-                await writer.WriteMessageAsync((byte)'n', PostgreSqlResponseSerializer.CreateNoData(), cancellationToken).ConfigureAwait(false);
-                return;
-            }
-        }
-        else if (describeType == (byte)'P' && portals.TryGetValue(name, out var portal))
-        {
-            if (TryInferDescribeResultSet(portal.Statement.Query, out var describedResultSet))
-            {
-                await writer.WriteMessageAsync((byte)'T', PostgreSqlResponseSerializer.CreateRowDescription(describedResultSet), cancellationToken).ConfigureAwait(false);
-                portal.IsDescribed = true;
-            }
-            else
-            {
-                await writer.WriteMessageAsync((byte)'n', PostgreSqlResponseSerializer.CreateNoData(), cancellationToken).ConfigureAwait(false);
-                portal.IsDescribed = false;
+                throw new InvalidDataException($"Unknown prepared statement '{name}'.");
             }
 
-            return;
+            statement = describedStatement;
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ParameterDescription, PostgreSqlResponseSerializer.CreateParameterDescription(statement.ParameterTypeOids), cancellationToken).ConfigureAwait(false);
+        }
+        else if (describeType == PostgreSqlConstants.DescribeTarget.Portal)
+        {
+            if (!session.Portals.TryGetValue(name, out portal))
+            {
+                throw new InvalidDataException($"Unknown portal '{name}'.");
+            }
+
+            statement = portal.Statement;
+        }
+        else
+        {
+            throw new InvalidDataException($"Invalid Describe target '{(char)describeType}'.");
         }
 
-        await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse("ERROR", "26000", $"Unknown describe target '{name}'"), cancellationToken).ConfigureAwait(false);
+        // The result shape is the callback's to decide; guessing it from the SQL text produced wrong
+        // column counts and types, and Execute must never emit a RowDescription of its own.
+        var context = new PostgreSqlQueryContext
+        {
+            RemoteEndPoint = session.RemoteEndPoint,
+            StartupParameters = session.StartupParameters,
+            RequestType = PostgreSqlQueryRequestType.Describe,
+            CommandText = statement.Query,
+            StatementName = statement.Name,
+            PortalName = portal?.Name,
+            Parameters = portal is null ? [] : DecodeParameters(portal),
+        };
+
+        var result = await ExecuteQueryHandlerAsync(context, session.BackendSession, cancellationToken).ConfigureAwait(false);
+        var describedResultSet = result.Error is null && result.ResultSets.Count > 0 ? result.ResultSets[0] : null;
+        if (portal is not null)
+        {
+            portal.DescribedColumnCount = describedResultSet?.Columns.Count ?? 0;
+        }
+
+        if (describedResultSet is not null && describedResultSet.Columns.Count > 0)
+        {
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.RowDescription, PostgreSqlResponseSerializer.CreateRowDescription(describedResultSet, portal?.ResultFormatCodes), cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.NoData, PostgreSqlResponseSerializer.CreateNoData(), cancellationToken).ConfigureAwait(false);
+        }
     }
 
-    private async ValueTask HandleExecuteMessageAsync(
-        PostgreSqlMessageWriter writer,
-        Dictionary<string, PostgreSqlPortal> portals,
-        EndPoint remoteEndPoint,
-        IReadOnlyDictionary<string, string> startupParameters,
-        PostgreSqlFrontendMessage message,
-        PostgreSqlBackendSession? backendSession,
-        CancellationToken cancellationToken)
+    private static PostgreSqlQueryParameter[] DecodeParameters(PostgreSqlPortal portal)
+    {
+        var parameters = new PostgreSqlQueryParameter[portal.Parameters.Count];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = portal.Parameters[i];
+            var typeOid = parameter.TypeOid == 0 ? PostgreSqlTypeMapper.TextOid : parameter.TypeOid;
+            var decodedValue = PostgreSqlValueConverter.DecodeParameterValue(typeOid, parameter.FormatCode, parameter.RawValue);
+            parameters[i] = new PostgreSqlQueryParameter
+            {
+                Name = $"${i + 1}",
+                Type = PostgreSqlTypeMapper.GetColumnType(typeOid),
+                Value = decodedValue ?? DBNull.Value,
+                TypeOid = typeOid,
+                FormatCode = parameter.FormatCode,
+                RawValue = parameter.RawValue,
+            };
+        }
+
+        return parameters;
+    }
+
+    private async ValueTask HandleExecuteMessageAsync(PostgreSqlMessageWriter writer, PostgreSqlSessionState session, PostgreSqlFrontendMessage message, CancellationToken cancellationToken)
     {
         var payload = message.Payload.AsSpan();
         var index = 0;
@@ -541,61 +685,98 @@ internal sealed class PostgreSqlConnectionProcessor
             throw new InvalidDataException("Invalid Execute message.");
         }
 
-        _ = BinaryPrimitives.ReadInt32BigEndian(payload.Slice(index, 4));
-        if (!portals.TryGetValue(portalName, out var portal))
+        var maxRows = BinaryPrimitives.ReadInt32BigEndian(payload.Slice(index, 4));
+        if (maxRows < 0)
+        {
+            throw new InvalidDataException("Invalid Execute row limit.");
+        }
+
+        if (!session.Portals.TryGetValue(portalName, out var portal))
         {
             throw new InvalidDataException($"Unknown portal '{portalName}'.");
         }
 
-        var parameters = portal.Parameters
-            .Select((parameter, parameterIndex) =>
-            {
-                var typeOid = parameter.TypeOid == 0 ? 25u : parameter.TypeOid;
-                var columnType = PostgreSqlTypeMapper.GetColumnType(typeOid);
-                var decodedValue = PostgreSqlValueConverter.DecodeParameterValue(typeOid, parameter.FormatCode, parameter.RawValue);
-                return new PostgreSqlQueryParameter
-                {
-                    Name = $"${parameterIndex + 1}",
-                    Type = columnType,
-                    Value = decodedValue ?? DBNull.Value,
-                };
-            })
-            .ToArray();
+        if (string.IsNullOrWhiteSpace(portal.Statement.Query))
+        {
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.EmptyQueryResponse, PostgreSqlResponseSerializer.CreateEmptyQueryResponse(), cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         var context = new PostgreSqlQueryContext
         {
-            RemoteEndPoint = remoteEndPoint,
-            StartupParameters = startupParameters,
+            RemoteEndPoint = session.RemoteEndPoint,
+            StartupParameters = session.StartupParameters,
             RequestType = PostgreSqlQueryRequestType.ExtendedQuery,
             CommandText = portal.Statement.Query,
             StatementName = portal.Statement.Name,
             PortalName = portal.Name,
-            Parameters = parameters,
+            Parameters = DecodeParameters(portal),
         };
 
-        var result = await ExecuteQueryHandlerAsync(context, backendSession, cancellationToken).ConfigureAwait(false);
-        await WriteQueryResultAsync(writer, result, includeReadyForQuery: false, includeRowDescription: !portal.IsDescribed, cancellationToken).ConfigureAwait(false);
+        var result = await ExecuteQueryHandlerAsync(context, session.BackendSession, cancellationToken).ConfigureAwait(false);
+
+        // Describe already told the client the shape. If execution disagrees, the DataRows would desynchronise
+        // the connection, so this is reported as an error instead.
+        if (result.Error is null && portal.DescribedColumnCount is { } describedColumnCount)
+        {
+            var executedColumnCount = result.ResultSets.Count > 0 ? result.ResultSets[0].Columns.Count : 0;
+            if (executedColumnCount != describedColumnCount)
+            {
+                _logger.LogError(
+                    "The query handler described {DescribedColumnCount} column(s) for '{CommandText}' but returned {ExecutedColumnCount} on execution. Return the same columns for PostgreSqlQueryRequestType.Describe as for the execution.",
+                    describedColumnCount,
+                    portal.Statement.Query,
+                    executedColumnCount);
+                result = PostgreSqlQueryResult.FromError(new PostgreSqlQueryError
+                {
+                    Code = PostgreSqlConstants.SqlStates.InternalError,
+                    Message = $"The query handler described {describedColumnCount} column(s) but returned {executedColumnCount} on execution.",
+                });
+            }
+        }
+
+        UpdateTransactionStatus(session, result);
+
+        // Execute never emits RowDescription; the client learns the shape from Describe.
+        await WriteQueryResultAsync(writer, result, session, includeReadyForQuery: false, includeRowDescription: false, maxRows, portal.ResultFormatCodes, cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask HandleSimpleQueryAsync(
-        PostgreSqlMessageWriter writer,
-        EndPoint remoteEndPoint,
-        IReadOnlyDictionary<string, string> startupParameters,
-        PostgreSqlFrontendMessage message,
-        PostgreSqlBackendSession? backendSession,
-        CancellationToken cancellationToken)
+    private async ValueTask HandleSimpleQueryAsync(PostgreSqlMessageWriter writer, PostgreSqlSessionState session, PostgreSqlFrontendMessage message, CancellationToken cancellationToken)
     {
         var sqlText = DecodeNullTerminatedString(message.Payload);
+        if (string.IsNullOrWhiteSpace(sqlText))
+        {
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.EmptyQueryResponse, PostgreSqlResponseSerializer.CreateEmptyQueryResponse(), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ReadyForQuery, PostgreSqlResponseSerializer.CreateReadyForQuery(session.TransactionStatus), cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         var context = new PostgreSqlQueryContext
         {
-            RemoteEndPoint = remoteEndPoint,
-            StartupParameters = startupParameters,
+            RemoteEndPoint = session.RemoteEndPoint,
+            StartupParameters = session.StartupParameters,
             RequestType = PostgreSqlQueryRequestType.SimpleQuery,
             CommandText = sqlText,
         };
 
-        var result = await ExecuteQueryHandlerAsync(context, backendSession, cancellationToken).ConfigureAwait(false);
-        await WriteQueryResultAsync(writer, result, includeReadyForQuery: true, includeRowDescription: true, cancellationToken).ConfigureAwait(false);
+        var result = await ExecuteQueryHandlerAsync(context, session.BackendSession, cancellationToken).ConfigureAwait(false);
+        UpdateTransactionStatus(session, result);
+        await WriteQueryResultAsync(writer, result, session, includeReadyForQuery: true, includeRowDescription: true, maxRows: 0, resultFormatCodes: null, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void UpdateTransactionStatus(PostgreSqlSessionState session, PostgreSqlQueryResult result)
+    {
+        session.TransactionStatus = result.TransactionStatus switch
+        {
+            PostgreSqlTransactionStatus.InTransaction => PostgreSqlConstants.TransactionStatus.InTransaction,
+            PostgreSqlTransactionStatus.Failed => PostgreSqlConstants.TransactionStatus.Failed,
+            _ => PostgreSqlConstants.TransactionStatus.Idle,
+        };
+
+        if (result.Error is not null && session.TransactionStatus == PostgreSqlConstants.TransactionStatus.InTransaction)
+        {
+            session.TransactionStatus = PostgreSqlConstants.TransactionStatus.Failed;
+        }
     }
 
     private async ValueTask<PostgreSqlQueryResult> ExecuteQueryHandlerAsync(PostgreSqlQueryContext context, PostgreSqlBackendSession? backendSession, CancellationToken cancellationToken)
@@ -612,20 +793,25 @@ internal sealed class PostgreSqlConnectionProcessor
 
             return await _queryHandler(context, commandCancellationTokenSource.Token).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (commandCancellationTokenSource is not null && commandCancellationTokenSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The connection itself is going away; this is not a query error.
+            throw;
+        }
+        catch (OperationCanceledException) when (commandCancellationTokenSource is not null && commandCancellationTokenSource.IsCancellationRequested)
         {
             return PostgreSqlQueryResult.FromError(new PostgreSqlQueryError
             {
-                Code = "57014",
+                Code = PostgreSqlConstants.SqlStates.QueryCanceled,
                 Message = "canceling statement due to user request",
             });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unhandled exception in PostgreSQL query handler");
+            _logger.LogError(ex, "Unhandled exception in PostgreSQL query handler for {RemoteEndPoint}", context.RemoteEndPoint);
             return PostgreSqlQueryResult.FromError(new PostgreSqlQueryError
             {
-                Code = "XX000",
+                Code = PostgreSqlConstants.SqlStates.InternalError,
                 Message = "Unhandled query handler exception",
             });
         }
@@ -640,17 +826,29 @@ internal sealed class PostgreSqlConnectionProcessor
         }
     }
 
-    private static async ValueTask WriteQueryResultAsync(PostgreSqlMessageWriter writer, PostgreSqlQueryResult result, bool includeReadyForQuery, bool includeRowDescription, CancellationToken cancellationToken)
+    private static async ValueTask WriteQueryResultAsync(
+        PostgreSqlMessageWriter writer,
+        PostgreSqlQueryResult result,
+        PostgreSqlSessionState session,
+        bool includeReadyForQuery,
+        bool includeRowDescription,
+        int maxRows,
+        IReadOnlyList<int>? resultFormatCodes,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(result);
 
         if (result.Error is not null)
         {
-            await writer.WriteMessageAsync((byte)'E', PostgreSqlResponseSerializer.CreateErrorResponse(result.Error), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ErrorResponse, PostgreSqlResponseSerializer.CreateErrorResponse(result.Error), cancellationToken).ConfigureAwait(false);
             if (includeReadyForQuery)
             {
-                await writer.WriteMessageAsync((byte)'Z', PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ReadyForQuery, PostgreSqlResponseSerializer.CreateReadyForQuery(session.TransactionStatus), cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                session.InErrorState = true;
             }
 
             return;
@@ -658,16 +856,15 @@ internal sealed class PostgreSqlConnectionProcessor
 
         foreach (var notice in result.Notices)
         {
-            await writer.WriteMessageAsync((byte)'N', PostgreSqlResponseSerializer.CreateNoticeResponse(notice), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.NoticeResponse, PostgreSqlResponseSerializer.CreateNoticeResponse(notice), cancellationToken).ConfigureAwait(false);
         }
 
         if (result.ResultSets.Count == 0)
         {
-            var commandTag = string.IsNullOrWhiteSpace(result.CommandTag) ? "OK" : result.CommandTag;
-            await writer.WriteMessageAsync((byte)'C', PostgreSqlResponseSerializer.CreateCommandComplete(commandTag, 0), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.CommandComplete, PostgreSqlResponseSerializer.CreateCommandComplete(result.CommandTag, "OK", result.AffectedRowCount), cancellationToken).ConfigureAwait(false);
             if (includeReadyForQuery)
             {
-                await writer.WriteMessageAsync((byte)'Z', PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ReadyForQuery, PostgreSqlResponseSerializer.CreateReadyForQuery(session.TransactionStatus), cancellationToken).ConfigureAwait(false);
             }
 
             return;
@@ -677,42 +874,54 @@ internal sealed class PostgreSqlConnectionProcessor
         {
             if (includeRowDescription)
             {
-                await writer.WriteMessageAsync((byte)'T', PostgreSqlResponseSerializer.CreateRowDescription(resultSet), cancellationToken).ConfigureAwait(false);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.RowDescription, PostgreSqlResponseSerializer.CreateRowDescription(resultSet, resultFormatCodes), cancellationToken).ConfigureAwait(false);
             }
 
-            foreach (var row in resultSet.Rows)
+            var rowCount = resultSet.Rows.Count;
+            var suspended = maxRows > 0 && rowCount > maxRows;
+            var rowsToWrite = suspended ? maxRows : rowCount;
+            for (var i = 0; i < rowsToWrite; i++)
             {
-                await writer.WriteMessageAsync((byte)'D', PostgreSqlResponseSerializer.CreateDataRow(resultSet, row), cancellationToken).ConfigureAwait(false);
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.DataRow, PostgreSqlResponseSerializer.CreateDataRow(resultSet, resultSet.Rows[i], resultFormatCodes), cancellationToken).ConfigureAwait(false);
             }
 
-            var commandTag = string.IsNullOrWhiteSpace(result.CommandTag) ? "SELECT" : result.CommandTag;
-            await writer.WriteMessageAsync((byte)'C', PostgreSqlResponseSerializer.CreateCommandComplete(commandTag, resultSet.Rows.Count), cancellationToken).ConfigureAwait(false);
+            if (suspended)
+            {
+                await writer.WriteMessageAsync(PostgreSqlConstants.Backend.PortalSuspended, PostgreSqlResponseSerializer.CreatePortalSuspended(), cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.CommandComplete, PostgreSqlResponseSerializer.CreateCommandComplete(result.CommandTag, "SELECT", result.AffectedRowCount ?? rowsToWrite), cancellationToken).ConfigureAwait(false);
         }
 
         if (includeReadyForQuery)
         {
-            await writer.WriteMessageAsync((byte)'Z', PostgreSqlResponseSerializer.CreateReadyForQuery(), cancellationToken).ConfigureAwait(false);
+            await writer.WriteMessageAsync(PostgreSqlConstants.Backend.ReadyForQuery, PostgreSqlResponseSerializer.CreateReadyForQuery(session.TransactionStatus), cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static void HandleCloseMessage(Dictionary<string, PostgreSqlStatement> preparedStatements, Dictionary<string, PostgreSqlPortal> portals, PostgreSqlFrontendMessage message)
+    private static void HandleCloseMessage(PostgreSqlSessionState session, PostgreSqlFrontendMessage message)
     {
         var payload = message.Payload.AsSpan();
-        var index = 0;
-        if (index >= payload.Length)
+        if (payload.IsEmpty)
         {
             throw new InvalidDataException("Invalid Close message.");
         }
 
+        var index = 0;
         var closeType = payload[index++];
         var name = PostgreSqlMessageReader.ReadNullTerminatedString(payload, ref index);
-        if (closeType == (byte)'S')
+        if (closeType == PostgreSqlConstants.DescribeTarget.Statement)
         {
-            _ = preparedStatements.Remove(name);
+            _ = session.PreparedStatements.Remove(name);
         }
-        else if (closeType == (byte)'P')
+        else if (closeType == PostgreSqlConstants.DescribeTarget.Portal)
         {
-            _ = portals.Remove(name);
+            _ = session.Portals.Remove(name);
+        }
+        else
+        {
+            throw new InvalidDataException($"Invalid Close target '{(char)closeType}'.");
         }
     }
 
@@ -725,7 +934,12 @@ internal sealed class PostgreSqlConnectionProcessor
 
         var count = BinaryPrimitives.ReadInt16BigEndian(payload.Slice(index, 2));
         index += 2;
-        var result = new List<int>(Math.Max((int)count, 0));
+        if (count < 0)
+        {
+            throw new InvalidDataException("Invalid format code count.");
+        }
+
+        var result = new List<int>(count);
         for (var i = 0; i < count; i++)
         {
             if (index + 2 > payload.Length)
@@ -733,7 +947,13 @@ internal sealed class PostgreSqlConnectionProcessor
                 throw new InvalidDataException("Invalid format code value.");
             }
 
-            result.Add(BinaryPrimitives.ReadInt16BigEndian(payload.Slice(index, 2)));
+            var formatCode = BinaryPrimitives.ReadInt16BigEndian(payload.Slice(index, 2));
+            if (formatCode is not 0 and not 1)
+            {
+                throw new InvalidDataException($"Invalid format code '{formatCode}'.");
+            }
+
+            result.Add(formatCode);
             index += 2;
         }
 
@@ -752,52 +972,9 @@ internal sealed class PostgreSqlConnectionProcessor
             return formatCodes[0];
         }
 
-        return parameterIndex < formatCodes.Count ? formatCodes[parameterIndex] : formatCodes[^1];
+        return formatCodes[parameterIndex];
     }
 
-    private static bool TryInferDescribeResultSet(string query, [NotNullWhen(true)] out PostgreSqlResultSet? resultSet)
-    {
-        resultSet = null;
-        if (string.IsNullOrWhiteSpace(query))
-        {
-            return false;
-        }
-
-        var trimmedQuery = query.TrimStart();
-        if (!trimmedQuery.StartsWith("select", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var selectClause = trimmedQuery["select".Length..].Trim();
-        var fromIndex = selectClause.IndexOf(" from ", StringComparison.OrdinalIgnoreCase);
-        if (fromIndex >= 0)
-        {
-            selectClause = selectClause[..fromIndex];
-        }
-
-        var expressions = selectClause.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (expressions.Length == 0)
-        {
-            return false;
-        }
-
-        resultSet = new PostgreSqlResultSet();
-        for (var i = 0; i < expressions.Length; i++)
-        {
-            var expression = expressions[i];
-            var columnName = $"column{i + 1}";
-            var asIndex = expression.LastIndexOf(" as ", StringComparison.OrdinalIgnoreCase);
-            if (asIndex >= 0 && asIndex + 4 < expression.Length)
-            {
-                columnName = expression[(asIndex + 4)..].Trim();
-            }
-
-            resultSet.Columns.Add(new PostgreSqlColumn(columnName, PostgreSqlColumnType.Text, isNullable: true));
-        }
-
-        return true;
-    }
 
     private static async Task<SslStream> UpgradeToTlsAsync(Stream input, Stream output, X509Certificate2 certificate, CancellationToken cancellationToken)
     {
@@ -806,93 +983,24 @@ internal sealed class PostgreSqlConnectionProcessor
         ArgumentNullException.ThrowIfNull(certificate);
 
         var sslStream = new SslStream(new DuplexStream(input, output), leaveInnerStreamOpen: true);
-        await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
+        try
         {
-            ServerCertificate = certificate,
-            ClientCertificateRequired = false,
-            EnabledSslProtocols = SslProtocols.None,
-            CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
-        }, cancellationToken).ConfigureAwait(false);
+            await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
+            {
+                ServerCertificate = certificate,
+                ClientCertificateRequired = false,
+                EnabledSslProtocols = SslProtocols.None,
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // A failed handshake is remotely triggerable, so the native TLS context must not be left to the finalizer.
+            await sslStream.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+
         return sslStream;
     }
 
-    [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Input and output streams are owned and disposed by the caller.")]
-    private sealed class DuplexStream : Stream
-    {
-        private readonly Stream _readStream;
-        private readonly Stream _writeStream;
-
-        public DuplexStream(Stream readStream, Stream writeStream)
-        {
-            ArgumentNullException.ThrowIfNull(readStream);
-            ArgumentNullException.ThrowIfNull(writeStream);
-
-            _readStream = readStream;
-            _writeStream = writeStream;
-        }
-
-        public override bool CanRead => _readStream.CanRead;
-
-        public override bool CanSeek => false;
-
-        public override bool CanWrite => _writeStream.CanWrite;
-
-        public override long Length => throw new NotSupportedException();
-
-        public override long Position
-        {
-            get => throw new NotSupportedException();
-            set => throw new NotSupportedException();
-        }
-
-        public override void Flush()
-        {
-            _writeStream.Flush();
-        }
-
-        public override Task FlushAsync(CancellationToken cancellationToken)
-        {
-            return _writeStream.FlushAsync(cancellationToken);
-        }
-
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return _readStream.Read(buffer, offset, count);
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return _readStream.ReadAsync(buffer, offset, count, cancellationToken);
-        }
-
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
-        {
-            return _readStream.ReadAsync(buffer, cancellationToken);
-        }
-
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            throw new NotSupportedException();
-        }
-
-        public override void SetLength(long value)
-        {
-            throw new NotSupportedException();
-        }
-
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            _writeStream.Write(buffer, offset, count);
-        }
-
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return _writeStream.WriteAsync(buffer, offset, count, cancellationToken);
-        }
-
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
-        {
-            return _writeStream.WriteAsync(buffer, cancellationToken);
-        }
-    }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlServer.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlServer.cs
@@ -1,21 +1,42 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using Meziantou.Framework.PostgreSql.Handler;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Meziantou.Framework.PostgreSql;
 
 /// <summary>A standalone PostgreSQL server.</summary>
-public sealed class PostgreSqlServer : IDisposable
+public sealed class PostgreSqlServer : IDisposable, IAsyncDisposable
 {
     private readonly PostgreSqlServerOptions _options;
     private readonly PostgreSqlAuthenticationDelegate _authenticationHandler;
     private readonly PostgreSqlQueryDelegate _queryHandler;
+    private readonly ILogger _logger;
     private readonly List<TcpListener> _listeners = [];
+    private readonly ConcurrentDictionary<Task, TcpClient> _connections = new();
+    private readonly Lock _stateLock = new();
+    private int _activeConnectionCount;
     private CancellationTokenSource? _cts;
+    private int[] _ports = [];
+    private bool _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="PostgreSqlServer"/> class.</summary>
     public PostgreSqlServer(PostgreSqlServerOptions? options, PostgreSqlAuthenticationDelegate authenticationHandler, PostgreSqlQueryDelegate queryHandler)
+        : this(options, authenticationHandler, queryHandler, logger: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="PostgreSqlServer"/> class.</summary>
+    /// <param name="options">Server configuration. When <see langword="null"/>, defaults are used.</param>
+    /// <param name="authenticationHandler">Callback invoked to authenticate a client.</param>
+    /// <param name="queryHandler">Callback invoked to handle a query.</param>
+    /// <param name="logger">
+    /// The logger used to report connection failures. When <see langword="null"/> nothing is logged, and a
+    /// connection that fails to negotiate, authenticate or answer a query does so silently.
+    /// </param>
+    public PostgreSqlServer(PostgreSqlServerOptions? options, PostgreSqlAuthenticationDelegate authenticationHandler, PostgreSqlQueryDelegate queryHandler, ILogger? logger)
     {
         ArgumentNullException.ThrowIfNull(authenticationHandler);
         ArgumentNullException.ThrowIfNull(queryHandler);
@@ -23,49 +44,164 @@ public sealed class PostgreSqlServer : IDisposable
         _options = options ?? new PostgreSqlServerOptions();
         _authenticationHandler = authenticationHandler;
         _queryHandler = queryHandler;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <summary>Gets the ports currently bound by the server.</summary>
-    public IReadOnlyList<int> Ports => _listeners.Select(listener => ((IPEndPoint)listener.LocalEndpoint).Port).ToArray();
+    public IReadOnlyList<int> Ports => _ports;
 
     /// <summary>Starts the server.</summary>
+    [SuppressMessage("Reliability", "CA2025:Ensure tasks using 'IDisposable' instances complete before the instances are disposed", Justification = "The accept loops and connection tasks intentionally outlive StartAsync. Shutdown closes the tracked clients on purpose, to make pending socket reads fail, and both loops handle ObjectDisposedException; StopAsync awaits the connection tasks before disposal completes.")]
     public Task StartAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_cts is not null && _cts.IsCancellationRequested, this);
-        if (_cts is not null)
+        lock (_stateLock)
         {
-            return Task.CompletedTask;
-        }
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_cts is not null)
+            {
+                return Task.CompletedTask;
+            }
 
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _ = _options.GetTlsCertificate();
-        var listenerOptions = _options.TcpListeners.Count > 0
-            ? _options.TcpListeners
-            : [new PostgreSqlTcpListenerOptions { BindAddress = IPAddress.Loopback, Port = 5432 }];
+            _ = _options.GetTlsCertificate();
+            var listenerOptions = _options.TcpListeners.Count > 0
+                ? _options.TcpListeners
+                : [new PostgreSqlTcpListenerOptions { BindAddress = IPAddress.Loopback, Port = 5432 }];
 
-        foreach (var listenerOption in listenerOptions)
-        {
-            var listener = new TcpListener(listenerOption.BindAddress, listenerOption.Port);
-            listener.Start();
-            _listeners.Add(listener);
-            _ = AcceptLoopAsync(listener, _cts.Token);
+            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            try
+            {
+                foreach (var listenerOption in listenerOptions)
+                {
+                    var listener = new TcpListener(listenerOption.BindAddress, listenerOption.Port);
+                    listener.Start();
+                    _listeners.Add(listener);
+                }
+            }
+            catch
+            {
+                // Binding is all-or-nothing: the caller has no reason to dispose a server whose start threw.
+                StopListeners();
+                cancellationTokenSource.Dispose();
+                throw;
+            }
+
+            _cts = cancellationTokenSource;
+            _ports = [.. _listeners.Select(listener => ((IPEndPoint)listener.LocalEndpoint).Port)];
+
+            // The token is captured by value; the accept loops never touch the CancellationTokenSource itself.
+            var shutdownToken = cancellationTokenSource.Token;
+            foreach (var listener in _listeners)
+            {
+                _ = AcceptLoopAsync(listener, shutdownToken);
+            }
         }
 
         return Task.CompletedTask;
     }
 
+    /// <summary>Stops accepting connections and waits for in-flight connections to complete.</summary>
+    /// <param name="cancellationToken">Bounds how long to wait for in-flight connections before abandoning them.</param>
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        CancellationTokenSource? cancellationTokenSource;
+        lock (_stateLock)
+        {
+            cancellationTokenSource = _cts;
+            StopListeners();
+        }
+
+        if (cancellationTokenSource is null)
+        {
+            return;
+        }
+
+        await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
+        // A socket read already in flight does not observe a CancellationToken, so the client is closed to
+        // force it to fail; otherwise a peer that connects and sends nothing would never complete.
+        foreach (var client in _connections.Values)
+        {
+            try
+            {
+                client.Close();
+            }
+            catch (SocketException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        try
+        {
+            await Task.WhenAll([.. _connections.Keys]).WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "A PostgreSQL connection faulted during shutdown");
+        }
+    }
+
     /// <summary>Stops the server and releases resources.</summary>
     public void Dispose()
     {
-        _cts?.Cancel();
+        lock (_stateLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
 
+            _disposed = true;
+        }
+
+        try
+        {
+            _cts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        StopListeners();
+        _cts?.Dispose();
+    }
+
+    /// <summary>Stops the server, waiting for in-flight connections, and releases resources.</summary>
+    public async ValueTask DisposeAsync()
+    {
+        bool alreadyDisposed;
+        lock (_stateLock)
+        {
+            alreadyDisposed = _disposed;
+        }
+
+        if (!alreadyDisposed)
+        {
+            await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        Dispose();
+    }
+
+    private void StopListeners()
+    {
         foreach (var listener in _listeners)
         {
-            listener.Stop();
+            try
+            {
+                listener.Stop();
+            }
+            catch (SocketException)
+            {
+            }
         }
 
         _listeners.Clear();
-        _cts?.Dispose();
     }
 
     private async Task AcceptLoopAsync(TcpListener listener, CancellationToken cancellationToken)
@@ -85,23 +221,74 @@ public sealed class PostgreSqlServer : IDisposable
             {
                 return;
             }
+            catch (SocketException ex) when (ex.SocketErrorCode is SocketError.ConnectionAborted or SocketError.ConnectionReset or SocketError.Interrupted)
+            {
+                // A peer that resets between the handshake and accept is routine; the listener is still usable.
+                continue;
+            }
+            catch (Exception ex)
+            {
+                // The task is fire-and-forget, so without this the listener would go deaf with no trace.
+                _logger.LogError(ex, "Stopped accepting PostgreSQL connections after a listener failure");
+                return;
+            }
 
-            _ = ProcessClientAsync(client, cancellationToken);
+            if (Interlocked.Increment(ref _activeConnectionCount) > _options.MaxConcurrentConnections)
+            {
+                _ = Interlocked.Decrement(ref _activeConnectionCount);
+                _logger.LogWarning("Rejected a PostgreSQL connection from {RemoteEndPoint}: the limit of {MaxConcurrentConnections} concurrent connections was reached", client.Client.RemoteEndPoint, _options.MaxConcurrentConnections);
+                client.Dispose();
+                continue;
+            }
+
+            TrackConnection(client, cancellationToken);
         }
+    }
+
+    private void TrackConnection(TcpClient client, CancellationToken cancellationToken)
+    {
+        Task? connectionTask = null;
+        connectionTask = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await ProcessClientAsync(client, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _ = Interlocked.Decrement(ref _activeConnectionCount);
+                    if (connectionTask is not null)
+                    {
+                        _ = _connections.TryRemove(connectionTask, out _);
+                    }
+                }
+            },
+            CancellationToken.None);
+
+        _connections[connectionTask] = client;
     }
 
     private async Task ProcessClientAsync(TcpClient client, CancellationToken cancellationToken)
     {
         using var _ = client;
         var endpoint = client.Client.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0);
-        var processor = new PostgreSqlConnectionProcessor(_options, _authenticationHandler, _queryHandler, NullLogger.Instance);
+        var processor = new PostgreSqlConnectionProcessor(_options, _authenticationHandler, _queryHandler, _logger);
         try
         {
+            // Each protocol message is written in a single call, but disabling Nagle also avoids delaying the
+            // last write of a response while the peer's ACK is outstanding.
+            client.NoDelay = true;
             using var stream = client.GetStream();
             await processor.ProcessAsync(stream, stream, endpoint, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+        catch (Exception ex)
+        {
+            // This runs on a fire-and-forget task, so an escaping exception would otherwise be unobserved.
+            _logger.LogDebug(ex, "PostgreSQL connection from {RemoteEndPoint} closed with exception", endpoint);
         }
     }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlServerOptions.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/PostgreSqlServerOptions.cs
@@ -9,12 +9,114 @@ namespace Meziantou.Framework.PostgreSql;
 /// <summary>Configuration options for the PostgreSQL server.</summary>
 public sealed class PostgreSqlServerOptions
 {
+    /// <summary>The default value of <see cref="MaxMessageSize"/>.</summary>
+    public const int DefaultMaxMessageSize = 16 * 1024 * 1024;
+
+    /// <summary>The maximum size, in bytes, of a startup packet. Matches PostgreSQL's own limit.</summary>
+    public const int MaxStartupPacketSize = 10000;
+
     private readonly Lock _tlsCertificateLock = new();
     private readonly ConcurrentDictionary<(int ProcessId, int SecretKey), PostgreSqlBackendSession> _backendSessions = new();
     private X509Certificate2? _tlsCertificate;
-    private bool _tlsCertificateLoaded;
+    private volatile bool _tlsCertificateLoaded;
+    private int _maxMessageSize = DefaultMaxMessageSize;
+    private int _maxConcurrentConnections = 1000;
+    private int _maxPreparedStatementsPerConnection = 1000;
+    private int _maxPortalsPerConnection = 1000;
+    private TimeSpan _handshakeTimeout = TimeSpan.FromSeconds(30);
+    private TimeSpan _idleTimeout = TimeSpan.FromMinutes(30);
 
     internal List<PostgreSqlTcpListenerOptions> TcpListeners { get; } = [];
+
+    /// <summary>Gets or sets the maximum size, in bytes, of a single inbound message.</summary>
+    /// <remarks>
+    /// The server buffers a whole message before parsing it, and the length is declared by the client. This limit
+    /// bounds that buffer. It applies from the very first message of a connection, so it also bounds what an
+    /// unauthenticated client can make the server allocate. Raise it when clients legitimately send large
+    /// parameters or SQL batches. The startup packet is bounded separately by <see cref="MaxStartupPacketSize"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is not strictly positive.</exception>
+    public int MaxMessageSize
+    {
+        get => _maxMessageSize;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+            _maxMessageSize = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum number of connections served concurrently. Additional connections are closed immediately.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">The value is not strictly positive.</exception>
+    public int MaxConcurrentConnections
+    {
+        get => _maxConcurrentConnections;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+            _maxConcurrentConnections = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum number of prepared statements a single connection may hold.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">The value is not strictly positive.</exception>
+    public int MaxPreparedStatementsPerConnection
+    {
+        get => _maxPreparedStatementsPerConnection;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+            _maxPreparedStatementsPerConnection = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum number of portals a single connection may hold.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">The value is not strictly positive.</exception>
+    public int MaxPortalsPerConnection
+    {
+        get => _maxPortalsPerConnection;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+            _maxPortalsPerConnection = value;
+        }
+    }
+
+    /// <summary>Gets or sets how long an unauthenticated connection may take to complete TLS negotiation and authentication.</summary>
+    /// <remarks>Use <see cref="Timeout.InfiniteTimeSpan"/> to disable. Leaving it disabled lets an unauthenticated peer hold a connection open indefinitely.</remarks>
+    public TimeSpan HandshakeTimeout
+    {
+        get => _handshakeTimeout;
+        set
+        {
+            if (value != Timeout.InfiniteTimeSpan)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
+            }
+
+            _handshakeTimeout = value;
+        }
+    }
+
+    /// <summary>Gets or sets how long an authenticated connection may stay idle between messages before it is closed.</summary>
+    /// <remarks>Use <see cref="Timeout.InfiniteTimeSpan"/> to disable.</remarks>
+    public TimeSpan IdleTimeout
+    {
+        get => _idleTimeout;
+        set
+        {
+            if (value != Timeout.InfiniteTimeSpan)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
+            }
+
+            _idleTimeout = value;
+        }
+    }
 
     /// <summary>Gets or sets a value indicating whether encryption is required by the server.</summary>
     public bool RequireEncryption { get; set; }
@@ -66,9 +168,12 @@ public sealed class PostgreSqlServerOptions
                 return _tlsCertificate;
             }
 
-            _tlsCertificate = PostgreSqlServerCertificateLoader.Load(this);
+            var certificate = PostgreSqlServerCertificateLoader.Load(this);
+            _tlsCertificate = certificate;
+
+            // Written last: _tlsCertificateLoaded is volatile, so a reader that observes true also observes the certificate.
             _tlsCertificateLoaded = true;
-            return _tlsCertificate;
+            return certificate;
         }
     }
 

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/DuplexStream.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/DuplexStream.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Meziantou.Framework.PostgreSql.Protocol;
+
+/// <summary>Presents a separate read stream and write stream as one <see cref="Stream"/>.</summary>
+/// <remarks>
+/// Needed because the Kestrel transport exposes the connection as two half-duplex pipes, while
+/// <see cref="System.Net.Security.SslStream"/> requires a single bidirectional stream.
+/// </remarks>
+[SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Input and output streams are owned and disposed by the caller.")]
+internal sealed class DuplexStream : Stream
+{
+    private readonly Stream _readStream;
+    private readonly Stream _writeStream;
+
+    public DuplexStream(Stream readStream, Stream writeStream)
+    {
+        ArgumentNullException.ThrowIfNull(readStream);
+        ArgumentNullException.ThrowIfNull(writeStream);
+
+        _readStream = readStream;
+        _writeStream = writeStream;
+    }
+
+    public override bool CanRead => _readStream.CanRead;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => _writeStream.CanWrite;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+        _writeStream.Flush();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        return _writeStream.FlushAsync(cancellationToken);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return _readStream.Read(buffer, offset, count);
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        return _readStream.ReadAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        return _readStream.ReadAsync(buffer, cancellationToken);
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _writeStream.Write(buffer, offset, count);
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        return _writeStream.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        return _writeStream.WriteAsync(buffer, cancellationToken);
+    }
+}

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlConstants.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlConstants.cs
@@ -5,4 +5,67 @@ internal static class PostgreSqlConstants
     public const int ProtocolVersion3 = 196608;
     public const int SslRequestCode = 80877103;
     public const int CancelRequestCode = 80877102;
+
+    /// <summary>Message type tags sent by the client. Several tags collide with <see cref="Backend"/> tags but mean something different.</summary>
+    public static class Frontend
+    {
+        public const byte Query = (byte)'Q';
+        public const byte Parse = (byte)'P';
+        public const byte Bind = (byte)'B';
+        public const byte Describe = (byte)'D';
+        public const byte Execute = (byte)'E';
+        public const byte Close = (byte)'C';
+        public const byte Sync = (byte)'S';
+        public const byte Flush = (byte)'H';
+        public const byte Terminate = (byte)'X';
+        public const byte PasswordMessage = (byte)'p';
+    }
+
+    /// <summary>Message type tags sent by the server.</summary>
+    public static class Backend
+    {
+        public const byte Authentication = (byte)'R';
+        public const byte ParameterStatus = (byte)'S';
+        public const byte BackendKeyData = (byte)'K';
+        public const byte ReadyForQuery = (byte)'Z';
+        public const byte ParseComplete = (byte)'1';
+        public const byte BindComplete = (byte)'2';
+        public const byte CloseComplete = (byte)'3';
+        public const byte RowDescription = (byte)'T';
+        public const byte DataRow = (byte)'D';
+        public const byte CommandComplete = (byte)'C';
+        public const byte ErrorResponse = (byte)'E';
+        public const byte NoticeResponse = (byte)'N';
+        public const byte ParameterDescription = (byte)'t';
+        public const byte NoData = (byte)'n';
+        public const byte EmptyQueryResponse = (byte)'I';
+        public const byte PortalSuspended = (byte)'s';
+    }
+
+    /// <summary>The target discriminator carried by Describe and Close messages.</summary>
+    public static class DescribeTarget
+    {
+        public const byte Statement = (byte)'S';
+        public const byte Portal = (byte)'P';
+    }
+
+    /// <summary>Transaction status reported by ReadyForQuery.</summary>
+    public static class TransactionStatus
+    {
+        public const byte Idle = (byte)'I';
+        public const byte InTransaction = (byte)'T';
+        public const byte Failed = (byte)'E';
+    }
+
+    public static class SqlStates
+    {
+        public const string ProtocolViolation = "08P01";
+        public const string InvalidAuthorizationSpecification = "28000";
+        public const string InvalidPassword = "28P01";
+        public const string InvalidSqlStatementName = "26000";
+        public const string QueryCanceled = "57014";
+        public const string InternalError = "XX000";
+        public const string ConfigurationLimitExceeded = "53400";
+        public const string SuccessfulCompletion = "00000";
+    }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlMessageReader.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlMessageReader.cs
@@ -20,18 +20,23 @@ internal static class PostgreSqlMessageReader
             throw new InvalidDataException("Invalid PostgreSQL startup packet length.");
         }
 
+        // The length is attacker-controlled and arrives before any body byte, so it is validated before allocating.
+        if (length > PostgreSqlServerOptions.MaxStartupPacketSize)
+        {
+            throw new InvalidDataException($"PostgreSQL startup packet length {length} exceeds the maximum of {PostgreSqlServerOptions.MaxStartupPacketSize} bytes.");
+        }
+
         var body = new byte[length - 4];
         await stream.ReadExactlyAsync(body, cancellationToken).ConfigureAwait(false);
         var requestCode = BinaryPrimitives.ReadInt32BigEndian(body.AsSpan(0, 4));
-        var payload = body.AsSpan(4).ToArray();
         return new PostgreSqlStartupPacket
         {
             RequestCode = requestCode,
-            Payload = payload,
+            Payload = body[4..],
         };
     }
 
-    public static async ValueTask<PostgreSqlFrontendMessage?> ReadMessageAsync(Stream stream, CancellationToken cancellationToken)
+    public static async ValueTask<PostgreSqlFrontendMessage?> ReadMessageAsync(Stream stream, int maxMessageSize, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(stream);
 
@@ -46,6 +51,12 @@ internal static class PostgreSqlMessageReader
         if (length < 4)
         {
             throw new InvalidDataException("Invalid PostgreSQL frontend message length.");
+        }
+
+        // The length is attacker-controlled and arrives before any body byte, so it is validated before allocating.
+        if (length - 4 > maxMessageSize)
+        {
+            throw new InvalidDataException($"PostgreSQL message length {length - 4} exceeds the configured maximum of {maxMessageSize} bytes.");
         }
 
         var payload = new byte[length - 4];

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlMessageWriter.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlMessageWriter.cs
@@ -20,14 +20,18 @@ internal sealed class PostgreSqlMessageWriter
 
     public async ValueTask WriteMessageAsync(byte messageType, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
     {
-        var header = new byte[5];
-        header[0] = messageType;
-        BinaryPrimitives.WriteInt32BigEndian(header.AsSpan(1, 4), payload.Length + 4);
+        // Header and payload go out in a single write: two writes on a NetworkStream interact badly with Nagle,
+        // holding the payload until the peer's delayed ACK arrives.
+        var buffer = new byte[5 + payload.Length];
+        buffer[0] = messageType;
+        BinaryPrimitives.WriteInt32BigEndian(buffer.AsSpan(1, 4), payload.Length + 4);
+        payload.Span.CopyTo(buffer.AsSpan(5));
 
-        await _stream.WriteAsync(header, cancellationToken).ConfigureAwait(false);
-        if (!payload.IsEmpty)
-        {
-            await _stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
-        }
+        await _stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    public ValueTask FlushAsync(CancellationToken cancellationToken)
+    {
+        return new ValueTask(_stream.FlushAsync(cancellationToken));
     }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlPortal.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlPortal.cs
@@ -10,5 +10,6 @@ internal sealed class PostgreSqlPortal
 
     public IReadOnlyList<int> ResultFormatCodes { get; init; } = [];
 
-    public bool IsDescribed { get; set; }
+    /// <summary>The number of columns announced by Describe, or <see langword="null"/> when the portal was never described.</summary>
+    public int? DescribedColumnCount { get; set; }
 }

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlResponseSerializer.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlResponseSerializer.cs
@@ -124,6 +124,16 @@ internal static class PostgreSqlResponseSerializer
         return [];
     }
 
+    public static byte[] CreateEmptyQueryResponse()
+    {
+        return [];
+    }
+
+    public static byte[] CreatePortalSuspended()
+    {
+        return [];
+    }
+
     public static byte[] CreateParameterDescription(IReadOnlyList<uint> parameterTypeOids)
     {
         ArgumentNullException.ThrowIfNull(parameterTypeOids);
@@ -140,29 +150,46 @@ internal static class PostgreSqlResponseSerializer
         return stream.ToArray();
     }
 
-    public static byte[] CreateRowDescription(PostgreSqlResultSet resultSet)
+    public static byte[] CreateRowDescription(PostgreSqlResultSet resultSet, IReadOnlyList<int>? resultFormatCodes = null)
     {
         ArgumentNullException.ThrowIfNull(resultSet);
 
         using var stream = new MemoryStream();
         using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
         WriteInt16BigEndian(writer, checked((short)resultSet.Columns.Count));
-        foreach (var column in resultSet.Columns)
+        for (var i = 0; i < resultSet.Columns.Count; i++)
         {
+            var column = resultSet.Columns[i];
             WriteNullTerminatedString(writer, column.Name);
             WriteInt32BigEndian(writer, 0);
             WriteInt16BigEndian(writer, 0);
             WriteUInt32BigEndian(writer, PostgreSqlTypeMapper.GetTypeOid(column.ColumnType));
             WriteInt16BigEndian(writer, PostgreSqlTypeMapper.GetTypeSize(column.ColumnType));
             WriteInt32BigEndian(writer, -1);
-            WriteInt16BigEndian(writer, 0);
+            WriteInt16BigEndian(writer, (short)ResolveResultFormatCode(resultFormatCodes, i));
         }
 
         writer.Flush();
         return stream.ToArray();
     }
 
-    public static byte[] CreateDataRow(PostgreSqlResultSet resultSet, IReadOnlyList<object?> row)
+    /// <summary>Resolves the format of a result column. Bind supplies zero codes (all text), one code for every column, or one per column.</summary>
+    public static int ResolveResultFormatCode(IReadOnlyList<int>? resultFormatCodes, int columnIndex)
+    {
+        if (resultFormatCodes is null || resultFormatCodes.Count == 0)
+        {
+            return 0;
+        }
+
+        if (resultFormatCodes.Count == 1)
+        {
+            return resultFormatCodes[0];
+        }
+
+        return columnIndex < resultFormatCodes.Count ? resultFormatCodes[columnIndex] : 0;
+    }
+
+    public static byte[] CreateDataRow(PostgreSqlResultSet resultSet, IReadOnlyList<object?> row, IReadOnlyList<int>? resultFormatCodes = null)
     {
         ArgumentNullException.ThrowIfNull(resultSet);
         ArgumentNullException.ThrowIfNull(row);
@@ -177,13 +204,13 @@ internal static class PostgreSqlResponseSerializer
         for (var i = 0; i < row.Count; i++)
         {
             var value = row[i];
-            if (value is null)
+            if (value is null or DBNull)
             {
                 WriteInt32BigEndian(writer, -1);
                 continue;
             }
 
-            var bytes = PostgreSqlValueConverter.EncodeResultValue(resultSet.Columns[i].ColumnType, value);
+            var bytes = PostgreSqlValueConverter.EncodeResultValue(resultSet.Columns[i].ColumnType, value, ResolveResultFormatCode(resultFormatCodes, i));
             WriteInt32BigEndian(writer, bytes.Length);
             writer.Write(bytes);
         }
@@ -192,16 +219,49 @@ internal static class PostgreSqlResponseSerializer
         return stream.ToArray();
     }
 
-    public static byte[] CreateCommandComplete(string commandTag, int rowCount)
+    public static byte[] CreateCommandComplete(string? commandTag, string defaultTag, int? affectedRowCount)
     {
-        ArgumentException.ThrowIfNullOrEmpty(commandTag);
-        var tag = rowCount >= 0 ? $"{commandTag} {rowCount.ToString(CultureInfo.InvariantCulture)}" : commandTag;
+        ArgumentException.ThrowIfNullOrEmpty(defaultTag);
+
+        string tag;
+        if (string.IsNullOrWhiteSpace(commandTag))
+        {
+            tag = $"{defaultTag} {(affectedRowCount ?? 0).ToString(CultureInfo.InvariantCulture)}";
+        }
+        else if (HasRowCount(commandTag))
+        {
+            // The caller already produced a complete tag such as "INSERT 0 1"; appending a count would corrupt it.
+            tag = commandTag;
+        }
+        else
+        {
+            tag = $"{commandTag} {(affectedRowCount ?? 0).ToString(CultureInfo.InvariantCulture)}";
+        }
 
         using var stream = new MemoryStream();
         using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
         WriteNullTerminatedString(writer, tag);
         writer.Flush();
         return stream.ToArray();
+    }
+
+    private static bool HasRowCount(string commandTag)
+    {
+        var lastSeparator = commandTag.LastIndexOf(' ', StringComparison.Ordinal);
+        if (lastSeparator < 0 || lastSeparator == commandTag.Length - 1)
+        {
+            return false;
+        }
+
+        foreach (var character in commandTag.AsSpan(lastSeparator + 1))
+        {
+            if (!char.IsAsciiDigit(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static byte[] CreateAuthenticationSaslMessage(int code, string payloadText)

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlScramHelper.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlScramHelper.cs
@@ -33,10 +33,15 @@ internal static class PostgreSqlScramHelper
         return result;
     }
 
-    public static bool TryParseClientFirstMessage(string message, [NotNullWhen(true)] out string? clientFirstMessageBare, [NotNullWhen(true)] out string? clientNonce)
+    public static bool TryParseClientFirstMessage(
+        string message,
+        [NotNullWhen(true)] out string? clientFirstMessageBare,
+        [NotNullWhen(true)] out string? clientNonce,
+        [NotNullWhen(true)] out string? gs2Header)
     {
         clientFirstMessageBare = null;
         clientNonce = null;
+        gs2Header = null;
         if (string.IsNullOrEmpty(message))
         {
             return false;
@@ -48,16 +53,43 @@ internal static class PostgreSqlScramHelper
             return false;
         }
 
+        // The gs2 flag is 'n' (client does not support channel binding) or 'y' (supports it but the server did
+        // not offer it). 'p' means the client demands channel binding, which this server never advertises.
+        gs2Header = message[..(gs2HeaderSeparatorIndex + 2)];
+        var flag = message[0];
+        if (flag is not 'n' and not 'y')
+        {
+            return false;
+        }
+
         clientFirstMessageBare = message[(gs2HeaderSeparatorIndex + 2)..];
         var attributes = ParseAttributes(clientFirstMessageBare);
         return attributes.TryGetValue("r", out clientNonce) && !string.IsNullOrWhiteSpace(clientNonce);
     }
 
-    public static bool TryParseClientFinalMessage(string message, [NotNullWhen(true)] out string? withoutProof, [NotNullWhen(true)] out byte[]? proof, [NotNullWhen(true)] out string? nonce)
+    /// <summary>Verifies that the client-final <c>c=</c> attribute repeats the gs2 header sent in client-first.</summary>
+    public static bool IsExpectedChannelBinding(string? channelBinding, string gs2Header)
+    {
+        if (channelBinding is null)
+        {
+            return false;
+        }
+
+        var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(gs2Header));
+        return string.Equals(channelBinding, expected, StringComparison.Ordinal);
+    }
+
+    public static bool TryParseClientFinalMessage(
+        string message,
+        [NotNullWhen(true)] out string? withoutProof,
+        [NotNullWhen(true)] out byte[]? proof,
+        [NotNullWhen(true)] out string? nonce,
+        out string? channelBinding)
     {
         withoutProof = null;
         proof = null;
         nonce = null;
+        channelBinding = null;
         if (string.IsNullOrWhiteSpace(message))
         {
             return false;
@@ -71,7 +103,16 @@ internal static class PostgreSqlScramHelper
             return false;
         }
 
-        proof = Convert.FromBase64String(proofValue);
+        _ = attributes.TryGetValue("c", out channelBinding);
+
+        // Honour the Try contract: malformed base64 is a parse failure, not an exception.
+        var proofBuffer = new byte[((proofValue.Length + 3) / 4) * 3];
+        if (!Convert.TryFromBase64String(proofValue, proofBuffer, out var proofLength))
+        {
+            return false;
+        }
+
+        proof = proofBuffer[..proofLength];
         var proofStart = message.IndexOf(",p=", StringComparison.Ordinal);
         if (proofStart < 0)
         {

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlSessionState.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlSessionState.cs
@@ -1,0 +1,30 @@
+using System.Net;
+
+namespace Meziantou.Framework.PostgreSql.Protocol;
+
+/// <summary>Holds the per-connection state of an authenticated session.</summary>
+internal sealed class PostgreSqlSessionState
+{
+    public PostgreSqlSessionState(EndPoint remoteEndPoint, IReadOnlyDictionary<string, string> startupParameters, PostgreSqlBackendSession? backendSession)
+    {
+        RemoteEndPoint = remoteEndPoint;
+        StartupParameters = startupParameters;
+        BackendSession = backendSession;
+    }
+
+    public EndPoint RemoteEndPoint { get; }
+
+    public IReadOnlyDictionary<string, string> StartupParameters { get; }
+
+    public PostgreSqlBackendSession? BackendSession { get; }
+
+    public Dictionary<string, PostgreSqlStatement> PreparedStatements { get; } = new(StringComparer.Ordinal);
+
+    public Dictionary<string, PostgreSqlPortal> Portals { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>Gets or sets a value indicating whether messages are being skipped until the next Sync.</summary>
+    public bool InErrorState { get; set; }
+
+    /// <summary>Gets or sets the transaction status reported by ReadyForQuery.</summary>
+    public byte TransactionStatus { get; set; } = PostgreSqlConstants.TransactionStatus.Idle;
+}

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlTypeMapper.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlTypeMapper.cs
@@ -4,6 +4,8 @@ namespace Meziantou.Framework.PostgreSql.Protocol;
 
 internal static class PostgreSqlTypeMapper
 {
+    public const uint TextOid = 25;
+
     public static uint GetTypeOid(PostgreSqlColumnType type)
     {
         return type switch

--- a/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlValueConverter.cs
+++ b/src/Meziantou.Framework.PostgreSqlServer/Protocol/PostgreSqlValueConverter.cs
@@ -1,10 +1,14 @@
 using System.Buffers.Binary;
+using System.Numerics;
 using Meziantou.Framework.PostgreSql.Handler;
 
 namespace Meziantou.Framework.PostgreSql.Protocol;
 
 internal static class PostgreSqlValueConverter
 {
+    /// <summary>The PostgreSQL binary date/time epoch. It is 2000-01-01, not the Unix epoch.</summary>
+    private static readonly DateTime PostgreSqlEpoch = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     public static object? DecodeParameterValue(uint typeOid, int formatCode, byte[]? rawValue)
     {
         if (rawValue is null)
@@ -20,13 +24,20 @@ internal static class PostgreSqlValueConverter
         return DecodeBinaryValue(typeOid, rawValue);
     }
 
-    public static byte[] EncodeResultValue(PostgreSqlColumnType columnType, object? value)
+    public static byte[] EncodeResultValue(PostgreSqlColumnType columnType, object? value, int formatCode)
     {
-        if (value is null)
+        if (value is null or DBNull)
         {
             return [];
         }
 
+        return formatCode == 1
+            ? EncodeBinaryResultValue(columnType, value)
+            : EncodeTextResultValue(columnType, value);
+    }
+
+    private static byte[] EncodeTextResultValue(PostgreSqlColumnType columnType, object value)
+    {
         var text = columnType switch
         {
             PostgreSqlColumnType.Boolean => Convert.ToBoolean(value, CultureInfo.InvariantCulture) ? "t" : "f",
@@ -69,12 +80,170 @@ internal static class PostgreSqlValueConverter
         return Encoding.UTF8.GetBytes(text);
     }
 
+    private static byte[] EncodeBinaryResultValue(PostgreSqlColumnType columnType, object value)
+    {
+        switch (columnType)
+        {
+            case PostgreSqlColumnType.Boolean:
+                return [Convert.ToBoolean(value, CultureInfo.InvariantCulture) ? (byte)1 : (byte)0];
+            case PostgreSqlColumnType.Int16:
+            {
+                var buffer = new byte[2];
+                BinaryPrimitives.WriteInt16BigEndian(buffer, Convert.ToInt16(value, CultureInfo.InvariantCulture));
+                return buffer;
+            }
+
+            case PostgreSqlColumnType.Int32:
+            {
+                var buffer = new byte[4];
+                BinaryPrimitives.WriteInt32BigEndian(buffer, Convert.ToInt32(value, CultureInfo.InvariantCulture));
+                return buffer;
+            }
+
+            case PostgreSqlColumnType.Int64:
+            {
+                var buffer = new byte[8];
+                BinaryPrimitives.WriteInt64BigEndian(buffer, Convert.ToInt64(value, CultureInfo.InvariantCulture));
+                return buffer;
+            }
+
+            case PostgreSqlColumnType.Single:
+            {
+                var buffer = new byte[4];
+                BinaryPrimitives.WriteInt32BigEndian(buffer, BitConverter.SingleToInt32Bits(Convert.ToSingle(value, CultureInfo.InvariantCulture)));
+                return buffer;
+            }
+
+            case PostgreSqlColumnType.Double:
+            {
+                var buffer = new byte[8];
+                BinaryPrimitives.WriteInt64BigEndian(buffer, BitConverter.DoubleToInt64Bits(Convert.ToDouble(value, CultureInfo.InvariantCulture)));
+                return buffer;
+            }
+
+            case PostgreSqlColumnType.Numeric:
+                return EncodeBinaryNumeric(Convert.ToDecimal(value, CultureInfo.InvariantCulture));
+            case PostgreSqlColumnType.Bytea:
+                return value as byte[] ?? Encoding.UTF8.GetBytes(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
+            case PostgreSqlColumnType.Uuid:
+            {
+                var guid = value switch
+                {
+                    Guid guidValue => guidValue,
+                    string text when Guid.TryParse(text, CultureInfo.InvariantCulture, out var parsed) => parsed,
+                    _ => throw new InvalidOperationException($"Value of type '{value.GetType()}' cannot be encoded as a uuid."),
+                };
+
+                return guid.ToByteArray(bigEndian: true);
+            }
+
+            case PostgreSqlColumnType.Date:
+            {
+                var date = value switch
+                {
+                    DateOnly dateOnly => dateOnly.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                    DateTime dateTime => dateTime,
+                    DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime,
+                    _ => Convert.ToDateTime(value, CultureInfo.InvariantCulture),
+                };
+
+                var buffer = new byte[4];
+                BinaryPrimitives.WriteInt32BigEndian(buffer, (int)(date.Date - PostgreSqlEpoch).TotalDays);
+                return buffer;
+            }
+
+            case PostgreSqlColumnType.Timestamp:
+            case PostgreSqlColumnType.TimestampTz:
+            {
+                var timestamp = value switch
+                {
+                    DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime,
+                    DateTime dateTime => dateTime.Kind == DateTimeKind.Local ? dateTime.ToUniversalTime() : dateTime,
+                    DateOnly dateOnly => dateOnly.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                    _ => Convert.ToDateTime(value, CultureInfo.InvariantCulture),
+                };
+
+                var microseconds = (timestamp - PostgreSqlEpoch).Ticks / (TimeSpan.TicksPerMillisecond / 1000);
+                var buffer = new byte[8];
+                BinaryPrimitives.WriteInt64BigEndian(buffer, microseconds);
+                return buffer;
+            }
+
+            default:
+                // text, varchar, json and jsonb use the same octets in both formats.
+                return Encoding.UTF8.GetBytes(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+    }
+
+    private static byte[] EncodeBinaryNumeric(decimal value)
+    {
+        // Layout: int16 digit count, int16 weight, uint16 sign, int16 display scale, then base-10000 digits.
+        var bits = decimal.GetBits(value);
+        var scale = (bits[3] >> 16) & 0xFF;
+        var isNegative = (bits[3] & unchecked((int)0x80000000)) != 0;
+        var unscaled = new BigInteger(new[] { bits[0], bits[1], bits[2] }.SelectMany(BitConverter.GetBytes).ToArray(), isUnsigned: true, isBigEndian: false);
+
+        // Align the fraction on a group boundary so the decimal point falls between two base-10000 digits.
+        var paddedScale = ((scale + 3) / 4) * 4;
+        unscaled *= BigInteger.Pow(10, paddedScale - scale);
+
+        var digits = new List<short>();
+        if (unscaled.IsZero)
+        {
+            digits.Add(0);
+        }
+        else
+        {
+            while (!unscaled.IsZero)
+            {
+                unscaled = BigInteger.DivRem(unscaled, 10000, out var remainder);
+                digits.Add((short)remainder);
+            }
+        }
+
+        digits.Reverse();
+        var weight = digits.Count - 1 - (paddedScale / 4);
+
+        // PostgreSQL stores neither leading nor trailing all-zero groups.
+        var start = 0;
+        while (start < digits.Count - 1 && digits[start] == 0)
+        {
+            start++;
+            weight--;
+        }
+
+        var end = digits.Count;
+        while (end > start + 1 && digits[end - 1] == 0)
+        {
+            end--;
+        }
+
+        var significant = digits.GetRange(start, end - start);
+        if (significant is [0])
+        {
+            significant.Clear();
+            weight = 0;
+        }
+
+        var buffer = new byte[8 + (significant.Count * 2)];
+        BinaryPrimitives.WriteInt16BigEndian(buffer.AsSpan(0, 2), (short)significant.Count);
+        BinaryPrimitives.WriteInt16BigEndian(buffer.AsSpan(2, 2), (short)weight);
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(4, 2), isNegative ? (ushort)0x4000 : (ushort)0);
+        BinaryPrimitives.WriteInt16BigEndian(buffer.AsSpan(6, 2), (short)scale);
+        for (var i = 0; i < significant.Count; i++)
+        {
+            BinaryPrimitives.WriteInt16BigEndian(buffer.AsSpan(8 + (i * 2), 2), significant[i]);
+        }
+
+        return buffer;
+    }
+
     private static object DecodeTextValue(uint typeOid, byte[] bytes)
     {
         var text = Encoding.UTF8.GetString(bytes);
         return typeOid switch
         {
-            16 => string.Equals(text, "t", StringComparison.OrdinalIgnoreCase),
+            16 => ParseBoolean(text),
             21 => short.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var int16) ? int16 : text,
             23 => int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var int32) ? int32 : text,
             20 => long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var int64) ? int64 : text,
@@ -99,10 +268,127 @@ internal static class PostgreSqlValueConverter
             20 when bytes.Length == 8 => BinaryPrimitives.ReadInt64BigEndian(bytes),
             700 when bytes.Length == 4 => BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32BigEndian(bytes)),
             701 when bytes.Length == 8 => BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64BigEndian(bytes)),
+            1082 when bytes.Length == 4 => DecodeBinaryDate(bytes),
+            1114 when bytes.Length == 8 => DecodeBinaryTimestamp(bytes),
+            1184 when bytes.Length == 8 => new DateTimeOffset(DecodeBinaryTimestamp(bytes), TimeSpan.Zero),
+            1700 => DecodeBinaryNumeric(bytes),
+            2950 when bytes.Length == 16 => new Guid(bytes, bigEndian: true),
             25 or 1043 or 114 or 3802 => Encoding.UTF8.GetString(bytes),
             17 => bytes,
             _ => bytes,
         };
+    }
+
+    private static object DecodeBinaryDate(byte[] bytes)
+    {
+        var days = BinaryPrimitives.ReadInt32BigEndian(bytes);
+        try
+        {
+            return DateOnly.FromDateTime(PostgreSqlEpoch.AddDays(days));
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // PostgreSQL uses sentinel values for infinity, which have no DateOnly representation.
+            return bytes;
+        }
+    }
+
+    private static DateTime DecodeBinaryTimestamp(byte[] bytes)
+    {
+        var microseconds = BinaryPrimitives.ReadInt64BigEndian(bytes);
+        return PostgreSqlEpoch.AddTicks(microseconds * (TimeSpan.TicksPerMillisecond / 1000));
+    }
+
+    private static object DecodeBinaryNumeric(byte[] bytes)
+    {
+        // Layout: int16 digit count, int16 weight, uint16 sign, int16 display scale, then base-10000 digits.
+        if (bytes.Length < 8)
+        {
+            return bytes;
+        }
+
+        var digitCount = BinaryPrimitives.ReadInt16BigEndian(bytes.AsSpan(0, 2));
+        var weight = BinaryPrimitives.ReadInt16BigEndian(bytes.AsSpan(2, 2));
+        var sign = BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(4, 2));
+        var scale = BinaryPrimitives.ReadInt16BigEndian(bytes.AsSpan(6, 2));
+        if (digitCount < 0 || scale < 0 || bytes.Length < 8 + (digitCount * 2))
+        {
+            return bytes;
+        }
+
+        // 0xC000 is NaN; the infinity sentinels have no decimal representation either.
+        if (sign is not 0 and not 0x4000)
+        {
+            return bytes;
+        }
+
+        try
+        {
+            decimal value = 0;
+            for (var i = 0; i < digitCount; i++)
+            {
+                var digit = BinaryPrimitives.ReadInt16BigEndian(bytes.AsSpan(8 + (i * 2), 2));
+                value += digit * Pow10000(weight - i);
+            }
+
+            if (sign == 0x4000)
+            {
+                value = -value;
+            }
+
+            return Math.Round(value, Math.Min((int)scale, 28), MidpointRounding.ToEven);
+        }
+        catch (OverflowException)
+        {
+            return bytes;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return bytes;
+        }
+    }
+
+    private static decimal Pow10000(int exponent)
+    {
+        decimal result = 1;
+        for (var i = 0; i < exponent; i++)
+        {
+            result *= 10000m;
+        }
+
+        for (var i = 0; i > exponent; i--)
+        {
+            result /= 10000m;
+        }
+
+        return result;
+    }
+
+    private static object ParseBoolean(string text)
+    {
+        // PostgreSQL accepts the full set below, case-insensitively and with surrounding whitespace trimmed.
+        var value = text.Trim();
+        if (value.Equals("t", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("y", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("on", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("1", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (value.Equals("f", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("n", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("off", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("0", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return text;
     }
 
     private static string EncodeBytea(object value)

--- a/src/Meziantou.Framework.PostgreSqlServer/readme.md
+++ b/src/Meziantou.Framework.PostgreSqlServer/readme.md
@@ -1,6 +1,9 @@
 # Meziantou.Framework.PostgreSqlServer
 
 `Meziantou.Framework.PostgreSqlServer` is a callback-based server library for accepting PostgreSQL protocol connections.
+Real PostgreSQL clients (Npgsql, `psql`, JDBC) connect to it, and you decide how to authenticate them and how to answer their queries.
+
+It is useful for test doubles, query gateways, proxies, and data virtualization — anything that should speak the PostgreSQL wire protocol without being PostgreSQL.
 
 ## Features
 
@@ -10,3 +13,143 @@
 - TLS negotiation (`SSLRequest`) on the same endpoint
 - Query cancellation support (`CancelRequest`)
 - ASP.NET Core hosting integration through `IHostApplicationBuilder`
+
+## Security: configure TLS
+
+Without a certificate the server answers `SSLRequest` with "not supported", and clients that allow it (Npgsql's default `SSL Mode=Prefer`) then log in over an unencrypted connection — sending the password in the clear for cleartext and MD5 authentication. Configure `TlsPfxPath` or the PEM options for any deployment that is not loopback-only, and set `RequireEncryption` to reject plaintext connections outright.
+
+```csharp
+var options = new PostgreSqlServerOptions
+{
+    RequireEncryption = true,
+    TlsPfxPath = "server.pfx",
+    TlsPfxPassword = "…",
+};
+```
+
+`RequireEncryption` without a certificate throws at startup rather than silently accepting plaintext.
+
+## Quickstart (standalone)
+
+```csharp
+using Meziantou.Framework.PostgreSql;
+using Meziantou.Framework.PostgreSql.Handler;
+
+var options = new PostgreSqlServerOptions
+{
+    AuthenticationMethod = PostgreSqlAuthenticationMethod.ScramSha256,
+};
+options.AddTcpListener(port: 5432);
+
+using var server = new PostgreSqlServer(
+    options,
+    authenticationHandler: (context, cancellationToken) =>
+    {
+        // ValidatePassword must be called for SCRAM-SHA-256: it is what computes the server signature.
+        var isValid = context.UserName == "app" && context.ValidatePassword("Password123!");
+        return ValueTask.FromResult(isValid
+            ? PostgreSqlAuthenticationResult.Success()
+            : PostgreSqlAuthenticationResult.Fail("invalid credentials"));
+    },
+    queryHandler: (context, cancellationToken) =>
+    {
+        var resultSet = new PostgreSqlResultSet();
+        resultSet.Columns.Add(new PostgreSqlColumn("id", PostgreSqlColumnType.Int32));
+        resultSet.Columns.Add(new PostgreSqlColumn("name", PostgreSqlColumnType.Text));
+
+        // A Describe request only needs the columns; the rows are ignored.
+        if (context.RequestType != PostgreSqlQueryRequestType.Describe)
+        {
+            resultSet.Rows.Add([1, "Meziantou"]);
+        }
+
+        var result = new PostgreSqlQueryResult();
+        result.ResultSets.Add(resultSet);
+        return ValueTask.FromResult(result);
+    },
+    logger: null);
+
+await server.StartAsync();
+Console.WriteLine($"Listening on port {server.Ports[0]}");
+Console.ReadLine();
+
+await server.StopAsync();
+```
+
+Bind to port `0` to let the OS choose a free port, then read it back from `Ports` — the usual pattern in tests.
+
+## The query callback must answer `Describe`
+
+Every driver that sends parameters uses the extended query protocol, which asks for the shape of the result **before** executing it. The server cannot infer that shape from the SQL text, so the callback is invoked with `PostgreSqlQueryRequestType.Describe` and must return the columns it will produce.
+
+- Return the same columns for `Describe` as for the execution. Rows returned for a `Describe` request are ignored.
+- Return a result with no result sets to answer "this command returns no rows".
+- If the executed shape does not match what `Describe` announced, the server reports an error rather than sending rows the client cannot read.
+
+`Describe` is not sent for simple queries (`PostgreSqlQueryRequestType.SimpleQuery`), which carry their own row description.
+
+## Reading parameters
+
+`PostgreSqlQueryParameter` exposes typed accessors (`AsInt32`, `AsGuid`, `AsDateTimeOffset`, `AsDecimal`, `AsJson`, …). Clients may send values in text or binary format; both are decoded. For a type the library does not model, `TypeOid`, `FormatCode` and `RawValue` give you the undecoded value.
+
+```csharp
+var id = context.Parameters[0].AsInt32();
+```
+
+## ASP.NET Core hosting
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.AddPostgreSqlServer(options =>
+{
+    options.AuthenticationMethod = PostgreSqlAuthenticationMethod.ScramSha256;
+    options.AddTcpListener(port: 5432);
+});
+
+var app = builder.Build();
+app.MapPostgreSqlAuthenticationHandler((context, cancellationToken) => /* … */);
+app.MapPostgreSqlQueryHandler((context, cancellationToken) => /* … */);
+app.Run();
+```
+
+Both handlers must be mapped. A connection that arrives before they are fails authentication or receives an error, rather than being served.
+
+## Reporting errors, tags and transaction state
+
+```csharp
+// An error the client sees as a PostgresException, without terminating the connection.
+return ValueTask.FromResult(PostgreSqlQueryResult.FromError(new PostgreSqlQueryError
+{
+    Code = "42601",
+    Message = "syntax error",
+}));
+
+// Affected rows for a command that returns no result set.
+return ValueTask.FromResult(new PostgreSqlQueryResult
+{
+    CommandTag = "UPDATE",
+    AffectedRowCount = 5,
+    TransactionStatus = PostgreSqlTransactionStatus.InTransaction,
+});
+```
+
+Set `TransactionStatus` when you implement `BEGIN`/`COMMIT`, otherwise clients cannot tell that a transaction block is open.
+
+## Limits
+
+The server bounds what an unauthenticated peer can consume. All of these are configurable on `PostgreSqlServerOptions`:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `MaxMessageSize` | 16 MB | Caps the buffer a client-declared message length can allocate |
+| `MaxConcurrentConnections` | 1000 | Connections beyond this are closed immediately |
+| `HandshakeTimeout` | 30 s | Bounds how long an unauthenticated connection may live |
+| `IdleTimeout` | 30 min | Closes authenticated connections that stop sending |
+| `MaxPreparedStatementsPerConnection` | 1000 | Bounds per-connection statement state |
+| `MaxPortalsPerConnection` | 1000 | Bounds per-connection portal state |
+
+The startup packet is capped at 10 000 bytes, the same limit PostgreSQL itself uses.
+
+## Diagnostics
+
+Pass an `ILogger` to the `PostgreSqlServer` constructor. Without one, a connection that fails to negotiate, authenticate or answer a query does so silently. The ASP.NET Core host resolves a logger from the container automatically.

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/Meziantou.Framework.PostgreSqlServer.Tests.csproj
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/Meziantou.Framework.PostgreSqlServer.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <ProjectReference Include="../../src/Meziantou.Framework.PostgreSqlServer/Meziantou.Framework.PostgreSqlServer.csproj" />
   </ItemGroup>

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlKestrelHostingTests.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlKestrelHostingTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using Meziantou.Framework.PostgreSql.Handler;
+using Meziantou.Framework.PostgreSql.Hosting;
+using Meziantou.Xunit;
+using Microsoft.AspNetCore.Builder;
+using Npgsql;
+
+namespace Meziantou.Framework.PostgreSql.Tests;
+
+/// <summary>
+/// The Kestrel host is not interchangeable with the standalone one: it hands the processor two distinct
+/// pipe-backed streams rather than a single NetworkStream, which is what the DuplexStream adapter exists for.
+/// </summary>
+[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+public sealed class PostgreSqlKestrelHostingTests
+{
+    private const string Password = "Password123!";
+
+    private static string ConnectionString(int port, string sslMode = "Disable")
+        => $"Host={IPAddress.Loopback};Port={port};Username=app;Password={Password};Database=postgres;SSL Mode={sslMode};Trust Server Certificate=true;Pooling=false;Timeout=30;Command Timeout=30;Server Compatibility Mode=NoTypeLoading";
+
+    private static int GetFreePort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static PostgreSqlQueryResult IntResult(int value)
+    {
+        var resultSet = new PostgreSqlResultSet();
+        resultSet.Columns.Add(new PostgreSqlColumn("n", PostgreSqlColumnType.Int32));
+        resultSet.Rows.Add([value]);
+        var result = new PostgreSqlQueryResult();
+        result.ResultSets.Add(resultSet);
+        return result;
+    }
+
+    private static async Task<WebApplication> StartHostAsync(int port, string? pfxPath = null, string? pfxPassword = null)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        _ = builder.AddPostgreSqlServer(options =>
+        {
+            options.AuthenticationMethod = PostgreSqlAuthenticationMethod.ClearTextPassword;
+            _ = options.AddTcpListener(port, IPAddress.Loopback);
+            if (pfxPath is not null)
+            {
+                options.TlsPfxPath = pfxPath;
+                options.TlsPfxPassword = pfxPassword;
+            }
+        });
+
+        var app = builder.Build();
+        _ = app.MapPostgreSqlAuthenticationHandler((context, _) => ValueTask.FromResult(context.ValidatePassword(Password)
+            ? PostgreSqlAuthenticationResult.Success()
+            : PostgreSqlAuthenticationResult.Fail("invalid password")));
+        _ = app.MapPostgreSqlQueryHandler((_, _) => ValueTask.FromResult(IntResult(99)));
+
+        await app.StartAsync();
+        return app;
+    }
+
+    [Fact]
+    public async Task QueriesWorkOverTheKestrelTransport()
+    {
+        var port = GetFreePort();
+        await using var app = await StartHostAsync(port);
+
+        await using var connection = new NpgsqlConnection(ConnectionString(port));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT n";
+        await using var reader = await command.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal(99, reader.GetInt32(0));
+    }
+
+    [Fact]
+    public async Task WrongPasswordIsRejectedOverTheKestrelTransport()
+    {
+        var port = GetFreePort();
+        await using var app = await StartHostAsync(port);
+
+        await using var connection = new NpgsqlConnection(ConnectionString(port).Replace(Password, "wrong", StringComparison.Ordinal));
+        var exception = await Assert.ThrowsAsync<PostgresException>(async () => await connection.OpenAsync());
+        Assert.Equal("28P01", exception.SqlState);
+    }
+
+    [Fact]
+    public async Task TlsWorksOverTheKestrelTransport()
+    {
+        // Exercises DuplexStream, which only the split-pipe transport uses.
+        using var certificate = TestCertificate.Create();
+        var port = GetFreePort();
+        await using var app = await StartHostAsync(port, certificate.PfxPath, certificate.PfxPassword);
+
+        await using var connection = new NpgsqlConnection(ConnectionString(port, sslMode: "Require"));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT n";
+        Assert.Equal(99, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WithoutAQueryHandlerTheServerReportsAnError()
+    {
+        var port = GetFreePort();
+        var builder = WebApplication.CreateSlimBuilder();
+        _ = builder.AddPostgreSqlServer(options =>
+        {
+            options.AuthenticationMethod = PostgreSqlAuthenticationMethod.ClearTextPassword;
+            _ = options.AddTcpListener(port, IPAddress.Loopback);
+        });
+
+        await using var app = builder.Build();
+        _ = app.MapPostgreSqlAuthenticationHandler((_, _) => ValueTask.FromResult(PostgreSqlAuthenticationResult.Success()));
+        await app.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(port));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT n";
+        _ = await Assert.ThrowsAsync<PostgresException>(async () => await command.ExecuteScalarAsync());
+    }
+}

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerBehaviorTests.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerBehaviorTests.cs
@@ -1,0 +1,484 @@
+using System.Net;
+using Meziantou.Framework.PostgreSql.Handler;
+using Meziantou.Xunit;
+using Npgsql;
+
+namespace Meziantou.Framework.PostgreSql.Tests;
+
+[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+public sealed class PostgreSqlServerBehaviorTests
+{
+    private const string Password = "Password123!";
+
+    private static PostgreSqlServer CreateServer(PostgreSqlQueryDelegate queryHandler, Action<PostgreSqlServerOptions>? configure = null)
+    {
+        var options = new PostgreSqlServerOptions { AuthenticationMethod = PostgreSqlAuthenticationMethod.ClearTextPassword };
+        options.AddTcpListener(0, IPAddress.Loopback);
+        configure?.Invoke(options);
+
+        return new PostgreSqlServer(
+            options,
+            (context, _) => ValueTask.FromResult(context.ValidatePassword(Password)
+                ? PostgreSqlAuthenticationResult.Success()
+                : PostgreSqlAuthenticationResult.Fail("invalid password")),
+            queryHandler);
+    }
+
+    private static string ConnectionString(int port)
+        => $"Host={IPAddress.Loopback};Port={port};Username=app;Password={Password};Database=postgres;SSL Mode=Disable;Pooling=false;Timeout=30;Command Timeout=30;Server Compatibility Mode=NoTypeLoading";
+
+    /// <summary>Answers Describe and execution with the same shape, which is what the protocol requires.</summary>
+    private static PostgreSqlQueryDelegate StaticResult(Func<PostgreSqlQueryResult> factory)
+        => (_, _) => ValueTask.FromResult(factory());
+
+    private static PostgreSqlQueryResult Rows(PostgreSqlColumnType type, string columnName, params object?[] values)
+    {
+        var resultSet = new PostgreSqlResultSet();
+        resultSet.Columns.Add(new PostgreSqlColumn(columnName, type));
+        foreach (var value in values)
+        {
+            resultSet.Rows.Add([value]);
+        }
+
+        var result = new PostgreSqlQueryResult();
+        result.ResultSets.Add(resultSet);
+        return result;
+    }
+
+    [Fact]
+    public async Task DeclaredColumnTypesReachTheClient()
+    {
+        // Without AllResultTypesAreUnknown the client decodes by the OID the server advertised, so this is
+        // what proves the handler's declared types are actually honoured.
+        using var server = CreateServer(StaticResult(() =>
+        {
+            var resultSet = new PostgreSqlResultSet();
+            resultSet.Columns.Add(new PostgreSqlColumn("n", PostgreSqlColumnType.Int32));
+            resultSet.Columns.Add(new PostgreSqlColumn("b", PostgreSqlColumnType.Boolean));
+            resultSet.Columns.Add(new PostgreSqlColumn("l", PostgreSqlColumnType.Int64));
+            resultSet.Columns.Add(new PostgreSqlColumn("d", PostgreSqlColumnType.Double));
+            resultSet.Columns.Add(new PostgreSqlColumn("s", PostgreSqlColumnType.Text));
+            resultSet.Columns.Add(new PostgreSqlColumn("g", PostgreSqlColumnType.Uuid));
+            resultSet.Columns.Add(new PostgreSqlColumn("m", PostgreSqlColumnType.Numeric));
+            resultSet.Rows.Add([42, true, 9_000_000_000L, 1.5d, "hello", Guid.Parse("9f89d58d-f350-4ad6-af79-b2cbf2f65fd2"), 123.45m]);
+
+            var result = new PostgreSqlQueryResult();
+            result.ResultSets.Add(resultSet);
+            return result;
+        }));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT anything";
+        await using var reader = await command.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal(42, reader.GetInt32(0));
+        Assert.True(reader.GetBoolean(1));
+        Assert.Equal(9_000_000_000L, reader.GetInt64(2));
+        Assert.Equal(1.5d, reader.GetDouble(3));
+        Assert.Equal("hello", reader.GetString(4));
+        Assert.Equal(Guid.Parse("9f89d58d-f350-4ad6-af79-b2cbf2f65fd2"), reader.GetGuid(5));
+        Assert.Equal(123.45m, reader.GetDecimal(6));
+        Assert.Equal("n", reader.GetName(0));
+    }
+
+    [Fact]
+    public async Task PreparedCommandsWork()
+    {
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "n", 7)));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT n FROM t";
+        await command.PrepareAsync();
+
+        Assert.Equal(7, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+        Assert.Equal(7, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task RowReturningCommandThatIsNotASelectWorks()
+    {
+        // The result shape used to be guessed from the SQL text, so anything not starting with "select" broke.
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "id", 11)));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE t SET x = 1 RETURNING id";
+        Assert.Equal(11, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The SQL text comes from the test's own inline data.")]
+    [InlineData("SELECT coalesce(a, b) AS x FROM t")]
+    [InlineData("SELECT 'a,b' AS x FROM t")]
+    [InlineData("SELECT * FROM t")]
+    [InlineData("WITH cte AS (SELECT 1) SELECT x FROM cte")]
+    public async Task QueriesWithCommasOrNoSelectPrefixKeepTheHandlerShape(string commandText)
+    {
+        // Each of these used to make the SQL-text parser miscount the columns and corrupt the DataRow stream.
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "x", 5)));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        await using var reader = await command.ExecuteReaderAsync();
+
+        Assert.Equal(1, reader.FieldCount);
+        Assert.Equal("x", reader.GetName(0));
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal(5, reader.GetInt32(0));
+    }
+
+    [Fact]
+    public async Task DbNullInARowIsSentAsSqlNull()
+    {
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "n", DBNull.Value)));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT n";
+        await using var reader = await command.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.True(reader.IsDBNull(0));
+    }
+
+    [Fact]
+    public async Task NullInARowIsSentAsSqlNull()
+    {
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Text, "s", (object?)null)));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT s";
+        await using var reader = await command.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.True(reader.IsDBNull(0));
+    }
+
+    [Fact]
+    public async Task AffectedRowCountIsReportedForNonQueryCommands()
+    {
+        using var server = CreateServer(StaticResult(() => new PostgreSqlQueryResult { CommandTag = "UPDATE", AffectedRowCount = 5 }));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE t SET x = 1";
+        Assert.Equal(5, await command.ExecuteNonQueryAsync());
+    }
+
+    [Fact]
+    public async Task ACommandTagThatAlreadyCarriesACountIsSentVerbatim()
+    {
+        // "INSERT 0 1" is a complete tag; appending a row count would have produced "INSERT 0 1 0".
+        using var server = CreateServer(StaticResult(() => new PostgreSqlQueryResult { CommandTag = "INSERT 0 1" }));
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+        await client.SendSimpleQueryAsync("INSERT INTO t VALUES (1)");
+        var messages = await client.ReadUntilReadyForQueryAsync();
+
+        var commandComplete = messages.Single(message => message.Type == (byte)'C');
+        Assert.Equal("INSERT 0 1", commandComplete.AsText());
+    }
+
+    [Fact]
+    public async Task TransactionStatusIsReportedToTheClient()
+    {
+        using var server = CreateServer((context, _) =>
+        {
+            var commandText = context.CommandText ?? "";
+            var result = new PostgreSqlQueryResult
+            {
+                CommandTag = commandText.StartsWith("BEGIN", StringComparison.OrdinalIgnoreCase) ? "BEGIN" : "COMMIT",
+                TransactionStatus = commandText.StartsWith("BEGIN", StringComparison.OrdinalIgnoreCase)
+                    ? PostgreSqlTransactionStatus.InTransaction
+                    : PostgreSqlTransactionStatus.Idle,
+            };
+
+            return ValueTask.FromResult(result);
+        });
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        await client.SendSimpleQueryAsync("BEGIN");
+        var afterBegin = await client.ReadUntilReadyForQueryAsync();
+        Assert.Equal((byte)'T', afterBegin[^1].Payload[0]);
+
+        await client.SendSimpleQueryAsync("COMMIT");
+        var afterCommit = await client.ReadUntilReadyForQueryAsync();
+        Assert.Equal((byte)'I', afterCommit[^1].Payload[0]);
+    }
+
+    [Fact]
+    public async Task EmptyQueryReturnsEmptyQueryResponse()
+    {
+        var handlerCalled = false;
+        using var server = CreateServer((_, _) =>
+        {
+            handlerCalled = true;
+            return ValueTask.FromResult(new PostgreSqlQueryResult());
+        });
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+        await client.SendSimpleQueryAsync("   ");
+        var messages = await client.ReadUntilReadyForQueryAsync();
+
+        Assert.Equal([(byte)'I', (byte)'Z'], messages.Select(message => message.Type));
+        Assert.False(handlerCalled);
+    }
+
+    [Fact]
+    public async Task TextFormatParametersAreDecoded()
+    {
+        // Npgsql binds in binary, so the text decoding path needs a raw client.
+        PostgreSqlQueryParameter? captured = null;
+        using var server = CreateServer((context, _) =>
+        {
+            if (context.RequestType == PostgreSqlQueryRequestType.ExtendedQuery && context.Parameters.Count == 1)
+            {
+                captured = context.Parameters[0];
+            }
+
+            return ValueTask.FromResult(Rows(PostgreSqlColumnType.Int32, "n", 1));
+        });
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+        await client.SendParseAsync("s1", "SELECT $1", [16]);
+        await client.SendBindWithParametersAsync("", "s1", formatCode: 0, ["TRUE"]);
+        await client.SendExecuteAsync("", maxRows: 0);
+        await client.SendSyncAsync();
+        _ = await client.ReadUntilReadyForQueryAsync();
+
+        Assert.NotNull(captured);
+
+        // PostgreSQL accepts TRUE/t/yes/on/1; only "t" used to decode as true.
+        Assert.True(captured.AsBoolean());
+        Assert.Equal(0, captured.FormatCode);
+        Assert.Equal(16u, captured.TypeOid);
+    }
+
+    [Fact]
+    public async Task BinaryUuidAndTimestampParametersAreDecoded()
+    {
+        var expectedGuid = Guid.Parse("9f89d58d-f350-4ad6-af79-b2cbf2f65fd2");
+        var expectedTimestamp = new DateTime(2024, 5, 1, 12, 0, 0, DateTimeKind.Utc);
+        var captured = new List<PostgreSqlQueryParameter>();
+
+        using var server = CreateServer((context, _) =>
+        {
+            if (context.RequestType == PostgreSqlQueryRequestType.ExtendedQuery && context.Parameters.Count == 3)
+            {
+                captured.Clear();
+                captured.AddRange(context.Parameters);
+            }
+
+            return ValueTask.FromResult(Rows(PostgreSqlColumnType.Int32, "n", 1));
+        });
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @g, @t, @d";
+        _ = command.Parameters.Add(new NpgsqlParameter("g", NpgsqlTypes.NpgsqlDbType.Uuid) { Value = expectedGuid });
+        _ = command.Parameters.Add(new NpgsqlParameter("t", NpgsqlTypes.NpgsqlDbType.TimestampTz) { Value = expectedTimestamp });
+        _ = command.Parameters.Add(new NpgsqlParameter("d", NpgsqlTypes.NpgsqlDbType.Numeric) { Value = 123.45m });
+        _ = await command.ExecuteScalarAsync();
+
+        Assert.HasCount(3, captured);
+        Assert.Equal(expectedGuid, captured[0].AsGuid());
+        Assert.Equal(expectedTimestamp, captured[1].AsDateTimeOffset()!.Value.UtcDateTime);
+        Assert.Equal(123.45m, captured[2].AsDecimal());
+    }
+
+    [Fact]
+    public async Task AConnectionStaysUsableAfterAQueryError()
+    {
+        var failNext = true;
+        using var server = CreateServer((context, _) =>
+        {
+            if (context.RequestType != PostgreSqlQueryRequestType.Describe && failNext)
+            {
+                failNext = false;
+                return ValueTask.FromResult(PostgreSqlQueryResult.FromError(new PostgreSqlQueryError { Code = "42601", Message = "syntax error" }));
+            }
+
+            return ValueTask.FromResult(Rows(PostgreSqlColumnType.Int32, "n", 3));
+        });
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+
+        await using (var failing = connection.CreateCommand())
+        {
+            failing.CommandText = "SELECT bad";
+            var exception = await Assert.ThrowsAsync<PostgresException>(async () => await failing.ExecuteScalarAsync());
+            Assert.Equal("42601", exception.SqlState);
+        }
+
+        await using var succeeding = connection.CreateCommand();
+        succeeding.CommandText = "SELECT n";
+        Assert.Equal(3, Convert.ToInt32(await succeeding.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task AQueryHandlerThatThrowsBecomesAnErrorAndTheConnectionSurvives()
+    {
+        var shouldThrow = true;
+        using var server = CreateServer((context, _) =>
+        {
+            if (context.RequestType != PostgreSqlQueryRequestType.Describe && shouldThrow)
+            {
+                shouldThrow = false;
+                throw new InvalidOperationException("boom");
+            }
+
+            return ValueTask.FromResult(Rows(PostgreSqlColumnType.Int32, "n", 4));
+        });
+        await server.StartAsync();
+
+        // Driven raw because Npgsql marks a connection Broken on any XX000, which would hide whether the
+        // server itself stayed usable.
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        await client.SendParseAsync("s1", "SELECT n");
+        await client.SendBindAsync("", "s1");
+        await client.SendDescribeAsync((byte)'P', "");
+        await client.SendExecuteAsync("", maxRows: 0);
+        await client.SendSyncAsync();
+
+        var failed = await client.ReadUntilReadyForQueryAsync();
+        var error = Assert.Single(failed, message => message.Type == (byte)'E');
+        Assert.Equal("XX000", error.ErrorFields()['C']);
+        Assert.Equal((byte)'Z', failed[^1].Type);
+
+        // The same connection continues to work after the handler faulted.
+        await client.SendSimpleQueryAsync("SELECT n");
+        var succeeded = await client.ReadUntilReadyForQueryAsync();
+        Assert.Equal([(byte)'T', (byte)'D', (byte)'C', (byte)'Z'], succeeded.Select(message => message.Type));
+        Assert.Equal(["4"], succeeded[1].DataRowValues());
+    }
+
+    [Fact]
+    public async Task DescribeStatementAndCloseAreHandled()
+    {
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "n", 1)));
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        await client.SendParseAsync("s1", "SELECT n");
+        await client.SendDescribeAsync((byte)'S', "s1");
+        await client.SendSyncAsync();
+        var described = await client.ReadUntilReadyForQueryAsync();
+
+        // ParseComplete, ParameterDescription, RowDescription, ReadyForQuery.
+        Assert.Equal([(byte)'1', (byte)'t', (byte)'T', (byte)'Z'], described.Select(message => message.Type));
+
+        await client.SendCloseAsync((byte)'S', "s1");
+        await client.SendSyncAsync();
+        var closed = await client.ReadUntilReadyForQueryAsync();
+        Assert.Equal([(byte)'3', (byte)'Z'], closed.Select(message => message.Type));
+    }
+
+    [Fact]
+    public async Task ExecuteRowLimitSuspendsThePortal()
+    {
+        using var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "n", 1, 2, 3, 4, 5)));
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        await client.SendParseAsync("s1", "SELECT n");
+        await client.SendBindAsync("", "s1");
+        await client.SendDescribeAsync((byte)'P', "");
+        await client.SendExecuteAsync("", maxRows: 2);
+        await client.SendSyncAsync();
+        var messages = await client.ReadUntilReadyForQueryAsync();
+
+        Assert.HasCount(2, messages.Where(message => message.Type == (byte)'D').ToArray());
+        Assert.Contains(messages, message => message.Type == (byte)'s');
+        Assert.DoesNotContain(messages, message => message.Type == (byte)'C');
+    }
+
+    [Fact]
+    public async Task DescribingAShapeThatDoesNotMatchExecutionIsReportedAsAnError()
+    {
+        // Better a clear error than DataRows that disagree with the RowDescription already sent.
+        using var server = CreateServer((context, _) => ValueTask.FromResult(
+            context.RequestType == PostgreSqlQueryRequestType.Describe
+                ? new PostgreSqlQueryResult()
+                : Rows(PostgreSqlColumnType.Int32, "n", 1)));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT n";
+        var exception = await Assert.ThrowsAsync<PostgresException>(async () => await command.ExecuteScalarAsync());
+        Assert.Equal("XX000", exception.SqlState);
+    }
+
+    [Fact]
+    public async Task DisposeIsIdempotentAndStopAsyncDrains()
+    {
+        var server = CreateServer(StaticResult(() => Rows(PostgreSqlColumnType.Int32, "n", 1)));
+        await server.StartAsync();
+        Assert.Single(server.Ports);
+
+        await server.StopAsync(CancellationToken.None);
+        server.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task AFailedBindLeavesNothingListening()
+    {
+        using var occupied = CreateServer(StaticResult(() => new PostgreSqlQueryResult()));
+        await occupied.StartAsync();
+        var takenPort = occupied.Ports[0];
+
+        var options = new PostgreSqlServerOptions { AuthenticationMethod = PostgreSqlAuthenticationMethod.ClearTextPassword };
+        _ = options.AddTcpListener(0, IPAddress.Loopback);
+        _ = options.AddTcpListener(takenPort, IPAddress.Loopback);
+
+        using var server = new PostgreSqlServer(
+            options,
+            (_, _) => ValueTask.FromResult(PostgreSqlAuthenticationResult.Success()),
+            (_, _) => ValueTask.FromResult(new PostgreSqlQueryResult()));
+
+        _ = await Assert.ThrowsAnyAsync<Exception>(() => server.StartAsync());
+
+        // Binding is all-or-nothing, so no port should be left bound and reported.
+        Assert.Empty(server.Ports);
+    }
+}

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerProtocolTests.cs
@@ -164,18 +164,20 @@ public sealed class PostgreSqlServerProtocolTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new NpgsqlConnection(CreateConnectionString(port));
-        await connection.OpenAsync();
-
-        await using var command = connection.CreateCommand();
-        command.CommandText = $"SELECT 1 /* {Marker} */";
-        command.AllResultTypesAreUnknown = true;
-        var result = await command.ExecuteScalarAsync();
+        // Npgsql always uses the extended protocol, so the simple query path needs a raw client.
+        using var client = await RawPostgreSqlClient.ConnectAsync(port);
+        await client.AuthenticateClearTextAsync();
+        await client.SendSimpleQueryAsync($"SELECT 1 /* {Marker} */");
+        var messages = await client.ReadUntilReadyForQueryAsync();
 
         var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(123, Convert.ToInt32(result, CultureInfo.InvariantCulture));
-        Assert.True(capturedContext.RequestType is PostgreSqlQueryRequestType.SimpleQuery or PostgreSqlQueryRequestType.ExtendedQuery);
+        Assert.Equal(PostgreSqlQueryRequestType.SimpleQuery, capturedContext.RequestType);
         Assert.Contains(Marker, capturedContext.CommandText);
+
+        // A simple query describes its own result: RowDescription, DataRow, CommandComplete, ReadyForQuery.
+        Assert.Equal([(byte)'T', (byte)'D', (byte)'C', (byte)'Z'], messages.Select(message => message.Type));
+        Assert.Equal(["123"], messages[1].DataRowValues());
+        Assert.Equal("SELECT 1", messages[2].AsText());
     }
 
     [Fact]
@@ -198,22 +200,26 @@ public sealed class PostgreSqlServerProtocolTests
             (context, cancellationToken) =>
             {
                 _ = cancellationToken;
+                if (context.CommandText?.Contains(Marker, StringComparison.Ordinal) != true)
+                {
+                    return ValueTask.FromResult(new PostgreSqlQueryResult());
+                }
+
+                // Describe must announce the same shape the execution produces.
+                if (context.RequestType == PostgreSqlQueryRequestType.Describe)
+                {
+                    return ValueTask.FromResult(CreateScalarResult(PostgreSqlColumnType.Int32, 42));
+                }
+
                 if (context.RequestType == PostgreSqlQueryRequestType.ExtendedQuery &&
                     context.Parameters.Count == 2 &&
                     context.Parameters[0].AsInt32() == 42 &&
                     context.Parameters[1].AsBoolean() == true)
                 {
                     queryContextTask.TrySetResult(context);
-                    return ValueTask.FromResult(CreateScalarResult(PostgreSqlColumnType.Int32, 42));
                 }
 
-                if (context.CommandText?.Contains(Marker, StringComparison.Ordinal) == true)
-                {
-                    queryContextTask.TrySetResult(context);
-                    return ValueTask.FromResult(CreateScalarResult(PostgreSqlColumnType.Int32, 42));
-                }
-
-                return ValueTask.FromResult(new PostgreSqlQueryResult());
+                return ValueTask.FromResult(CreateScalarResult(PostgreSqlColumnType.Int32, 42));
             });
 
         await server.StartAsync();
@@ -263,10 +269,20 @@ public sealed class PostgreSqlServerProtocolTests
             (context, cancellationToken) =>
             {
                 _ = cancellationToken;
+                if (context.CommandText?.Contains(Marker, StringComparison.Ordinal) != true)
+                {
+                    return ValueTask.FromResult(new PostgreSqlQueryResult());
+                }
+
+                // Describe must announce the same shape the execution produces.
+                if (context.RequestType == PostgreSqlQueryRequestType.Describe)
+                {
+                    return ValueTask.FromResult(CreateScalarResult(PostgreSqlColumnType.Int32, 42));
+                }
+
                 if (context.RequestType == PostgreSqlQueryRequestType.ExtendedQuery &&
                     context.Parameters.Count == 1 &&
-                    ReferenceEquals(context.Parameters[0].Value, DBNull.Value) &&
-                    context.CommandText?.Contains(Marker, StringComparison.Ordinal) == true)
+                    ReferenceEquals(context.Parameters[0].Value, DBNull.Value))
                 {
                     queryContextTask.TrySetResult(context);
                     return ValueTask.FromResult(CreateScalarResult(PostgreSqlColumnType.Int32, 42));
@@ -343,6 +359,7 @@ public sealed class PostgreSqlServerProtocolTests
     {
         const string Marker = "cancel-query-marker";
         var queryCanceledTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var queryStartedTask = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var options = new PostgreSqlServerOptions
         {
@@ -357,8 +374,10 @@ public sealed class PostgreSqlServerProtocolTests
                 : PostgreSqlAuthenticationResult.Fail("invalid password")),
             async (context, cancellationToken) =>
             {
-                if (context.CommandText?.Contains(Marker, StringComparison.Ordinal) == true)
+                if (context.RequestType != PostgreSqlQueryRequestType.Describe &&
+                    context.CommandText?.Contains(Marker, StringComparison.Ordinal) == true)
                 {
+                    queryStartedTask.TrySetResult();
                     try
                     {
                         await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
@@ -383,9 +402,14 @@ public sealed class PostgreSqlServerProtocolTests
         command.CommandText = $"SELECT 1 /* {Marker} */";
         command.AllResultTypesAreUnknown = true;
 
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
-        _ = await Assert.ThrowsAnyAsync<Exception>(() => command.ExecuteNonQueryAsync(cancellationTokenSource.Token));
-        Assert.True(await queryCanceledTask.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        // Cancel once the handler has actually started, rather than racing a wall-clock timer against the round trip.
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var executeTask = command.ExecuteNonQueryAsync(cancellationTokenSource.Token);
+        await queryStartedTask.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await cancellationTokenSource.CancelAsync();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => executeTask);
+        Assert.True(await queryCanceledTask.Task.WaitAsync(TimeSpan.FromSeconds(30)));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerSecurityTests.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerSecurityTests.cs
@@ -1,0 +1,325 @@
+using System.Net;
+using Meziantou.Framework.PostgreSql.Handler;
+using Meziantou.Xunit;
+using Npgsql;
+
+namespace Meziantou.Framework.PostgreSql.Tests;
+
+[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+public sealed class PostgreSqlServerSecurityTests
+{
+    private const string Password = "Password123!";
+
+    private static PostgreSqlServer CreateServer(
+        PostgreSqlAuthenticationMethod method = PostgreSqlAuthenticationMethod.ClearTextPassword,
+        Action<PostgreSqlServerOptions>? configure = null,
+        PostgreSqlAuthenticationDelegate? authenticationHandler = null)
+    {
+        var options = new PostgreSqlServerOptions { AuthenticationMethod = method };
+        options.AddTcpListener(0, IPAddress.Loopback);
+        configure?.Invoke(options);
+
+        return new PostgreSqlServer(
+            options,
+            authenticationHandler ?? ((context, _) => ValueTask.FromResult(context.ValidatePassword(Password)
+                ? PostgreSqlAuthenticationResult.Success()
+                : PostgreSqlAuthenticationResult.Fail("invalid password"))),
+            (context, _) => ValueTask.FromResult(CreateIntResult()));
+    }
+
+    private static PostgreSqlQueryResult CreateIntResult(int value = 1)
+    {
+        var resultSet = new PostgreSqlResultSet();
+        resultSet.Columns.Add(new PostgreSqlColumn("value", PostgreSqlColumnType.Int32));
+        resultSet.Rows.Add([value]);
+        var result = new PostgreSqlQueryResult();
+        result.ResultSets.Add(resultSet);
+        return result;
+    }
+
+    private static string ConnectionString(int port, string password = Password, string sslMode = "Disable")
+        => $"Host={IPAddress.Loopback};Port={port};Username=app;Password={password};Database=postgres;SSL Mode={sslMode};Trust Server Certificate=true;Pooling=false;Timeout=30;Command Timeout=30;Server Compatibility Mode=NoTypeLoading";
+
+    [Theory]
+    [InlineData(PostgreSqlAuthenticationMethod.ClearTextPassword)]
+    [InlineData(PostgreSqlAuthenticationMethod.Md5Password)]
+    [InlineData(PostgreSqlAuthenticationMethod.ScramSha256)]
+    public async Task WrongPassword_IsRejected(PostgreSqlAuthenticationMethod method)
+    {
+        using var server = CreateServer(method);
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0], password: "wrong-password"));
+        var exception = await Assert.ThrowsAsync<PostgresException>(async () => await connection.OpenAsync());
+        Assert.Equal("28P01", exception.SqlState);
+    }
+
+    [Theory]
+    [InlineData(PostgreSqlAuthenticationMethod.ClearTextPassword)]
+    [InlineData(PostgreSqlAuthenticationMethod.Md5Password)]
+    [InlineData(PostgreSqlAuthenticationMethod.ScramSha256)]
+    public async Task CorrectPassword_IsAccepted(PostgreSqlAuthenticationMethod method)
+    {
+        using var server = CreateServer(method);
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+    }
+
+    [Fact]
+    public async Task Md5Authentication_ProvidesSaltAndResponse()
+    {
+        PostgreSqlAuthenticationContext? captured = null;
+        using var server = CreateServer(
+            PostgreSqlAuthenticationMethod.Md5Password,
+            authenticationHandler: (context, _) =>
+            {
+                captured = context;
+                return ValueTask.FromResult(context.ValidatePassword(Password)
+                    ? PostgreSqlAuthenticationResult.Success()
+                    : PostgreSqlAuthenticationResult.Fail("invalid password"));
+            });
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        await connection.OpenAsync();
+
+        Assert.NotNull(captured);
+        Assert.Equal(PostgreSqlAuthenticationMethod.Md5Password, captured.Method);
+        Assert.Equal("app", captured.UserName);
+        Assert.Equal("postgres", captured.Database);
+        Assert.NotNull(captured.Md5PasswordResponse);
+        Assert.StartsWith("md5", captured.Md5PasswordResponse);
+    }
+
+    [Fact]
+    public async Task ScramSuccessWithoutValidatePassword_IsReportedAsAHandlerError()
+    {
+        // ValidatePassword is what computes the SCRAM server signature, so returning Success() without
+        // calling it cannot produce a valid exchange. The client must not be told its credentials were wrong.
+        using var server = CreateServer(
+            PostgreSqlAuthenticationMethod.ScramSha256,
+            authenticationHandler: (_, _) => ValueTask.FromResult(PostgreSqlAuthenticationResult.Success()));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        var exception = await Assert.ThrowsAsync<PostgresException>(async () => await connection.OpenAsync());
+        Assert.Equal("XX000", exception.SqlState);
+        Assert.Contains("ValidatePassword", exception.MessageText);
+    }
+
+    [Fact]
+    public async Task AuthenticationHandlerThatThrows_ReportsAnErrorInsteadOfDroppingTheConnection()
+    {
+        using var server = CreateServer(
+            PostgreSqlAuthenticationMethod.ClearTextPassword,
+            authenticationHandler: (_, _) => throw new InvalidOperationException("boom"));
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0]));
+        var exception = await Assert.ThrowsAsync<PostgresException>(async () => await connection.OpenAsync());
+        Assert.Equal("XX000", exception.SqlState);
+    }
+
+    [Fact]
+    public async Task StartupPacketLargerThanTheLimit_IsRejectedWithoutAllocatingIt()
+    {
+        using var server = CreateServer();
+        await server.StartAsync();
+        var port = server.Ports[0];
+
+        using (var client = await RawPostgreSqlClient.ConnectAsync(port))
+        {
+            // 1 GiB declared, no body sent. Before the limit this allocated the full buffer up front.
+            await client.SendRawStartupAsync(1024 * 1024 * 1024, ReadOnlyMemory<byte>.Empty);
+            Assert.Null(await client.ReadMessageAsync());
+        }
+
+        await AssertServerStillWorksAsync(port);
+    }
+
+    [Fact]
+    public async Task MessageLargerThanTheLimit_IsRejectedWithoutAllocatingIt()
+    {
+        using var server = CreateServer(configure: options => options.MaxMessageSize = 8 * 1024);
+        await server.StartAsync();
+        var port = server.Ports[0];
+
+        using (var client = await RawPostgreSqlClient.ConnectAsync(port))
+        {
+            await client.AuthenticateClearTextAsync();
+            await client.SendRawMessageAsync((byte)'Q', int.MaxValue - 8, ReadOnlyMemory<byte>.Empty);
+            var messages = await client.ReadUntilReadyForQueryAsync();
+            Assert.All(messages, message => Assert.NotEqual((byte)'D', message.Type));
+        }
+
+        await AssertServerStillWorksAsync(port);
+    }
+
+    [Fact]
+    public async Task DuplicateSslRequest_IsRejected()
+    {
+        // Without this the negotiation loop let a client stack SslStreams on a single connection.
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.SendSslRequestAsync();
+        Assert.Equal((byte)'N', await client.ReadSingleByteAsync());
+
+        await client.SendSslRequestAsync();
+        var message = await client.ReadMessageAsync();
+        Assert.NotNull(message);
+        Assert.Equal((byte)'E', message.Type);
+        Assert.Equal("08P01", message.ErrorFields()['C']);
+    }
+
+    [Fact]
+    public async Task UnknownMessageType_IsReportedAndTheConnectionSurvivesAfterSync()
+    {
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        await client.SendMessageAsync((byte)'!', ReadOnlyMemory<byte>.Empty);
+        await client.SendSyncAsync();
+        var messages = await client.ReadUntilReadyForQueryAsync();
+        Assert.Equal((byte)'E', messages[0].Type);
+        Assert.Equal((byte)'Z', messages[^1].Type);
+
+        // The same connection must still be usable.
+        await client.SendSimpleQueryAsync("SELECT 1");
+        var afterRecovery = await client.ReadUntilReadyForQueryAsync();
+        Assert.Contains(afterRecovery, message => message.Type == (byte)'D');
+    }
+
+    [Fact]
+    public async Task BindToAnUnknownStatement_ReportsAnErrorAndSkipsUntilSync()
+    {
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        await client.SendBindAsync(portalName: "", statementName: "does-not-exist");
+
+        // Messages between the error and Sync must be discarded rather than answered.
+        await client.SendMessageAsync((byte)'E', ExecutePayload());
+        await client.SendSyncAsync();
+
+        var messages = await client.ReadUntilReadyForQueryAsync();
+        Assert.Equal((byte)'E', messages[0].Type);
+        Assert.Equal("08P01", messages[0].ErrorFields()['C']);
+        Assert.Equal([(byte)'E', (byte)'Z'], messages.Select(message => message.Type));
+
+        await client.SendSimpleQueryAsync("SELECT 1");
+        var afterRecovery = await client.ReadUntilReadyForQueryAsync();
+        Assert.Contains(afterRecovery, message => message.Type == (byte)'D');
+    }
+
+    [Fact]
+    public async Task PreparedStatementLimit_IsEnforced()
+    {
+        using var server = CreateServer(configure: options => options.MaxPreparedStatementsPerConnection = 4);
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.AuthenticateClearTextAsync();
+
+        for (var i = 0; i < 10; i++)
+        {
+            await client.SendParseAsync($"statement-{i}", "SELECT 1");
+        }
+
+        await client.SendSyncAsync();
+        var messages = await client.ReadUntilReadyForQueryAsync();
+        Assert.Contains(messages, message => message.Type == (byte)'E');
+    }
+
+    [Fact]
+    public async Task RequireEncryptionWithoutTls_RejectsTheConnection()
+    {
+        using var certificate = TestCertificate.Create();
+        using var server = CreateServer(configure: options =>
+        {
+            options.RequireEncryption = true;
+            options.TlsPfxPath = certificate.PfxPath;
+            options.TlsPfxPassword = certificate.PfxPassword;
+        });
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0], sslMode: "Disable"));
+        var exception = await Assert.ThrowsAsync<PostgresException>(async () => await connection.OpenAsync());
+        Assert.Equal("28000", exception.SqlState);
+    }
+
+    [Fact]
+    public async Task RequireEncryption_AlsoAppliesToCancelRequests()
+    {
+        // The cancel path used to return before the encryption check, so it accepted plaintext.
+        using var certificate = TestCertificate.Create();
+        using var server = CreateServer(configure: options =>
+        {
+            options.RequireEncryption = true;
+            options.TlsPfxPath = certificate.PfxPath;
+            options.TlsPfxPassword = certificate.PfxPassword;
+        });
+        await server.StartAsync();
+
+        using var client = await RawPostgreSqlClient.ConnectAsync(server.Ports[0]);
+        await client.SendCancelRequestAsync(processId: 1, secretKey: 2);
+        var message = await client.ReadMessageAsync();
+        Assert.NotNull(message);
+        Assert.Equal((byte)'E', message.Type);
+        Assert.Equal("28000", message.ErrorFields()['C']);
+    }
+
+    [Fact]
+    public async Task SslRequestWithoutACertificate_FallsBackToPlaintext()
+    {
+        // The default configuration has no certificate, and Npgsql's default SSL mode asks for TLS first.
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        await using var connection = new NpgsqlConnection(ConnectionString(server.Ports[0], sslMode: "Prefer"));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        Assert.Equal(1, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task ConcurrentConnectionLimit_IsEnforced()
+    {
+        using var server = CreateServer(configure: options => options.MaxConcurrentConnections = 1);
+        await server.StartAsync();
+        var port = server.Ports[0];
+
+        await using var first = new NpgsqlConnection(ConnectionString(port));
+        await first.OpenAsync();
+
+        await using var second = new NpgsqlConnection(ConnectionString(port));
+        _ = await Assert.ThrowsAnyAsync<Exception>(async () => await second.OpenAsync());
+    }
+
+    private static async Task AssertServerStillWorksAsync(int port)
+    {
+        await using var connection = new NpgsqlConnection(ConnectionString(port));
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        Assert.Equal(1, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+    }
+
+    private static byte[] ExecutePayload()
+    {
+        // Portal name (empty) followed by an unlimited row count.
+        return [0, 0, 0, 0, 0];
+    }
+}

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/RawPostgreSqlClient.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/RawPostgreSqlClient.cs
@@ -1,0 +1,326 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Meziantou.Framework.PostgreSql.Tests;
+
+/// <summary>
+/// A minimal PostgreSQL frontend that speaks the wire protocol directly.
+/// Npgsql never sends simple queries, Close, Flush or malformed packets, so those paths need a raw client.
+/// </summary>
+internal sealed class RawPostgreSqlClient : IDisposable
+{
+    private readonly TcpClient _client;
+    private readonly NetworkStream _stream;
+
+    private RawPostgreSqlClient(TcpClient client)
+    {
+        _client = client;
+        _stream = client.GetStream();
+    }
+
+    public static async Task<RawPostgreSqlClient> ConnectAsync(int port)
+    {
+        var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        return new RawPostgreSqlClient(client);
+    }
+
+    /// <summary>Performs a cleartext-password startup exchange and reads through to ReadyForQuery.</summary>
+    public async Task AuthenticateClearTextAsync(string userName = "app", string database = "postgres", string password = "Password123!")
+    {
+        await SendStartupAsync(userName, database);
+
+        var authentication = await ReadMessageAsync();
+        Assert.Equal((byte)'R', authentication!.Type);
+
+        await SendMessageAsync((byte)'p', NullTerminated(password));
+        while (true)
+        {
+            var message = await ReadMessageAsync();
+            Assert.NotNull(message);
+            if (message.Type == (byte)'Z')
+            {
+                return;
+            }
+
+            Assert.NotEqual((byte)'E', message.Type);
+        }
+    }
+
+    public async Task SendStartupAsync(string userName, string database)
+    {
+        var payload = new List<byte>();
+        payload.AddRange(NullTerminated("user"));
+        payload.AddRange(NullTerminated(userName));
+        payload.AddRange(NullTerminated("database"));
+        payload.AddRange(NullTerminated(database));
+        payload.Add(0);
+
+        var packet = new byte[8 + payload.Count];
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(0, 4), packet.Length);
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(4, 4), 196608);
+        payload.CopyTo(packet, 8);
+        await _stream.WriteAsync(packet);
+    }
+
+    /// <summary>Writes a raw startup packet, including a deliberately wrong declared length.</summary>
+    public async Task SendRawStartupAsync(int declaredLength, ReadOnlyMemory<byte> body)
+    {
+        var header = new byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(header, declaredLength);
+        await _stream.WriteAsync(header);
+        if (!body.IsEmpty)
+        {
+            await _stream.WriteAsync(body);
+        }
+    }
+
+    public async Task SendMessageAsync(byte type, ReadOnlyMemory<byte> payload)
+    {
+        var buffer = new byte[5 + payload.Length];
+        buffer[0] = type;
+        BinaryPrimitives.WriteInt32BigEndian(buffer.AsSpan(1, 4), payload.Length + 4);
+        payload.Span.CopyTo(buffer.AsSpan(5));
+        await _stream.WriteAsync(buffer);
+    }
+
+    /// <summary>Writes a message header whose declared length does not match the body that follows.</summary>
+    public async Task SendRawMessageAsync(byte type, int declaredPayloadLength, ReadOnlyMemory<byte> body)
+    {
+        var header = new byte[5];
+        header[0] = type;
+        BinaryPrimitives.WriteInt32BigEndian(header.AsSpan(1, 4), declaredPayloadLength + 4);
+        await _stream.WriteAsync(header);
+        if (!body.IsEmpty)
+        {
+            await _stream.WriteAsync(body);
+        }
+    }
+
+    public Task SendSimpleQueryAsync(string sql) => SendMessageAsync((byte)'Q', NullTerminated(sql));
+
+    public async Task SendSslRequestAsync()
+    {
+        var packet = new byte[8];
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(0, 4), 8);
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(4, 4), 80877103);
+        await _stream.WriteAsync(packet);
+    }
+
+    public async Task SendCancelRequestAsync(int processId, int secretKey)
+    {
+        var packet = new byte[16];
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(0, 4), 16);
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(4, 4), 80877102);
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(8, 4), processId);
+        BinaryPrimitives.WriteInt32BigEndian(packet.AsSpan(12, 4), secretKey);
+        await _stream.WriteAsync(packet);
+    }
+
+    public async Task<byte> ReadSingleByteAsync()
+    {
+        var buffer = new byte[1];
+        Assert.True(await TryReadExactlyAsync(buffer));
+        return buffer[0];
+    }
+
+    public Task SendParseAsync(string statementName, string query, uint[]? parameterTypeOids = null)
+    {
+        var payload = new List<byte>();
+        payload.AddRange(NullTerminated(statementName));
+        payload.AddRange(NullTerminated(query));
+        payload.AddRange(Int16BigEndian((short)(parameterTypeOids?.Length ?? 0)));
+        foreach (var oid in parameterTypeOids ?? [])
+        {
+            var buffer = new byte[4];
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, oid);
+            payload.AddRange(buffer);
+        }
+
+        return SendMessageAsync((byte)'P', payload.ToArray());
+    }
+
+    public Task SendBindWithParametersAsync(string portalName, string statementName, short formatCode, string[] values)
+    {
+        var payload = new List<byte>();
+        payload.AddRange(NullTerminated(portalName));
+        payload.AddRange(NullTerminated(statementName));
+        payload.AddRange(Int16BigEndian(1));
+        payload.AddRange(Int16BigEndian(formatCode));
+        payload.AddRange(Int16BigEndian((short)values.Length));
+        foreach (var value in values)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            var length = new byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(length, bytes.Length);
+            payload.AddRange(length);
+            payload.AddRange(bytes);
+        }
+
+        payload.AddRange(Int16BigEndian(0));
+        return SendMessageAsync((byte)'B', payload.ToArray());
+    }
+
+    public Task SendExecuteAsync(string portalName, int maxRows)
+    {
+        var payload = new List<byte>();
+        payload.AddRange(NullTerminated(portalName));
+        var buffer = new byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, maxRows);
+        payload.AddRange(buffer);
+        return SendMessageAsync((byte)'E', payload.ToArray());
+    }
+
+    private static byte[] Int16BigEndian(short value)
+    {
+        var buffer = new byte[2];
+        BinaryPrimitives.WriteInt16BigEndian(buffer, value);
+        return buffer;
+    }
+
+    public Task SendBindAsync(string portalName, string statementName)
+    {
+        var payload = new List<byte>();
+        payload.AddRange(NullTerminated(portalName));
+        payload.AddRange(NullTerminated(statementName));
+        payload.AddRange([0, 0]);
+        payload.AddRange([0, 0]);
+        payload.AddRange([0, 0]);
+        return SendMessageAsync((byte)'B', payload.ToArray());
+    }
+
+    public Task SendDescribeAsync(byte target, string name)
+    {
+        var payload = new List<byte> { target };
+        payload.AddRange(NullTerminated(name));
+        return SendMessageAsync((byte)'D', payload.ToArray());
+    }
+
+    public Task SendCloseAsync(byte target, string name)
+    {
+        var payload = new List<byte> { target };
+        payload.AddRange(NullTerminated(name));
+        return SendMessageAsync((byte)'C', payload.ToArray());
+    }
+
+    public Task SendSyncAsync() => SendMessageAsync((byte)'S', ReadOnlyMemory<byte>.Empty);
+
+    public async Task<RawMessage?> ReadMessageAsync()
+    {
+        var header = new byte[5];
+        if (!await TryReadExactlyAsync(header))
+        {
+            return null;
+        }
+
+        var length = BinaryPrimitives.ReadInt32BigEndian(header.AsSpan(1, 4));
+        var payload = new byte[length - 4];
+        if (payload.Length > 0 && !await TryReadExactlyAsync(payload))
+        {
+            return null;
+        }
+
+        return new RawMessage(header[0], payload);
+    }
+
+    /// <summary>Reads messages until ReadyForQuery, or until the connection closes.</summary>
+    public async Task<List<RawMessage>> ReadUntilReadyForQueryAsync()
+    {
+        var messages = new List<RawMessage>();
+        while (true)
+        {
+            var message = await ReadMessageAsync();
+            if (message is null)
+            {
+                return messages;
+            }
+
+            messages.Add(message);
+            if (message.Type == (byte)'Z')
+            {
+                return messages;
+            }
+        }
+    }
+
+    private async Task<bool> TryReadExactlyAsync(Memory<byte> destination)
+    {
+        var total = 0;
+        while (total < destination.Length)
+        {
+            var read = await _stream.ReadAsync(destination[total..]);
+            if (read == 0)
+            {
+                return false;
+            }
+
+            total += read;
+        }
+
+        return true;
+    }
+
+    private static byte[] NullTerminated(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var result = new byte[bytes.Length + 1];
+        bytes.CopyTo(result, 0);
+        return result;
+    }
+
+    public void Dispose()
+    {
+        _stream.Dispose();
+        _client.Dispose();
+    }
+
+    internal sealed record RawMessage(byte Type, byte[] Payload)
+    {
+        public string AsText() => Encoding.UTF8.GetString(Payload).TrimEnd('\0');
+
+        /// <summary>Decodes a DataRow payload into its field values, with <see langword="null"/> for SQL NULL.</summary>
+        public string?[] DataRowValues()
+        {
+            var fieldCount = BinaryPrimitives.ReadInt16BigEndian(Payload.AsSpan(0, 2));
+            var values = new string?[fieldCount];
+            var index = 2;
+            for (var i = 0; i < fieldCount; i++)
+            {
+                var length = BinaryPrimitives.ReadInt32BigEndian(Payload.AsSpan(index, 4));
+                index += 4;
+                if (length < 0)
+                {
+                    values[i] = null;
+                    continue;
+                }
+
+                values[i] = Encoding.UTF8.GetString(Payload.AsSpan(index, length));
+                index += length;
+            }
+
+            return values;
+        }
+
+        /// <summary>Reads the fields of an ErrorResponse or NoticeResponse, keyed by their field code.</summary>
+        public Dictionary<char, string> ErrorFields()
+        {
+            var fields = new Dictionary<char, string>();
+            var index = 0;
+            while (index < Payload.Length && Payload[index] != 0)
+            {
+                var code = (char)Payload[index++];
+                var end = Array.IndexOf(Payload, (byte)0, index);
+                if (end < 0)
+                {
+                    break;
+                }
+
+                fields[code] = Encoding.UTF8.GetString(Payload.AsSpan(index, end - index));
+                index = end + 1;
+            }
+
+            return fields;
+        }
+    }
+}

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/TestCertificate.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/TestCertificate.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Meziantou.Framework.PostgreSql.Tests;
+
+/// <summary>A self-signed loopback certificate written to a temporary directory.</summary>
+internal sealed class TestCertificate : IDisposable
+{
+    private readonly string _directoryPath;
+
+    private TestCertificate(string directoryPath, string pfxPath, string pfxPassword)
+    {
+        _directoryPath = directoryPath;
+        PfxPath = pfxPath;
+        PfxPassword = pfxPassword;
+    }
+
+    public string PfxPath { get; }
+
+    public string PfxPassword { get; }
+
+    public static TestCertificate Create()
+    {
+        var directoryPath = Path.Combine(AppContext.BaseDirectory, "certificates", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(directoryPath);
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension([new Oid("1.3.6.1.5.5.7.3.1")], critical: false));
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddIpAddress(IPAddress.Loopback);
+        request.CertificateExtensions.Add(sanBuilder.Build());
+
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddHours(1));
+        const string Password = "Password123!";
+
+        var pfxPath = Path.Combine(directoryPath, "server.pfx");
+        File.WriteAllBytes(pfxPath, certificate.Export(X509ContentType.Pfx, Password));
+
+        return new TestCertificate(directoryPath, pfxPath, Password);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directoryPath, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
A whole-project review of `Meziantou.Framework.PostgreSqlServer` turned up 55 findings. This fixes 49 of them.

The library is the server side of the PostgreSQL v3 wire protocol, so the defects fall into three groups: **the extended query protocol was not correctly implemented**, **nothing bounded what an unauthenticated peer could consume**, and **the standalone host could not be diagnosed**. The sibling `Meziantou.Framework.TdsServer` already had the correct shape for most of the lifecycle issues, so those fixes are ported from it rather than invented.

## Behavioural change reviewers should look at first

`Describe` now invokes the query callback with `PostgreSqlQueryRequestType.Describe`, and **`Execute` no longer emits `RowDescription`**.

This was forced, not chosen. The previous code guessed the result shape by string-splitting the SQL (strip `select`, cut at `" from "`, split on `,`), advertised the guess as `RowDescription`, and then *suppressed* the real description the callback returned. Confirmed against Npgsql:

- `SELECT coalesce(@a, 0)` split into two columns while the callback returned one → *"Row's number of columns (1) differs from the row description's (2)"*, connection unusable. Same for a comma inside a string literal, `select *`, and a quoted identifier containing `" as "`.
- Every column was advertised as `text` (OID 25), so a column declared `Int32` or `Timestamp` came back as a string. `PostgreSqlColumn(name, type)` — the library's central contract — was inert for extended-query clients.
- `Prepare()` failed outright: `Describe('S')` always answered `NoData` and `Execute` then sent a `RowDescription`, which Npgsql rejects.

I tested the narrower fix (answer `NoData`, let `Execute` describe) first. It does not work — Npgsql rejects `RowDescription` at Execute exactly as the spec requires. The shape has to come from the callback.

That also means **any row-returning command not starting with `select`** — `UPDATE … RETURNING`, `WITH`, `CALL`, `SHOW` — was broken before, not just `Prepare()`.

A handler must now return the same columns for a `Describe` request as for the execution. When the two disagree the server reports an error rather than sending DataRows that contradict the RowDescription already sent. Documented in the readme, covered by tests.

## Protocol correctness

- **Error state added.** A protocol error now sends `ErrorResponse`, skips to `Sync`, and resumes. Previously an unknown statement or portal name threw out of the message loop and closed the socket with *nothing* on the wire.
- **Bind result format codes honoured** instead of parsed and ignored — binary encoding implemented for every supported type, including the base-10000 `numeric` layout. This is what makes `Prepare()` work, since Npgsql requests binary results.
- **Binary parameter decoding** for `uuid`, `date`, `timestamp`, `timestamptz`, `numeric` (PostgreSQL's 2000-01-01 epoch). These fell through to a raw `byte[]` while `Type` still reported the rich type. `TypeOid`, `FormatCode` and `RawValue` are now exposed as a permanent escape hatch, plus `AsGuid`/`AsDateTime`/`AsDateTimeOffset`.
- **`DBNull.Value` sent as SQL NULL.** It previously reached `Convert.ToInt32` and threw, killing the connection mid-result-set — and the library itself normalises null parameters to `DBNull.Value`, so handlers naturally round-trip it back.
- **Transaction status** reported via `PostgreSqlQueryResult.TransactionStatus`. It was hardcoded to `'I'`, so `NpgsqlTransaction`, JDBC and psql `BEGIN` all misbehaved.
- **CommandComplete tags** fixed: previously `"OK 0"`, `"UPDATE 0"` (so `ExecuteNonQuery` always returned 0) and `"INSERT 0 1 0"`. New `AffectedRowCount`; a tag already carrying a count is sent verbatim.
- `max_rows` implemented with `PortalSuspended`; `EmptyQueryResponse` for empty queries; Bind format-code counts validated.
- **Text-format booleans** accept the full set PostgreSQL accepts. Only `"t"` decoded as true, so `"TRUE"` from pgjdbc or psql silently became `false` — the opposite value, no error.

## Denial of service

The client-declared length drove `new byte[length - 4]` **before any body byte was read**, with only a floor check: 28 bytes of traffic allocated 1 GiB and held it for as long as the socket stayed open, pre-authentication, with nothing bounding connection count or duration. Added, all configurable: `MaxMessageSize` (16 MB), a 10,000-byte startup cap matching PostgreSQL's own, `MaxConcurrentConnections`, `HandshakeTimeout`, `IdleTimeout`, and per-connection statement/portal caps.

`SSLRequest` is now answered at most once — the loop re-read the next startup packet *through* the new `SslStream`, so a client could stack TLS layers on one connection, paying a cheap client handshake for a server RSA signature each time, with every inner stream leaking until finalization. A failed handshake now disposes the `SslStream`. `RequireEncryption` is checked before the `CancelRequest` branch, which previously returned early and accepted plaintext.

## Lifecycle and diagnostics

- `PostgreSqlServer` takes an optional `ILogger` (3-arg constructor kept, so existing code compiles unchanged). It hardcoded `NullLogger` with no way to supply one.
- The accept loop no longer dies silently on a `SocketException`, leaving the port bound but deaf. Connection tasks have a catch-all, so malformed input can't become an unobserved task exception (a process kill under `ThrowUnobservedTaskExceptions`).
- `Dispose` is idempotent; listener binding is all-or-nothing; `StopAsync`/`IAsyncDisposable` drain in-flight connections.
- `PostgreSqlBackendSession` serialises Begin/End/Cancel — a CancelRequest arrives on a *different* connection, so `Cancel` could hit a source `EndCommand` had just disposed, throwing on an unrelated connection and dropping the cancel.
- Connection-level cancellation propagates instead of being logged at Error as an XX000; authentication callback exceptions become a protocol error; a SCRAM handler returning `Success()` without calling `ValidatePassword` gets an explanatory error instead of `28P01`.

## Tests: 110, up from 20

The old suite could not have caught most of this. Every executing test set `AllResultTypesAreUnknown = true` — the one Npgsql setting that suppresses type checking. No test sent a wrong password, a simple query, a text-format parameter or a malformed byte. The Kestrel host had zero coverage. `Npgsql_SimpleQuery_UsesSimpleRequestType` asserted `RequestType is SimpleQuery or ExtendedQuery` against a two-member enum, and the MD5 test had no assertions at all.

Added: wrong-password rejection for all three mechanisms; a raw protocol client driving simple query, `Close`, `Describe`-statement, unknown message types and malformed packets, asserting the server survives and the connection recovers after `Sync`; connection reuse after a handler error and after a handler throws; the Kestrel host including TLS over the split-pipe transport `DuplexStream` exists for; text-format and binary parameters; and type fidelity asserted *without* `AllResultTypesAreUnknown`. The cancellation test now signals from the handler instead of racing a 300 ms timer (already patched twice for flakiness).

## Verification

Strict `Release` + `IsOfficialBuild` build clean, 110/110 tests pass on both TFMs, `dotnet run ./eng/update-all.cs` run and idempotent. **Public API change is additive only** — `ref/Meziantou.Framework.PostgreSqlServer.cs` regenerated, no removals or signature changes.

## Deliberately not fixed

Six findings are left open because they are product decisions rather than defects:

- **SCRAM verifier API** — `ValidatePassword(string)` forces callers to store plaintext passwords. Fixing it changes *when* user code is invoked in the handshake, so it needs a deliberate API design and a version bump.
- `PostgreSqlColumnType` has no raw-OID escape hatch.
- Pipe-native I/O — performance only; the per-message double write (the part with a real latency cost) is fixed.
- Certificate lifetime / freezing options after start — needs an ownership decision.
- Extracting the authentication state machine — partially done (`PostgreSqlSessionState` extracted, `DuplexStream` moved out).
