### PR TITLE
Add time zone support to recurrence evaluation and the iCalendar writer

### DIFF
--- a/ref/Meziantou.Framework.Scheduling.cs
+++ b/ref/Meziantou.Framework.Scheduling.cs
@@ -19,6 +19,8 @@ namespace Meziantou.Framework.Scheduling
         public static Meziantou.Framework.Scheduling.CronExpression Parse(System.ReadOnlySpan<char> expression) => throw null;
         public static bool TryParse(System.ReadOnlySpan<char> expression, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.CronExpression? cronExpression) => throw null;
         public System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrences(System.DateTime startDate) => throw null;
+        public System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(System.DateTime startDate, System.TimeZoneInfo timeZone) => throw null;
+        public System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(System.DateTimeOffset startDate, System.TimeZoneInfo timeZone) => throw null;
     }
 
     public sealed class Event
@@ -32,6 +34,7 @@ namespace Meziantou.Framework.Scheduling
         public System.DateTime DateTimeStamp { get => throw null; set { } }
         public System.DateTime Start { get => throw null; set { } }
         public System.DateTime End { get => throw null; set { } }
+        public System.TimeZoneInfo? TimeZone { get => throw null; set { } }
         public Meziantou.Framework.Scheduling.RecurrenceRule? RecurrenceRule { get => throw null; set { } }
         public Meziantou.Framework.Scheduling.EventStatus Status { get => throw null; set { } }
         public System.Collections.Generic.IDictionary<string, string> AdditionalProperties { get => throw null; }
@@ -94,6 +97,8 @@ namespace Meziantou.Framework.Scheduling
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? rrule, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.RecurrenceRule? recurrenceRule) => throw null;
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? rrule, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.RecurrenceRule? recurrenceRule, out string? error) => throw null;
         public virtual System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrences(System.DateTime startDate) => throw null;
+        public virtual System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(System.DateTime startDate, System.TimeZoneInfo timeZone) => throw null;
+        public System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(System.DateTimeOffset startDate, System.TimeZoneInfo timeZone) => throw null;
         protected abstract System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate);
         public override string ToString() => throw null;
     }
@@ -102,6 +107,14 @@ namespace Meziantou.Framework.Scheduling
     {
         public static System.DateTime? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate) => throw null;
         public static System.DateTimeOffset? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTimeOffset startDate) => throw null;
+        public static System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate, System.TimeZoneInfo timeZone) => throw null;
+        public static System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTimeOffset startDate, System.TimeZoneInfo timeZone) => throw null;
+        public static System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate, string timeZoneId) => throw null;
+        public static System.Collections.Generic.IEnumerable<System.DateTimeOffset> GetNextOccurrences(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTimeOffset startDate, string timeZoneId) => throw null;
+        public static System.DateTimeOffset? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate, System.TimeZoneInfo timeZone) => throw null;
+        public static System.DateTimeOffset? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTimeOffset startDate, System.TimeZoneInfo timeZone) => throw null;
+        public static System.DateTimeOffset? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate, string timeZoneId) => throw null;
+        public static System.DateTimeOffset? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTimeOffset startDate, string timeZoneId) => throw null;
     }
 
     public static class RecurrenceRuleHumanizerExtensions

--- a/src/Meziantou.Framework.Scheduling/CronExpression.cs
+++ b/src/Meziantou.Framework.Scheduling/CronExpression.cs
@@ -545,6 +545,39 @@ public sealed class CronExpression : IRecurrenceRule
         }
     }
 
+    /// <summary>Gets all occurrences of the expression, reading <paramref name="startDate"/> as a wall-clock time in <paramref name="timeZone"/>.</summary>
+    /// <param name="startDate">The wall-clock time to start generating occurrences from. Its <see cref="DateTime.Kind"/> is ignored.</param>
+    /// <param name="timeZone">The time zone the expression is evaluated in.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    /// <remarks>
+    /// <para>The occurrences keep their wall-clock time across a daylight saving transition, so their UTC offset changes.
+    /// A local time made invalid or ambiguous by a transition is resolved as RFC 5545 section 3.3.5 requires: an ambiguous
+    /// time keeps its first occurrence, and an invalid time is read with the UTC offset in effect before the gap.</para>
+    /// <para>As a consequence, an hourly expression repeats an instant across a forward transition and skips the instants
+    /// of the repeated hour across a backward one.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="timeZone"/> is <see langword="null"/>.</exception>
+    public IEnumerable<DateTimeOffset> GetNextOccurrences(DateTime startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return Utilities.ToDateTimeOffsets(GetNextOccurrences(DateTime.SpecifyKind(startDate, DateTimeKind.Unspecified)), timeZone);
+    }
+
+    /// <summary>Gets all occurrences of the expression, starting from the instant <paramref name="startDate"/> denotes.</summary>
+    /// <param name="startDate">The instant to start generating occurrences from. It is reduced to a wall-clock time in <paramref name="timeZone"/>.</param>
+    /// <param name="timeZone">The time zone the expression is evaluated in.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    /// <remarks>Reducing an instant to a wall-clock time is lossy in the hour repeated by a backward transition, where both
+    /// readings denote the same wall clock. Use the <see cref="DateTime"/> overload to control which one is meant.</remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="timeZone"/> is <see langword="null"/>.</exception>
+    public IEnumerable<DateTimeOffset> GetNextOccurrences(DateTimeOffset startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return GetNextOccurrences(TimeZoneInfo.ConvertTime(startDate, timeZone).DateTime, timeZone);
+    }
+
     private DateTime? GetNextOccurrence(DateTime from)
     {
         var current = from;

--- a/src/Meziantou.Framework.Scheduling/Event.cs
+++ b/src/Meziantou.Framework.Scheduling/Event.cs
@@ -30,6 +30,18 @@ public sealed class Event
     /// <summary>Gets or sets the end date and time of the event.</summary>
     public DateTime End { get; set; }
 
+    /// <summary>Gets or sets the time zone <see cref="Start"/> and <see cref="End"/> are expressed in.</summary>
+    /// <remarks>
+    /// <para>When set, the two properties are written as DTSTART;TZID= and DTEND;TZID= (RFC 5545 section 3.3.5 form 3),
+    /// and the calendar carries a matching VTIMEZONE component. When <see langword="null"/>, they are written as a UTC
+    /// or a floating date-time, as before.</para>
+    /// <para>A value whose <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/> is taken as a wall-clock
+    /// reading in this time zone. A <see cref="DateTimeKind.Utc"/> or <see cref="DateTimeKind.Local"/> value denotes an
+    /// instant and is converted to this time zone.</para>
+    /// <para><see cref="Created"/>, <see cref="LastModified"/> and <see cref="DateTimeStamp"/> are not affected.</para>
+    /// </remarks>
+    public TimeZoneInfo? TimeZone { get; set; }
+
     /// <summary>Gets or sets the recurrence rule for repeating events.</summary>
     public RecurrenceRule? RecurrenceRule { get; set; }
 

--- a/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
@@ -176,11 +176,10 @@ public sealed class InternetCalendar
         if (timeZone is null || recurrenceRule.EndDate is not { Kind: DateTimeKind.Unspecified } endDate)
             return text;
 
-        // TimeZoneInfo.ConvertTimeToUtc rejects a time that does not exist in the time zone, so a value in the
-        // gap of a forward transition is resolved rather than failing the whole write.
-        var utc = timeZone.IsInvalidTime(endDate)
-            ? DateTime.SpecifyKind(endDate - timeZone.BaseUtcOffset, DateTimeKind.Utc)
-            : TimeZoneInfo.ConvertTimeToUtc(endDate, timeZone);
+        // The bound has to be read the same way the occurrences it bounds are, so UNTIL goes through the
+        // RFC 5545 section 3.3.5 disambiguation rather than TimeZoneInfo.ConvertTimeToUtc, which throws on a
+        // time inside the gap of a forward transition and resolves an ambiguous one to its second occurrence.
+        var utc = Utilities.ToDateTimeOffset(endDate, timeZone).UtcDateTime;
 
         // The replaced token is a fixed-length value this library itself produced, so the substitution is unambiguous.
         var floating = ";UNTIL=" + endDate.ToString(Utilities.FloatingDateTimeFormat, CultureInfo.InvariantCulture);

--- a/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
@@ -15,10 +15,6 @@ namespace Meziantou.Framework.Scheduling;
 /// </example>
 public sealed class InternetCalendar
 {
-    /// <summary>iCalendar requires CRLF between content lines (RFC 5545 section 3.1), which
-    /// <see cref="TextWriter.WriteLine()"/> does not guarantee: it emits <see cref="Environment.NewLine"/>.</summary>
-    private const string CrLf = "\r\n";
-
     /// <summary>The product identifier written as PRODID, in the FPI form suggested by RFC 5545 section 3.7.3.</summary>
     private const string ProductIdentifier = "-//Meziantou//Meziantou.Framework.Scheduling//EN";
 
@@ -72,51 +68,123 @@ public sealed class InternetCalendar
         END:VCALENDAR
         */
 
-        WriteLine(writer, "BEGIN:VCALENDAR");
+        // The identifiers are validated before the first write so an invalid one cannot produce partial output.
+        var timeZones = GetTimeZones();
+
+        Utilities.WriteLine(writer, "BEGIN:VCALENDAR");
         if (!string.IsNullOrEmpty(Version))
             WriteTextProperty(writer, "VERSION", Version);
 
         // PRODID is REQUIRED in a VCALENDAR (RFC 5545 section 3.6).
-        WriteLine(writer, "PRODID:" + ProductIdentifier);
+        Utilities.WriteLine(writer, "PRODID:" + ProductIdentifier);
 
         WriteAdditionalProperties(writer, AdditionalProperties);
 
+        // A VTIMEZONE must precede the components referencing its TZID.
+        foreach (var timeZone in timeZones)
+        {
+            VTimeZoneWriter.Write(writer, timeZone.TimeZone, timeZone.ReferenceDate);
+        }
+
         foreach (var @event in Events)
         {
-            WriteLine(writer, "BEGIN:VEVENT");
+            Utilities.WriteLine(writer, "BEGIN:VEVENT");
             if (!string.IsNullOrEmpty(@event.Id))
                 WriteTextProperty(writer, "UID", @event.Id);
 
-            WriteLine(writer, "STATUS:" + Utilities.StatusToString(@event.Status));
+            Utilities.WriteLine(writer, "STATUS:" + Utilities.StatusToString(@event.Status));
             if ((@event.Organizer?.Address) is not null)
-                WriteLine(writer, "ORGANIZER:" + @event.Organizer.Address);
+                Utilities.WriteLine(writer, "ORGANIZER:" + @event.Organizer.Address);
 
             foreach (var attendee in @event.Attendees)
             {
                 if (attendee is null)
                     continue;
 
-                WriteLine(writer, "ATTENDEE:" + attendee.Address);
+                Utilities.WriteLine(writer, "ATTENDEE:" + attendee.Address);
             }
 
-            WriteLine(writer, "CREATED:" + Utilities.DateTimeToString(@event.Created));
-            WriteLine(writer, "LAST-MODIFIED:" + Utilities.DateTimeToString(@event.LastModified));
-            WriteLine(writer, "DTSTAMP:" + Utilities.DateTimeToString(@event.DateTimeStamp));
-            WriteLine(writer, "DTSTART:" + Utilities.DateTimeToString(@event.Start));
-            WriteLine(writer, "DTEND:" + Utilities.DateTimeToString(@event.End));
+            Utilities.WriteLine(writer, "CREATED:" + Utilities.DateTimeToString(@event.Created));
+            Utilities.WriteLine(writer, "LAST-MODIFIED:" + Utilities.DateTimeToString(@event.LastModified));
+            Utilities.WriteLine(writer, "DTSTAMP:" + Utilities.DateTimeToString(@event.DateTimeStamp));
+            WriteDateTimeProperty(writer, "DTSTART", @event.Start, @event.TimeZone);
+            WriteDateTimeProperty(writer, "DTEND", @event.End, @event.TimeZone);
             if (@event.RecurrenceRule is not null)
-                WriteLine(writer, "RRULE:" + @event.RecurrenceRule.Text);
+                Utilities.WriteLine(writer, "RRULE:" + GetRecurrenceRuleValue(@event.RecurrenceRule, @event.TimeZone));
 
             if (!string.IsNullOrEmpty(@event.Summary))
                 WriteTextProperty(writer, "SUMMARY", @event.Summary);
 
             WriteAdditionalProperties(writer, @event.AdditionalProperties);
 
-            WriteLine(writer, "DESCRIPTION:\\n");
-            WriteLine(writer, "END:VEVENT");
+            Utilities.WriteLine(writer, "DESCRIPTION:\\n");
+            Utilities.WriteLine(writer, "END:VEVENT");
         }
 
-        WriteLine(writer, "END:VCALENDAR");
+        Utilities.WriteLine(writer, "END:VCALENDAR");
+    }
+
+    /// <summary>Collects the distinct time zones referenced by the events, with the earliest start each is used for.</summary>
+    private List<(TimeZoneInfo TimeZone, DateTime ReferenceDate)> GetTimeZones()
+    {
+        var result = new List<(TimeZoneInfo TimeZone, DateTime ReferenceDate)>();
+        var indexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var @event in Events)
+        {
+            if (@event?.TimeZone is not { } timeZone)
+                continue;
+
+            if (!Utilities.IsValidTimeZoneId(timeZone.Id))
+                throw new InvalidOperationException($"The time zone identifier '{timeZone.Id}' cannot be written as a TZID property parameter");
+
+            var referenceDate = Utilities.ToWallClock(@event.Start, timeZone);
+            if (indexes.TryGetValue(timeZone.Id, out var index))
+            {
+                if (referenceDate < result[index].ReferenceDate)
+                {
+                    result[index] = (result[index].TimeZone, referenceDate);
+                }
+            }
+            else
+            {
+                indexes.Add(timeZone.Id, result.Count);
+                result.Add((timeZone, referenceDate));
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Writes a date-time property, using the TZID form (RFC 5545 section 3.3.5) when the event has a time zone.</summary>
+    private static void WriteDateTimeProperty(TextWriter writer, string name, DateTime value, TimeZoneInfo? timeZone)
+    {
+        if (timeZone is null)
+        {
+            Utilities.WriteLine(writer, name + ':' + Utilities.DateTimeToString(value));
+            return;
+        }
+
+        // The identifier was validated before any output was written.
+        var wallClock = Utilities.ToWallClock(value, timeZone);
+        Utilities.WriteLine(writer, name + ";TZID=" + timeZone.Id + ':' + wallClock.ToString(Utilities.FloatingDateTimeFormat, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>RFC 5545 section 3.3.10: when DTSTART carries a TZID, UNTIL must be a UTC date-time.</summary>
+    private static string GetRecurrenceRuleValue(RecurrenceRule recurrenceRule, TimeZoneInfo? timeZone)
+    {
+        var text = recurrenceRule.Text;
+        if (timeZone is null || recurrenceRule.EndDate is not { Kind: DateTimeKind.Unspecified } endDate)
+            return text;
+
+        // TimeZoneInfo.ConvertTimeToUtc rejects a time that does not exist in the time zone, so a value in the
+        // gap of a forward transition is resolved rather than failing the whole write.
+        var utc = timeZone.IsInvalidTime(endDate)
+            ? DateTime.SpecifyKind(endDate - timeZone.BaseUtcOffset, DateTimeKind.Utc)
+            : TimeZoneInfo.ConvertTimeToUtc(endDate, timeZone);
+
+        // The replaced token is a fixed-length value this library itself produced, so the substitution is unambiguous.
+        var floating = ";UNTIL=" + endDate.ToString(Utilities.FloatingDateTimeFormat, CultureInfo.InvariantCulture);
+        return text.Replace(floating, ";UNTIL=" + utc.ToString(Utilities.UtcDateTimeFormat, CultureInfo.InvariantCulture), StringComparison.Ordinal);
     }
 
     private static void WriteAdditionalProperties(TextWriter writer, IDictionary<string, string> properties)
@@ -139,14 +207,7 @@ public sealed class InternetCalendar
         writer.Write(name);
         writer.Write(':');
         WriteEscaped(writer, value);
-        writer.Write(CrLf);
-    }
-
-    /// <summary>Writes a content line whose value is already in its final form.</summary>
-    private static void WriteLine(TextWriter writer, string line)
-    {
-        writer.Write(line);
-        writer.Write(CrLf);
+        writer.Write(Utilities.CrLf);
     }
 
     /// <summary>Escapes an iCalendar TEXT value per RFC 5545 section 3.3.11.</summary>

--- a/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
+++ b/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks);netstandard2.0</TargetFrameworks>
     <Description>RecurrenceRule (RFC 5545) and Cron expression parser and evaluator</Description>
-    <Version>4.0.5</Version>
+    <Version>4.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
@@ -793,6 +793,78 @@ public abstract class RecurrenceRule : IRecurrenceRule
         }
     }
 
+    /// <summary>Gets all occurrences of the recurrence, reading <paramref name="startDate"/> as a wall-clock time in <paramref name="timeZone"/>.</summary>
+    /// <param name="startDate">The wall-clock time to start generating occurrences from. Its <see cref="DateTime.Kind"/> is ignored.</param>
+    /// <param name="timeZone">The time zone the recurrence is expressed in, as an iCalendar DTSTART;TZID= would.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    /// <remarks>
+    /// <para>The occurrences keep their wall-clock time across a daylight saving transition, so their UTC offset changes.
+    /// A local time made invalid or ambiguous by a transition is resolved as RFC 5545 section 3.3.5 requires: an ambiguous
+    /// time keeps its first occurrence, and an invalid time is read with the UTC offset in effect before the gap.</para>
+    /// <para>As a consequence, a sub-daily recurrence repeats an instant across a forward transition and skips the instants
+    /// of the repeated hour across a backward one.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="timeZone"/> is <see langword="null"/>.</exception>
+    public virtual IEnumerable<DateTimeOffset> GetNextOccurrences(DateTime startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return Iterate(this, DateTime.SpecifyKind(startDate, DateTimeKind.Unspecified), timeZone);
+
+        static IEnumerable<DateTimeOffset> Iterate(RecurrenceRule rule, DateTime wallClockStart, TimeZoneInfo timeZone)
+        {
+            if (rule.Occurrences is 0)
+                yield break;
+
+            var count = 0;
+            DateTime? lastInstant = null;
+            foreach (var next in rule.GetNextOccurrencesInternal(wallClockStart))
+            {
+                var occurrence = Utilities.ToDateTimeOffset(next, timeZone);
+
+                // A duplicate is not part of the recurrence set, so it does not count towards COUNT either.
+                // Dropping it first also leaves the values below increasing, which is what lets UNTIL stop
+                // the enumeration instead of only filtering it.
+                if (Utilities.IsDuplicate(lastInstant, occurrence))
+                    continue;
+
+                if (rule.EndDate.HasValue && IsAfterEndDate(next, occurrence, rule.EndDate.Value))
+                    yield break;
+
+                lastInstant = occurrence.UtcDateTime;
+                yield return occurrence;
+
+                count++;
+                if (rule.Occurrences.HasValue && count >= rule.Occurrences.Value)
+                    yield break;
+            }
+        }
+
+        static bool IsAfterEndDate(DateTime wallClock, DateTimeOffset occurrence, DateTime endDate) => endDate.Kind switch
+        {
+            // A UTC UNTIL bounds the recurrence by instant, not by wall clock.
+            DateTimeKind.Utc => occurrence.UtcDateTime > endDate,
+            DateTimeKind.Local => occurrence.UtcDateTime > endDate.ToUniversalTime(),
+
+            // A floating UNTIL is a wall-clock reading in the recurrence's own time zone.
+            _ => wallClock > endDate,
+        };
+    }
+
+    /// <summary>Gets all occurrences of the recurrence, starting from the instant <paramref name="startDate"/> denotes.</summary>
+    /// <param name="startDate">The instant to start generating occurrences from. It is reduced to a wall-clock time in <paramref name="timeZone"/>.</param>
+    /// <param name="timeZone">The time zone the recurrence is expressed in, as an iCalendar DTSTART;TZID= would.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    /// <remarks>Reducing an instant to a wall-clock time is lossy in the hour repeated by a backward transition, where both
+    /// readings denote the same wall clock. Use the <see cref="DateTime"/> overload to control which one is meant.</remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="timeZone"/> is <see langword="null"/>.</exception>
+    public IEnumerable<DateTimeOffset> GetNextOccurrences(DateTimeOffset startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return GetNextOccurrences(TimeZoneInfo.ConvertTime(startDate, timeZone).DateTime, timeZone);
+    }
+
     /// <summary>When implemented in a derived class, generates the internal sequence of occurrence dates.</summary>
     /// <param name="startDate">The date to start generating occurrences from.</param>
     /// <returns>An enumerable sequence of occurrence dates.</returns>

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs
@@ -18,7 +18,8 @@ public static class RecurrenceRuleExtensions
     /// <summary>Gets the next occurrence of the recurrence starting from the specified date.</summary>
     /// <param name="startDate">The date to start searching for the next occurrence.</param>
     /// <returns>The next occurrence date with the same offset as <paramref name="startDate"/>, or <see langword="null"/> if there are no more occurrences.</returns>
-    /// <remarks>The occurrences are computed using the local time of <paramref name="startDate"/>, and the offset of <paramref name="startDate"/> is applied to the result.</remarks>
+    /// <remarks>The occurrences are computed using the local time of <paramref name="startDate"/>, and the offset of <paramref name="startDate"/> is applied to the result.
+    /// The offset is therefore the same for every occurrence; use an overload that takes a <see cref="TimeZoneInfo"/> to follow daylight saving transitions.</remarks>
     public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate)
     {
         ArgumentNullException.ThrowIfNull(recurrenceRule);
@@ -27,5 +28,125 @@ public static class RecurrenceRuleExtensions
             return new DateTimeOffset(DateTime.SpecifyKind(occurrence, DateTimeKind.Unspecified), startDate.Offset);
 
         return null;
+    }
+
+    /// <summary>Gets all occurrences of the recurrence, reading <paramref name="startDate"/> as a wall-clock time in <paramref name="timeZone"/>.</summary>
+    /// <param name="startDate">The wall-clock time to start generating occurrences from. Its <see cref="DateTime.Kind"/> is ignored.</param>
+    /// <param name="timeZone">The time zone the recurrence is expressed in.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    public static IEnumerable<DateTimeOffset> GetNextOccurrences(this IRecurrenceRule recurrenceRule, DateTime startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        // Extension methods bind statically, so a variable typed as IRecurrenceRule would otherwise miss the
+        // implementations that bound UNTIL by instant instead of by wall clock.
+        if (recurrenceRule is RecurrenceRule rule)
+            return rule.GetNextOccurrences(startDate, timeZone);
+
+        if (recurrenceRule is CronExpression cronExpression)
+            return cronExpression.GetNextOccurrences(startDate, timeZone);
+
+        return Utilities.ToDateTimeOffsets(recurrenceRule.GetNextOccurrences(DateTime.SpecifyKind(startDate, DateTimeKind.Unspecified)), timeZone);
+    }
+
+    /// <summary>Gets all occurrences of the recurrence, starting from the instant <paramref name="startDate"/> denotes.</summary>
+    /// <param name="startDate">The instant to start generating occurrences from. It is reduced to a wall-clock time in <paramref name="timeZone"/>.</param>
+    /// <param name="timeZone">The time zone the recurrence is expressed in.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    public static IEnumerable<DateTimeOffset> GetNextOccurrences(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return recurrenceRule.GetNextOccurrences(TimeZoneInfo.ConvertTime(startDate, timeZone).DateTime, timeZone);
+    }
+
+    /// <summary>Gets all occurrences of the recurrence, reading <paramref name="startDate"/> as a wall-clock time in the specified time zone.</summary>
+    /// <param name="startDate">The wall-clock time to start generating occurrences from. Its <see cref="DateTime.Kind"/> is ignored.</param>
+    /// <param name="timeZoneId">The identifier of the time zone the recurrence is expressed in.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    /// <exception cref="TimeZoneNotFoundException">No time zone matches <paramref name="timeZoneId"/>.</exception>
+    /// <remarks>On .NET Framework the runtime provides no conversion between IANA and Windows identifiers, so an
+    /// IANA identifier such as <c>America/New_York</c> does not resolve on Windows. Resolve the
+    /// <see cref="TimeZoneInfo"/> there and use the overload that takes one.</remarks>
+    public static IEnumerable<DateTimeOffset> GetNextOccurrences(this IRecurrenceRule recurrenceRule, DateTime startDate, string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        return recurrenceRule.GetNextOccurrences(startDate, TimeZones.Find(timeZoneId));
+    }
+
+    /// <summary>Gets all occurrences of the recurrence, starting from the instant <paramref name="startDate"/> denotes.</summary>
+    /// <param name="startDate">The instant to start generating occurrences from. It is reduced to a wall-clock time in the specified time zone.</param>
+    /// <param name="timeZoneId">The identifier of the time zone the recurrence is expressed in.</param>
+    /// <returns>An enumerable sequence of occurrences, each carrying the UTC offset in effect at that occurrence.</returns>
+    /// <exception cref="TimeZoneNotFoundException">No time zone matches <paramref name="timeZoneId"/>.</exception>
+    /// <remarks>On .NET Framework the runtime provides no conversion between IANA and Windows identifiers, so an
+    /// IANA identifier such as <c>America/New_York</c> does not resolve on Windows. Resolve the
+    /// <see cref="TimeZoneInfo"/> there and use the overload that takes one.</remarks>
+    public static IEnumerable<DateTimeOffset> GetNextOccurrences(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate, string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        return recurrenceRule.GetNextOccurrences(startDate, TimeZones.Find(timeZoneId));
+    }
+
+    /// <summary>Gets the next occurrence of the recurrence, reading <paramref name="startDate"/> as a wall-clock time in <paramref name="timeZone"/>.</summary>
+    /// <param name="startDate">The wall-clock time to start searching from. Its <see cref="DateTime.Kind"/> is ignored.</param>
+    /// <param name="timeZone">The time zone the recurrence is expressed in.</param>
+    /// <returns>The next occurrence with the UTC offset in effect at that occurrence, or <see langword="null"/> if there are no more occurrences.</returns>
+    public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTime startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        foreach (var occurrence in recurrenceRule.GetNextOccurrences(startDate, timeZone))
+            return occurrence;
+
+        return null;
+    }
+
+    /// <summary>Gets the next occurrence of the recurrence, starting from the instant <paramref name="startDate"/> denotes.</summary>
+    /// <param name="startDate">The instant to start searching from. It is reduced to a wall-clock time in <paramref name="timeZone"/>.</param>
+    /// <param name="timeZone">The time zone the recurrence is expressed in.</param>
+    /// <returns>The next occurrence with the UTC offset in effect at that occurrence, or <see langword="null"/> if there are no more occurrences.</returns>
+    public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        foreach (var occurrence in recurrenceRule.GetNextOccurrences(startDate, timeZone))
+            return occurrence;
+
+        return null;
+    }
+
+    /// <summary>Gets the next occurrence of the recurrence, reading <paramref name="startDate"/> as a wall-clock time in the specified time zone.</summary>
+    /// <param name="startDate">The wall-clock time to start searching from. Its <see cref="DateTime.Kind"/> is ignored.</param>
+    /// <param name="timeZoneId">The identifier of the time zone the recurrence is expressed in.</param>
+    /// <returns>The next occurrence with the UTC offset in effect at that occurrence, or <see langword="null"/> if there are no more occurrences.</returns>
+    /// <exception cref="TimeZoneNotFoundException">No time zone matches <paramref name="timeZoneId"/>.</exception>
+    /// <remarks>On .NET Framework the runtime provides no conversion between IANA and Windows identifiers, so an
+    /// IANA identifier such as <c>America/New_York</c> does not resolve on Windows. Resolve the
+    /// <see cref="TimeZoneInfo"/> there and use the overload that takes one.</remarks>
+    public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTime startDate, string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        return recurrenceRule.GetNextOccurrence(startDate, TimeZones.Find(timeZoneId));
+    }
+
+    /// <summary>Gets the next occurrence of the recurrence, starting from the instant <paramref name="startDate"/> denotes.</summary>
+    /// <param name="startDate">The instant to start searching from. It is reduced to a wall-clock time in the specified time zone.</param>
+    /// <param name="timeZoneId">The identifier of the time zone the recurrence is expressed in.</param>
+    /// <returns>The next occurrence with the UTC offset in effect at that occurrence, or <see langword="null"/> if there are no more occurrences.</returns>
+    /// <exception cref="TimeZoneNotFoundException">No time zone matches <paramref name="timeZoneId"/>.</exception>
+    /// <remarks>On .NET Framework the runtime provides no conversion between IANA and Windows identifiers, so an
+    /// IANA identifier such as <c>America/New_York</c> does not resolve on Windows. Resolve the
+    /// <see cref="TimeZoneInfo"/> there and use the overload that takes one.</remarks>
+    public static DateTimeOffset? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTimeOffset startDate, string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(recurrenceRule);
+
+        return recurrenceRule.GetNextOccurrence(startDate, TimeZones.Find(timeZoneId));
     }
 }

--- a/src/Meziantou.Framework.Scheduling/TimeZones.cs
+++ b/src/Meziantou.Framework.Scheduling/TimeZones.cs
@@ -1,0 +1,56 @@
+namespace Meziantou.Framework.Scheduling;
+
+/// <summary>Resolves the time zones referenced by an iCalendar TZID parameter.</summary>
+/// <remarks>
+/// <para>On .NET 6 and later both IANA identifiers (<c>America/New_York</c>) and Windows identifiers
+/// (<c>Eastern Standard Time</c>) are accepted on every platform.</para>
+/// <para>On .NET Framework the runtime provides no conversion between the two, so an IANA identifier
+/// does not resolve on Windows. Those callers should resolve the <see cref="TimeZoneInfo"/> themselves
+/// and use the overloads that take one.</para>
+/// </remarks>
+internal static class TimeZones
+{
+    /// <summary>Finds the time zone with the specified identifier.</summary>
+    /// <param name="timeZoneId">The time zone identifier, as written in a TZID property parameter.</param>
+    /// <returns>The time zone matching <paramref name="timeZoneId"/>.</returns>
+    /// <exception cref="TimeZoneNotFoundException">No time zone matches <paramref name="timeZoneId"/>.</exception>
+    public static TimeZoneInfo Find(string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(timeZoneId);
+
+        if (TryFind(timeZoneId, out var timeZone))
+            return timeZone;
+
+        throw new TimeZoneNotFoundException($"The time zone '{timeZoneId}' was not found");
+    }
+
+    /// <summary>Attempts to find the time zone with the specified identifier.</summary>
+    /// <param name="timeZoneId">The time zone identifier, as written in a TZID property parameter.</param>
+    /// <param name="timeZone">When successful, contains the time zone matching <paramref name="timeZoneId"/>.</param>
+    /// <returns><see langword="true"/> if the time zone was found; otherwise, <see langword="false"/>.</returns>
+    public static bool TryFind(string timeZoneId, [NotNullWhen(returnValue: true)] out TimeZoneInfo? timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZoneId);
+
+#if NET6_0_OR_GREATER
+        return TimeZoneInfo.TryFindSystemTimeZoneById(timeZoneId, out timeZone);
+#else
+        // TimeZoneInfo.TryFindSystemTimeZoneById does not exist before .NET 6.
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            timeZone = null;
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            timeZone = null;
+            return false;
+        }
+#endif
+    }
+}

--- a/src/Meziantou.Framework.Scheduling/Utilities.cs
+++ b/src/Meziantou.Framework.Scheduling/Utilities.cs
@@ -5,6 +5,16 @@ internal static class Utilities
     public const string FloatingDateTimeFormat = "yyyyMMddTHHmmss";
     public const string UtcDateTimeFormat = "yyyyMMddTHHmmssZ";
 
+    /// <summary>iCalendar requires CRLF between content lines (RFC 5545 section 3.1), which
+    /// <see cref="TextWriter.WriteLine()"/> does not guarantee: it emits <see cref="Environment.NewLine"/>.</summary>
+    public const string CrLf = "\r\n";
+
+    public static void WriteLine(TextWriter writer, string value)
+    {
+        writer.Write(value);
+        writer.Write(CrLf);
+    }
+
     public static DateTime ParseDateTime(string str)
     {
         string[] formats =
@@ -69,6 +79,129 @@ internal static class Utilities
             // Form 1: a floating date-time, interpreted in the reader's own time zone.
             _ => dt.ToString(FloatingDateTimeFormat, CultureInfo.InvariantCulture),
         };
+    }
+
+    /// <summary>Converts a wall-clock date-time to an instant in <paramref name="timeZone"/> using the disambiguation rules of RFC 5545 section 3.3.5.</summary>
+    public static DateTimeOffset ToDateTimeOffset(DateTime wallClock, TimeZoneInfo timeZone)
+    {
+        var local = DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified);
+
+        if (timeZone.IsAmbiguousTime(local))
+        {
+            // The local time occurs twice and RFC 5545 keeps the first occurrence. Since instant = local - offset,
+            // the first occurrence is the reading with the greatest offset. TimeZoneInfo.GetUtcOffset returns the
+            // standard offset here, which is the second occurrence, so the ambiguous offsets are inspected instead.
+            var offsets = timeZone.GetAmbiguousTimeOffsets(local);
+            var offset = offsets[0];
+            for (var i = 1; i < offsets.Length; i++)
+            {
+                if (offsets[i] > offset)
+                {
+                    offset = offsets[i];
+                }
+            }
+
+            return new DateTimeOffset(local, offset);
+        }
+
+        if (timeZone.IsInvalidTime(local))
+        {
+            // The local time is skipped by a forward transition. RFC 5545 reads it with the UTC offset in effect
+            // before the gap; rendering that instant in the time zone surfaces 02:30 EST as 03:30 EDT.
+            return TimeZoneInfo.ConvertTime(new DateTimeOffset(local, GetUtcOffsetBeforeGap(local, timeZone)), timeZone);
+        }
+
+        return new DateTimeOffset(local, timeZone.GetUtcOffset(local));
+    }
+
+    /// <summary>Converts wall-clock occurrences to instants in <paramref name="timeZone"/>, dropping the duplicates
+    /// that a forward transition creates.</summary>
+    public static IEnumerable<DateTimeOffset> ToDateTimeOffsets(IEnumerable<DateTime> wallClockOccurrences, TimeZoneInfo timeZone)
+    {
+        DateTime? lastInstant = null;
+        foreach (var wallClock in wallClockOccurrences)
+        {
+            var occurrence = ToDateTimeOffset(wallClock, timeZone);
+            if (IsDuplicate(lastInstant, occurrence))
+                continue;
+
+            lastInstant = occurrence.UtcDateTime;
+            yield return occurrence;
+        }
+    }
+
+    /// <summary>RFC 5545 section 3.8.5.3: duplicate instances are ignored.</summary>
+    /// <remarks>
+    /// <para>Every local time in the gap of a forward transition is read at the UTC offset in effect before the
+    /// gap, which maps the whole gap onto the instants the hour after it also denotes. A sub-hourly recurrence
+    /// therefore repeats a run of instants, and the repeats are neither adjacent to nor ordered after the
+    /// instances they duplicate.</para>
+    /// <para>Keeping only what is strictly after the last instant produced removes every such repeat, and leaves
+    /// the recurrence set increasing. The duplicate and the instance it repeats convert to the very same value,
+    /// so which of the two is kept does not matter.</para>
+    /// </remarks>
+    public static bool IsDuplicate(DateTime? lastInstant, DateTimeOffset occurrence)
+    {
+        return lastInstant.HasValue && occurrence.UtcDateTime <= lastInstant.Value;
+    }
+
+    /// <summary>Gets the UTC offset in effect immediately before the forward transition that skips <paramref name="local"/>.</summary>
+    private static TimeSpan GetUtcOffsetBeforeGap(DateTime local, TimeZoneInfo timeZone)
+    {
+        // A gap exists when the offset grows from o1 to o2 (o1 < o2) at instant T, skipping the local times in
+        // [T + o1, T + o2). Reading the local time with o1 lands at or after T and so reports o2, and reading it
+        // with o2 lands before T and so reports o1. Two probes therefore yield both offsets, and the smaller one
+        // is the offset in effect before the gap.
+        var first = timeZone.GetUtcOffset(DateTime.SpecifyKind(local - timeZone.BaseUtcOffset, DateTimeKind.Utc));
+        var second = timeZone.GetUtcOffset(DateTime.SpecifyKind(local - first, DateTimeKind.Utc));
+        return first < second ? first : second;
+    }
+
+    /// <summary>Expresses <paramref name="value"/> as a wall-clock reading in <paramref name="timeZone"/>.</summary>
+    public static DateTime ToWallClock(DateTime value, TimeZoneInfo timeZone)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => TimeZoneInfo.ConvertTimeFromUtc(value, timeZone),
+            DateTimeKind.Local => TimeZoneInfo.ConvertTime(value, TimeZoneInfo.Local, timeZone),
+            _ => value,
+        };
+    }
+
+    /// <summary>Formats a UTC offset as the utc-offset value type (RFC 5545 section 3.3.14).</summary>
+    public static string UtcOffsetToString(TimeSpan offset)
+    {
+        // RFC 5545 forbids "-0000", so a zero offset is always written with a plus sign.
+        var sign = offset.Ticks < 0 ? '-' : '+';
+        var absolute = offset.Duration();
+
+        var sb = new StringBuilder(7);
+        sb.Append(sign);
+        sb.Append(((int)absolute.TotalHours).ToString("00", CultureInfo.InvariantCulture));
+        sb.Append(absolute.Minutes.ToString("00", CultureInfo.InvariantCulture));
+        if (absolute.Seconds is not 0)
+        {
+            sb.Append(absolute.Seconds.ToString("00", CultureInfo.InvariantCulture));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>A TZID written as a property parameter must be a paramtext that needs no DQUOTE
+    /// (RFC 5545 section 3.2); rather than quote or escape, an identifier outside this set is rejected.</summary>
+    public static bool IsValidTimeZoneId([NotNullWhen(returnValue: true)] string? id)
+    {
+        if (string.IsNullOrEmpty(id) || id.Length > 100)
+            return false;
+
+        foreach (var c in id)
+        {
+            // Covers IANA identifiers (America/Argentina/Buenos_Aires, Etc/GMT+5) and Windows ones (Romance Standard Time).
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('/' or '_' or '-' or '+' or '.' or ' '))
+                return false;
+        }
+
+        return true;
     }
 
     public static string StatusToString(EventStatus status)

--- a/src/Meziantou.Framework.Scheduling/VTimeZoneWriter.cs
+++ b/src/Meziantou.Framework.Scheduling/VTimeZoneWriter.cs
@@ -1,0 +1,119 @@
+namespace Meziantou.Framework.Scheduling;
+
+/// <summary>Writes the VTIMEZONE component (RFC 5545 section 3.6.5) describing a <see cref="TimeZoneInfo"/>.</summary>
+internal static class VTimeZoneWriter
+{
+    public static void Write(TextWriter writer, TimeZoneInfo timeZone, DateTime referenceDate)
+    {
+        Utilities.WriteLine(writer, "BEGIN:VTIMEZONE");
+
+        // The identifier was validated before any output was written.
+        Utilities.WriteLine(writer, "TZID:" + timeZone.Id);
+
+        var rule = SelectRule(timeZone, referenceDate);
+        if (rule is null)
+        {
+            // RFC 5545 section 3.6.5 requires at least one sub-component, so a time zone without daylight
+            // saving time is described by a single STANDARD whose FROM and TO offsets are equal.
+            var offset = Utilities.UtcOffsetToString(timeZone.BaseUtcOffset);
+            Utilities.WriteLine(writer, "BEGIN:STANDARD");
+            Utilities.WriteLine(writer, "DTSTART:19700101T000000");
+            Utilities.WriteLine(writer, "TZOFFSETFROM:" + offset);
+            Utilities.WriteLine(writer, "TZOFFSETTO:" + offset);
+            Utilities.WriteLine(writer, "END:STANDARD");
+        }
+        else
+        {
+#if NET6_0_OR_GREATER
+            var standardOffset = timeZone.BaseUtcOffset + rule.BaseUtcOffsetDelta;
+#else
+            // TimeZoneInfo.AdjustmentRule.BaseUtcOffsetDelta does not exist before .NET 6.
+            var standardOffset = timeZone.BaseUtcOffset;
+#endif
+            var daylightOffset = standardOffset + rule.DaylightDelta;
+
+            // The sub-components are anchored in the year of the events rather than in the year the rule
+            // starts, so a consumer applies the transitions to them instead of only to later occurrences.
+            var year = referenceDate.Year < 1970 ? 1970 : referenceDate.Year;
+
+            WriteSubComponent(writer, "DAYLIGHT", rule.DaylightTransitionStart, year, standardOffset, daylightOffset);
+            WriteSubComponent(writer, "STANDARD", rule.DaylightTransitionEnd, year, daylightOffset, standardOffset);
+        }
+
+        Utilities.WriteLine(writer, "END:VTIMEZONE");
+    }
+
+    private static void WriteSubComponent(TextWriter writer, string name, TimeZoneInfo.TransitionTime transition, int year, TimeSpan from, TimeSpan to)
+    {
+        Utilities.WriteLine(writer, "BEGIN:" + name);
+
+        // The DTSTART of a sub-component is a local time expressed in the TZOFFSETFROM offset, and never carries a TZID.
+        Utilities.WriteLine(writer, "DTSTART:" + GetOnset(transition, year).ToString(Utilities.FloatingDateTimeFormat, CultureInfo.InvariantCulture));
+        Utilities.WriteLine(writer, "TZOFFSETFROM:" + Utilities.UtcOffsetToString(from));
+        Utilities.WriteLine(writer, "TZOFFSETTO:" + Utilities.UtcOffsetToString(to));
+        Utilities.WriteLine(writer, "RRULE:" + GetRecurrenceRule(transition));
+        Utilities.WriteLine(writer, "END:" + name);
+    }
+
+    private static string GetRecurrenceRule(TimeZoneInfo.TransitionTime transition)
+    {
+        var month = transition.Month.ToString(CultureInfo.InvariantCulture);
+        if (transition.IsFixedDateRule)
+            return "FREQ=YEARLY;BYMONTH=" + month + ";BYMONTHDAY=" + transition.Day.ToString(CultureInfo.InvariantCulture);
+
+        // TimeZoneInfo.TransitionTime.Week is 1 to 5, where 5 means the last occurrence in the month: the BYDAY ordinal -1.
+        var ordinal = transition.Week >= 5 ? "-1" : transition.Week.ToString(CultureInfo.InvariantCulture);
+        return "FREQ=YEARLY;BYMONTH=" + month + ";BYDAY=" + ordinal + Utilities.DayOfWeekToString(transition.DayOfWeek);
+    }
+
+    private static DateTime GetOnset(TimeZoneInfo.TransitionTime transition, int year)
+    {
+        DateTime date;
+        if (transition.IsFixedDateRule)
+        {
+            date = new DateTime(year, transition.Month, Math.Min(transition.Day, DateTime.DaysInMonth(year, transition.Month)));
+        }
+        else
+        {
+            var firstOfMonth = new DateTime(year, transition.Month, 1);
+            var daysToFirstMatch = ((int)transition.DayOfWeek - (int)firstOfMonth.DayOfWeek + 7) % 7;
+            date = firstOfMonth.AddDays(daysToFirstMatch + (7 * (transition.Week - 1)));
+            if (date.Month != transition.Month)
+            {
+                // The requested week does not exist in this month, so the last one is used.
+                date = date.AddDays(-7);
+            }
+        }
+
+        return date + transition.TimeOfDay.TimeOfDay;
+    }
+
+    private static TimeZoneInfo.AdjustmentRule? SelectRule(TimeZoneInfo timeZone, DateTime referenceDate)
+    {
+        // Only one rule is written: the runtime exposes the whole time zone history on Unix but usually a
+        // single rule on Windows, so writing every rule would make the output vary by platform.
+        TimeZoneInfo.AdjustmentRule? applicable = null;
+        foreach (var rule in timeZone.GetAdjustmentRules())
+        {
+            // A period without daylight saving time is modelled as a rule with a zero delta.
+            if (rule.DaylightDelta == TimeSpan.Zero)
+                continue;
+
+            // A rule that has already ended cannot describe the events. A time zone that once observed
+            // daylight saving time and no longer does is left with no rule at all, and so is written as
+            // a single STANDARD component.
+            if (rule.DateEnd < referenceDate.Date)
+                continue;
+
+            applicable ??= rule;
+
+            // The rule is expanded to an open-ended yearly recurrence, so the one to write is the one stating
+            // the ongoing pattern. Unix materializes each year as its own fixed-date rule and adds a single
+            // open-ended floating rule for the pattern itself; the fixed ones only hold for their own year.
+            if (!rule.DaylightTransitionStart.IsFixedDateRule && !rule.DaylightTransitionEnd.IsFixedDateRule)
+                return rule;
+        }
+
+        return applicable;
+    }
+}

--- a/src/Meziantou.Framework.Scheduling/readme.md
+++ b/src/Meziantou.Framework.Scheduling/readme.md
@@ -30,6 +30,88 @@ Supported languages for human-readable text:
 - English (`en`, `en-*`, and invariant culture)
 - French (`fr`, `fr-*`)
 
+### Time zones
+
+`GetNextOccurrences` also accepts a time zone. The occurrences keep their wall-clock time across a daylight
+saving transition, so each one carries the UTC offset in effect at that moment:
+
+````c#
+var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=9");
+var timeZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+
+foreach (var occurrence in rrule.GetNextOccurrences(new DateTime(2024, 03, 09), timeZone).Take(3))
+{
+    Console.WriteLine(occurrence);
+}
+
+// 2024-03-09 09:00:00 -05:00
+// 2024-03-10 09:00:00 -04:00   <- the offset changes, the wall clock does not
+// 2024-03-11 09:00:00 -04:00
+````
+
+The start date is read as a wall-clock time in that time zone, and a `DateTimeOffset` overload accepts an
+instant instead. A time zone identifier can be passed directly, which `TimeZones.Find` resolves:
+
+````c#
+var occurrences = rrule.GetNextOccurrences(startDate, "America/New_York");
+````
+
+A local time that a transition makes invalid or ambiguous is resolved as RFC 5545 section 3.3.5 requires:
+an ambiguous time keeps its first occurrence, and an invalid time is read with the UTC offset in effect
+before the gap, so `02:30` on a spring-forward day surfaces as `03:30` at the new offset. This is what
+[errata 4271](https://www.rfc-editor.org/errata/eid4271) settles for recurrence instances; only an invalid
+*date*, such as February 30, is dropped from the recurrence set.
+
+Reading a gap that way maps it onto the instants of the hour that follows it, so a sub-hourly recurrence
+would otherwise repeat them. Those duplicates are ignored, per RFC 5545 section 3.8.5.3, and do not count
+towards `COUNT`. Across a backward transition the repeated hour is visited once, so its second pass is not
+produced.
+
+`UNTIL` is honoured as an instant when it is a UTC value, and as a wall-clock reading when it is floating.
+
+`CronExpression` supports the same overloads.
+
+## iCalendar
+
+`InternetCalendar` writes events in the iCalendar format. Setting `Event.TimeZone` writes the start and end
+as `DTSTART;TZID=`/`DTEND;TZID=` and emits a matching `VTIMEZONE` component:
+
+````c#
+var calendar = new InternetCalendar();
+calendar.Events.Add(new Event
+{
+    Start = new DateTime(2024, 01, 02, 08, 00, 00),
+    End = new DateTime(2024, 01, 02, 09, 00, 00),
+    TimeZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York"),
+});
+
+var ics = calendar.ToIcs();
+````
+
+````text
+BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20071104T020000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+...
+DTSTART;TZID=America/New_York:20240102T080000
+````
+
+A `Start` or `End` whose `Kind` is `Unspecified` is taken as a wall-clock reading in that time zone; a `Utc`
+or `Local` value denotes an instant and is converted to it. The component describes the adjustment rule in
+effect for the events, expanded to an open-ended yearly recurrence.
+
 ## Cron expressions
 
 The library also provides `CronExpression` to parse and evaluate cron schedules.

--- a/tests/Meziantou.Framework.Scheduling.Tests/CronExpressionTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/CronExpressionTests.cs
@@ -266,6 +266,111 @@ public sealed class CronExpressionTests
         }
     }
 
+    [Fact]
+    public void GetNextOccurrences_NullTimeZone_ThrowsBeforeEnumeration()
+    {
+        var cron = CronExpression.Parse("0 9 * * *");
+
+        Assert.Throws<ArgumentNullException>(() => cron.GetNextOccurrences(new DateTime(2024, 01, 01), timeZone: null!));
+    }
+
+#if !INVARIANT_GLOBALIZATION_MODE_ENABLED
+    // An IANA identifier does not resolve on Windows when globalization is invariant.
+    private static TimeZoneInfo NewYork => TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+
+    [Fact]
+    public void GetNextOccurrences_TimeZone_AcrossSpringForward_KeepsTheWallClockTime()
+    {
+        var cron = CronExpression.Parse("0 9 * * *");
+
+        var occurrences = cron.GetNextOccurrences(new DateTime(2024, 03, 09, 00, 00, 00), NewYork).Take(3).ToArray();
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 09, 09, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 09, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 11, 09, 00, 00, TimeSpan.FromHours(-4)));
+    }
+
+    [Fact]
+    public void GetNextOccurrences_TimeZone_AcrossFallBack_KeepsTheWallClockTime()
+    {
+        var cron = CronExpression.Parse("0 9 * * *");
+
+        var occurrences = cron.GetNextOccurrences(new DateTime(2024, 11, 02, 00, 00, 00), NewYork).Take(3).ToArray();
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 11, 02, 09, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 11, 03, 09, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 11, 04, 09, 00, 00, TimeSpan.FromHours(-5)));
+    }
+
+    [Fact]
+    public void GetNextOccurrences_TimeZone_InvalidLocalTime_UsesTheOffsetBeforeTheGap()
+    {
+        var cron = CronExpression.Parse("30 2 * * *");
+
+        var occurrences = cron.GetNextOccurrences(new DateTime(2024, 03, 10, 00, 00, 00), NewYork).Take(1).ToArray();
+
+        AssertOccurrences(occurrences, new DateTimeOffset(2024, 03, 10, 03, 30, 00, TimeSpan.FromHours(-4)));
+        Assert.Equal(new DateTime(2024, 03, 10, 07, 30, 00, DateTimeKind.Utc), occurrences[0].UtcDateTime);
+    }
+
+    [Fact]
+    public void GetNextOccurrences_TimeZone_AmbiguousLocalTime_UsesTheFirstOccurrence()
+    {
+        var cron = CronExpression.Parse("30 1 * * *");
+
+        var occurrences = cron.GetNextOccurrences(new DateTime(2024, 11, 03, 00, 00, 00), NewYork).Take(1).ToArray();
+
+        AssertOccurrences(occurrences, new DateTimeOffset(2024, 11, 03, 01, 30, 00, TimeSpan.FromHours(-4)));
+        Assert.Equal(new DateTime(2024, 11, 03, 05, 30, 00, DateTimeKind.Utc), occurrences[0].UtcDateTime);
+    }
+
+    [Fact]
+    public void GetNextOccurrences_TimeZone_Hourly_AcrossSpringForward_DropsTheInstantRepeatedByTheGap()
+    {
+        var cron = CronExpression.Parse("0 * * * *");
+
+        var occurrences = cron.GetNextOccurrences(new DateTime(2024, 03, 10, 00, 00, 00), NewYork).Take(5).ToArray();
+
+        // 02:00 does not exist and is read at the -05:00 offset in effect before the gap, which is the instant
+        // 03:00 already denotes. RFC 5545 section 3.8.5.3 keeps only one of the two.
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 10, 00, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 01, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 03, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 04, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 05, 00, 00, TimeSpan.FromHours(-4)));
+
+        Assert.HasCount(occurrences.Length, occurrences.Select(occurrence => occurrence.UtcDateTime).Distinct());
+    }
+
+    [Fact]
+    public void GetNextOccurrences_TimeZoneId_MatchesTheTimeZoneInfoOverload()
+    {
+        var cron = CronExpression.Parse("0 9 * * *");
+        var startDate = new DateTime(2024, 03, 09, 00, 00, 00);
+
+        var expected = cron.GetNextOccurrences(startDate, NewYork).Take(4).ToArray();
+        var actual = cron.GetNextOccurrences(startDate, "America/New_York").Take(4).ToArray();
+
+        AssertOccurrences(actual, expected);
+    }
+#endif
+
+    private static void AssertOccurrences(IEnumerable<DateTimeOffset> occurrences, params DateTimeOffset[] expectedOccurrences)
+    {
+        var actualList = occurrences.ToList();
+        Assert.HasCount(expectedOccurrences.Length, actualList);
+        for (var i = 0; i < expectedOccurrences.Length; i++)
+        {
+            // DateTimeOffset.Equals compares the instants, so an occurrence with the wrong offset would
+            // still be equal to the expected one. The wall clock and the offset are compared instead.
+            Assert.Equal(expectedOccurrences[i].DateTime, actualList[i].DateTime);
+            Assert.Equal(expectedOccurrences[i].Offset, actualList[i].Offset);
+        }
+    }
+
     private static void AssertOccurrencesStartWith(IEnumerable<DateTime> occurrences, params DateTime[] expectedOccurrences)
     {
         var actualList = occurrences.Take(expectedOccurrences.Length).ToList();

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -367,6 +367,66 @@ public sealed class InternetCalendarTests
     }
 
     [Fact]
+    public void ToIcs_WritesARecurrenceUntilInAForwardGapAtTheOffsetBeforeIt()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        rrule.EndDate = new DateTime(2024, 03, 10, 02, 30, 00, DateTimeKind.Unspecified);
+        var @event = CreateEvent();
+        @event.TimeZone = CreateTestTimeZone();
+        @event.RecurrenceRule = rrule;
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // 02:30 does not exist on the transition day, so it is read at the -05:00 offset in effect before the gap
+        Assert.Equal("RRULE:FREQ=DAILY;UNTIL=20240310T073000Z", GetContentLine(ics, "RRULE"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesAnAmbiguousRecurrenceUntilAtItsFirstOccurrence()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        rrule.EndDate = new DateTime(2024, 11, 03, 01, 30, 00, DateTimeKind.Unspecified);
+        var @event = CreateEvent();
+        @event.TimeZone = CreateTestTimeZone();
+        @event.RecurrenceRule = rrule;
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // 01:30 happens twice and RFC 5545 keeps the first, at -04:00. TimeZoneInfo.ConvertTimeToUtc would have
+        // resolved it to the second one and written 20241103T063000Z.
+        Assert.Equal("RRULE:FREQ=DAILY;UNTIL=20241103T053000Z", GetContentLine(ics, "RRULE"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesARecurrenceUntilUsingTheStandardOffsetOfItsOwnPeriod()
+    {
+        // A time zone whose standard offset itself shifts, which is what makes BaseUtcOffset the wrong thing to
+        // subtract for a time inside the gap.
+        var daylightStart = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 3, week: 2, DayOfWeek.Sunday);
+        var daylightEnd = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 11, week: 1, DayOfWeek.Sunday);
+        var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            new DateTime(2007, 1, 1),
+            DateTime.MaxValue.Date,
+            TimeSpan.FromHours(1),
+            daylightStart,
+            daylightEnd,
+            baseUtcOffsetDelta: TimeSpan.FromHours(1));
+        var timeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Shifted", TimeSpan.FromHours(-5), "Test Shifted", "STD", "DST", [rule]);
+
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        rrule.EndDate = new DateTime(2024, 03, 10, 02, 30, 00, DateTimeKind.Unspecified);
+        var @event = CreateEvent();
+        @event.TimeZone = timeZone;
+        @event.RecurrenceRule = rrule;
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // The offset before the gap is -04:00, the base offset plus the rule's delta, so UNTIL is 06:30Z.
+        // Subtracting BaseUtcOffset alone would have written 07:30Z.
+        Assert.Equal("RRULE:FREQ=DAILY;UNTIL=20240310T063000Z", GetContentLine(ics, "RRULE"));
+    }
+
+    [Fact]
     public void ToIcs_KeepsTheRecurrenceUntilUnchangedWithoutATimeZone()
     {
         var rrule = RecurrenceRule.Parse("FREQ=DAILY");

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -20,9 +20,13 @@ public sealed class InternetCalendarTests
 
     private static string GetContentLine(string ics, string name)
     {
-        foreach (var contentLine in ics.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        // A VTIMEZONE component has DTSTART and RRULE properties of its own, so only the event is searched.
+        foreach (var contentLine in GetEventContentLines(ics))
         {
-            if (contentLine.StartsWith(name + ":", StringComparison.Ordinal))
+            // A property may carry parameters, as in "DTSTART;TZID=...:20240102T080000"
+            if (contentLine.StartsWith(name, StringComparison.Ordinal) &&
+                contentLine.Length > name.Length &&
+                contentLine[name.Length] is ':' or ';')
             {
                 return contentLine;
             }
@@ -30,6 +34,32 @@ public sealed class InternetCalendarTests
 
         Assert.Fail($"No '{name}' content line in:\n{ics}");
         throw new System.Diagnostics.UnreachableException();
+    }
+
+    private static string GetContentLineValue(string ics, string name)
+    {
+        var line = GetContentLine(ics, name);
+        return line[(line.IndexOf(':', StringComparison.Ordinal) + 1)..];
+    }
+
+    private static IEnumerable<string> GetEventContentLines(string ics)
+    {
+        var inEvent = false;
+        foreach (var contentLine in ics.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.Equals(contentLine, "BEGIN:VEVENT", StringComparison.Ordinal))
+            {
+                inEvent = true;
+            }
+            else if (string.Equals(contentLine, "END:VEVENT", StringComparison.Ordinal))
+            {
+                inEvent = false;
+            }
+            else if (inEvent)
+            {
+                yield return contentLine;
+            }
+        }
     }
 
     private static InternetCalendar CreateCalendarWithEvent(Event @event)
@@ -47,6 +77,401 @@ public sealed class InternetCalendarTests
             End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Utc),
         };
     }
+
+    private static TimeZoneInfo CreateTestTimeZone(string id = "Test/New_York")
+    {
+        // A synthetic time zone keeps the expected output independent of the platform's time zone database.
+        var daylightStart = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 3, week: 2, DayOfWeek.Sunday);
+        var daylightEnd = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 11, week: 1, DayOfWeek.Sunday);
+        var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(new DateTime(2007, 1, 1), DateTime.MaxValue.Date, TimeSpan.FromHours(1), daylightStart, daylightEnd);
+        return TimeZoneInfo.CreateCustomTimeZone(id, TimeSpan.FromHours(-5), "Test Eastern", "EST", "EDT", [rule]);
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheStartAndEndWithTheTimeZoneIdentifier()
+    {
+        var @event = new Event
+        {
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified),
+            TimeZone = CreateTestTimeZone(),
+        };
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Equal("DTSTART;TZID=Test/New_York:20240102T080000", GetContentLine(ics, "DTSTART"));
+        Assert.Equal("DTEND;TZID=Test/New_York:20240102T090000", GetContentLine(ics, "DTEND"));
+    }
+
+    [Fact]
+    public void ToIcs_ConvertsAUtcStartToTheEventTimeZone()
+    {
+        var @event = new Event
+        {
+            Start = new DateTime(2024, 01, 02, 13, 00, 00, DateTimeKind.Utc),
+            End = new DateTime(2024, 01, 02, 14, 00, 00, DateTimeKind.Utc),
+            TimeZone = CreateTestTimeZone(),
+        };
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Equal("DTSTART;TZID=Test/New_York:20240102T080000", GetContentLine(ics, "DTSTART"));
+        Assert.Equal("DTEND;TZID=Test/New_York:20240102T090000", GetContentLine(ics, "DTEND"));
+    }
+
+    [Fact]
+    public void ToIcs_ConvertsALocalStartToTheEventTimeZone()
+    {
+        var timeZone = CreateTestTimeZone();
+        var start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Local);
+        var @event = new Event
+        {
+            Start = start,
+            End = start.AddHours(1),
+            TimeZone = timeZone,
+        };
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        var expected = TimeZoneInfo.ConvertTime(start, TimeZoneInfo.Local, timeZone).ToString("yyyyMMddTHHmmss", CultureInfo.InvariantCulture);
+        Assert.Equal("DTSTART;TZID=Test/New_York:" + expected, GetContentLine(ics, "DTSTART"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheVTimeZoneComponent()
+    {
+        var @event = CreateEvent();
+        @event.Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified);
+        @event.End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified);
+        @event.TimeZone = CreateTestTimeZone();
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // The components are anchored in the year of the event: 2024-03-10 is the second Sunday of March 2024
+        var expected = string.Join("\r\n",
+            "BEGIN:VTIMEZONE",
+            "TZID:Test/New_York",
+            "BEGIN:DAYLIGHT",
+            "DTSTART:20240310T020000",
+            "TZOFFSETFROM:-0500",
+            "TZOFFSETTO:-0400",
+            "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+            "END:DAYLIGHT",
+            "BEGIN:STANDARD",
+            "DTSTART:20241103T020000",
+            "TZOFFSETFROM:-0400",
+            "TZOFFSETTO:-0500",
+            "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
+            "END:STANDARD",
+            "END:VTIMEZONE") + "\r\n";
+
+        Assert.Contains(expected, ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheVTimeZoneComponentBeforeTheFirstEvent()
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = CreateTestTimeZone();
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.True(ics.IndexOf("BEGIN:VTIMEZONE", StringComparison.Ordinal) < ics.IndexOf("BEGIN:VEVENT", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheVTimeZoneComponentOnceForEventsSharingATimeZone()
+    {
+        var timeZone = CreateTestTimeZone();
+        var calendar = new InternetCalendar();
+        for (var i = 0; i < 2; i++)
+        {
+            var @event = CreateEvent();
+            @event.TimeZone = timeZone;
+            calendar.Events.Add(@event);
+        }
+
+        var ics = calendar.ToIcs();
+
+        Assert.Equal(1, CountContentLines(ics, "BEGIN:VTIMEZONE"));
+        Assert.Equal(2, CountContentLines(ics, "BEGIN:VEVENT"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesOneVTimeZoneComponentPerDistinctTimeZone()
+    {
+        var calendar = new InternetCalendar();
+        foreach (var id in new[] { "Test/New_York", "Test/Chicago" })
+        {
+            var @event = CreateEvent();
+            @event.TimeZone = CreateTestTimeZone(id);
+            calendar.Events.Add(@event);
+        }
+
+        var ics = calendar.ToIcs();
+
+        Assert.Equal(2, CountContentLines(ics, "BEGIN:VTIMEZONE"));
+        Assert.Equal(1, CountContentLines(ics, "TZID:Test/New_York"));
+        Assert.Equal(1, CountContentLines(ics, "TZID:Test/Chicago"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesASingleStandardComponentForATimeZoneWithoutDaylightSavingTime()
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Kolkata", TimeSpan.FromMinutes(330), "Test India", "IST");
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        var expected = string.Join("\r\n",
+            "BEGIN:VTIMEZONE",
+            "TZID:Test/Kolkata",
+            "BEGIN:STANDARD",
+            "DTSTART:19700101T000000",
+            "TZOFFSETFROM:+0530",
+            "TZOFFSETTO:+0530",
+            "END:STANDARD",
+            "END:VTIMEZONE") + "\r\n";
+
+        Assert.Contains(expected, ics);
+        Assert.DoesNotContain("BEGIN:DAYLIGHT", ics);
+    }
+
+    [Fact]
+    public void ToIcs_PrefersTheOngoingPatternOverAYearSpecificRule()
+    {
+        // Unix materializes every year as its own fixed-date rule spanning only that year's daylight saving
+        // window, and states the pattern itself in a single open-ended floating rule. Expanding a year-specific
+        // rule yearly would claim the transition always falls on that same day of the month.
+        var rules = new[]
+        {
+            TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+                new DateTime(2024, 3, 10),
+                new DateTime(2024, 11, 2),
+                TimeSpan.FromHours(1),
+                TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 3, day: 10),
+                TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 11, day: 3)),
+            TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+                new DateTime(2024, 11, 4),
+                DateTime.MaxValue.Date,
+                TimeSpan.FromHours(1),
+                TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 3, week: 2, DayOfWeek.Sunday),
+                TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 11, week: 1, DayOfWeek.Sunday)),
+        };
+
+        var @event = CreateEvent();
+        @event.Start = new DateTime(2024, 03, 06, 09, 00, 00, DateTimeKind.Unspecified);
+        @event.End = new DateTime(2024, 03, 06, 10, 00, 00, DateTimeKind.Unspecified);
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Materialized", TimeSpan.FromHours(-5), "Test Eastern", "EST", "EDT", rules);
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Contains("RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\n", ics);
+        Assert.Contains("RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\n", ics);
+        Assert.DoesNotContain("BYMONTHDAY", ics);
+    }
+
+    [Fact]
+    public void ToIcs_AnchorsTheTransitionsInTheYearOfTheEvent()
+    {
+        var @event = CreateEvent();
+        @event.Start = new DateTime(2024, 03, 06, 09, 00, 00, DateTimeKind.Unspecified);
+        @event.End = new DateTime(2024, 03, 06, 10, 00, 00, DateTimeKind.Unspecified);
+        @event.TimeZone = CreateTestTimeZone();
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // The rule starts in 2007, but anchoring the component there would leave a consumer applying the
+        // transitions only to later years. 2024-03-10 is the second Sunday of March 2024.
+        Assert.Contains("DTSTART:20240310T020000\r\n", ics);
+        Assert.Contains("DTSTART:20241103T020000\r\n", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesASingleStandardComponentWhenTheTimeZoneNoLongerObservesDaylightSavingTime()
+    {
+        // A time zone that observed daylight saving time in the past still reports the expired rules.
+        var expired = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            new DateTime(1942, 1, 1),
+            new DateTime(1945, 10, 15),
+            TimeSpan.FromHours(1),
+            TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), month: 1, day: 1),
+            TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), month: 10, day: 14));
+
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Kolkata2", TimeSpan.FromMinutes(330), "Test India", "IST", "IDT", [expired]);
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.DoesNotContain("BEGIN:DAYLIGHT", ics);
+        Assert.Contains("TZOFFSETTO:+0530\r\n", ics);
+        Assert.DoesNotContain("TZOFFSETTO:+0630", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheLastWeekOfTheMonthAsTheMinusOneOrdinal()
+    {
+        var daylightStart = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 1, 0, 0), month: 3, week: 5, DayOfWeek.Sunday);
+        var daylightEnd = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), month: 10, week: 5, DayOfWeek.Sunday);
+        var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(new DateTime(2007, 1, 1), DateTime.MaxValue.Date, TimeSpan.FromHours(1), daylightStart, daylightEnd);
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Paris", TimeSpan.FromHours(1), "Test Paris", "CET", "CEST", [rule]);
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Contains("RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\n", ics);
+        Assert.Contains("RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\n", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesAFixedDateTransitionAsAMonthDay()
+    {
+        var daylightStart = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), month: 4, day: 1);
+        var daylightEnd = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), month: 10, day: 15);
+        var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(new DateTime(2007, 1, 1), DateTime.MaxValue.Date, TimeSpan.FromHours(1), daylightStart, daylightEnd);
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Fixed", TimeSpan.Zero, "Test Fixed", "STD", "DST", [rule]);
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Contains("RRULE:FREQ=YEARLY;BYMONTH=4;BYMONTHDAY=1\r\n", ics);
+        Assert.Contains("RRULE:FREQ=YEARLY;BYMONTH=10;BYMONTHDAY=15\r\n", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesAZeroOffsetWithAPlusSign()
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/Utc", TimeSpan.Zero, "Test UTC", "UTC");
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Contains("TZOFFSETFROM:+0000\r\n", ics);
+        Assert.Contains("TZOFFSETTO:+0000\r\n", ics);
+        Assert.DoesNotContain("-0000", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheRecurrenceUntilInUtcWhenTheEventHasATimeZone()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        rrule.EndDate = new DateTime(2024, 03, 01, 08, 00, 00, DateTimeKind.Unspecified);
+        var @event = CreateEvent();
+        @event.TimeZone = CreateTestTimeZone();
+        @event.RecurrenceRule = rrule;
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // 08:00 in a -05:00 time zone is 13:00Z
+        Assert.Equal("RRULE:FREQ=DAILY;UNTIL=20240301T130000Z", GetContentLine(ics, "RRULE"));
+    }
+
+    [Fact]
+    public void ToIcs_KeepsTheRecurrenceUntilUnchangedWithoutATimeZone()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        rrule.EndDate = new DateTime(2024, 03, 01, 08, 00, 00, DateTimeKind.Unspecified);
+        var @event = CreateEvent();
+        @event.RecurrenceRule = rrule;
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Equal("RRULE:FREQ=DAILY;UNTIL=20240301T080000", GetContentLine(ics, "RRULE"));
+    }
+
+    [Fact]
+    public void ToIcs_KeepsTheTimeStampsUnchangedWhenTheEventHasATimeZone()
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = CreateTestTimeZone();
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        foreach (var name in new[] { "CREATED", "LAST-MODIFIED", "DTSTAMP" })
+        {
+            Assert.DoesNotContain(";TZID=", GetContentLine(ics, name));
+            Assert.Matches(@"^\d{8}T\d{6}Z?$", GetContentLineValue(ics, name));
+        }
+    }
+
+    [Theory]
+    [InlineData("Evil\r\nBEGIN:VEVENT")]
+    [InlineData("Evil;TZID=Other")]
+    [InlineData("Evil:INJECTED")]
+    [InlineData("Evil,Other")]
+    [InlineData("Evil\"Quoted")]
+    [InlineData("Evil\u0007Bell")]
+    public void ToIcs_ThrowsWhenTheTimeZoneIdentifierIsNotSafe(string id)
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone(id, TimeSpan.Zero, id, id);
+
+        Assert.Throws<InvalidOperationException>(() => CreateCalendarWithEvent(@event).ToIcs());
+    }
+
+    [Fact]
+    public void ToIcs_ThrowsBeforeWritingAnythingWhenTheTimeZoneIdentifierIsNotSafe()
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone("Evil\r\nBEGIN:VEVENT", TimeSpan.Zero, "Evil", "Evil");
+        var calendar = CreateCalendarWithEvent(@event);
+
+        using var writer = new StringWriter();
+        Assert.Throws<InvalidOperationException>(() => calendar.ToIcs(writer));
+        Assert.Equal("", writer.ToString());
+    }
+
+    [Theory]
+    [InlineData("America/Argentina/Buenos_Aires")]
+    [InlineData("Etc/GMT+5")]
+    [InlineData("Romance Standard Time")]
+    [InlineData("America/New_York")]
+    public void ToIcs_AcceptsCommonTimeZoneIdentifiers(string id)
+    {
+        var @event = CreateEvent();
+        @event.TimeZone = TimeZoneInfo.CreateCustomTimeZone(id, TimeSpan.Zero, id, id);
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        Assert.Contains("TZID:" + id + "\r\n", ics);
+    }
+
+#if !INVARIANT_GLOBALIZATION_MODE_ENABLED
+    [Fact]
+    public void ToIcs_WritesAWellFormedVTimeZoneForASystemTimeZone()
+    {
+        // An IANA identifier does not resolve on Windows when globalization is invariant.
+        var @event = CreateEvent();
+        @event.Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified);
+        @event.End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified);
+        @event.TimeZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+
+        var ics = CreateCalendarWithEvent(@event).ToIcs();
+
+        // The adjustment rules a platform reports vary, so only the shape of the component is asserted
+        Assert.Equal(1, CountContentLines(ics, "BEGIN:VTIMEZONE"));
+        Assert.Equal(1, CountContentLines(ics, "END:VTIMEZONE"));
+        Assert.Contains("TZID:America/New_York\r\n", ics);
+        Assert.Equal(1, CountContentLines(ics, "BEGIN:STANDARD"));
+
+        foreach (var contentLine in ics.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (contentLine.StartsWith("TZOFFSET", StringComparison.Ordinal))
+            {
+                Assert.Matches(@"^TZOFFSET(FROM|TO):[+-]\d{4}(\d{2})?$", contentLine);
+            }
+            else if (contentLine.StartsWith("RRULE:", StringComparison.Ordinal))
+            {
+                Assert.StartsWith("RRULE:FREQ=YEARLY;BYMONTH=", contentLine);
+            }
+            else if (contentLine.StartsWith("DTSTART:", StringComparison.Ordinal))
+            {
+                // A sub-component DTSTART is a local time: no Z suffix and no TZID parameter
+                Assert.Matches(@"^DTSTART:\d{8}T\d{6}$", contentLine);
+            }
+        }
+    }
+#endif
 
     [Fact]
     public void ToIcs_SeparatesContentLinesWithCrLf()
@@ -218,7 +643,7 @@ public sealed class InternetCalendarTests
 
         foreach (var name in new[] { "DTSTART", "DTEND", "CREATED", "LAST-MODIFIED", "DTSTAMP" })
         {
-            var value = GetContentLine(ics, name)[(name.Length + 1)..];
+            var value = GetContentLineValue(ics, name);
             Assert.Matches(@"^\d{8}T\d{6}Z?$", value);
         }
     }

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.RFC2445.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.RFC2445.cs
@@ -12,6 +12,27 @@ public partial class RecurrenceRuleTests
         AssertOccurrences(occurrences, checkEnd: false, expectedOccurrences.Length, expectedOccurrences);
     }
 
+    private static void AssertOccurrences(IEnumerable<DateTimeOffset> occurrences, params DateTimeOffset[] expectedOccurrences)
+    {
+        var occurrenceCount = 0;
+        using var enumerator1 = occurrences.GetEnumerator();
+        using (var enumerator2 = ((IEnumerable<DateTimeOffset>)expectedOccurrences).GetEnumerator())
+        {
+            while (enumerator1.MoveNext() && enumerator2.MoveNext())
+            {
+                occurrenceCount++;
+
+                // DateTimeOffset.Equals compares the instants, so an occurrence with the wrong offset would
+                // still be equal to the expected one. The wall clock and the offset are compared instead.
+                Assert.Equal(enumerator2.Current.DateTime, enumerator1.Current.DateTime);
+                Assert.Equal(enumerator2.Current.Offset, enumerator1.Current.Offset);
+            }
+        }
+
+        Assert.Equal(expectedOccurrences.Length, occurrenceCount);
+        Assert.False(enumerator1.MoveNext());
+    }
+
     private static void AssertOccurrences(IEnumerable<DateTime> occurrences, bool checkEnd, int? maxOccurences, params DateTime[] expectedOccurrences)
     {
         var occurrenceCount = 0;

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -853,6 +853,301 @@ public partial class RecurrenceRuleTests
         TestGetHumanText("FREQ=HOURLY;COUNT=10", "fr-FR", "toutes les heures pour 10 fois");
     }
 
+    [Fact]
+    public void GetNextOccurrences_Utc_MatchesTheDateTimeOverload()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=3");
+        var startDate = new DateTime(2024, 03, 09, 09, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, TimeZoneInfo.Utc);
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 09, 09, 00, 00, TimeSpan.Zero),
+            new DateTimeOffset(2024, 03, 10, 09, 00, 00, TimeSpan.Zero),
+            new DateTimeOffset(2024, 03, 11, 09, 00, 00, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void GetNextOccurrences_NullTimeZone_ThrowsBeforeEnumeration()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+
+        Assert.Throws<ArgumentNullException>(() => rrule.GetNextOccurrences(new DateTime(2024, 01, 01), timeZone: null!));
+    }
+
+    [Fact]
+    public void GetNextOccurrence_TimeZone_ReturnsNullWhenTheRuleIsExhausted()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=0");
+
+        Assert.Null(rrule.GetNextOccurrence(new DateTime(2024, 01, 01, 09, 00, 00), TimeZoneInfo.Utc));
+    }
+
+#if !INVARIANT_GLOBALIZATION_MODE_ENABLED
+    // An IANA identifier does not resolve on Windows when globalization is invariant.
+    private static TimeZoneInfo NewYork => TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+
+    private static TimeZoneInfo Sydney => TimeZoneInfo.FindSystemTimeZoneById("Australia/Sydney");
+
+    [Fact]
+    public void Daily_TimeZone_AcrossSpringForward_KeepsTheWallClockTime()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=3");
+        var startDate = new DateTime(2024, 03, 09, 09, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork);
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 09, 09, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 09, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 11, 09, 00, 00, TimeSpan.FromHours(-4)));
+    }
+
+    [Fact]
+    public void Daily_TimeZone_AcrossFallBack_KeepsTheWallClockTime()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=3");
+        var startDate = new DateTime(2024, 11, 02, 09, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork);
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 11, 02, 09, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 11, 03, 09, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 11, 04, 09, 00, 00, TimeSpan.FromHours(-5)));
+    }
+
+    [Fact]
+    public void Daily_TimeZone_InvalidLocalTime_UsesTheOffsetBeforeTheGap()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=2;BYMINUTE=30;BYSECOND=0;COUNT=2");
+        var startDate = new DateTime(2024, 03, 09, 02, 30, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork).ToArray();
+
+        // 02:30 does not exist on 2024-03-10: read with the -05:00 offset in effect before the gap, it is 07:30Z
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 09, 02, 30, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 03, 30, 00, TimeSpan.FromHours(-4)));
+
+        Assert.Equal(new DateTime(2024, 03, 10, 07, 30, 00, DateTimeKind.Utc), occurrences[1].UtcDateTime);
+    }
+
+    [Fact]
+    public void Daily_TimeZone_AmbiguousLocalTime_UsesTheFirstOccurrence()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=1;BYMINUTE=30;BYSECOND=0;COUNT=3");
+        var startDate = new DateTime(2024, 11, 02, 01, 30, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork).ToArray();
+
+        // 01:30 happens twice on 2024-11-03 and RFC 5545 keeps the first one, at the -04:00 offset
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 11, 02, 01, 30, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 11, 03, 01, 30, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 11, 04, 01, 30, 00, TimeSpan.FromHours(-5)));
+
+        Assert.Equal(new DateTime(2024, 11, 03, 05, 30, 00, DateTimeKind.Utc), occurrences[1].UtcDateTime);
+    }
+
+    [Fact]
+    public void Hourly_TimeZone_AcrossSpringForward_DropsTheInstantRepeatedByTheGap()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=HOURLY;COUNT=5");
+        var startDate = new DateTime(2024, 03, 10, 00, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork).ToArray();
+
+        // 02:00 does not exist and is read at the -05:00 offset in effect before the gap, which is the instant
+        // 03:00 already denotes. RFC 5545 section 3.8.5.3 keeps only one of the two, and the duplicate does not
+        // count towards COUNT, so a fifth distinct occurrence is produced instead.
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 10, 00, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 01, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 03, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 04, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 05, 00, 00, TimeSpan.FromHours(-4)));
+
+        Assert.HasCount(occurrences.Length, occurrences.Select(occurrence => occurrence.UtcDateTime).Distinct());
+    }
+
+    [Fact]
+    public void Minutely_TimeZone_AcrossSpringForward_DropsTheInstantsRepeatedByTheGap()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=MINUTELY;INTERVAL=20;COUNT=6");
+        var startDate = new DateTime(2024, 03, 10, 01, 20, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork).ToArray();
+
+        // Every local time in the 02:00 gap is read at the -05:00 offset in effect before it, mapping the whole
+        // gap onto the instants of the hour that follows. Those repeats are not adjacent to the instances they
+        // duplicate, so suppressing them keeps the recurrence set increasing.
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 10, 01, 20, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 01, 40, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 10, 03, 00, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 03, 20, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 03, 40, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 03, 10, 04, 00, 00, TimeSpan.FromHours(-4)));
+
+        var instants = occurrences.Select(occurrence => occurrence.UtcDateTime).ToArray();
+        Assert.HasCount(instants.Length, instants.Distinct());
+        Assert.Equal(instants.Order().ToArray(), instants);
+    }
+
+    [Fact]
+    public void Hourly_TimeZone_AcrossFallBack_SkipsTheRepeatedHour()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=HOURLY;COUNT=4");
+        var startDate = new DateTime(2024, 11, 03, 00, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork).ToArray();
+
+        // Every wall clock keeps its first reading, so the second pass over 01:00 (06:00Z) is never produced
+        Assert.Equal(new DateTime(2024, 11, 03, 04, 00, 00, DateTimeKind.Utc), occurrences[0].UtcDateTime);
+        Assert.Equal(new DateTime(2024, 11, 03, 05, 00, 00, DateTimeKind.Utc), occurrences[1].UtcDateTime);
+        Assert.Equal(new DateTime(2024, 11, 03, 07, 00, 00, DateTimeKind.Utc), occurrences[2].UtcDateTime);
+        Assert.Equal(new DateTime(2024, 11, 03, 08, 00, 00, DateTimeKind.Utc), occurrences[3].UtcDateTime);
+    }
+
+    [Fact]
+    public void Daily_TimeZone_SouthernHemisphere_AcrossDaylightSavingStart()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=2");
+        var startDate = new DateTime(2024, 10, 05, 09, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, Sydney);
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 10, 05, 09, 00, 00, TimeSpan.FromHours(10)),
+            new DateTimeOffset(2024, 10, 06, 09, 00, 00, TimeSpan.FromHours(11)));
+    }
+
+    [Fact]
+    public void Daily_TimeZone_SouthernHemisphere_InvalidLocalTime()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=2;BYMINUTE=30;BYSECOND=0;COUNT=1");
+        var startDate = new DateTime(2024, 10, 06, 00, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, Sydney);
+
+        AssertOccurrences(occurrences, new DateTimeOffset(2024, 10, 06, 03, 30, 00, TimeSpan.FromHours(11)));
+    }
+
+    [Fact]
+    public void Daily_TimeZone_SouthernHemisphere_AmbiguousLocalTime()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=2;BYMINUTE=30;BYSECOND=0;COUNT=1");
+        var startDate = new DateTime(2024, 04, 07, 00, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, Sydney);
+
+        AssertOccurrences(occurrences, new DateTimeOffset(2024, 04, 07, 02, 30, 00, TimeSpan.FromHours(11)));
+    }
+
+    [Fact]
+    public void Daily_TimeZone_UtcUntil_IsComparedAsAnInstantNotAsAWallClock()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;UNTIL=20240310T120000Z");
+        var startDate = new DateTime(2024, 03, 08, 09, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork);
+
+        // 2024-03-10 09:00-04:00 is 13:00Z, which is past the UNTIL instant, so it is excluded.
+        // Comparing the wall clock instead would have kept it.
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 08, 09, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 09, 09, 00, 00, TimeSpan.FromHours(-5)));
+    }
+
+    [Fact]
+    public void Daily_TimeZone_Count_IsUnaffectedByATransition()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=5");
+        var startDate = new DateTime(2024, 03, 08, 09, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork).ToArray();
+
+        Assert.HasCount(5, occurrences);
+        Assert.All(occurrences, occurrence => Assert.Equal(new TimeSpan(09, 00, 00), occurrence.TimeOfDay));
+        Assert.Equal(
+            new[] { -5, -5, -4, -4, -4 },
+            occurrences.Select(occurrence => (int)occurrence.Offset.TotalHours).ToArray());
+    }
+
+    [Fact]
+    public void Monthly_TimeZone_BySetPosition_AcrossATransition()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=MONTHLY;BYDAY=SU;BYSETPOS=2;BYHOUR=2;BYMINUTE=30;BYSECOND=0;COUNT=2");
+        var startDate = new DateTime(2024, 03, 01, 00, 00, 00);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork);
+
+        // The second Sunday of March 2024 is the 10th, where 02:30 falls in the gap
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 10, 03, 30, 00, TimeSpan.FromHours(-4)),
+            new DateTimeOffset(2024, 04, 14, 02, 30, 00, TimeSpan.FromHours(-4)));
+    }
+
+    [Fact]
+    public void GetNextOccurrences_TimeZoneId_MatchesTheTimeZoneInfoOverload()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=4");
+        var startDate = new DateTime(2024, 03, 09, 09, 00, 00);
+
+        var expected = rrule.GetNextOccurrences(startDate, NewYork);
+        var actual = rrule.GetNextOccurrences(startDate, "America/New_York");
+
+        AssertOccurrences(actual, expected.ToArray());
+    }
+
+    [Fact]
+    public void GetNextOccurrences_UnknownTimeZoneId_ThrowsBeforeEnumeration()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+
+        Assert.Throws<TimeZoneNotFoundException>(() => rrule.GetNextOccurrences(new DateTime(2024, 01, 01), "Not/AZone"));
+    }
+
+    [Fact]
+    public void GetNextOccurrences_ThroughIRecurrenceRule_UsesTheInstantBasedUntil()
+    {
+        IRecurrenceRule rrule = RecurrenceRule.Parse("FREQ=DAILY;UNTIL=20240310T120000Z");
+        var startDate = new DateTime(2024, 03, 08, 09, 00, 00);
+
+        // Extension methods bind statically, so this is what guards the dispatch back to RecurrenceRule
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork);
+
+        AssertOccurrences(occurrences,
+            new DateTimeOffset(2024, 03, 08, 09, 00, 00, TimeSpan.FromHours(-5)),
+            new DateTimeOffset(2024, 03, 09, 09, 00, 00, TimeSpan.FromHours(-5)));
+    }
+
+    [Fact]
+    public void GetNextOccurrences_DateTimeOffsetStart_IsReducedToTheTimeZoneWallClock()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=1");
+        var startDate = new DateTimeOffset(2024, 03, 09, 12, 00, 00, TimeSpan.Zero);
+
+        var occurrences = rrule.GetNextOccurrences(startDate, NewYork);
+
+        AssertOccurrences(occurrences, new DateTimeOffset(2024, 03, 09, 07, 00, 00, TimeSpan.FromHours(-5)));
+    }
+
+    [Fact]
+    public void GetNextOccurrence_TimeZone_ReturnsTheFirstOccurrence()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0");
+        var startDate = new DateTime(2024, 03, 10, 00, 00, 00);
+
+        var occurrence = rrule.GetNextOccurrence(startDate, NewYork);
+
+        Assert.NotNull(occurrence);
+        Assert.Equal(new DateTime(2024, 03, 10, 09, 00, 00), occurrence.Value.DateTime);
+        Assert.Equal(TimeSpan.FromHours(-4), occurrence.Value.Offset);
+    }
+#endif
+
     private static void TestGetHumanText(string rruleText, string cultureInfo, string expectedText)
     {
 #if INVARIANT_GLOBALIZATION_MODE_ENABLED


### PR DESCRIPTION
## What

Adds time zone support to `Meziantou.Framework.Scheduling`, in two halves:

**Evaluation.** `RecurrenceRule` and `CronExpression` gain `GetNextOccurrences(DateTime | DateTimeOffset, TimeZoneInfo)`, returning `IEnumerable<DateTimeOffset>` where each occurrence carries the UTC offset in effect at that moment. Occurrences keep their wall-clock time across a transition:

```csharp
var rrule = RecurrenceRule.Parse("FREQ=WEEKLY;BYDAY=WE;COUNT=4");
rrule.GetNextOccurrences(start, TimeZoneInfo.FindSystemTimeZoneById("America/New_York"))
// 2024-03-06 09:00:00 -05:00
// 2024-03-13 09:00:00 -04:00   <- offset changes, wall clock does not
```

Eight extension members on `IRecurrenceRule` cover the singular `GetNextOccurrence` and `string timeZoneId` overloads.

**Serialization.** `Event.TimeZone` makes `InternetCalendar.ToIcs` emit `DTSTART;TZID=` / `DTEND;TZID=` plus a matching `VTIMEZONE` component derived from the `TimeZoneInfo`.

## Why

The library had no time zone concept at all — `TimeZoneInfo` appeared nowhere in `src`, `tests` or `ref`. `GetNextOccurrences` did pure wall-clock arithmetic, and the one offset-aware API re-attached the *start date's* fixed offset to every occurrence, so it was wrong the moment a transition was crossed. On the writer side only forms 1 and 2 of RFC 5545 §3.3.5 were implemented, there was no property-parameter support at all, and no `VTIMEZONE` was ever written.

## Behaviour change

A UTC `UNTIL` is now compared **as an instant** rather than as a wall clock. `FREQ=DAILY;UNTIL=20240310T120000Z` evaluated in New York now yields 2 occurrences instead of 3. `GetNextOccurrences(DateTime)` is untouched and byte-for-byte identical.

## Design notes for the reviewer

**Why the time zone is a parameter and not a property on the rule.** The RRULE grammar has 13 rule parts and no `TZID` among them — the zone qualifies `DTSTART`, not `RRULE`. `(DateTime, TimeZoneInfo)` is the zoned start date that the BCL has no single type for (`DateTimeOffset` holds a fixed offset, which is exactly what changes). A property would also be unserializable by `Text`, so `Parse(rule.Text)` would stop round-tripping, and `RecurrenceRule` is mutable and shareable across events in different zones.

**No generator changed.** All seven expand pure wall clock and preserve `DateTimeKind`, so the conversion sits at the single seam in `RecurrenceRule.GetNextOccurrences`.

**DST edges follow RFC 5545 §3.3.5**, with two details worth checking:
- Ambiguous times use `GetAmbiguousTimeOffsets`, not `GetUtcOffset` — the latter returns the *second* occurrence, the RFC wants the first.
- The gap offset is derived by probing the zone rather than assuming `BaseUtcOffset`, which is wrong wherever the standard offset itself moves (Lord Howe, Morocco, Dublin).

§3.3.10 contradicts itself on nonexistent local times ("MUST be ignored" vs. "interpreted per §3.3.5"). [Errata 4271](https://www.rfc-editor.org/errata/eid4271) (Verified) resolves it in favour of §3.3.5 and restricts the "MUST be ignored" clause to invalid *dates* like February 30.

**Duplicate suppression.** Reading a gap at the pre-gap offset maps the whole gap onto the instants of the following hour, so a sub-hourly recurrence repeats a run of them — and the repeats are neither adjacent to nor ordered after what they duplicate. Anything at or before the highest instant already emitted is dropped, per §3.8.5.3; duplicates do not count towards `COUNT`.

**TZID handling.** §3.2.19 defines `TZID` as `paramtext`, which *cannot* be quoted — so validate-and-reject is the only conforming strategy, not merely the safer one. Validation runs before the first write, so a hostile identifier cannot produce partial output.

**VTIMEZONE rule selection.** Only one adjustment rule is written: the runtime reports the full history on Unix but usually a single rule on Windows, so writing all of them would make output vary by platform. Unix also materializes each year as its own *fixed-date* rule and states the real pattern in one open-ended *floating* rule, so the floating one is preferred and the sub-components are anchored in the year of the events. A zone whose rules have all expired (e.g. `Asia/Kolkata`) gets a single `STANDARD` component. Both of these were found by generating real `.ics` output, not by unit tests.

`TimeZones` (TZID string resolution) is `internal` — it can be promoted later if anyone asks; removing it later would be breaking.

## Testing

| Check | Result |
|---|---|
| `dotnet test` (net10.0 + net11.0) | 744 passed, 0 failed (51 new) |
| `/p:InvariantGlobalization=true` | 620 passed, 12 skipped |
| Release, all 3 TFMs incl. netstandard2.0 | clean |
| Release + `IsOfficialBuild` (IDE/MFAS analyzers) | clean |
| `dotnet run ./eng/update-all.cs` | clean |

Time zone tests are guarded with `#if !INVARIANT_GLOBALIZATION_MODE_ENABLED`, matching the existing precedent in `RelativeDateTests` — IANA ids do not resolve on Windows in the invariant CI leg. `VTIMEZONE` output is asserted against synthetic `CreateCustomTimeZone` zones so it does not depend on the platform's tz database; a real zone gets structural assertions only.

`ref/Meziantou.Framework.Scheduling.cs` is regenerated and purely additive. Package version bumped 4.0.5 → 4.1.0.

## Follow-ups not in this PR

- `Event` is still a pure POCO, so callers must thread `evt.RecurrenceRule.GetNextOccurrences(evt.Start, evt.TimeZone)` by hand. An `Event.GetNextOccurrences()` would close that gap — it needs a decision on what a null `TimeZone` means.
- `Utilities.ParseDateTime` forces `Kind=Utc` on every form, so an offsetless `UNTIL` is silently treated as UTC and the floating-`UNTIL` branch is unreachable from parsing. Fixing it would flip `EndDate.Kind` and change `Text` output for existing callers, so it was left out deliberately.
- No ICS parser — `VTIMEZONE` is written but never read.
