### PR TITLE
Add ReadOnlySpan<char> overloads to CodeOwnersFile.Parse and TryParse

### DIFF
--- a/ref/Meziantou.Framework.CodeOwners.cs
+++ b/ref/Meziantou.Framework.CodeOwners.cs
@@ -47,8 +47,11 @@ namespace Meziantou.Framework.CodeOwners
     {
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.CodeOwners.CodeOwnersEntry> Entries { get => throw null; }
         public static Meziantou.Framework.CodeOwners.CodeOwnersFile Parse(string content, Meziantou.Framework.CodeOwners.CodeOwnersDialect dialect) => throw null;
+        public static Meziantou.Framework.CodeOwners.CodeOwnersFile Parse(System.ReadOnlySpan<char> content, Meziantou.Framework.CodeOwners.CodeOwnersDialect dialect) => throw null;
         public static bool TryParse(string content, Meziantou.Framework.CodeOwners.CodeOwnersDialect dialect, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.CodeOwners.CodeOwnersFile? file) => throw null;
+        public static bool TryParse(System.ReadOnlySpan<char> content, Meziantou.Framework.CodeOwners.CodeOwnersDialect dialect, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.CodeOwners.CodeOwnersFile? file) => throw null;
         public static bool TryParse(string content, Meziantou.Framework.CodeOwners.CodeOwnersDialect dialect, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.CodeOwners.CodeOwnersFile? file, out Meziantou.Framework.CodeOwners.CodeOwnersParseError error) => throw null;
+        public static bool TryParse(System.ReadOnlySpan<char> content, Meziantou.Framework.CodeOwners.CodeOwnersDialect dialect, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.CodeOwners.CodeOwnersFile? file, out Meziantou.Framework.CodeOwners.CodeOwnersParseError error) => throw null;
     }
 
     public readonly struct CodeOwnersParseError : System.IEquatable<Meziantou.Framework.CodeOwners.CodeOwnersParseError>

--- a/src/Meziantou.Framework.CodeOwners/CodeOwnersFile.cs
+++ b/src/Meziantou.Framework.CodeOwners/CodeOwnersFile.cs
@@ -29,6 +29,17 @@ public sealed class CodeOwnersFile
     /// <exception cref="CodeOwnersParseException"><paramref name="content"/> is not a valid CODEOWNERS file. Parsing stops at the first error.</exception>
     public static CodeOwnersFile Parse(string content, CodeOwnersDialect dialect)
     {
+        return Parse(content.AsSpan(), dialect);
+    }
+
+    /// <summary>Parses the content of a CODEOWNERS file.</summary>
+    /// <param name="content">The content of the CODEOWNERS file.</param>
+    /// <param name="dialect">The syntax <paramref name="content"/> uses. Sections are only recognized by <see cref="CodeOwnersDialect.GitLab"/>.</param>
+    /// <returns>The parsed <see cref="CodeOwnersFile"/>.</returns>
+    /// <exception cref="CodeOwnersParseException"><paramref name="content"/> is not a valid CODEOWNERS file. Parsing stops at the first error.</exception>
+    /// <remarks>The returned <see cref="CodeOwnersFile"/> does not reference <paramref name="content"/>: every value it exposes is copied out of it.</remarks>
+    public static CodeOwnersFile Parse(ReadOnlySpan<char> content, CodeOwnersDialect dialect)
+    {
         var context = new CodeOwnersParserContext(content, dialect);
         var entries = context.Parse();
         if (context.HasError)
@@ -45,6 +56,17 @@ public sealed class CodeOwnersFile
     /// <remarks>Use the <see cref="TryParse(string, CodeOwnersDialect, out CodeOwnersFile, out CodeOwnersParseError)"/> overload to know why the file is invalid.</remarks>
     public static bool TryParse(string content, CodeOwnersDialect dialect, [NotNullWhen(true)] out CodeOwnersFile? file)
     {
+        return TryParse(content.AsSpan(), dialect, out file, out _);
+    }
+
+    /// <summary>Parses the content of a CODEOWNERS file and returns a value indicating whether it is valid.</summary>
+    /// <param name="content">The content of the CODEOWNERS file.</param>
+    /// <param name="dialect">The syntax <paramref name="content"/> uses. Sections are only recognized by <see cref="CodeOwnersDialect.GitLab"/>.</param>
+    /// <param name="file">When this method returns <see langword="true"/>, contains the parsed <see cref="CodeOwnersFile"/>; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when <paramref name="content"/> is a valid CODEOWNERS file; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>Use the <see cref="TryParse(ReadOnlySpan{char}, CodeOwnersDialect, out CodeOwnersFile, out CodeOwnersParseError)"/> overload to know why the file is invalid.</remarks>
+    public static bool TryParse(ReadOnlySpan<char> content, CodeOwnersDialect dialect, [NotNullWhen(true)] out CodeOwnersFile? file)
+    {
         return TryParse(content, dialect, out file, out _);
     }
 
@@ -55,6 +77,18 @@ public sealed class CodeOwnersFile
     /// <param name="error">When this method returns <see langword="false"/>, contains the first error found in <paramref name="content"/>; otherwise, <see langword="default"/>.</param>
     /// <returns><see langword="true"/> when <paramref name="content"/> is a valid CODEOWNERS file; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(string content, CodeOwnersDialect dialect, [NotNullWhen(true)] out CodeOwnersFile? file, out CodeOwnersParseError error)
+    {
+        return TryParse(content.AsSpan(), dialect, out file, out error);
+    }
+
+    /// <summary>Parses the content of a CODEOWNERS file and returns a value indicating whether it is valid.</summary>
+    /// <param name="content">The content of the CODEOWNERS file.</param>
+    /// <param name="dialect">The syntax <paramref name="content"/> uses. Sections are only recognized by <see cref="CodeOwnersDialect.GitLab"/>.</param>
+    /// <param name="file">When this method returns <see langword="true"/>, contains the parsed <see cref="CodeOwnersFile"/>; otherwise, <see langword="null"/>.</param>
+    /// <param name="error">When this method returns <see langword="false"/>, contains the first error found in <paramref name="content"/>; otherwise, <see langword="default"/>.</param>
+    /// <returns><see langword="true"/> when <paramref name="content"/> is a valid CODEOWNERS file; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>The parsed <see cref="CodeOwnersFile"/> does not reference <paramref name="content"/>: every value it exposes is copied out of it.</remarks>
+    public static bool TryParse(ReadOnlySpan<char> content, CodeOwnersDialect dialect, [NotNullWhen(true)] out CodeOwnersFile? file, out CodeOwnersParseError error)
     {
         var context = new CodeOwnersParserContext(content, dialect);
         var entries = context.Parse();

--- a/src/Meziantou.Framework.CodeOwners/CodeOwnersParserContext.cs
+++ b/src/Meziantou.Framework.CodeOwners/CodeOwnersParserContext.cs
@@ -6,19 +6,19 @@ namespace Meziantou.Framework.CodeOwners;
 
 /// <summary>Parses a CODEOWNERS file, stopping at the first error.</summary>
 [StructLayout(LayoutKind.Auto)]
-internal struct CodeOwnersParserContext
+internal ref struct CodeOwnersParserContext
 {
     private static readonly SearchValues<char> PatternSeparatorSearchValues = SearchValues.Create(" \t\r\n\\");
     private static readonly SearchValues<char> MemberSeparatorSearchValues = SearchValues.Create(" \t\r\n");
 
     private readonly List<CodeOwnersEntry> _entries = [];
-    private readonly string _content;
+    private readonly ReadOnlySpan<char> _content;
     private readonly CodeOwnersDialect _dialect;
     private (CodeOwnersParseErrorKind Kind, int Index)? _error;
     private CodeOwnersSection? _currentSection;
     private int _index;
 
-    public CodeOwnersParserContext(string content, CodeOwnersDialect dialect)
+    public CodeOwnersParserContext(ReadOnlySpan<char> content, CodeOwnersDialect dialect)
     {
         _content = content;
         _dialect = dialect;
@@ -180,7 +180,7 @@ internal struct CodeOwnersParserContext
 
         // A section header cannot span multiple lines. Without this bound, an unclosed '[' would consume
         // the remaining lines of the file and silently discard them.
-        var remaining = _content.AsSpan(_index);
+        var remaining = _content[_index..];
         var separatorIndex = remaining.IndexOfAny(']', '\r', '\n');
         if (separatorIndex < 0 || remaining[separatorIndex] is not ']')
         {
@@ -200,7 +200,7 @@ internal struct CodeOwnersParserContext
         var startIndex = _index;
         _ = Consume();
 
-        var remaining = _content.AsSpan(_index);
+        var remaining = _content[_index..];
         var separatorIndex = remaining.IndexOfAny(']', '\r', '\n');
         if (separatorIndex < 0 || remaining[separatorIndex] is not ']')
         {
@@ -279,7 +279,7 @@ internal struct CodeOwnersParserContext
 
     private string? ParsePattern()
     {
-        var remaining = _content.AsSpan(_index);
+        var remaining = _content[_index..];
         var separatorIndex = remaining.IndexOfAny(PatternSeparatorSearchValues);
         if (separatorIndex < 0)
         {
@@ -360,20 +360,20 @@ internal struct CodeOwnersParserContext
             var tokenStartIndex = _index - 1;
             var ownerStart = isUsername ? _index : tokenStartIndex;
 
-            var remaining = _content.AsSpan(_index);
+            var remaining = _content[_index..];
             var separatorIndex = remaining.IndexOfAny(MemberSeparatorSearchValues);
             string owner;
             char? separator;
             if (separatorIndex < 0)
             {
-                owner = _content.AsSpan(ownerStart).ToString();
+                owner = _content[ownerStart..].ToString();
                 _index = _content.Length;
                 separator = null;
             }
             else
             {
                 var ownerLength = _index + separatorIndex - ownerStart;
-                owner = _content.AsSpan(ownerStart, ownerLength).ToString();
+                owner = _content.Slice(ownerStart, ownerLength).ToString();
                 separator = remaining[separatorIndex];
                 _index += separatorIndex;
             }
@@ -512,7 +512,7 @@ internal struct CodeOwnersParserContext
     /// <summary>Consumes the current line, including its line ending, and returns it without its line ending.</summary>
     private ReadOnlySpan<char> ConsumeLine()
     {
-        var remaining = _content.AsSpan(_index);
+        var remaining = _content[_index..];
         var endOfLineIndex = remaining.IndexOfAny('\r', '\n');
         if (endOfLineIndex < 0)
         {
@@ -530,7 +530,7 @@ internal struct CodeOwnersParserContext
         if (EndOfFile)
             return;
 
-        var endOfLineIndex = _content.AsSpan(_index).IndexOfAny('\r', '\n');
+        var endOfLineIndex = _content[_index..].IndexOfAny('\r', '\n');
         if (endOfLineIndex < 0)
         {
             _index = _content.Length;
@@ -546,7 +546,7 @@ internal struct CodeOwnersParserContext
         if (EndOfFile)
             return;
 
-        var nextNonWhitespaceIndex = _content.AsSpan(_index).IndexOfAnyExcept(' ', '\t');
+        var nextNonWhitespaceIndex = _content[_index..].IndexOfAnyExcept(' ', '\t');
         if (nextNonWhitespaceIndex < 0)
         {
             _index = _content.Length;

--- a/src/Meziantou.Framework.CodeOwners/readme.md
+++ b/src/Meziantou.Framework.CodeOwners/readme.md
@@ -50,6 +50,13 @@ else
 }
 ````
 
+`Parse` and both `TryParse` overloads also accept a `ReadOnlySpan<char>`, so a file read into a buffer does not have to be turned into a `string` first. The parsed `CodeOwnersFile` never references the span: every value it exposes is copied out of it, and reported error positions are relative to the start of the span.
+
+````c#
+char[] buffer = ...;
+CodeOwnersFile file = CodeOwnersFile.Parse(buffer.AsSpan(0, length), CodeOwnersDialect.GitHub);
+````
+
 A `CodeOwnersFile` only exists for a valid file: neither method hands back a partially parsed one. `Entries`, `Owners` and `DefaultOwners` are read-only views that cannot be cast back to a mutable list.
 
 In the GitLab dialect an owner can also be a role, written `@@developer`, `@@maintainer` or `@@owner` (plural accepted). Anything else after `@@` is an error, as is a `@` inside a username.

--- a/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
@@ -376,6 +376,54 @@ public sealed class CodeOwnersParserTests
     }
 
     [Fact]
+    public void ParseSpan()
+    {
+        // The span is a slice of a larger buffer, so the parser cannot rely on it starting at index 0
+        var buffer = "<<[Test][2] @defaultOwner\n* @user1 docs@example.com\n>>".ToCharArray();
+        var actual = CodeOwnersFile.Parse(buffer.AsSpan(2, buffer.Length - 4), CodeOwnersDialect.GitLab).Entries;
+
+        var expected = new[] { Entry("*", new CodeOwnersSection("Test", requiredReviewerCount: 2, defaultOwners: [User("defaultOwner")]), User("user1"), Email("docs@example.com")) };
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryParseSpanValidFile()
+    {
+        var expected = new[] { Entry("*", User("user1")) };
+
+        Assert.True(CodeOwnersFile.TryParse("* @user1".AsSpan(), CodeOwnersDialect.GitLab, out var file, out var error));
+        Assert.Equal(expected, file.Entries);
+        Assert.Equal(default, error);
+
+        Assert.True(CodeOwnersFile.TryParse("* @user1".AsSpan(), CodeOwnersDialect.GitLab, out file));
+        Assert.Equal(expected, file.Entries);
+    }
+
+    [Fact]
+    public void ParseSpanInvalidFileReportsThePositionRelativeToTheSpan()
+    {
+        var buffer = "<<* @user1\n[Test][0]\n>>".ToCharArray();
+        var expected = new CodeOwnersParseError(CodeOwnersParseErrorKind.InvalidRequiredReviewerCount, 2, 7);
+
+        var exception = Assert.Throws<CodeOwnersParseException>(() => CodeOwnersFile.Parse(buffer.AsSpan(2, buffer.Length - 4), CodeOwnersDialect.GitLab));
+        Assert.Equal(expected, exception.Error);
+
+        Assert.False(CodeOwnersFile.TryParse(buffer.AsSpan(2, buffer.Length - 4), CodeOwnersDialect.GitLab, out var file, out var error));
+        Assert.Null(file);
+        Assert.Equal(expected, error);
+
+        Assert.False(CodeOwnersFile.TryParse(buffer.AsSpan(2, buffer.Length - 4), CodeOwnersDialect.GitLab, out file));
+        Assert.Null(file);
+    }
+
+    [Fact]
+    public void ParseEmptySpan()
+    {
+        Assert.Empty(CodeOwnersFile.Parse([], CodeOwnersDialect.GitLab).Entries);
+        Assert.Empty(CodeOwnersFile.Parse(ReadOnlySpan<char>.Empty, CodeOwnersDialect.GitLab).Entries);
+    }
+
+    [Fact]
     public void ErrorAndExceptionMessageDescribeTheProblem()
     {
         Assert.False(CodeOwnersFile.TryParse("* @user1\n[Test][0]\n", CodeOwnersDialect.GitLab, out _, out var error));


### PR DESCRIPTION
## What

Adds three public overloads on `CodeOwnersFile` that take a `ReadOnlySpan<char>` instead of a `string`:

- `Parse(ReadOnlySpan<char>, CodeOwnersDialect)`
- `TryParse(ReadOnlySpan<char>, CodeOwnersDialect, out CodeOwnersFile?)`
- `TryParse(ReadOnlySpan<char>, CodeOwnersDialect, out CodeOwnersFile?, out CodeOwnersParseError)`

`CodeOwnersParserContext` became a `ref struct` holding a `ReadOnlySpan<char>`, and the `string` overloads forward to the span ones, so there is a single implementation.

## Why

Parsing required a `string`, so a caller holding the content in a buffer (or a slice of a larger one) had to materialize a string first.

## Notes for reviewers

- Existing `string` call sites keep binding to the `string` overloads: an exact match beats the implicit `string` → `ReadOnlySpan<char>` conversion, so this is not a source break.
- The parsed `CodeOwnersFile` holds no reference to the caller's buffer — every value it exposes (patterns, owner names, section names) was already copied out with `ToString()`.
- One behavior change: `Parse(null!, dialect)` used to throw a `NullReferenceException` and now returns an empty file, since `null.AsSpan()` is an empty span. The parameter is annotated non-nullable, so no null check was added.
- `ref/Meziantou.Framework.CodeOwners.cs` regenerated (3 added lines), and the package readme documents the new overloads.

## Tests

4 new tests in `CodeOwnersParserTests`, including parsing a slice of a larger `char[]` buffer to check the parser does not assume the content starts at index 0 and that error line/position are relative to the span.

- `dotnet test tests/Meziantou.Framework.CodeOwners.Tests` — 152 passed (76 per TFM, net10.0 and net11.0), 0 failed, 0 skipped
- `dotnet build src/Meziantou.Framework.CodeOwners -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` — clean
- `dotnet run ./eng/update-all.cs` — no files changed