### PR TITLE
Add a global diagnostic filter to DiagnosticReporter

### DIFF
--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticFilter.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticFilter.cs
@@ -1,0 +1,21 @@
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS
+#pragma warning disable
+#endif
+#nullable enable
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Roslyn;
+
+/// <summary>
+/// Decides whether a diagnostic can be reported by a <see cref="DiagnosticReporter"/>.
+/// </summary>
+/// <param name="diagnostic">The diagnostic about to be reported. <c>diagnostic.Descriptor</c> and <c>diagnostic.Location.SourceTree</c> give access to the descriptor and the syntax tree.</param>
+/// <param name="options">The analyzer options of the context the diagnostic is reported from.</param>
+/// <param name="cancellationToken">The cancellation token of the context the diagnostic is reported from.</param>
+/// <returns><see langword="true"/> to report the diagnostic; <see langword="false"/> to drop it.</returns>
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
+internal delegate bool DiagnosticFilter(Diagnostic diagnostic, AnalyzerOptions options, CancellationToken cancellationToken);

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
@@ -51,11 +51,26 @@ internal readonly struct DiagnosticReporter
         CancellationToken = context.CancellationToken;
     }
 
+    /// <summary>
+    /// Gets or sets a filter evaluated before a diagnostic is reported by any <see cref="DiagnosticReporter"/>. When the filter returns <see langword="false"/>, the diagnostic is not reported.
+    /// </summary>
+    /// <remarks>
+    /// The value defaults to <see langword="null"/>, so no filtering occurs. It is meant to be set once, when the analyzer is initialized. As the types of this package are embedded, the filter only applies to the assembly that consumes the package.
+    /// </remarks>
+    public static DiagnosticFilter? CanReportDiagnostic { get; set; }
+
     public AnalyzerOptions Options { get; }
 
     public CancellationToken CancellationToken { get; }
 
-    public void ReportDiagnostic(Diagnostic diagnostic) => _reportDiagnostic(diagnostic);
+    public void ReportDiagnostic(Diagnostic diagnostic)
+    {
+        var filter = CanReportDiagnostic;
+        if (filter is not null && !filter(diagnostic, Options, CancellationToken))
+            return;
+
+        _reportDiagnostic(diagnostic);
+    }
 
     public static implicit operator DiagnosticReporter(SymbolAnalysisContext context) => new(context);
     public static implicit operator DiagnosticReporter(OperationAnalysisContext context) => new(context);

--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
 
     <developmentDependency>true</developmentDependency>

--- a/src/Meziantou.Framework.Roslyn/readme.md
+++ b/src/Meziantou.Framework.Roslyn/readme.md
@@ -25,6 +25,7 @@ using Meziantou.Framework.Roslyn;
 - `Compilation.IsNet9OrGreater`
 - `ContextExtensions.ReportDiagnostic`
 - `DiagnosticReporter`
+- `DiagnosticReporter.CanReportDiagnostic`
 - `ExpressionSyntax.Parenthesize`
 - `GeneratedCodeExtensions.IsGeneratedCodeFile`
 - `IOperation.UnwrapImplicitConversions`
@@ -59,6 +60,19 @@ if (type.IsOrInheritsFrom(baseType))
 {
 }
 ````
+
+### Diagnostic filtering
+
+`DiagnosticReporter.CanReportDiagnostic` is a global filter evaluated before a diagnostic is reported. It defaults to `null`, so no filtering occurs. When it is set, every diagnostic reported through a `DiagnosticReporter` or through the `ReportDiagnostic` extension methods of the analysis contexts is evaluated, and returning `false` drops it:
+
+````csharp
+DiagnosticReporter.CanReportDiagnostic = (diagnostic, options, cancellationToken)
+    => diagnostic.Location.SourceTree?.IsGeneratedCode(options, cancellationToken) is not true;
+````
+
+The delegate gets the `Diagnostic` about to be reported, so the descriptor is available with `diagnostic.Descriptor` and the syntax tree with `diagnostic.Location.SourceTree`. The `AnalyzerOptions` and the `CancellationToken` are the ones of the context the diagnostic is reported from.
+
+The filter is meant to be set once, when the analyzer is initialized. As all types of this package are embedded, it only applies to the assembly that consumes the package. Diagnostics reported directly on a Roslyn context, such as `SymbolAnalysisContext.ReportDiagnostic(Diagnostic)`, don't go through the reporter and are not filtered.
 
 ## Type embedding
 

--- a/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
@@ -253,6 +253,7 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
                 public static ITypeSymbol? GetFlowType(IOperation operation, CancellationToken cancellationToken) => LocalDataFlowAnalysis.GetActualType(operation, cancellationToken);
                 public static ITypeSymbol? GetUnwrappedType(IOperation operation, CancellationToken cancellationToken) => LocalDataFlowAnalysis.GetActualType(operation, useDataFlowAnalysis: false, cancellationToken);
                 public static string ReporterName => typeof(DiagnosticReporter).Name;
+                public static void SetDiagnosticFilter() => DiagnosticReporter.CanReportDiagnostic = (diagnostic, options, cancellationToken) => diagnostic.Location.SourceTree?.IsGeneratedCode(options, cancellationToken) is not true;
                 public static DiagnosticInvocationReportOptions InvocationReportOptions => DiagnosticInvocationReportOptions.ReportOnMember | DiagnosticInvocationReportOptions.ReportOnArguments;
             }
             """;
@@ -403,6 +404,7 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
         "ContextExtensions.cs",
         "ContextExtensions.g.cs",
         "DiagnosticFieldReportOptions.cs",
+        "DiagnosticFilter.cs",
         "DiagnosticInvocationReportOptions.cs",
         "DiagnosticMethodReportOptions.cs",
         "DiagnosticParameterReportOptions.cs",

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -242,6 +242,115 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public async Task DiagnosticReporter_DoesNotFilterDiagnosticsByDefault()
+    {
+        using var scope = await DiagnosticFilterScope.EnterAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(DiagnosticReporter.CanReportDiagnostic);
+    }
+
+    [Fact]
+    public async Task DiagnosticReporter_CanReportDiagnosticReceivesTheDiagnosticAndTheContextData()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample;
+            """);
+        var symbol = GetRequiredType(compilation, "Sample");
+        var descriptor = CreateDescriptor("MFTEST100");
+        var options = new AnalyzerOptions([]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Diagnostic? reported = null;
+
+        // A DiagnosticAnalyzer cannot be defined in this assembly (RS1041), so the context is created directly
+#pragma warning disable CS0618
+        var context = new SymbolAnalysisContext(symbol, compilation, options, diagnostic => reported = diagnostic, _ => true, cancellationTokenSource.Token);
+#pragma warning restore CS0618
+
+        Diagnostic? filteredDiagnostic = null;
+        AnalyzerOptions? filteredOptions = null;
+        CancellationToken filteredCancellationToken = default;
+
+        using (var scope = await DiagnosticFilterScope.EnterAsync(TestContext.Current.CancellationToken))
+        {
+            // The filter is global, so the diagnostics of the tests running concurrently must not be filtered
+            DiagnosticReporter.CanReportDiagnostic = (diagnostic, analyzerOptions, cancellationToken) =>
+            {
+                if (!ReferenceEquals(diagnostic.Descriptor, descriptor))
+                    return true;
+
+                filteredDiagnostic = diagnostic;
+                filteredOptions = analyzerOptions;
+                filteredCancellationToken = cancellationToken;
+                return false;
+            };
+
+            context.ReportDiagnostic(descriptor, symbol);
+        }
+
+        Assert.Null(reported);
+        Assert.NotNull(filteredDiagnostic);
+        Assert.Same(descriptor, filteredDiagnostic.Descriptor);
+        Assert.Same(compilation.SyntaxTrees.Single(), filteredDiagnostic.Location.SourceTree);
+        Assert.Same(options, filteredOptions);
+        Assert.Equal(cancellationTokenSource.Token, filteredCancellationToken);
+    }
+
+    [Fact]
+    public async Task DiagnosticReporter_CanReportDiagnosticReportsTheDiagnosticWhenItReturnsTrue()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample;
+            """);
+        var symbol = GetRequiredType(compilation, "Sample");
+        var descriptor = CreateDescriptor("MFTEST101");
+        Diagnostic? reported = null;
+
+        // A DiagnosticAnalyzer cannot be defined in this assembly (RS1041), so the context is created directly
+#pragma warning disable CS0618
+        var context = new SymbolAnalysisContext(symbol, compilation, new AnalyzerOptions([]), diagnostic => reported = diagnostic, _ => true, cancellationToken: default);
+#pragma warning restore CS0618
+
+        using (var scope = await DiagnosticFilterScope.EnterAsync(TestContext.Current.CancellationToken))
+        {
+            DiagnosticReporter.CanReportDiagnostic = (diagnostic, analyzerOptions, cancellationToken) => true;
+
+            context.ReportDiagnostic(descriptor, symbol);
+        }
+
+        Assert.NotNull(reported);
+        Assert.Same(descriptor, reported.Descriptor);
+    }
+
+    [Fact]
+    public async Task DiagnosticReporter_CanReportDiagnosticFiltersTheDiagnosticsOfAnAnalyzer()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+            }
+            """);
+
+        ImmutableArray<Diagnostic> diagnostics;
+        using (var scope = await DiagnosticFilterScope.EnterAsync(TestContext.Current.CancellationToken))
+        {
+            // The filter is global, so the diagnostics of the tests running concurrently must not be filtered
+            DiagnosticReporter.CanReportDiagnostic = (diagnostic, analyzerOptions, cancellationToken)
+                => diagnostic.Id is not DiagnosticFilterAnalyzer.DiagnosticId || !diagnostic.GetMessage(CultureInfo.InvariantCulture).Contains("dropped", StringComparison.Ordinal);
+
+            diagnostics = await compilation
+                .WithAnalyzers([new DiagnosticFilterAnalyzer()])
+                .GetAnalyzerDiagnosticsAsync(TestContext.Current.CancellationToken);
+        }
+
+        Assert.Equal(
+            [
+                "Message context-kept",
+                "Message reporter-kept",
+            ],
+            diagnostics.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture)).OrderBy(message => message, StringComparer.Ordinal));
+    }
+
+    [Fact]
     public void ReportDiagnostic_DeclaresMessageArgsAsParams()
     {
         var messageArgsParameters = typeof(ContextExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -2137,8 +2246,73 @@ public sealed class RoslynHelperTests
 
     private static DiagnosticDescriptor CreateDescriptor()
     {
-        return new DiagnosticDescriptor("MFTEST001", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        return CreateDescriptor("MFTEST001");
     }
+
+    private static DiagnosticDescriptor CreateDescriptor(string id)
+    {
+        return new DiagnosticDescriptor(id, "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+    }
+
+    /// <summary>
+    /// <see cref="DiagnosticReporter.CanReportDiagnostic"/> is global, so the tests that set it must not run concurrently.
+    /// </summary>
+    private sealed class DiagnosticFilterScope : IDisposable
+    {
+        private static readonly SemaphoreSlim Semaphore = new(initialCount: 1, maxCount: 1);
+
+        private DiagnosticFilterScope()
+        {
+        }
+
+        public static async Task<DiagnosticFilterScope> EnterAsync(CancellationToken cancellationToken)
+        {
+            await Semaphore.WaitAsync(cancellationToken);
+
+            return new DiagnosticFilterScope();
+        }
+
+        public void Dispose()
+        {
+            DiagnosticReporter.CanReportDiagnostic = null;
+            Semaphore.Release();
+        }
+    }
+
+    // RS1036/RS1038/RS1041 only apply to analyzers shipped in an analyzer package. This one only exists to exercise the extension methods.
+#pragma warning disable RS1036 // A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>'
+#pragma warning disable RS1038 // This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces
+#pragma warning disable RS1041 // This compiler extension should not be implemented in an assembly with target framework
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class DiagnosticFilterAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "MFTEST004";
+
+        private static readonly DiagnosticDescriptor Descriptor = new(DiagnosticId, "Title", "Message {0}", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var declaration = (ClassDeclarationSyntax)context.Node;
+            DiagnosticReporter reporter = context;
+
+            reporter.ReportDiagnostic(Descriptor, declaration, "reporter-kept");
+            reporter.ReportDiagnostic(Descriptor, declaration, "reporter-dropped");
+            context.ReportDiagnostic(Descriptor, declaration, "context-kept");
+            context.ReportDiagnostic(Descriptor, declaration, "context-dropped");
+        }
+    }
+#pragma warning restore RS1041
+#pragma warning restore RS1038
+#pragma warning restore RS1036
 
     // RS1036/RS1038/RS1041 only apply to analyzers shipped in an analyzer package. This one only exists to exercise the extension methods.
 #pragma warning disable RS1036 // A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>'


### PR DESCRIPTION
## What

Adds an opt-in global filter to `DiagnosticReporter` in `Meziantou.Framework.Roslyn`:

```csharp
internal delegate bool DiagnosticFilter(Diagnostic diagnostic, AnalyzerOptions options, CancellationToken cancellationToken);

// on DiagnosticReporter
public static DiagnosticFilter? CanReportDiagnostic { get; set; }
```

```csharp
DiagnosticReporter.CanReportDiagnostic = (diagnostic, options, cancellationToken)
    => diagnostic.Location.SourceTree?.IsGeneratedCode(options, cancellationToken) is not true;
```

## Why

An analyzer that wants a cross-cutting rule — never report in generated code, honor a custom `.editorconfig` opt-out — had to repeat the check at every call site. The hook defaults to `null`, so nothing changes unless it is set.

## How

The filter is evaluated in `DiagnosticReporter.ReportDiagnostic(Diagnostic)`, the single choke point that all 26 `ContextExtensions.ReportDiagnostic` overloads and the 135 generated context forwarders bottom out at. Both the reporter overloads and the `this SymbolAnalysisContext` / `SyntaxNodeAnalysisContext` / … extension methods are therefore filtered, and `ContextExtensions.cs`, `ContextExtensions.tt` and `ContextExtensions.g.cs` are untouched.

The delegate takes the `Diagnostic` rather than a `DiagnosticDescriptor` + `SyntaxTree`: `diagnostic.Descriptor` and `diagnostic.Location.SourceTree` already carry those, and the built diagnostic also exposes the message args, properties and additional locations. The `AnalyzerOptions` and `CancellationToken` are the ones of the context the diagnostic is reported from (`Options` was exposed on the reporter in #2975).

## Notes for reviewers

- The static is read into a local before being invoked, so a concurrent setter cannot cause a torn read.
- Because all package types are `internal` + `[Microsoft.CodeAnalysis.Embedded]`, the hook is scoped to the assembly that consumes the package, not process-global. It is meant to be set once, during analyzer initialization. Diagnostics reported directly on a Roslyn context (`context.ReportDiagnostic(diagnostic)`) don't go through the reporter and are not filtered. Both points are documented in the readme.
- Package version bumped `1.0.9` → `1.0.10`; `DiagnosticFilter.cs` added to the expected `SourceFileNames` list and the packed-package consumer source in `RoslynPackageTests`.
- `[Fact]` methods of the same class run concurrently in this repo's xunit configuration, so the four new tests serialize through a `SemaphoreSlim`-based scope that resets the static on dispose, and each filter returns `true` for any descriptor that isn't its own so concurrent tests are unaffected.

## Verification

- Full `RoslynHelperTests` for Roslyn 4.8 / 5.0 / 5.3 / 5.6 × net10.0/net11.0 — all pass; the 4 new tests confirmed to run, and the 5.6 suite repeated 3× to check for flakiness.
- `Meziantou.Framework.Roslyn.PackageTests` — 14/14, including packing and compiling a consumer project against the package.
- `Meziantou.Framework.FullPath.Analyzer` (the only in-repo consumer of `DiagnosticReporter`) builds clean; Release + `IsOfficialBuild=true` build clean with `/p:TreatsWarningsAsErrors=true`.
- `dotnet run ./eng/update-all.cs` — no regenerated files beyond these changes.
