### PR TITLE
Add an iCalendar parser to Meziantou.Framework.Scheduling

### DIFF
--- a/ref/Meziantou.Framework.Scheduling.cs
+++ b/ref/Meziantou.Framework.Scheduling.cs
@@ -27,6 +27,7 @@ namespace Meziantou.Framework.Scheduling
     {
         public string? Id { get => throw null; set { } }
         public string? Summary { get => throw null; set { } }
+        public string? Description { get => throw null; set { } }
         public Meziantou.Framework.Scheduling.Organizer? Organizer { get => throw null; set { } }
         public System.Collections.Generic.IList<Meziantou.Framework.Scheduling.Attendee> Attendees { get => throw null; }
         public System.DateTime Created { get => throw null; set { } }
@@ -60,12 +61,22 @@ namespace Meziantou.Framework.Scheduling
         public void ToIcs(System.IO.Stream stream) { }
         public void ToIcs(System.IO.TextWriter writer) { }
         public string ToIcs() => throw null;
+        public static Meziantou.Framework.Scheduling.InternetCalendar Parse(string ics) => throw null;
+        public static Meziantou.Framework.Scheduling.InternetCalendar Parse(System.ReadOnlySpan<char> ics) => throw null;
+        public static Meziantou.Framework.Scheduling.InternetCalendar Parse(System.IO.Stream stream) => throw null;
+        public static Meziantou.Framework.Scheduling.InternetCalendar Parse(System.IO.TextReader reader) => throw null;
+        public static bool TryParse(System.ReadOnlySpan<char> ics, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.InternetCalendar? calendar) => throw null;
+        public static bool TryParse(System.ReadOnlySpan<char> ics, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.InternetCalendar? calendar, out string? error) => throw null;
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? ics, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.InternetCalendar? calendar) => throw null;
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? ics, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.InternetCalendar? calendar, out string? error) => throw null;
+        public static bool TryParse(System.IO.TextReader reader, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.InternetCalendar? calendar, out string? error) => throw null;
     }
 
     public sealed class InternetCalendarUserAddress
     {
         public System.Uri Uri { get => throw null; }
         public InternetCalendarUserAddress(string email) { }
+        public InternetCalendarUserAddress(System.Uri uri) { }
         public override string ToString() => throw null;
     }
 

--- a/src/Meziantou.Framework.Scheduling/ContentLine.cs
+++ b/src/Meziantou.Framework.Scheduling/ContentLine.cs
@@ -1,0 +1,175 @@
+namespace Meziantou.Framework.Scheduling;
+
+/// <summary>An iCalendar content line (RFC 5545 section 3.1): a property name, its parameters and its value.</summary>
+internal sealed class ContentLine
+{
+    private readonly List<KeyValuePair<string, string>>? _parameters;
+
+    private ContentLine(string name, List<KeyValuePair<string, string>>? parameters, string value)
+    {
+        Name = name;
+        _parameters = parameters;
+        Value = value;
+    }
+
+    /// <summary>The property name, as written. iCalendar names are case-insensitive.</summary>
+    public string Name { get; }
+
+    /// <summary>The value as written, before the decoding its value type calls for.</summary>
+    public string Value { get; }
+
+    /// <summary>Gets the value of a property parameter, or <see langword="null"/> when the line does not carry it.</summary>
+    public string? GetParameter(string name)
+    {
+        if (_parameters is null)
+            return null;
+
+        foreach (var parameter in _parameters)
+        {
+            if (string.Equals(parameter.Key, name, StringComparison.OrdinalIgnoreCase))
+                return parameter.Value;
+        }
+
+        return null;
+    }
+
+    /// <summary>Gets the value decoded as an iCalendar TEXT value (RFC 5545 section 3.3.11).</summary>
+    public string GetTextValue()
+    {
+        var value = Value;
+        if (value.IndexOf('\\', StringComparison.Ordinal) < 0)
+            return value;
+
+        var sb = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] is not '\\' || i + 1 >= value.Length)
+            {
+                sb.Append(value[i]);
+                continue;
+            }
+
+            i++;
+            sb.Append(value[i] switch
+            {
+                'n' or 'N' => '\n',
+
+                // Covers the "\\", "\;" and "\," escapes, and leniently passes through anything else
+                // a producer escaped: dropping the backslash is closer to the intent than keeping it.
+                var escaped => escaped,
+            });
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Parses an unfolded content line.</summary>
+    public static bool TryParse(string line, [NotNullWhen(returnValue: true)] out ContentLine? contentLine, out string? error)
+    {
+        contentLine = null;
+
+        var index = 0;
+        if (!TryReadName(line, ref index, out var name))
+        {
+            error = $"'{line}' does not start with a property name";
+            return false;
+        }
+
+        List<KeyValuePair<string, string>>? parameters = null;
+        while (index < line.Length && line[index] is ';')
+        {
+            index++;
+            if (!TryReadName(line, ref index, out var parameterName))
+            {
+                error = $"'{line}' contains a property parameter without a name";
+                return false;
+            }
+
+            if (index >= line.Length || line[index] is not '=')
+            {
+                error = $"The property parameter '{parameterName}' of '{line}' has no value";
+                return false;
+            }
+
+            index++;
+            if (!TryReadParameterValue(line, ref index, out var parameterValue))
+            {
+                error = $"The property parameter '{parameterName}' of '{line}' has an unterminated quoted value";
+                return false;
+            }
+
+            parameters ??= [];
+            parameters.Add(new KeyValuePair<string, string>(parameterName, parameterValue));
+        }
+
+        if (index >= line.Length || line[index] is not ':')
+        {
+            error = $"'{line}' has no value";
+            return false;
+        }
+
+        contentLine = new ContentLine(name, parameters, line[(index + 1)..]);
+        error = null;
+        return true;
+    }
+
+    /// <summary>Reads a name (RFC 5545 section 3.1: ALPHA / DIGIT / "-").</summary>
+    private static bool TryReadName(string line, ref int index, [NotNullWhen(returnValue: true)] out string? name)
+    {
+        var start = index;
+        while (index < line.Length && (char.IsAsciiLetterOrDigit(line[index]) || line[index] is '-'))
+        {
+            index++;
+        }
+
+        if (index == start)
+        {
+            name = null;
+            return false;
+        }
+
+        name = line[start..index];
+        return true;
+    }
+
+    /// <summary>Reads a param-value list (RFC 5545 section 3.2), which may contain quoted values holding a colon.</summary>
+    private static bool TryReadParameterValue(string line, ref int index, [NotNullWhen(returnValue: true)] out string? value)
+    {
+        var sb = new StringBuilder();
+        while (index < line.Length)
+        {
+            var c = line[index];
+            if (c is '"')
+            {
+                index++;
+                var start = index;
+                while (index < line.Length && line[index] is not '"')
+                {
+                    index++;
+                }
+
+                if (index >= line.Length)
+                {
+                    value = null;
+                    return false;
+                }
+
+                sb.Append(line, start, index - start);
+                index++;
+            }
+            else if (c is ';' or ':')
+            {
+                // Only an unquoted separator ends the parameter.
+                break;
+            }
+            else
+            {
+                sb.Append(c);
+                index++;
+            }
+        }
+
+        value = sb.ToString();
+        return true;
+    }
+}

--- a/src/Meziantou.Framework.Scheduling/Event.cs
+++ b/src/Meziantou.Framework.Scheduling/Event.cs
@@ -9,6 +9,9 @@ public sealed class Event
     /// <summary>Gets or sets the event summary or title.</summary>
     public string? Summary { get; set; }
 
+    /// <summary>Gets or sets the event description.</summary>
+    public string? Description { get; set; }
+
     /// <summary>Gets or sets the event organizer.</summary>
     public Organizer? Organizer { get; set; }
 

--- a/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
@@ -117,7 +117,16 @@ public sealed class InternetCalendar
 
             WriteAdditionalProperties(writer, @event.AdditionalProperties);
 
-            Utilities.WriteLine(writer, "DESCRIPTION:\\n");
+            if (@event.Description is { } description)
+            {
+                WriteTextProperty(writer, "DESCRIPTION", description);
+            }
+            else
+            {
+                // The escaped empty line this library has always written when no description is set.
+                Utilities.WriteLine(writer, "DESCRIPTION:\\n");
+            }
+
             Utilities.WriteLine(writer, "END:VEVENT");
         }
 
@@ -262,5 +271,101 @@ public sealed class InternetCalendar
         using var writer = new StringWriter();
         ToIcs(writer);
         return writer.ToString();
+    }
+
+    /// <summary>Parses an iCalendar object (RFC 5545).</summary>
+    /// <param name="ics">The iCalendar content to parse.</param>
+    /// <returns>The parsed calendar.</returns>
+    /// <exception cref="FormatException">The content is not a valid iCalendar object.</exception>
+    public static InternetCalendar Parse(string ics)
+    {
+        return Parse(ics.AsSpan());
+    }
+
+    /// <summary>Parses an iCalendar object (RFC 5545).</summary>
+    /// <param name="ics">The iCalendar content to parse.</param>
+    /// <returns>The parsed calendar.</returns>
+    /// <exception cref="FormatException">The content is not a valid iCalendar object.</exception>
+    public static InternetCalendar Parse(ReadOnlySpan<char> ics)
+    {
+        if (!TryParse(ics, out var calendar, out var error))
+            throw new FormatException("The iCalendar content is invalid: " + error);
+
+        return calendar;
+    }
+
+    /// <summary>Parses an iCalendar object (RFC 5545) read from a stream as UTF-8.</summary>
+    /// <param name="stream">The stream to read the iCalendar content from.</param>
+    /// <returns>The parsed calendar.</returns>
+    /// <exception cref="FormatException">The content is not a valid iCalendar object.</exception>
+    public static InternetCalendar Parse(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        // RFC 5545 section 6 makes UTF-8 the default charset, and StreamReader honours a byte order mark.
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+        return Parse(reader);
+    }
+
+    /// <summary>Parses an iCalendar object (RFC 5545).</summary>
+    /// <param name="reader">The text reader to read the iCalendar content from.</param>
+    /// <returns>The parsed calendar.</returns>
+    /// <exception cref="FormatException">The content is not a valid iCalendar object.</exception>
+    public static InternetCalendar Parse(TextReader reader)
+    {
+        if (!TryParse(reader, out var calendar, out var error))
+            throw new FormatException("The iCalendar content is invalid: " + error);
+
+        return calendar;
+    }
+
+    /// <summary>Attempts to parse an iCalendar object (RFC 5545).</summary>
+    /// <param name="ics">The iCalendar content to parse.</param>
+    /// <param name="calendar">When successful, contains the parsed calendar.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> ics, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar)
+    {
+        return TryParse(ics, out calendar, out _);
+    }
+
+    /// <summary>Attempts to parse an iCalendar object (RFC 5545).</summary>
+    /// <param name="ics">The iCalendar content to parse.</param>
+    /// <param name="calendar">When successful, contains the parsed calendar.</param>
+    /// <param name="error">When parsing fails, contains the error message.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> ics, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar, out string? error)
+    {
+        return InternetCalendarParser.TryParse(ics, out calendar, out error);
+    }
+
+    /// <summary>Attempts to parse an iCalendar object (RFC 5545).</summary>
+    /// <param name="ics">The iCalendar content to parse.</param>
+    /// <param name="calendar">When successful, contains the parsed calendar.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse([NotNullWhen(returnValue: true)] string? ics, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar)
+    {
+        return TryParse(ics.AsSpan(), out calendar, out _);
+    }
+
+    /// <summary>Attempts to parse an iCalendar object (RFC 5545).</summary>
+    /// <param name="ics">The iCalendar content to parse.</param>
+    /// <param name="calendar">When successful, contains the parsed calendar.</param>
+    /// <param name="error">When parsing fails, contains the error message.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse([NotNullWhen(returnValue: true)] string? ics, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar, out string? error)
+    {
+        return TryParse(ics.AsSpan(), out calendar, out error);
+    }
+
+    /// <summary>Attempts to parse an iCalendar object (RFC 5545).</summary>
+    /// <param name="reader">The text reader to read the iCalendar content from.</param>
+    /// <param name="calendar">When successful, contains the parsed calendar.</param>
+    /// <param name="error">When parsing fails, contains the error message.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse(TextReader reader, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        return InternetCalendarParser.TryParse(reader, out calendar, out error);
     }
 }

--- a/src/Meziantou.Framework.Scheduling/InternetCalendarParser.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendarParser.cs
@@ -1,0 +1,531 @@
+namespace Meziantou.Framework.Scheduling;
+
+/// <summary>Reads an iCalendar stream (RFC 5545) into an <see cref="InternetCalendar"/>.</summary>
+internal static class InternetCalendarParser
+{
+    public static bool TryParse(TextReader reader, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar, out string? error)
+    {
+        if (!TryReadContentLines(reader, out var lines, out error))
+        {
+            calendar = null;
+            return false;
+        }
+
+        return TryParse(lines, out calendar, out error);
+    }
+
+    public static bool TryParse(ReadOnlySpan<char> ics, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar, out string? error)
+    {
+        if (!TryReadContentLines(ics, out var lines, out error))
+        {
+            calendar = null;
+            return false;
+        }
+
+        return TryParse(lines, out calendar, out error);
+    }
+
+    private static bool TryParse(List<ContentLine> lines, [NotNullWhen(returnValue: true)] out InternetCalendar? calendar, out string? error)
+    {
+        calendar = null;
+
+        var index = 0;
+        if (index >= lines.Count || !IsBegin(lines[index], out var component) || component is not "VCALENDAR")
+        {
+            error = "The content does not start with BEGIN:VCALENDAR";
+            return false;
+        }
+
+        index++;
+        var result = new InternetCalendar();
+        while (index < lines.Count)
+        {
+            var line = lines[index];
+            if (IsBegin(line, out component))
+            {
+                index++;
+                if (component is "VEVENT")
+                {
+                    if (!TryParseEvent(lines, ref index, out var @event, out error))
+                        return false;
+
+                    result.Events.Add(@event);
+                }
+                else
+                {
+                    // VTIMEZONE, VTODO, VJOURNAL and VFREEBUSY have no counterpart in the model. The time zone
+                    // of an event is resolved from the TZID parameter of its DTSTART rather than from VTIMEZONE.
+                    if (!TrySkipComponent(lines, ref index, component, out error))
+                        return false;
+                }
+
+                continue;
+            }
+
+            if (IsEnd(line, out component))
+            {
+                if (component is not "VCALENDAR")
+                {
+                    error = $"Unexpected 'END:{component}' in a VCALENDAR component";
+                    return false;
+                }
+
+                index++;
+
+                // RFC 5545 section 3.4 allows several iCalendar objects in one stream, but the model holds one.
+                if (index != lines.Count)
+                {
+                    error = "The content contains more than one iCalendar object";
+                    return false;
+                }
+
+                calendar = result;
+                error = null;
+                return true;
+            }
+
+            index++;
+            switch (line.Name.ToUpperInvariant())
+            {
+                case "VERSION":
+                    result.Version = line.GetTextValue();
+                    break;
+
+                // PRODID identifies the product that wrote the calendar, which this library sets itself.
+                case "PRODID":
+                    break;
+
+                default:
+                    result.AdditionalProperties[line.Name] = line.GetTextValue();
+                    break;
+            }
+        }
+
+        error = "The VCALENDAR component is not terminated by END:VCALENDAR";
+        return false;
+    }
+
+    private static bool TryParseEvent(List<ContentLine> lines, ref int index, [NotNullWhen(returnValue: true)] out Event? @event, out string? error)
+    {
+        @event = null;
+
+        var result = new Event();
+        string? timeZoneId = null;
+        while (index < lines.Count)
+        {
+            var line = lines[index];
+            if (IsBegin(line, out var component))
+            {
+                // A VALARM has no counterpart in the model.
+                index++;
+                if (!TrySkipComponent(lines, ref index, component, out error))
+                    return false;
+
+                continue;
+            }
+
+            if (IsEnd(line, out component))
+            {
+                if (component is not "VEVENT")
+                {
+                    error = $"Unexpected 'END:{component}' in a VEVENT component";
+                    return false;
+                }
+
+                index++;
+                if (timeZoneId is not null)
+                {
+                    if (!TimeZones.TryFind(timeZoneId, out var timeZone))
+                    {
+                        error = $"The time zone '{timeZoneId}' referenced by a TZID property parameter was not found";
+                        return false;
+                    }
+
+                    result.TimeZone = timeZone;
+                }
+
+                @event = result;
+                error = null;
+                return true;
+            }
+
+            index++;
+            switch (line.Name.ToUpperInvariant())
+            {
+                case "UID":
+                    result.Id = line.GetTextValue();
+                    break;
+
+                case "SUMMARY":
+                    result.Summary = line.GetTextValue();
+                    break;
+
+                case "DESCRIPTION":
+                    result.Description = line.GetTextValue();
+                    break;
+
+                case "STATUS":
+                    if (!TryParseStatus(line.GetTextValue(), out var status, out error))
+                        return false;
+
+                    result.Status = status;
+                    break;
+
+                case "ORGANIZER":
+                    if (!TryParseUserAddress(line, out var organizer, out error))
+                        return false;
+
+                    result.Organizer = new Organizer { Address = organizer };
+                    break;
+
+                case "ATTENDEE":
+                    if (!TryParseUserAddress(line, out var attendee, out error))
+                        return false;
+
+                    result.Attendees.Add(new Attendee { Address = attendee });
+                    break;
+
+                case "CREATED":
+                    if (!TryParseDateTimeProperty(line, ref timeZoneId, out var created, out error))
+                        return false;
+
+                    result.Created = created;
+                    break;
+
+                case "LAST-MODIFIED":
+                    if (!TryParseDateTimeProperty(line, ref timeZoneId, out var lastModified, out error))
+                        return false;
+
+                    result.LastModified = lastModified;
+                    break;
+
+                case "DTSTAMP":
+                    if (!TryParseDateTimeProperty(line, ref timeZoneId, out var dateTimeStamp, out error))
+                        return false;
+
+                    result.DateTimeStamp = dateTimeStamp;
+                    break;
+
+                case "DTSTART":
+                    if (!TryParseDateTimeProperty(line, ref timeZoneId, out var start, out error))
+                        return false;
+
+                    result.Start = start;
+                    break;
+
+                case "DTEND":
+                    if (!TryParseDateTimeProperty(line, ref timeZoneId, out var end, out error))
+                        return false;
+
+                    result.End = end;
+                    break;
+
+                case "RRULE":
+                    if (!RecurrenceRule.TryParse(line.Value, out var recurrenceRule, out var recurrenceRuleError))
+                    {
+                        error = $"The RRULE value '{line.Value}' is invalid: {recurrenceRuleError}";
+                        return false;
+                    }
+
+                    result.RecurrenceRule = recurrenceRule;
+                    break;
+
+                default:
+                    result.AdditionalProperties[line.Name] = line.GetTextValue();
+                    break;
+            }
+        }
+
+        error = "The VEVENT component is not terminated by END:VEVENT";
+        return false;
+    }
+
+    private static bool TryParseStatus(string value, out EventStatus status, out string? error)
+    {
+        switch (value.ToUpperInvariant())
+        {
+            case "TENTATIVE":
+                status = EventStatus.Tentative;
+                error = null;
+                return true;
+
+            case "CONFIRMED":
+                status = EventStatus.Confirmed;
+                error = null;
+                return true;
+
+            case "CANCELLED":
+                status = EventStatus.Cancelled;
+                error = null;
+                return true;
+
+            default:
+                // The statuses of the other components (RFC 5545 section 3.8.1.11) cannot describe an event.
+                status = default;
+                error = $"The STATUS value '{value}' is not one of the statuses of an event";
+                return false;
+        }
+    }
+
+    private static bool TryParseUserAddress(ContentLine line, out InternetCalendarUserAddress? address, out string? error)
+    {
+        // RFC 5545 section 3.3.3: a CAL-ADDRESS is a URI, usually a mailto one.
+        if (!Uri.TryCreate(line.Value, UriKind.Absolute, out var uri))
+        {
+            address = null;
+            error = $"The {line.Name} value '{line.Value}' is not a calendar user address";
+            return false;
+        }
+
+        address = new InternetCalendarUserAddress(uri);
+        error = null;
+        return true;
+    }
+
+    /// <summary>Parses a DATE-TIME or DATE value (RFC 5545 sections 3.3.4 and 3.3.5), recording the time zone it names.</summary>
+    private static bool TryParseDateTimeProperty(ContentLine line, ref string? timeZoneId, out DateTime value, out string? error)
+    {
+        if (!TryParseDateTime(line.Value, out value))
+        {
+            error = $"The {line.Name} value '{line.Value}' is not a date-time";
+            return false;
+        }
+
+        if (line.GetParameter("TZID") is not { Length: > 0 } id)
+        {
+            error = null;
+            return true;
+        }
+
+        if (value.Kind is DateTimeKind.Utc)
+        {
+            // RFC 5545 section 3.2.19: a UTC value already carries its offset, so a TZID would contradict it.
+            error = $"The {line.Name} value '{line.Value}' is a UTC date-time and cannot carry a TZID property parameter";
+            return false;
+        }
+
+        if (timeZoneId is not null && !string.Equals(timeZoneId, id, StringComparison.Ordinal))
+        {
+            // An Event holds a single time zone, so it cannot describe properties expressed in different ones.
+            error = $"The properties of the event reference two different time zones, '{timeZoneId}' and '{id}'";
+            return false;
+        }
+
+        timeZoneId = id;
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseDateTime(string value, out DateTime result)
+    {
+        // A DATE value, which VALUE=DATE marks, denotes the whole day and is read as its first instant.
+        if (value.Length is 8)
+            return DateTime.TryParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+
+        // Form 2: a date-time in UTC.
+        if (value.Length > 0 && value[^1] is 'Z')
+        {
+            if (!DateTime.TryParseExact(value, "yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture, DateTimeStyles.None, out result))
+                return false;
+
+            result = DateTime.SpecifyKind(result, DateTimeKind.Utc);
+            return true;
+        }
+
+        // Form 1 and form 3: a floating date-time, or a date-time in the time zone the TZID parameter names.
+        return DateTime.TryParseExact(value, "yyyyMMdd'T'HHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+    }
+
+    /// <summary>Consumes a component whose content the model does not represent, including the components nested in it.</summary>
+    private static bool TrySkipComponent(List<ContentLine> lines, ref int index, string component, out string? error)
+    {
+        var depth = 1;
+        while (index < lines.Count)
+        {
+            var line = lines[index];
+            index++;
+
+            if (IsBegin(line, out _))
+            {
+                depth++;
+            }
+            else if (IsEnd(line, out var end))
+            {
+                depth--;
+                if (depth is 0)
+                {
+                    if (!string.Equals(end, component, StringComparison.Ordinal))
+                    {
+                        error = $"The {component} component is terminated by 'END:{end}'";
+                        return false;
+                    }
+
+                    error = null;
+                    return true;
+                }
+            }
+        }
+
+        error = $"The {component} component is not terminated by 'END:{component}'";
+        return false;
+    }
+
+    private static bool IsBegin(ContentLine line, out string component)
+    {
+        return IsDelimiter(line, "BEGIN", out component);
+    }
+
+    private static bool IsEnd(ContentLine line, out string component)
+    {
+        return IsDelimiter(line, "END", out component);
+    }
+
+    private static bool IsDelimiter(ContentLine line, string name, out string component)
+    {
+        if (string.Equals(line.Name, name, StringComparison.OrdinalIgnoreCase))
+        {
+            component = line.Value.ToUpperInvariant();
+            return true;
+        }
+
+        component = "";
+        return false;
+    }
+
+    /// <summary>Reads the content lines of a text reader.</summary>
+    private static bool TryReadContentLines(TextReader reader, [NotNullWhen(returnValue: true)] out List<ContentLine>? lines, out string? error)
+    {
+        var reading = new ContentLineReader();
+        while (reader.ReadLine() is { } line)
+        {
+            if (!reading.TryAppend(line.AsSpan(), out error))
+            {
+                lines = null;
+                return false;
+            }
+        }
+
+        return reading.TryComplete(out lines, out error);
+    }
+
+    /// <summary>Reads the content lines of a span, which spares the caller the string a text reader would need.</summary>
+    private static bool TryReadContentLines(ReadOnlySpan<char> ics, [NotNullWhen(returnValue: true)] out List<ContentLine>? lines, out string? error)
+    {
+        var reading = new ContentLineReader();
+        while (!ics.IsEmpty)
+        {
+            ReadOnlySpan<char> line;
+            var index = ics.IndexOfAny('\r', '\n');
+            if (index < 0)
+            {
+                line = ics;
+                ics = default;
+            }
+            else
+            {
+                line = ics[..index];
+
+                // A CRLF, a lone CR and a lone LF each end a line, as TextReader.ReadLine also treats them.
+                var length = ics[index] is '\r' && index + 1 < ics.Length && ics[index + 1] is '\n' ? 2 : 1;
+                ics = ics[(index + length)..];
+            }
+
+            if (!reading.TryAppend(line, out error))
+            {
+                lines = null;
+                return false;
+            }
+        }
+
+        return reading.TryComplete(out lines, out error);
+    }
+
+    /// <summary>Assembles content lines from the lines of a stream, undoing the folding described by RFC 5545 section 3.1.</summary>
+    private sealed class ContentLineReader
+    {
+        private readonly List<ContentLine> _lines = [];
+        private StringBuilder? _current;
+        private bool _isFirstLine = true;
+
+        public bool TryAppend(ReadOnlySpan<char> line, out string? error)
+        {
+            if (_isFirstLine)
+            {
+                _isFirstLine = false;
+
+                // A stream read as text may still start with the encoded byte order mark.
+                if (line.Length > 0 && line[0] is '\uFEFF')
+                {
+                    line = line[1..];
+                }
+            }
+
+            // A line break followed by a single white space continues the previous content line.
+            if (line.Length > 0 && line[0] is ' ' or '\t')
+            {
+                if (_current is null)
+                {
+                    error = $"The content starts with the continuation of a content line, '{line.ToString()}'";
+                    return false;
+                }
+
+                Append(_current, line[1..]);
+                error = null;
+                return true;
+            }
+
+            if (!TryFlush(out error))
+                return false;
+
+            // An empty line is not a content line; producers occasionally leave one before END:VCALENDAR.
+            if (line.Length is not 0)
+            {
+                _current = new StringBuilder(line.Length);
+                Append(_current, line);
+            }
+
+            return true;
+        }
+
+        public bool TryComplete([NotNullWhen(returnValue: true)] out List<ContentLine>? lines, out string? error)
+        {
+            if (!TryFlush(out error))
+            {
+                lines = null;
+                return false;
+            }
+
+            lines = _lines;
+            return true;
+        }
+
+        private bool TryFlush(out string? error)
+        {
+            if (_current is null)
+            {
+                error = null;
+                return true;
+            }
+
+            if (!ContentLine.TryParse(_current.ToString(), out var contentLine, out error))
+                return false;
+
+            _lines.Add(contentLine);
+            _current = null;
+            return true;
+        }
+
+        private static void Append(StringBuilder sb, ReadOnlySpan<char> value)
+        {
+#if NETSTANDARD2_0
+            // StringBuilder.Append(ReadOnlySpan<char>) does not exist on .NET Standard 2.0.
+            foreach (var c in value)
+            {
+                sb.Append(c);
+            }
+#else
+            sb.Append(value);
+#endif
+        }
+    }
+}

--- a/src/Meziantou.Framework.Scheduling/InternetCalendarUserAddress.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendarUserAddress.cs
@@ -15,6 +15,15 @@ public sealed class InternetCalendarUserAddress
         Uri = new Uri("mailto:" + email);
     }
 
+    /// <summary>Initializes a new instance of the <see cref="InternetCalendarUserAddress"/> class with the specified URI.</summary>
+    /// <param name="uri">The URI of the calendar user, such as a mailto URI.</param>
+    public InternetCalendarUserAddress(Uri uri)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+
+        Uri = uri;
+    }
+
     public override string ToString()
     {
         return Uri.ToString();

--- a/src/Meziantou.Framework.Scheduling/readme.md
+++ b/src/Meziantou.Framework.Scheduling/readme.md
@@ -73,6 +73,39 @@ produced.
 
 ## iCalendar
 
+`InternetCalendar` reads and writes events in the iCalendar format.
+
+### Reading
+
+`InternetCalendar.Parse` reads an iCalendar object from a string, a `ReadOnlySpan<char>`, a `TextReader` or
+a UTF-8 `Stream`, and `TryParse` reports why the content was rejected instead of throwing:
+
+````c#
+var calendar = InternetCalendar.Parse(File.ReadAllText("invite.ics"));
+foreach (var @event in calendar.Events)
+{
+    Console.WriteLine($"{@event.Start:g} {@event.Summary}");
+}
+
+if (!InternetCalendar.TryParse(content, out var parsed, out var error))
+{
+    Console.WriteLine(error);
+}
+````
+
+The parser unfolds content lines, decodes `TEXT` values and reads the three date-time forms of RFC 5545
+section 3.3.5: `20240102T080000Z` becomes a `Utc` value, `20240102T080000` a floating (`Unspecified`) one,
+and `DTSTART;TZID=America/New_York:20240102T080000` a wall-clock value together with `Event.TimeZone`,
+which `TimeZoneInfo.FindSystemTimeZoneById` resolves from the identifier. A `VTIMEZONE` component is not
+used to build the time zone, so an identifier the platform does not know is reported as an error rather
+than silently dropped.
+
+An event property the model does not have, such as `X-MICROSOFT-CDO-BUSYSTATUS`, goes to
+`Event.AdditionalProperties`; the components the model does not represent — `VTODO`, `VJOURNAL`,
+`VFREEBUSY`, `VALARM` and `VTIMEZONE` — are skipped.
+
+### Writing
+
 `InternetCalendar` writes events in the iCalendar format. Setting `Event.TimeZone` writes the start and end
 as `DTSTART;TZID=`/`DTEND;TZID=` and emits a matching `VTIMEZONE` component:
 

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -707,4 +707,344 @@ public sealed class InternetCalendarTests
             Assert.Matches(@"^\d{8}T\d{6}Z?$", value);
         }
     }
+
+    private static string CreateIcs(params string[] eventContentLines)
+    {
+        var lines = new List<string> { "BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Test//Test//EN", "BEGIN:VEVENT" };
+        lines.AddRange(eventContentLines);
+        lines.Add("END:VEVENT");
+        lines.Add("END:VCALENDAR");
+        return string.Join("\r\n", lines) + "\r\n";
+    }
+
+    private static Event ParseSingleEvent(params string[] eventContentLines)
+    {
+        var calendar = InternetCalendar.Parse(CreateIcs(eventContentLines));
+        return Assert.Single(calendar.Events);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheCalendarProperties()
+    {
+        var calendar = InternetCalendar.Parse("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nMETHOD:REQUEST\r\nEND:VCALENDAR\r\n");
+
+        Assert.Equal("2.0", calendar.Version);
+        Assert.Empty(calendar.Events);
+
+        // PRODID identifies the writer, so it is not carried over to the parsed calendar.
+        Assert.Equal(new[] { KeyValuePair.Create("METHOD", "REQUEST") }, calendar.AdditionalProperties);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheEventProperties()
+    {
+        var @event = ParseSingleEvent(
+            "UID:event-1",
+            "SUMMARY:Meeting",
+            "DESCRIPTION:Agenda",
+            "STATUS:CONFIRMED",
+            "ORGANIZER:mailto:organizer@meziantou.net",
+            "ATTENDEE:mailto:first@meziantou.net",
+            "ATTENDEE:mailto:second@meziantou.net",
+            "CREATED:20141208T100900Z",
+            "LAST-MODIFIED:19960817T133000Z",
+            "DTSTAMP:20141208T100900Z",
+            "DTSTART:20240102T080000Z",
+            "DTEND:20240102T090000Z",
+            "X-MICROSOFT-CDO-BUSYSTATUS:OOF");
+
+        Assert.Equal("event-1", @event.Id);
+        Assert.Equal("Meeting", @event.Summary);
+        Assert.Equal("Agenda", @event.Description);
+        Assert.Equal(EventStatus.Confirmed, @event.Status);
+        Assert.Equal("mailto:organizer@meziantou.net", @event.Organizer?.Address?.ToString());
+        Assert.Equal(["mailto:first@meziantou.net", "mailto:second@meziantou.net"], @event.Attendees.Select(a => a.Address?.ToString()));
+        Assert.Equal(new DateTime(2014, 12, 08, 10, 09, 00, DateTimeKind.Utc), @event.Created);
+        Assert.Equal(new DateTime(1996, 08, 17, 13, 30, 00, DateTimeKind.Utc), @event.LastModified);
+        Assert.Equal(new DateTime(2014, 12, 08, 10, 09, 00, DateTimeKind.Utc), @event.DateTimeStamp);
+        Assert.Equal(new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Utc), @event.Start);
+        Assert.Equal(new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Utc), @event.End);
+        Assert.Null(@event.TimeZone);
+        Assert.Equal(new[] { KeyValuePair.Create("X-MICROSOFT-CDO-BUSYSTATUS", "OOF") }, @event.AdditionalProperties);
+    }
+
+    [Theory]
+    [InlineData("TENTATIVE", EventStatus.Tentative)]
+    [InlineData("CONFIRMED", EventStatus.Confirmed)]
+    [InlineData("CANCELLED", EventStatus.Cancelled)]
+    [InlineData("cancelled", EventStatus.Cancelled)]
+    public void Parse_ReadsTheStatus(string value, EventStatus expected)
+    {
+        Assert.Equal(expected, ParseSingleEvent("STATUS:" + value).Status);
+    }
+
+    [Fact]
+    public void Parse_RejectsAStatusThatCannotDescribeAnEvent()
+    {
+        Assert.False(InternetCalendar.TryParse(CreateIcs("STATUS:NEEDS-ACTION"), out _, out var error));
+        Assert.Contains("NEEDS-ACTION", error);
+    }
+
+    [Fact]
+    public void Parse_ReadsAFloatingDateTime()
+    {
+        var @event = ParseSingleEvent("DTSTART:20240102T080000");
+
+        Assert.Equal(new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified), @event.Start);
+        Assert.Equal(DateTimeKind.Unspecified, @event.Start.Kind);
+        Assert.Null(@event.TimeZone);
+    }
+
+    [Fact]
+    public void Parse_ReadsADateValueAsItsFirstInstant()
+    {
+        var @event = ParseSingleEvent("DTSTART;VALUE=DATE:20240102");
+
+        Assert.Equal(new DateTime(2024, 01, 02, 00, 00, 00, DateTimeKind.Unspecified), @event.Start);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheTimeZoneNamedByTheTzidParameter()
+    {
+        // UTC is the only identifier every platform is guaranteed to resolve.
+        var @event = ParseSingleEvent("DTSTART;TZID=UTC:20240102T080000", "DTEND;TZID=UTC:20240102T090000");
+
+        Assert.Equal(TimeZoneInfo.Utc, @event.TimeZone);
+        Assert.Equal(new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified), @event.Start);
+        Assert.Equal(new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified), @event.End);
+    }
+
+    [Fact]
+    public void Parse_RejectsATimeZoneThatIsNotFound()
+    {
+        Assert.False(InternetCalendar.TryParse(CreateIcs("DTSTART;TZID=Nowhere/Unknown:20240102T080000"), out _, out var error));
+        Assert.Contains("Nowhere/Unknown", error);
+    }
+
+    [Fact]
+    public void Parse_RejectsAnEventWhosePropertiesUseTwoTimeZones()
+    {
+        var ics = CreateIcs("DTSTART;TZID=UTC:20240102T080000", "DTEND;TZID=Europe/Paris:20240102T090000");
+
+        Assert.False(InternetCalendar.TryParse(ics, out _, out var error));
+        Assert.Contains("two different time zones", error);
+    }
+
+    [Fact]
+    public void Parse_RejectsAUtcDateTimeCarryingATzidParameter()
+    {
+        Assert.False(InternetCalendar.TryParse(CreateIcs("DTSTART;TZID=UTC:20240102T080000Z"), out _, out var error));
+        Assert.Contains("TZID", error);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheRecurrenceRule()
+    {
+        var @event = ParseSingleEvent("RRULE:FREQ=WEEKLY;INTERVAL=3;BYDAY=TU");
+
+        Assert.Equal("FREQ=WEEKLY;INTERVAL=3;BYDAY=TU", @event.RecurrenceRule?.Text);
+    }
+
+    [Fact]
+    public void Parse_RejectsAnInvalidRecurrenceRule()
+    {
+        Assert.False(InternetCalendar.TryParse(CreateIcs("RRULE:FREQ=NEVER"), out _, out var error));
+        Assert.Contains("FREQ=NEVER", error);
+    }
+
+    [Fact]
+    public void Parse_UnfoldsAContentLine()
+    {
+        // RFC 5545 section 3.1: a CRLF followed by a single white space continues the previous content line.
+        var @event = ParseSingleEvent("SUMMARY:A very\r\n  long\r\n\t summary");
+
+        Assert.Equal("A very long summary", @event.Summary);
+    }
+
+    [Fact]
+    public void Parse_UnescapesATextValue()
+    {
+        var @event = ParseSingleEvent(@"SUMMARY:a\, b\; c\\ d\ne");
+
+        Assert.Equal("a, b; c\\ d\ne", @event.Summary);
+    }
+
+    [Fact]
+    public void Parse_KeepsAColonInsideAQuotedParameterValue()
+    {
+        // The colon inside the quoted value must not be taken for the start of the property value.
+        var @event = ParseSingleEvent("DTSTART;X-NOTE=\"a:b\";TZID=UTC:20240102T080000");
+
+        Assert.Equal(TimeZoneInfo.Utc, @event.TimeZone);
+        Assert.Equal(new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified), @event.Start);
+    }
+
+    [Fact]
+    public void Parse_ReadsSeveralEvents()
+    {
+        var ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:first\r\nEND:VEVENT\r\n" +
+            "BEGIN:VEVENT\r\nUID:second\r\nEND:VEVENT\r\n" +
+            "END:VCALENDAR\r\n";
+
+        var calendar = InternetCalendar.Parse(ics);
+
+        Assert.Equal(["first", "second"], calendar.Events.Select(e => e.Id));
+    }
+
+    [Fact]
+    public void Parse_SkipsTheComponentsTheModelDoesNotRepresent()
+    {
+        var ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VTIMEZONE\r\nTZID:UTC\r\nBEGIN:STANDARD\r\nDTSTART:19700101T000000\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n" +
+            "BEGIN:VTODO\r\nUID:todo\r\nEND:VTODO\r\n" +
+            "BEGIN:VEVENT\r\nUID:event\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\nEND:VALARM\r\nEND:VEVENT\r\n" +
+            "END:VCALENDAR\r\n";
+
+        var calendar = InternetCalendar.Parse(ics);
+
+        var @event = Assert.Single(calendar.Events);
+        Assert.Equal("event", @event.Id);
+        Assert.Empty(@event.AdditionalProperties);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("VERSION:2.0\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\nBEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")]
+    [InlineData(" continuation\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nVERSION\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\n;PARAM=1:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nNAME;=1:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nNAME;PARAM:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nNAME;PARAM=\"unterminated:value\r\nEND:VCALENDAR\r\n")]
+    [InlineData("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:not-a-date\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")]
+    public void TryParse_ReturnsFalseForInvalidContent(string ics)
+    {
+        Assert.False(InternetCalendar.TryParse(ics, out var calendar, out var error));
+        Assert.Null(calendar);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void Parse_ThrowsForInvalidContent()
+    {
+        Assert.Throws<FormatException>(() => InternetCalendar.Parse("BEGIN:VTODO\r\nEND:VTODO\r\n"));
+    }
+
+    [Fact]
+    public void Parse_ReadsAStream()
+    {
+        using var stream = new MemoryStream(new UTF8Encoding(encoderShouldEmitUTF8Identifier: true).GetBytes(CreateIcs("SUMMARY:Réunion")));
+
+        var calendar = InternetCalendar.Parse(stream);
+
+        Assert.Equal("Réunion", Assert.Single(calendar.Events).Summary);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheOutputOfToIcs()
+    {
+        var calendar = new InternetCalendar();
+        calendar.AdditionalProperties["METHOD"] = "REQUEST";
+        calendar.Events.Add(new Event
+        {
+            Id = "event-1",
+            Summary = "A summary; with, escapes\\",
+            Description = "Line 1\nLine 2",
+            Status = EventStatus.Cancelled,
+            Organizer = new Organizer { Address = new InternetCalendarUserAddress("organizer@meziantou.net") },
+            Attendees = { new Attendee { Address = new InternetCalendarUserAddress("attendee@meziantou.net") } },
+            Created = new DateTime(2014, 12, 08, 10, 09, 00, DateTimeKind.Utc),
+            LastModified = new DateTime(2014, 12, 08, 10, 09, 00, DateTimeKind.Utc),
+            DateTimeStamp = new DateTime(2014, 12, 08, 10, 09, 00, DateTimeKind.Utc),
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Utc),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Utc),
+            RecurrenceRule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=10"),
+            AdditionalProperties = { ["X-MICROSOFT-CDO-BUSYSTATUS"] = "OOF" },
+        });
+
+        var parsed = InternetCalendar.Parse(calendar.ToIcs());
+
+        Assert.Equal(calendar.ToIcs(), parsed.ToIcs());
+
+        var expected = Assert.Single(calendar.Events);
+        var actual = Assert.Single(parsed.Events);
+        Assert.Equal(expected.Id, actual.Id);
+        Assert.Equal(expected.Summary, actual.Summary);
+        Assert.Equal(expected.Description, actual.Description);
+        Assert.Equal(expected.Status, actual.Status);
+        Assert.Equal(expected.Organizer?.Address?.Uri, actual.Organizer?.Address?.Uri);
+        Assert.Equal(expected.Start, actual.Start);
+        Assert.Equal(expected.End, actual.End);
+        Assert.Equal(expected.RecurrenceRule?.Text, actual.RecurrenceRule?.Text);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheOutputOfToIcsForAnEventWithATimeZone()
+    {
+        var recurrenceRule = RecurrenceRule.Parse("FREQ=DAILY");
+        recurrenceRule.EndDate = new DateTime(2024, 02, 01, 08, 00, 00, DateTimeKind.Unspecified);
+
+        var calendar = CreateCalendarWithEvent(new Event
+        {
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified),
+            TimeZone = TimeZoneInfo.Utc,
+            RecurrenceRule = recurrenceRule,
+        });
+
+        var parsed = InternetCalendar.Parse(calendar.ToIcs());
+
+        var @event = Assert.Single(parsed.Events);
+        Assert.Equal(TimeZoneInfo.Utc, @event.TimeZone);
+        Assert.Equal(new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified), @event.Start);
+        Assert.Equal(new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified), @event.End);
+
+        // The writer turned the floating UNTIL into a UTC one, which the parser reads back as an instant.
+        Assert.Equal(new DateTime(2024, 02, 01, 08, 00, 00, DateTimeKind.Utc), @event.RecurrenceRule?.EndDate);
+        Assert.Equal(calendar.ToIcs(), parsed.ToIcs());
+    }
+
+    [Fact]
+    public void Parse_ReadsASlicedSpan()
+    {
+        var ics = CreateIcs("SUMMARY:Meeting");
+        var padded = "﻿leading" + ics + "trailing";
+
+        var calendar = InternetCalendar.Parse(padded.AsSpan("﻿leading".Length, ics.Length));
+
+        Assert.Equal("Meeting", Assert.Single(calendar.Events).Summary);
+    }
+
+    [Theory]
+    [InlineData("\r\n")]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    public void Parse_AcceptsEveryLineBreak(string lineBreak)
+    {
+        var ics = string.Join(lineBreak, "BEGIN:VCALENDAR", "BEGIN:VEVENT", "SUMMARY:A", "  summary", "END:VEVENT", "END:VCALENDAR") + lineBreak;
+
+        Assert.Equal("A summary", Assert.Single(InternetCalendar.Parse(ics.AsSpan()).Events).Summary);
+    }
+
+    [Fact]
+    public void Parse_ReadsTheSameCalendarFromASpanAndFromATextReader()
+    {
+        var ics = CreateIcs("UID:event-1", "SUMMARY:Meeting", "DTSTART:20240102T080000Z");
+
+        using var reader = new StringReader(ics);
+        Assert.Equal(InternetCalendar.Parse(ics.AsSpan()).ToIcs(), InternetCalendar.Parse(reader).ToIcs());
+    }
+
+    [Fact]
+    public void TryParse_ReturnsFalseForANullString()
+    {
+        Assert.False(InternetCalendar.TryParse(ics: null, out var calendar, out var error));
+        Assert.Null(calendar);
+        Assert.NotNull(error);
+    }
 }


### PR DESCRIPTION
`InternetCalendar` could write the iCalendar format but not read it. This adds the parsing side.

## What changed

**New public API on `InternetCalendar`**, following the overload shape `RecurrenceRule` and `CronExpression` already use in this namespace:

```csharp
public static InternetCalendar Parse(string ics)
public static InternetCalendar Parse(ReadOnlySpan<char> ics)
public static InternetCalendar Parse(Stream stream)          // UTF-8, honours a BOM
public static InternetCalendar Parse(TextReader reader)
public static bool TryParse(ReadOnlySpan<char> ics, out InternetCalendar? calendar[, out string? error])
public static bool TryParse(string? ics, out InternetCalendar? calendar[, out string? error])
public static bool TryParse(TextReader reader, out InternetCalendar? calendar, out string? error)
```

**New internal types**

- `ContentLine` — the content line grammar of RFC 5545 sections 3.1 and 3.2, including property parameters whose quoted value may contain a colon, plus the `TEXT` unescaping of section 3.3.11.
- `InternetCalendarParser` — undoes line folding, walks the component nesting, maps properties onto the model. Line reading is split from the component walk so a `ReadOnlySpan<char>` is read without copying the whole input; only the unfolded content lines are materialized. The span feed treats CRLF, a lone CR and a lone LF as line breaks, the way `TextReader.ReadLine` does.

**Mapping.** `UID`, `SUMMARY`, `DESCRIPTION`, `STATUS`, `ORGANIZER`, `ATTENDEE`, `CREATED`, `LAST-MODIFIED`, `DTSTAMP`, `DTSTART`, `DTEND` and `RRULE` go to their properties; anything else goes to `AdditionalProperties`. `VTIMEZONE`, `VTODO`, `VJOURNAL`, `VFREEBUSY` and `VALARM` are skipped. `PRODID` is dropped, since the writer emits its own.

All three date-time forms of section 3.3.5 are read: a value ending in `Z` becomes a `Utc` `DateTime`, a floating one an `Unspecified` `DateTime`, and a `TZID` parameter yields a wall-clock `DateTime` together with `Event.TimeZone`.

## Points worth a reviewer's attention

- **`Event.Description` is new, and the writer now emits it.** Without it the parser would have to drop `DESCRIPTION` outright. The writer still writes the escaped empty line it always wrote when the property is `null`, so existing output is unchanged.
- **`InternetCalendarUserAddress` gains a `Uri` constructor**, which is what a parsed `CAL-ADDRESS` yields; the existing `string` constructor prepends `mailto:` and cannot be used here.
- **Unresolvable time zones are errors, not silent downgrades.** A `TZID` the platform does not know, and a `DTSTART`/`DTEND` naming two different time zones (which the single-`TimeZone` model cannot represent), both fail the parse. Dropping either would change what the event means. A `VTIMEZONE` component is not used to build a `TimeZoneInfo`; the identifier is resolved against the system database.
- **Known gap, left alone as out of scope:** `RecurrenceRule` cannot parse a floating `UNTIL` — `Utilities.ParseDateTime` only accepts the `Z` and explicit-offset forms — so a real `.ics` carrying `UNTIL=20240201T080000` fails, and the writer can itself emit one when the event has no `TimeZone`. Fixing it means deciding what `Kind` a floating `UNTIL` should produce, which touches `GetNextOccurrences` bounding semantics.

## Verification

- `ref/Meziantou.Framework.Scheduling.cs` regenerated; `dotnet run ./eng/update-all.cs` exits 0 with no further changes.
- Builds clean on `net10.0`, `net11.0` and `netstandard2.0` in Debug and in Release with `-p:IsOfficialBuild=true -p:TreatWarningsAsErrors=true`.
- 836/836 tests pass; `InternetCalendarTests` goes from 24 to 93 tests per target framework.
