### PR TITLE
Expose the AnalyzerOptions on DiagnosticReporter

### DIFF
--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
@@ -19,32 +19,39 @@ internal readonly struct DiagnosticReporter
     public DiagnosticReporter(SymbolAnalysisContext context)
     {
         _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
         CancellationToken = context.CancellationToken;
     }
 
     public DiagnosticReporter(OperationAnalysisContext context)
     {
         _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
         CancellationToken = context.CancellationToken;
     }
 
     public DiagnosticReporter(OperationBlockAnalysisContext context)
     {
         _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
         CancellationToken = context.CancellationToken;
     }
 
     public DiagnosticReporter(SyntaxNodeAnalysisContext context)
     {
         _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
         CancellationToken = context.CancellationToken;
     }
 
     public DiagnosticReporter(CompilationAnalysisContext context)
     {
         _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
         CancellationToken = context.CancellationToken;
     }
+
+    public AnalyzerOptions Options { get; }
 
     public CancellationToken CancellationToken { get; }
 

--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
 
     <developmentDependency>true</developmentDependency>

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -217,6 +217,31 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public async Task DiagnosticReporter_ExposesTheAnalyzerOptionsOfTheContext()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M() => System.Console.WriteLine();
+            }
+            """);
+
+        var diagnostics = await compilation
+            .WithAnalyzers([new AnalyzerOptionsAnalyzer()])
+            .GetAnalyzerDiagnosticsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            [
+                "Message CompilationAnalysisContext",
+                "Message OperationAnalysisContext",
+                "Message OperationBlockAnalysisContext",
+                "Message SymbolAnalysisContext",
+                "Message SyntaxNodeAnalysisContext",
+            ],
+            diagnostics.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture)).Distinct(StringComparer.Ordinal).OrderBy(message => message, StringComparer.Ordinal));
+    }
+
+    [Fact]
     public void ReportDiagnostic_DeclaresMessageArgsAsParams()
     {
         var messageArgsParameters = typeof(ContextExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -2147,6 +2172,40 @@ public sealed class RoslynHelperTests
             reporter.ReportDiagnostic(Descriptor, location);
             context.ReportDiagnostic(Descriptor, declaration, "context-node");
             context.ReportDiagnostic(Descriptor, (IEnumerable<Location>)[location], "context-locations");
+        }
+    }
+#pragma warning restore RS1041
+#pragma warning restore RS1038
+#pragma warning restore RS1036
+
+    // RS1036/RS1038/RS1041 only apply to analyzers shipped in an analyzer package. This one only exists to exercise the extension methods.
+#pragma warning disable RS1036 // A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>'
+#pragma warning disable RS1038 // This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces
+#pragma warning disable RS1041 // This compiler extension should not be implemented in an assembly with target framework
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class AnalyzerOptionsAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Descriptor = new("MFTEST003", "Title", "Message {0}", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(syntaxNodeContext => ReportWhenOptionsMatch(syntaxNodeContext, syntaxNodeContext.Options, syntaxNodeContext.Node.GetLocation(), nameof(SyntaxNodeAnalysisContext)), SyntaxKind.ClassDeclaration);
+            context.RegisterSymbolAction(symbolContext => ReportWhenOptionsMatch(symbolContext, symbolContext.Options, symbolContext.Symbol.Locations[0], nameof(SymbolAnalysisContext)), SymbolKind.NamedType);
+            context.RegisterOperationAction(operationContext => ReportWhenOptionsMatch(operationContext, operationContext.Options, operationContext.Operation.Syntax.GetLocation(), nameof(OperationAnalysisContext)), OperationKind.Invocation);
+            context.RegisterOperationBlockAction(operationBlockContext => ReportWhenOptionsMatch(operationBlockContext, operationBlockContext.Options, operationBlockContext.OperationBlocks[0].Syntax.GetLocation(), nameof(OperationBlockAnalysisContext)));
+            context.RegisterCompilationAction(compilationContext => ReportWhenOptionsMatch(compilationContext, compilationContext.Options, location: null, nameof(CompilationAnalysisContext)));
+        }
+
+        private static void ReportWhenOptionsMatch(DiagnosticReporter reporter, AnalyzerOptions options, Location? location, string contextName)
+        {
+            if (ReferenceEquals(reporter.Options, options))
+            {
+                reporter.ReportDiagnostic(Diagnostic.Create(Descriptor, location, contextName));
+            }
         }
     }
 #pragma warning restore RS1041


### PR DESCRIPTION
## What changed

`DiagnosticReporter` now exposes an `AnalyzerOptions Options { get; }` property, captured in each of its five context constructors (`SymbolAnalysisContext`, `OperationAnalysisContext`, `OperationBlockAnalysisContext`, `SyntaxNodeAnalysisContext`, `CompilationAnalysisContext`).

## Why

An analyzer that funnels its reporting through `DiagnosticReporter` had no way to reach the `AnalyzerOptions` of the context it came from, so it had to keep passing the original context alongside the reporter just to read `.editorconfig` values or additional files. Since every context that can build a reporter already carries `Options`, forwarding it removes that second parameter.

## Notes for reviewers

- `ContextExtensions.g.cs` is unchanged and needed no regeneration: the T4 template only emits `ReportDiagnostic` forwarders.
- The package version was bumped from `1.0.8` to `1.0.9`, matching the patch-bump convention used by previous feature PRs on this source package.
- New test `DiagnosticReporter_ExposesTheAnalyzerOptionsOfTheContext` registers all five action kinds and reports a diagnostic only when `reporter.Options` is reference-equal to the context's own `Options`, then asserts all five messages are present — so a missing assignment in any one constructor fails the test.

## Verification

- All four Roslyn variants (4.8 / 5.0 / 5.3 / 5.6) build clean with `/p:TreatsWarningsAsErrors=true` (0 warnings).
- Tests pass on all four: 153/153, 153/153, 153/153, 154/154 — 0 failed, 0 skipped. The new test was confirmed to actually run via a filtered run (1 total, 1 succeeded).
- `dotnet run ./eng/update-all.cs` completed and produced no file changes.