### PR TITLE
Support volumes in TemporaryContainers

### DIFF
--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -134,6 +134,8 @@ namespace Meziantou.Framework.TemporaryContainers
         public void Add(Meziantou.Framework.TemporaryContainers.IMount mount) { }
         public void AddBindMount(string hostPath, string containerPath, bool readOnly = false) { }
         public void AddVolume(string volumeName, string containerPath) { }
+        public void AddVolume(string volumeName, string containerPath, bool readOnly) { }
+        public void AddVolume(Meziantou.Framework.TemporaryContainers.TemporaryVolume volume, string containerPath, bool readOnly = false) { }
         public void AddTmpfs(string containerPath) { }
         public System.Collections.Generic.IEnumerator<Meziantou.Framework.TemporaryContainers.IMount> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
@@ -371,6 +373,17 @@ namespace Meziantou.Framework.TemporaryContainers
         public System.Collections.Generic.IAsyncEnumerable<Meziantou.Framework.TemporaryContainers.LogEntry> GetLogsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
+    public class TemporaryVolume : System.IAsyncDisposable
+    {
+        public string Name { get => throw null; }
+        public Meziantou.Framework.TemporaryContainers.VolumeDefinition Definition { get => throw null; }
+        public Meziantou.Framework.TemporaryContainers.ContainerRuntime Runtime { get => throw null; }
+        public System.Threading.Tasks.Task EnsureCreatedAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public System.Threading.Tasks.Task<bool> ExistsAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public System.Threading.Tasks.Task DeleteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
+    }
+
     public sealed class TmpfsMount : Meziantou.Framework.TemporaryContainers.IMount, System.IEquatable<Meziantou.Framework.TemporaryContainers.TmpfsMount>
     {
         public string Target { get => throw null; init { } }
@@ -384,18 +397,41 @@ namespace Meziantou.Framework.TemporaryContainers
         public void Deconstruct(out string Target) => throw null;
     }
 
+    public class VolumeDefinition
+    {
+        public Meziantou.Framework.TemporaryContainers.ContainerRuntime Runtime { get => throw null; set { } }
+        public string? Name { get => throw null; set { } }
+        public string? Driver { get => throw null; set { } }
+        public string? ReuseId { get => throw null; set { } }
+        public Meziantou.Framework.TemporaryContainers.ContainerLabelCollection Labels { get => throw null; }
+        public Meziantou.Framework.TemporaryContainers.VolumeDriverOptionCollection DriverOptions { get => throw null; }
+        public VolumeDefinition(Meziantou.Framework.TemporaryContainers.VolumeDefinition other) { }
+        public virtual Meziantou.Framework.TemporaryContainers.TemporaryVolume CreateVolume() => throw null;
+    }
+
+    public sealed class VolumeDriverOptionCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
+    {
+        public int Count { get => throw null; }
+        public void Add(string name, string value) { }
+        public bool Remove(string name) => throw null;
+        public bool Contains(string name) => throw null;
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() => throw null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+    }
+
     public sealed class VolumeMount : Meziantou.Framework.TemporaryContainers.IMount, System.IEquatable<Meziantou.Framework.TemporaryContainers.VolumeMount>
     {
         public string Name { get => throw null; init { } }
         public string Target { get => throw null; init { } }
-        public VolumeMount(string Name, string Target) { }
+        public bool ReadOnly { get => throw null; init { } }
+        public VolumeMount(string Name, string Target, bool ReadOnly = false) { }
         public override string ToString() => throw null;
         public static bool operator !=(Meziantou.Framework.TemporaryContainers.VolumeMount? left, Meziantou.Framework.TemporaryContainers.VolumeMount? right) => throw null;
         public static bool operator ==(Meziantou.Framework.TemporaryContainers.VolumeMount? left, Meziantou.Framework.TemporaryContainers.VolumeMount? right) => throw null;
         public override int GetHashCode() => throw null;
         public override bool Equals(object? obj) => throw null;
         public bool Equals(Meziantou.Framework.TemporaryContainers.VolumeMount? other) => throw null;
-        public void Deconstruct(out string Name, out string Target) => throw null;
+        public void Deconstruct(out string Name, out string Target, out bool ReadOnly) => throw null;
     }
 
     public static class Wait

--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -374,7 +374,7 @@ namespace Meziantou.Framework.TemporaryContainers
         public System.Collections.Generic.IAsyncEnumerable<Meziantou.Framework.TemporaryContainers.LogEntry> GetLogsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
-    public class TemporaryVolume : System.IAsyncDisposable
+    public sealed class TemporaryVolume : System.IAsyncDisposable
     {
         public string Name { get => throw null; }
         public Meziantou.Framework.TemporaryContainers.VolumeDefinition Definition { get => throw null; }
@@ -398,7 +398,7 @@ namespace Meziantou.Framework.TemporaryContainers
         public void Deconstruct(out string Target) => throw null;
     }
 
-    public class VolumeDefinition
+    public sealed class VolumeDefinition
     {
         public Meziantou.Framework.TemporaryContainers.ContainerRuntime Runtime { get => throw null; set { } }
         public string? Name { get => throw null; set { } }
@@ -407,7 +407,7 @@ namespace Meziantou.Framework.TemporaryContainers
         public Meziantou.Framework.TemporaryContainers.ContainerLabelCollection Labels { get => throw null; }
         public Meziantou.Framework.TemporaryContainers.VolumeDriverOptionCollection DriverOptions { get => throw null; }
         public VolumeDefinition(Meziantou.Framework.TemporaryContainers.VolumeDefinition other) { }
-        public virtual Meziantou.Framework.TemporaryContainers.TemporaryVolume CreateVolume() => throw null;
+        public Meziantou.Framework.TemporaryContainers.TemporaryVolume CreateVolume() => throw null;
     }
 
     public sealed class VolumeDriverOptionCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerLabelCollection.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerLabelCollection.cs
@@ -2,7 +2,7 @@ using System.Collections;
 
 namespace Meziantou.Framework.TemporaryContainers;
 
-/// <summary>A collection of labels applied to a container.</summary>
+/// <summary>A collection of labels applied to a container or a volume.</summary>
 public sealed class ContainerLabelCollection : IEnumerable<KeyValuePair<string, string>>
 {
     private readonly Dictionary<string, string> _labels;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerMountCollection.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerMountCollection.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Meziantou.Framework.TemporaryContainers.Internals;
 
 namespace Meziantou.Framework.TemporaryContainers;
 
@@ -43,6 +44,25 @@ public sealed class ContainerMountCollection : IEnumerable<IMount>
     public void AddVolume(string volumeName, string containerPath)
     {
         _mounts.Add(new VolumeMount(volumeName, containerPath));
+    }
+
+    /// <summary>Adds a named volume mount.</summary>
+    /// <param name="volumeName">The volume name.</param>
+    /// <param name="containerPath">The path inside the container.</param>
+    /// <param name="readOnly">Whether the mount is read-only.</param>
+    public void AddVolume(string volumeName, string containerPath, bool readOnly)
+    {
+        _mounts.Add(new VolumeMount(volumeName, containerPath, readOnly));
+    }
+
+    /// <summary>Adds a mount for a <see cref="TemporaryVolume"/>. The volume is created, if needed, when the container is created.</summary>
+    /// <param name="volume">The volume to mount.</param>
+    /// <param name="containerPath">The path inside the container.</param>
+    /// <param name="readOnly">Whether the mount is read-only.</param>
+    public void AddVolume(TemporaryVolume volume, string containerPath, bool readOnly = false)
+    {
+        ArgumentNullException.ThrowIfNull(volume);
+        _mounts.Add(new OwnedVolumeMount(volume, containerPath, readOnly));
     }
 
     /// <summary>Adds a tmpfs (in-memory) mount.</summary>

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
@@ -36,6 +36,9 @@ public abstract class ContainerRuntime
             throw CreateUnavailableRuntimeException(this);
     }
 
+    /// <summary>The runtime that actually runs the commands. Only <see cref="Auto"/> differs from the instance itself, and resolving it may run a command or open a connection.</summary>
+    internal virtual Task<ContainerRuntime> GetEffectiveRuntimeAsync(CancellationToken cancellationToken) => Task.FromResult(this);
+
     internal virtual bool SupportsPause => false;
 
     internal virtual bool SupportsRestart => false;
@@ -89,6 +92,15 @@ public abstract class ContainerRuntime
         => throw CreateNotSupportedException();
 
     internal virtual IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition)
+        => throw CreateNotSupportedException();
+
+    internal virtual Task CreateVolumeAsync(VolumeDefinition definition, string name, CancellationToken cancellationToken)
+        => throw CreateNotSupportedException();
+
+    internal virtual Task DeleteVolumeAsync(string name, CancellationToken cancellationToken)
+        => throw CreateNotSupportedException();
+
+    internal virtual Task<bool> VolumeExistsAsync(string name, CancellationToken cancellationToken)
         => throw CreateNotSupportedException();
 
     private NotSupportedException CreateNotSupportedException() => new($"The '{this}' runtime cannot execute container operations.");

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -7,8 +7,6 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 /// <summary>CLI dialect for Apple's <c>container</c> runtime (macOS). Best-effort: verified against the documented CLI, not executed in CI on non-macOS hosts.</summary>
 internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 {
-    private const string ReuseNamePrefix = "meziantou-tc-";
-
     public AppleContainerRuntime(string name, string? executablePath = null)
         : base(name, executablePath)
     {
@@ -89,22 +87,24 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 
     internal override async Task<string?> FindReusableContainerAsync(string reuseId, CancellationToken cancellationToken)
     {
-        var name = GetReuseName(reuseId);
+        var name = ResourceNaming.GetReuseName(reuseId);
         var result = await Cli.RunBufferedAsync(["inspect", name], cancellationToken, allowNonZero: true).ConfigureAwait(false);
         return result.ExitCode == 0 ? name : null;
     }
 
     internal override IReadOnlyList<string> BuildCreateArguments(ContainerDefinition definition, string imageRef)
     {
-        if (definition.Resources.ReadOnlyRootFilesystem)
-            throw new NotSupportedException("Apple's container runtime does not support a read-only root filesystem.");
-        if (definition.Network.Network is not null || definition.Network.Alias is not null)
-            throw new NotSupportedException("Apple's container runtime does not support custom network options.");
+        if (definition.Network.Alias is not null)
+            throw new NotSupportedException("Apple's container runtime does not support network aliases.");
 
         var args = new List<string> { "create" };
 
-        var name = definition.ReuseId is { } reuseId ? GetReuseName(reuseId) : definition.Name;
+        var name = definition.ReuseId is { } reuseId ? ResourceNaming.GetReuseName(reuseId) : definition.Name;
         AddOption(args, "--name", name);
+        AddOption(args, "--network", definition.Network.Network);
+
+        if (definition.Resources.ReadOnlyRootFilesystem)
+            args.Add("--read-only");
         AddOption(args, "--user", definition.User);
         AddOption(args, "--workdir", definition.WorkingDirectory);
 
@@ -150,6 +150,32 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 
         return args;
     }
+
+    internal override IReadOnlyList<string> BuildCreateVolumeArguments(VolumeDefinition definition, string name)
+    {
+        if (definition.Driver is not null)
+            throw new NotSupportedException("Apple's container runtime does not support volume drivers.");
+
+        var args = new List<string> { "volume", "create" };
+        foreach (var (labelName, labelValue) in definition.Labels)
+        {
+            args.Add("--label");
+            args.Add($"{labelName}={labelValue}");
+        }
+
+        foreach (var (optionName, optionValue) in definition.DriverOptions)
+        {
+            args.Add("--opt");
+            args.Add($"{optionName}={optionValue}");
+        }
+
+        args.Add(name);
+        return args;
+    }
+
+    internal override IReadOnlyList<string> BuildDeleteVolumeArguments(string name) => ["volume", "delete", name];
+
+    internal override IReadOnlyList<string> BuildVolumeExistsArguments(string name) => ["volume", "inspect", name];
 
     internal override IReadOnlyList<string> BuildStartArguments(string id) => ["start", id];
 
@@ -346,29 +372,43 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
         switch (mount)
         {
             case BindMount bind:
-                args.Add("--volume");
-                args.Add(bind.ReadOnly ? $"{bind.Source}:{bind.Target}:ro" : $"{bind.Source}:{bind.Target}");
+                AddMountDescriptor(args, "bind", bind.Source, bind.Target, bind.ReadOnly);
                 break;
 
             case VolumeMount volume:
-                args.Add("--volume");
-                args.Add($"{volume.Name}:{volume.Target}");
+                AddMountDescriptor(args, "volume", volume.Name, volume.Target, volume.ReadOnly);
                 break;
 
-            case TmpfsMount:
-                throw new NotSupportedException("Apple's container runtime does not support tmpfs mounts.");
+            case OwnedVolumeMount owned:
+                AddMountDescriptor(args, "volume", owned.Volume.Name, owned.Target, owned.ReadOnly);
+                break;
+
+            case TmpfsMount tmpfs:
+                args.Add("--tmpfs");
+                args.Add(tmpfs.Target);
+                break;
 
             default:
                 throw new NotSupportedException($"Mount type '{mount.GetType()}' is not supported.");
         }
     }
 
-    private static string GetReuseName(string reuseId)
+    private static void AddMountDescriptor(List<string> args, string type, string source, string target, bool readOnly)
     {
-        var builder = new StringBuilder(ReuseNamePrefix, ReuseNamePrefix.Length + reuseId.Length);
-        foreach (var ch in reuseId)
-            builder.Append(char.IsAsciiLetterOrDigit(ch) || ch is '_' or '.' or '-' ? ch : '-');
+        // Apple's parser splits the descriptor on ',' without honouring quotes, so a value containing one cannot be
+        // expressed at all.
+        EnsureDescriptorValue(source);
+        EnsureDescriptorValue(target);
 
-        return builder.ToString();
+        args.Add("--mount");
+        args.Add(readOnly
+            ? $"type={type},source={source},target={target},readonly"
+            : $"type={type},source={source},target={target}");
+    }
+
+    private static void EnsureDescriptorValue(string value)
+    {
+        if (value.Contains(',', StringComparison.Ordinal))
+            throw new NotSupportedException($"Apple's container runtime cannot mount '{value}' because the path contains a comma.");
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
@@ -58,6 +58,9 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
         yield return Podman;
     }
 
+    internal override async Task<ContainerRuntime> GetEffectiveRuntimeAsync(CancellationToken cancellationToken)
+        => await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+
     internal override bool SupportsPause => ResolvedRuntime.SupportsPause;
 
     internal override bool SupportsRestart => ResolvedRuntime.SupportsRestart;
@@ -161,4 +164,22 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
 
     internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition)
         => ResolvedRuntime.ResolvePortMap(info, definition);
+
+    internal override async Task CreateVolumeAsync(VolumeDefinition definition, string name, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.CreateVolumeAsync(definition, name, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal override async Task DeleteVolumeAsync(string name, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.DeleteVolumeAsync(name, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal override async Task<bool> VolumeExistsAsync(string name, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.VolumeExistsAsync(name, cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiCreateRequestBuilder.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiCreateRequestBuilder.cs
@@ -64,6 +64,18 @@ internal static class DockerApiCreateRequestBuilder
                         Type = "volume",
                         Source = volume.Name,
                         Target = volume.Target,
+                        ReadOnly = volume.ReadOnly,
+                    });
+                    break;
+
+                case OwnedVolumeMount owned:
+                    mounts ??= [];
+                    mounts.Add(new DockerApiModels.Mount
+                    {
+                        Type = "volume",
+                        Source = owned.Volume.Name,
+                        Target = owned.Target,
+                        ReadOnly = owned.ReadOnly,
                     });
                     break;
 

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
@@ -11,6 +11,7 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 [JsonSerializable(typeof(DockerApiModels.ExecInspectResponse))]
 [JsonSerializable(typeof(DockerInspectResult))]
 [JsonSerializable(typeof(DockerApiModels.CreateContainerRequest))]
+[JsonSerializable(typeof(DockerApiModels.VolumeCreateRequest))]
 [JsonSerializable(typeof(DockerApiModels.ExecCreateRequest))]
 [JsonSerializable(typeof(DockerApiModels.ExecStartRequest))]
 [JsonSerializable(typeof(DockerApiModels.AuthConfigFile))]

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiModels.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiModels.cs
@@ -80,6 +80,14 @@ internal static class DockerApiModels
         public NetworkingConfig? NetworkingConfig { get; set; }
     }
 
+    internal sealed class VolumeCreateRequest
+    {
+        public string? Name { get; set; }
+        public string? Driver { get; set; }
+        public Dictionary<string, string>? DriverOpts { get; set; }
+        public Dictionary<string, string>? Labels { get; set; }
+    }
+
     internal sealed class EmptyObject
     {
         public static EmptyObject Instance { get; } = new EmptyObject();

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -81,12 +81,41 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
     internal override async Task DeleteAsync(string id, CancellationToken cancellationToken)
     {
-        using var response = await SendAsync(HttpMethod.Delete, "/containers/" + Uri.EscapeDataString(id) + "?force=1", content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
+        // 'v=1' removes the anonymous volumes the image declared, which would otherwise pile up after every run. Named
+        // volumes are never touched by it.
+        using var response = await SendAsync(HttpMethod.Delete, "/containers/" + Uri.EscapeDataString(id) + "?force=1&v=1", content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
     }
 
     internal override async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken)
     {
         using var response = await SendAsync(HttpMethod.Get, "/containers/" + Uri.EscapeDataString(id) + "/json", content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
+        return response.StatusCode != HttpStatusCode.NotFound;
+    }
+
+    internal override async Task CreateVolumeAsync(VolumeDefinition definition, string name, CancellationToken cancellationToken)
+    {
+        var payload = new DockerApiModels.VolumeCreateRequest
+        {
+            Name = name,
+            Driver = definition.Driver,
+            DriverOpts = definition.DriverOptions.Count > 0 ? definition.DriverOptions.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal) : null,
+            Labels = definition.Labels.Count > 0 ? definition.Labels.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal) : null,
+        };
+
+        using var content = CreateJsonContent(payload, DockerApiJsonContext.Default.VolumeCreateRequest);
+        using var response = await SendAsync(HttpMethod.Post, "/volumes/create", content, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal override async Task DeleteVolumeAsync(string name, CancellationToken cancellationToken)
+    {
+        // A volume still used by a container answers 409, which the caller detects by probing the volume again rather
+        // than by an exception, so removal behaves like the CLI runtimes.
+        using var response = await SendAsync(HttpMethod.Delete, "/volumes/" + Uri.EscapeDataString(name) + "?force=1", content: null, cancellationToken, allowNotFound: true, allowConflict: true).ConfigureAwait(false);
+    }
+
+    internal override async Task<bool> VolumeExistsAsync(string name, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(HttpMethod.Get, "/volumes/" + Uri.EscapeDataString(name), content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
         return response.StatusCode != HttpStatusCode.NotFound;
     }
 
@@ -255,7 +284,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         }
     }
 
-    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string endpoint, HttpContent? content, CancellationToken cancellationToken, bool allowNotFound = false, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string endpoint, HttpContent? content, CancellationToken cancellationToken, bool allowNotFound = false, bool allowConflict = false, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
     {
         var connection = await EnsureConnectionOrThrowAsync(cancellationToken).ConfigureAwait(false);
         using var request = new HttpRequestMessage(method, BuildEndpoint(connection, endpoint))
@@ -265,8 +294,12 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
         var response = await connection.HttpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
 
-        if (response.IsSuccessStatusCode || allowNotFound && response.StatusCode == HttpStatusCode.NotFound)
+        if (response.IsSuccessStatusCode
+            || allowNotFound && response.StatusCode == HttpStatusCode.NotFound
+            || allowConflict && response.StatusCode == HttpStatusCode.Conflict)
+        {
             return response;
+        }
 
         throw await CreateRequestExceptionAsync(response, method.Method, request.RequestUri?.AbsolutePath ?? endpoint, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
@@ -121,7 +121,7 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
         if (_flavor is Flavor.Wslc)
             pullPolicyValue = null;
 
-        return DockerCreateArgumentBuilder.Build(definition, imageRef, pullPolicyValue);
+        return DockerCreateArgumentBuilder.Build(definition, imageRef, pullPolicyValue, quotedMountFieldsSupported: _flavor is Flavor.Docker);
     }
 
     internal override IReadOnlyList<string> BuildStartArguments(string id) => ["start", id];
@@ -136,7 +136,10 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
 
     internal override IReadOnlyList<string> BuildKillArguments(string id) => ["kill", id];
 
-    internal override IReadOnlyList<string> BuildRemoveArguments(string id) => ["rm", "-f", id];
+    // '-v' removes the anonymous volumes the image declared, which would otherwise pile up after every run. Named
+    // volumes are never touched by it. wslc has no such flag.
+    internal override IReadOnlyList<string> BuildRemoveArguments(string id)
+        => _flavor is Flavor.Wslc ? ["rm", "-f", id] : ["rm", "-f", "-v", id];
 
     internal override IReadOnlyList<string> BuildExistsArguments(string id)
         => _flavor is Flavor.Wslc
@@ -185,6 +188,53 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
     internal override ContainerInfo ParseInspect(string output)
     {
         return DockerContainerInfoParser.ParseInspectOutput(output);
+    }
+
+    internal override IReadOnlyList<string> BuildCreateVolumeArguments(VolumeDefinition definition, string name)
+    {
+        EnsureVolumesSupported();
+
+        var args = new List<string> { "volume", "create" };
+        if (definition.Driver is { } driver)
+        {
+            args.Add("--driver");
+            args.Add(driver);
+        }
+
+        foreach (var (labelName, labelValue) in definition.Labels)
+        {
+            args.Add("--label");
+            args.Add($"{labelName}={labelValue}");
+        }
+
+        foreach (var (optionName, optionValue) in definition.DriverOptions)
+        {
+            args.Add("--opt");
+            args.Add($"{optionName}={optionValue}");
+        }
+
+        args.Add(name);
+        return args;
+    }
+
+    // '--force' is deliberately not used: on docker it only hides the not-found error, which the caller already
+    // tolerates, while on podman it also removes the containers using the volume.
+    internal override IReadOnlyList<string> BuildDeleteVolumeArguments(string name)
+    {
+        EnsureVolumesSupported();
+        return ["volume", "rm", name];
+    }
+
+    internal override IReadOnlyList<string> BuildVolumeExistsArguments(string name)
+    {
+        EnsureVolumesSupported();
+        return ["volume", "inspect", name];
+    }
+
+    private void EnsureVolumesSupported()
+    {
+        if (_flavor is Flavor.Wslc)
+            throw new NotSupportedException("The 'wslc' CLI does not have volume commands.");
     }
 
     internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition) => info.Ports;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerCreateArgumentBuilder.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerCreateArgumentBuilder.cs
@@ -4,7 +4,8 @@ internal static class DockerCreateArgumentBuilder
 {
     public const string ReuseLabel = "meziantou.tc.reuse";
 
-    public static List<string> Build(ContainerDefinition definition, string imageRef, string? pullPolicyValue)
+    /// <param name="quotedMountFieldsSupported">Whether the runtime parses the <c>--mount</c> descriptor as a CSV record, which is the only way to express a value containing a comma. Docker does; podman and wslc split on the comma instead.</param>
+    public static List<string> Build(ContainerDefinition definition, string imageRef, string? pullPolicyValue, bool quotedMountFieldsSupported)
     {
         var args = new List<string> { "create" };
 
@@ -53,7 +54,7 @@ internal static class DockerCreateArgumentBuilder
         }
 
         foreach (var mount in definition.Mounts)
-            AppendMount(args, mount);
+            AppendMount(args, mount, quotedMountFieldsSupported);
 
         var entrypoint = new List<string>(definition.Entrypoint);
         if (entrypoint.Count > 0)
@@ -79,21 +80,20 @@ internal static class DockerCreateArgumentBuilder
         }
     }
 
-    private static void AppendMount(List<string> args, IMount mount)
+    private static void AppendMount(List<string> args, IMount mount, bool quotedMountFieldsSupported)
     {
         switch (mount)
         {
             case BindMount bind:
-                args.Add("--mount");
-                var descriptor = $"type=bind,source={bind.Source},target={bind.Target}";
-                if (bind.ReadOnly)
-                    descriptor += ",readonly";
-                args.Add(descriptor);
+                AddMountDescriptor(args, "bind", bind.Source, bind.Target, bind.ReadOnly, quotedMountFieldsSupported);
                 break;
 
             case VolumeMount volume:
-                args.Add("--mount");
-                args.Add($"type=volume,source={volume.Name},target={volume.Target}");
+                AddMountDescriptor(args, "volume", volume.Name, volume.Target, volume.ReadOnly, quotedMountFieldsSupported);
+                break;
+
+            case OwnedVolumeMount owned:
+                AddMountDescriptor(args, "volume", owned.Volume.Name, owned.Target, owned.ReadOnly, quotedMountFieldsSupported);
                 break;
 
             case TmpfsMount tmpfs:
@@ -104,5 +104,34 @@ internal static class DockerCreateArgumentBuilder
             default:
                 throw new NotSupportedException($"Mount type '{mount.GetType()}' is not supported.");
         }
+    }
+
+    private static void AddMountDescriptor(List<string> args, string type, string source, string target, bool readOnly, bool quotedMountFieldsSupported)
+    {
+        var descriptor = new StringBuilder("type=").Append(type);
+        AppendMountField(descriptor, "source", source, quotedMountFieldsSupported);
+        AppendMountField(descriptor, "target", target, quotedMountFieldsSupported);
+        if (readOnly)
+            descriptor.Append(",readonly");
+
+        args.Add("--mount");
+        args.Add(descriptor.ToString());
+    }
+
+    /// <summary>Appends one <c>key=value</c> field to a <c>--mount</c> descriptor, quoting it when the value would otherwise be read as several fields.</summary>
+    private static void AppendMountField(StringBuilder descriptor, string key, string value, bool quotedMountFieldsSupported)
+    {
+        descriptor.Append(',');
+        if (!value.Contains(',', StringComparison.Ordinal) && !value.Contains('"', StringComparison.Ordinal))
+        {
+            descriptor.Append(key).Append('=').Append(value);
+            return;
+        }
+
+        if (!quotedMountFieldsSupported)
+            throw new NotSupportedException($"The runtime cannot mount '{value}' because the path contains a comma or a quote.");
+
+        // The whole descriptor is one CSV record, so a field holding a separator is quoted and its own quotes doubled.
+        descriptor.Append('"').Append(key).Append('=').Append(value.Replace("\"", "\"\"", StringComparison.Ordinal)).Append('"');
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
@@ -150,6 +150,18 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
 
     internal abstract ContainerInfo ParseInspect(string output);
 
+    internal virtual IReadOnlyList<string> BuildCreateVolumeArguments(VolumeDefinition definition, string name)
+        => throw CreateVolumesNotSupportedException();
+
+    internal virtual IReadOnlyList<string> BuildDeleteVolumeArguments(string name)
+        => throw CreateVolumesNotSupportedException();
+
+    internal virtual IReadOnlyList<string> BuildVolumeExistsArguments(string name)
+        => throw CreateVolumesNotSupportedException();
+
+    private NotSupportedException CreateVolumesNotSupportedException()
+        => new($"The '{this}' runtime does not support volumes.");
+
     /// <summary>Last chance to adjust the definition before a new container is created. Not called when an existing container is adopted through <see cref="ContainerDefinition.ReuseId"/>.</summary>
     internal virtual void PrepareDefinitionForCreate(ContainerDefinition definition)
     {
@@ -226,6 +238,22 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
     internal override async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken)
     {
         var result = await Cli.RunBufferedAsync(BuildExistsArguments(id), cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        return result.ExitCode == 0;
+    }
+
+    internal override async Task CreateVolumeAsync(VolumeDefinition definition, string name, CancellationToken cancellationToken)
+    {
+        await Cli.RunBufferedAsync(BuildCreateVolumeArguments(definition, name), cancellationToken).ConfigureAwait(false);
+    }
+
+    internal override async Task DeleteVolumeAsync(string name, CancellationToken cancellationToken)
+    {
+        await Cli.RunBufferedAsync(BuildDeleteVolumeArguments(name), cancellationToken, allowNonZero: true).ConfigureAwait(false);
+    }
+
+    internal override async Task<bool> VolumeExistsAsync(string name, CancellationToken cancellationToken)
+    {
+        var result = await Cli.RunBufferedAsync(BuildVolumeExistsArguments(name), cancellationToken, allowNonZero: true).ConfigureAwait(false);
         return result.ExitCode == 0;
     }
 

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/OwnedVolumeMount.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/OwnedVolumeMount.cs
@@ -1,0 +1,7 @@
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>A <see cref="VolumeMount"/> that keeps the <see cref="TemporaryVolume"/> it comes from, so the container can create the volume before it starts.</summary>
+/// <param name="Volume">The volume to mount.</param>
+/// <param name="Target">The path inside the container.</param>
+/// <param name="ReadOnly">Whether the mount is read-only.</param>
+internal sealed record OwnedVolumeMount(TemporaryVolume Volume, string Target, bool ReadOnly) : IMount;

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/ResourceNaming.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/ResourceNaming.cs
@@ -1,0 +1,27 @@
+using System.Text;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Builds the names the library assigns to the resources it creates.</summary>
+internal static class ResourceNaming
+{
+    public const string Prefix = "meziantou-tc-";
+
+    /// <summary>Builds a deterministic name from a reuse identifier, so the same identifier always resolves to the same resource.</summary>
+    /// <param name="reuseId">The reuse identifier.</param>
+    /// <returns>A name accepted by every supported runtime.</returns>
+    public static string GetReuseName(string reuseId)
+    {
+        // Runtimes only accept letters, digits and a few separators, and the name must not start with a separator, which
+        // the prefix guarantees.
+        var builder = new StringBuilder(Prefix, Prefix.Length + reuseId.Length);
+        foreach (var ch in reuseId)
+            builder.Append(char.IsAsciiLetterOrDigit(ch) || ch is '_' or '.' or '-' ? ch : '-');
+
+        return builder.ToString();
+    }
+
+    /// <summary>Builds a random name for a resource the library owns.</summary>
+    /// <returns>A name accepted by every supported runtime.</returns>
+    public static string GetRandomName() => Prefix + Guid.NewGuid().ToString("N");
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj
+++ b/src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.8</Version>
+    <Version>1.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Manage temporary containers for integration tests using the docker, podman, apple/container, or wslc CLI.</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.cs
@@ -1,3 +1,5 @@
+using Meziantou.Framework.TemporaryContainers.Internals;
+
 namespace Meziantou.Framework.TemporaryContainers;
 
 /// <summary>A temporary container created from a <see cref="ContainerDefinition"/>. Dispose the instance to remove the container (unless <see cref="ContainerDefinition.ReuseId"/> is set).</summary>
@@ -49,6 +51,7 @@ public partial class TemporaryContainer : IAsyncDisposable
             return;
 
         await EnsureRuntimeSupportedAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureOwnedVolumesCreatedAsync(cancellationToken).ConfigureAwait(false);
 
         _id = await Runtime.EnsureCreatedAsync(_definition, cancellationToken).ConfigureAwait(false);
 
@@ -131,6 +134,20 @@ public partial class TemporaryContainer : IAsyncDisposable
         catch
         {
             // Best-effort cleanup: ignore failures during disposal.
+        }
+    }
+
+    /// <summary>Creates the volumes added through <see cref="ContainerMountCollection.AddVolume(TemporaryVolume, string, bool)"/>, so a mount never silently resolves to an empty volume the runtime auto-created.</summary>
+    private async Task EnsureOwnedVolumesCreatedAsync(CancellationToken cancellationToken)
+    {
+        ContainerRuntime? effectiveRuntime = null;
+        foreach (var mount in _definition.Mounts)
+        {
+            if (mount is not OwnedVolumeMount owned)
+                continue;
+
+            effectiveRuntime ??= await Runtime.GetEffectiveRuntimeAsync(cancellationToken).ConfigureAwait(false);
+            await owned.Volume.EnsureCreatedAsync(effectiveRuntime, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryVolume.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryVolume.cs
@@ -1,0 +1,126 @@
+using Meziantou.Framework.TemporaryContainers.Internals;
+
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A temporary volume created from a <see cref="VolumeDefinition"/>. Dispose the instance to remove the volume.</summary>
+/// <remarks>Disposing only removes the volume when this instance created it and <see cref="VolumeDefinition.ReuseId"/> is not set. A volume that already existed when <see cref="EnsureCreatedAsync(CancellationToken)"/> ran is adopted and left behind, so pointing a definition at an existing volume never destroys it.</remarks>
+public class TemporaryVolume : IAsyncDisposable
+{
+    private readonly VolumeDefinition _definition;
+    private ContainerRuntime? _runtime;
+    private bool _created;
+    private bool _owned;
+    private bool _disposed;
+
+    internal TemporaryVolume(VolumeDefinition definition)
+    {
+        _definition = definition;
+
+        // Apple's runtime requires the name up front, so it is resolved here rather than assigned by the runtime.
+        Name = definition.Name
+            ?? (definition.ReuseId is { } reuseId ? ResourceNaming.GetReuseName(reuseId) : ResourceNaming.GetRandomName());
+    }
+
+    /// <summary>Gets the volume name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the definition owned by this volume.</summary>
+    public VolumeDefinition Definition => _definition;
+
+    /// <summary>Gets the container runtime in use.</summary>
+    public ContainerRuntime Runtime => _runtime ??= _definition.Runtime;
+
+    /// <summary>Creates the volume if it does not exist yet. An existing volume is adopted instead, and is not removed on dispose.</summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes once the volume exists.</returns>
+    public async Task EnsureCreatedAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_created)
+            return;
+
+        _runtime ??= _definition.Runtime;
+        await _runtime.EnsureSupportedAsync(cancellationToken).ConfigureAwait(false);
+
+        // Probing first serves two purposes: it keeps creation idempotent on the runtimes that reject an existing name,
+        // and it records whether this instance owns the volume so dispose cannot delete somebody else's data.
+        if (await _runtime.VolumeExistsAsync(Name, cancellationToken).ConfigureAwait(false))
+        {
+            _created = true;
+            return;
+        }
+
+        await _runtime.CreateVolumeAsync(_definition, Name, cancellationToken).ConfigureAwait(false);
+        _created = true;
+        _owned = true;
+    }
+
+    /// <summary>Creates the volume with the runtime of the container that mounts it, so both always talk to the same engine.</summary>
+    internal async Task EnsureCreatedAsync(ContainerRuntime containerRuntime, CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        // A volume created in one engine is invisible to another, which surfaces as an unexplained empty directory
+        // rather than as an error. A volume that was not pinned to a runtime follows the container instead of resolving
+        // one of its own.
+        if (_runtime is null && _definition.Runtime == ContainerRuntime.Auto)
+            _runtime = containerRuntime;
+
+        var volumeRuntime = await Runtime.GetEffectiveRuntimeAsync(cancellationToken).ConfigureAwait(false);
+        if (volumeRuntime != containerRuntime)
+            throw new InvalidOperationException($"The volume '{Name}' uses the '{volumeRuntime}' runtime, but the container uses '{containerRuntime}'. Both must use the same runtime.");
+
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Determines whether the volume exists.</summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns><see langword="true"/> if the volume exists; otherwise, <see langword="false"/>.</returns>
+    public async Task<bool> ExistsAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _runtime ??= _definition.Runtime;
+        await _runtime.EnsureSupportedAsync(cancellationToken).ConfigureAwait(false);
+        return await _runtime.VolumeExistsAsync(Name, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Removes the volume.</summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes once the volume is removed.</returns>
+    /// <exception cref="InvalidOperationException">The volume could not be removed, for instance because a container still uses it.</exception>
+    public async Task DeleteAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _runtime ??= _definition.Runtime;
+        await _runtime.EnsureSupportedAsync(cancellationToken).ConfigureAwait(false);
+        await _runtime.DeleteVolumeAsync(Name, cancellationToken).ConfigureAwait(false);
+
+        // The runtimes report "still in use" the same way they report "already gone", so the outcome is confirmed
+        // rather than inferred from an exit code.
+        if (await _runtime.VolumeExistsAsync(Name, cancellationToken).ConfigureAwait(false))
+            throw new InvalidOperationException($"The volume '{Name}' could not be removed. It is probably still used by a container.");
+
+        _created = false;
+        _owned = false;
+    }
+
+    /// <summary>Removes the volume when this instance created it and <see cref="VolumeDefinition.ReuseId"/> is not set. Cleanup is best-effort and never throws.</summary>
+    /// <returns>A task that completes once cleanup finishes.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        try
+        {
+            if (_owned && _definition.ReuseId is null)
+                await Runtime.DeleteVolumeAsync(Name, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort cleanup: ignore failures during disposal.
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryVolume.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryVolume.cs
@@ -4,7 +4,7 @@ namespace Meziantou.Framework.TemporaryContainers;
 
 /// <summary>A temporary volume created from a <see cref="VolumeDefinition"/>. Dispose the instance to remove the volume.</summary>
 /// <remarks>Disposing only removes the volume when this instance created it and <see cref="VolumeDefinition.ReuseId"/> is not set. A volume that already existed when <see cref="EnsureCreatedAsync(CancellationToken)"/> ran is adopted and left behind, so pointing a definition at an existing volume never destroys it.</remarks>
-public class TemporaryVolume : IAsyncDisposable
+public sealed class TemporaryVolume : IAsyncDisposable
 {
     private readonly VolumeDefinition _definition;
     private ContainerRuntime? _runtime;

--- a/src/Meziantou.Framework.TemporaryContainers/VolumeDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/VolumeDefinition.cs
@@ -1,0 +1,71 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>Describes how a volume should be created. Configure an instance and call <see cref="CreateVolume"/> to obtain a <see cref="TemporaryVolume"/>.</summary>
+/// <example>
+/// <code>
+/// await using var volume = new VolumeDefinition().CreateVolume();
+///
+/// var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8"));
+/// definition.Mounts.AddVolume(volume, "/data");
+///
+/// await using var container = definition.CreateContainer();
+/// await container.StartAsync();
+/// </code>
+/// </example>
+public class VolumeDefinition
+{
+    private ContainerRuntime _runtime = ContainerRuntime.Auto;
+
+    /// <summary>Initializes a new instance of the <see cref="VolumeDefinition"/> class.</summary>
+    public VolumeDefinition()
+    {
+        Labels = new ContainerLabelCollection();
+        DriverOptions = new VolumeDriverOptionCollection();
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="VolumeDefinition"/> class by deep-copying another definition.</summary>
+    /// <param name="other">The definition to copy.</param>
+    public VolumeDefinition(VolumeDefinition other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        Runtime = other.Runtime;
+        Name = other.Name;
+        Driver = other.Driver;
+        ReuseId = other.ReuseId;
+        Labels = new ContainerLabelCollection(other.Labels);
+        DriverOptions = new VolumeDriverOptionCollection(other.DriverOptions);
+    }
+
+    /// <summary>Gets or sets the container runtime to use.</summary>
+    public ContainerRuntime Runtime
+    {
+        get => _runtime;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _runtime = value;
+        }
+    }
+
+    /// <summary>Gets or sets the volume name. When <see langword="null"/>, a random name is generated, or a name derived from <see cref="ReuseId"/> when that is set.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Gets or sets the volume driver. When <see langword="null"/>, the runtime uses its default driver.</summary>
+    public string? Driver { get; set; }
+
+    /// <summary>Gets or sets an identifier used to reuse an existing volume across runs. When set, the volume is not removed on dispose.</summary>
+    public string? ReuseId { get; set; }
+
+    /// <summary>Gets the labels.</summary>
+    public ContainerLabelCollection Labels { get; }
+
+    /// <summary>Gets the driver-specific options.</summary>
+    public VolumeDriverOptionCollection DriverOptions { get; }
+
+    /// <summary>Creates a <see cref="TemporaryVolume"/> from a deep copy of this definition. Later changes to this definition do not affect the returned volume.</summary>
+    /// <returns>A new volume.</returns>
+    public virtual TemporaryVolume CreateVolume()
+    {
+        return new TemporaryVolume(new VolumeDefinition(this));
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/VolumeDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/VolumeDefinition.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Framework.TemporaryContainers;
 /// await container.StartAsync();
 /// </code>
 /// </example>
-public class VolumeDefinition
+public sealed class VolumeDefinition
 {
     private ContainerRuntime _runtime = ContainerRuntime.Auto;
 
@@ -64,7 +64,7 @@ public class VolumeDefinition
 
     /// <summary>Creates a <see cref="TemporaryVolume"/> from a deep copy of this definition. Later changes to this definition do not affect the returned volume.</summary>
     /// <returns>A new volume.</returns>
-    public virtual TemporaryVolume CreateVolume()
+    public TemporaryVolume CreateVolume()
     {
         return new TemporaryVolume(new VolumeDefinition(this));
     }

--- a/src/Meziantou.Framework.TemporaryContainers/VolumeDriverOptionCollection.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/VolumeDriverOptionCollection.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A collection of driver-specific options applied to a volume.</summary>
+public sealed class VolumeDriverOptionCollection : IEnumerable<KeyValuePair<string, string>>
+{
+    private readonly Dictionary<string, string> _options;
+
+    internal VolumeDriverOptionCollection()
+    {
+        _options = new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+
+    internal VolumeDriverOptionCollection(VolumeDriverOptionCollection other)
+    {
+        _options = new Dictionary<string, string>(other._options, StringComparer.Ordinal);
+    }
+
+    /// <summary>Gets the number of options in the collection.</summary>
+    public int Count => _options.Count;
+
+    /// <summary>Adds or replaces an option.</summary>
+    /// <param name="name">The option name.</param>
+    /// <param name="value">The option value.</param>
+    public void Add(string name, string value)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
+        _options[name] = value;
+    }
+
+    /// <summary>Removes an option.</summary>
+    /// <param name="name">The option name.</param>
+    /// <returns><see langword="true"/> if the option was removed; otherwise, <see langword="false"/>.</returns>
+    public bool Remove(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return _options.Remove(name);
+    }
+
+    /// <summary>Determines whether an option is defined.</summary>
+    /// <param name="name">The option name.</param>
+    /// <returns><see langword="true"/> if the option is defined; otherwise, <see langword="false"/>.</returns>
+    public bool Contains(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return _options.ContainsKey(name);
+    }
+
+    /// <summary>Returns an enumerator over the options.</summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _options.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Meziantou.Framework.TemporaryContainers/VolumeMount.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/VolumeMount.cs
@@ -3,4 +3,5 @@ namespace Meziantou.Framework.TemporaryContainers;
 /// <summary>A named volume mounted into the container.</summary>
 /// <param name="Name">The volume name.</param>
 /// <param name="Target">The path inside the container.</param>
-public sealed record VolumeMount(string Name, string Target) : IMount;
+/// <param name="ReadOnly">Whether the mount is read-only.</param>
+public sealed record VolumeMount(string Name, string Target, bool ReadOnly = false) : IMount;

--- a/src/Meziantou.Framework.TemporaryContainers/readme.md
+++ b/src/Meziantou.Framework.TemporaryContainers/readme.md
@@ -31,6 +31,33 @@ await using var container = definition.CreateContainer();
 await container.StartAsync();
 ```
 
+## Volumes and mounts
+
+```c#
+var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8"));
+definition.Mounts.AddBindMount("/host/data", "/data", readOnly: true);
+definition.Mounts.AddVolume("existing-volume", "/var/lib/redis");
+definition.Mounts.AddTmpfs("/scratch");
+```
+
+A `TemporaryVolume` creates the volume and removes it when disposed, so a test can share data between two containers without leaving anything behind:
+
+```c#
+await using var volume = new VolumeDefinition().CreateVolume();
+
+var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8"));
+definition.Mounts.AddVolume(volume, "/data"); // add `readOnly: true` for a read-only mount
+
+await using var container = definition.CreateContainer();
+await container.StartAsync(); // creates the volume if needed, then the container
+```
+
+Declare the volume before the containers that mount it, so it is disposed last: a runtime refuses to remove a volume a container still references.
+
+The volume is only removed when the library created it. A `VolumeDefinition.Name` that already exists is adopted and left behind, and a volume with a `ReuseId` is kept so the next run can reuse it. Anonymous volumes declared by the image are removed with the container.
+
+Runtime differences: `wslc` has no volume commands; Apple's `container` has no volume driver, its mount descriptors cannot contain a comma, and (as of 1.1.0) it hangs on a container that mounts a volume a deleted container used, so a volume there is best kept to a single container.
+
 ## Database helpers
 
 `CreateRedis`, `CreatePostgreSql`, `CreateMongoDb`, and `CreateSqlServer` return pre-configured definitions whose container exposes `GetConnectionString()`.

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
@@ -14,4 +14,12 @@ public sealed class AppleContainerContainerTests() : ContainerRuntimeTestsBase(C
 
     [Fact]
     public Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout() => AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync();
+
+    // AssertVolumeSharedBetweenContainersAsync is not run here: apple/container 1.1.0 hangs on any operation against
+    // a container that mounts a volume a deleted container used, which takes the whole test host down with it.
+    [Fact]
+    public Task Volume_IsCreatedWithTheContainerAndRemovedOnDemand() => AssertVolumeLifecycleAsync();
+
+    [Fact]
+    public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
@@ -40,18 +40,57 @@ public sealed class AppleContainerRuntimeAdapterTests
     }
 
     [Fact]
+    public void BuildCreateMapsMountsAndResources()
+    {
+        var runtime = CreateRuntime();
+        var definition = new ContainerDefinition(new RegistryImage("nginx"));
+        definition.Resources.ReadOnlyRootFilesystem = true;
+        definition.Network.Network = "my-network";
+        definition.Mounts.AddBindMount("/host", "/container", readOnly: true);
+        definition.Mounts.AddVolume("data", "/var/lib/data");
+        definition.Mounts.AddVolume("config", "/etc/app", readOnly: true);
+        definition.Mounts.AddTmpfs("/scratch");
+
+        var args = runtime.BuildCreateArguments(definition, "nginx");
+
+        Assert.Contains("--read-only", args);
+        Assert.Contains("--network", args);
+        Assert.Contains("my-network", args);
+        Assert.Contains("type=bind,source=/host,target=/container,readonly", args);
+        Assert.Contains("type=volume,source=data,target=/var/lib/data", args);
+        Assert.Contains("type=volume,source=config,target=/etc/app,readonly", args);
+        Assert.Contains("--tmpfs", args);
+        Assert.Contains("/scratch", args);
+    }
+
+    [Fact]
+    public void BuildsVolumeArguments()
+    {
+        var runtime = CreateRuntime();
+        var definition = new VolumeDefinition();
+        definition.Labels.Add("owner", "meziantou");
+        definition.DriverOptions.Add("size", "10m");
+
+        Assert.Equal("volume create --label owner=meziantou --opt size=10m my-volume", string.Join(' ', runtime.BuildCreateVolumeArguments(definition, "my-volume")));
+        Assert.Equal("volume delete my-volume", string.Join(' ', runtime.BuildDeleteVolumeArguments("my-volume")));
+        Assert.Equal("volume inspect my-volume", string.Join(' ', runtime.BuildVolumeExistsArguments("my-volume")));
+    }
+
+    [Fact]
     public void ThrowsForUnsupportedOptions()
     {
         var runtime = CreateRuntime();
 
-        var readOnly = new ContainerDefinition(new RegistryImage("nginx"));
-        readOnly.Resources.ReadOnlyRootFilesystem = true;
-        Assert.Throws<NotSupportedException>(() => runtime.BuildCreateArguments(readOnly, "nginx"));
+        var alias = new ContainerDefinition(new RegistryImage("nginx"));
+        alias.Network.Alias = "my-alias";
+        Assert.Throws<NotSupportedException>(() => runtime.BuildCreateArguments(alias, "nginx"));
 
-        var tmpfs = new ContainerDefinition(new RegistryImage("nginx"));
-        tmpfs.Mounts.AddTmpfs("/tmp");
-        Assert.Throws<NotSupportedException>(() => runtime.BuildCreateArguments(tmpfs, "nginx"));
+        // Apple's parser splits the mount descriptor on ',' without honouring quotes.
+        var comma = new ContainerDefinition(new RegistryImage("nginx"));
+        comma.Mounts.AddBindMount("/host/a,b", "/container");
+        Assert.Throws<NotSupportedException>(() => runtime.BuildCreateArguments(comma, "nginx"));
 
+        Assert.Throws<NotSupportedException>(() => runtime.BuildCreateVolumeArguments(new VolumeDefinition { Driver = "local" }, "my-volume"));
         Assert.Throws<NotSupportedException>(() => runtime.BuildPauseArguments("abc"));
         Assert.Throws<NotSupportedException>(() => runtime.BuildRestartArguments("abc"));
     }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -575,6 +575,107 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
         Assert.Equal(ContainerState.Running, (await container.InspectAsync(XunitCancellationToken)).State);
     }
 
+    /// <summary>Shared assertion that the library creates the volume a container mounts, that the volume outlives the
+    /// container, and that it is removed on demand (called from the runtimes that support volumes).</summary>
+    protected Task AssertVolumeLifecycleAsync()
+    {
+        return ContainerTestHelper.RunWithRuntimeRetryAsync(async () =>
+        {
+            var mountPath = UseWindowsContainerImages ? "C:/data" : "/data";
+            var filePath = mountPath + "/payload.txt";
+
+            // The volume is declared first so it is disposed last: a runtime refuses to remove a volume a container
+            // still references, and that failure would be swallowed by the best-effort cleanup.
+            await using var volume = new VolumeDefinition { Runtime = Runtime }.CreateVolume();
+            Assert.False(await volume.ExistsAsync(XunitCancellationToken));
+
+            var definition = CreateHttpServerDefinition();
+            definition.Mounts.AddVolume(volume, mountPath);
+            await using (var container = await StartWithRetryAsync(definition))
+            {
+                // Starting the container is what creates the volume: nothing called EnsureCreatedAsync.
+                Assert.True(await volume.ExistsAsync(XunitCancellationToken), "Starting the container did not create the volume it mounts.");
+
+                using var payload = new MemoryStream(Encoding.UTF8.GetBytes("content written through the mount"));
+                await container.WriteFileAsync(filePath, payload, XunitCancellationToken);
+
+                await using var stream = await container.OpenReadAsync(filePath, XunitCancellationToken);
+                using var streamReader = new StreamReader(stream);
+                Assert.Equal("content written through the mount", await streamReader.ReadToEndAsync(XunitCancellationToken));
+            }
+
+            Assert.True(await volume.ExistsAsync(XunitCancellationToken), "The volume did not survive the container that mounted it.");
+
+            await volume.DeleteAsync(XunitCancellationToken);
+            Assert.False(await volume.ExistsAsync(XunitCancellationToken), "The volume was not removed.");
+        }, XunitCancellationToken);
+    }
+
+    /// <summary>Shared assertion that a volume carries its content from one container to the next (called from the
+    /// runtimes that support it). Apple's <c>container</c> 1.1.0 hangs on any operation against a container that
+    /// mounts a volume a deleted container used, so this is not run for every runtime.</summary>
+    protected Task AssertVolumeSharedBetweenContainersAsync()
+    {
+        return ContainerTestHelper.RunWithRuntimeRetryAsync(async () =>
+        {
+            var mountPath = UseWindowsContainerImages ? "C:/data" : "/data";
+            var filePath = mountPath + "/payload.txt";
+
+            await using var volume = new VolumeDefinition { Runtime = Runtime }.CreateVolume();
+
+            var writerDefinition = CreateHttpServerDefinition();
+            writerDefinition.Mounts.AddVolume(volume, mountPath);
+            await using (var writer = await StartWithRetryAsync(writerDefinition))
+            {
+                using var payload = new MemoryStream(Encoding.UTF8.GetBytes("content from the first container"));
+                await writer.WriteFileAsync(filePath, payload, XunitCancellationToken);
+            }
+
+            var readerDefinition = CreateHttpServerDefinition();
+            readerDefinition.Mounts.AddVolume(volume, mountPath);
+            await using (var reader = await StartWithRetryAsync(readerDefinition))
+            {
+                await using var stream = await reader.OpenReadAsync(filePath, XunitCancellationToken);
+                using var streamReader = new StreamReader(stream);
+                Assert.Equal("content from the first container", await streamReader.ReadToEndAsync(XunitCancellationToken));
+            }
+        }, XunitCancellationToken);
+    }
+
+    /// <summary>Shared assertion that a read-only volume mount rejects writes (called from the runtimes that support volumes).</summary>
+    protected Task AssertReadOnlyVolumeMountAsync()
+    {
+        return ContainerTestHelper.RunWithRuntimeRetryAsync(async () =>
+        {
+            var mountPath = UseWindowsContainerImages ? "C:/data" : "/data";
+
+            await using var volume = new VolumeDefinition { Runtime = Runtime }.CreateVolume();
+
+            var definition = CreateHttpServerDefinition();
+            definition.Mounts.AddVolume(volume, mountPath, readOnly: true);
+            await using var container = await StartWithRetryAsync(definition);
+
+            var exec = await container.ExecAsync(options =>
+            {
+                if (UseWindowsContainerImages)
+                {
+                    options.Command.Add("powershell");
+                    options.Command.Add("-NoProfile");
+                    options.Command.Add("-Command");
+                    options.Command.Add($"Set-Content -Path {mountPath}/denied.txt -Value 'nope'");
+                }
+                else
+                {
+                    options.Command.Add("sh");
+                    options.Command.Add("-c");
+                    options.Command.Add($"echo nope > {mountPath}/denied.txt");
+                }
+            }, XunitCancellationToken);
+
+            Assert.NotEqual(0, exec.ExitCode);
+        }, XunitCancellationToken);
+    }
+
     protected ContainerDefinition CreateHttpServerDefinition()
     {
         var definition = new ContainerDefinition(new RegistryImage(ContainerImage))

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -596,12 +596,8 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
                 // Starting the container is what creates the volume: nothing called EnsureCreatedAsync.
                 Assert.True(await volume.ExistsAsync(XunitCancellationToken), "Starting the container did not create the volume it mounts.");
 
-                using var payload = new MemoryStream(Encoding.UTF8.GetBytes("content written through the mount"));
-                await container.WriteFileAsync(filePath, payload, XunitCancellationToken);
-
-                await using var stream = await container.OpenReadAsync(filePath, XunitCancellationToken);
-                using var streamReader = new StreamReader(stream);
-                Assert.Equal("content written through the mount", await streamReader.ReadToEndAsync(XunitCancellationToken));
+                await WriteThroughMountAsync(container, filePath, "content written through the mount");
+                Assert.Equal("content written through the mount", await ReadThroughMountAsync(container, filePath));
             }
 
             Assert.True(await volume.ExistsAsync(XunitCancellationToken), "The volume did not survive the container that mounted it.");
@@ -627,19 +623,64 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
             writerDefinition.Mounts.AddVolume(volume, mountPath);
             await using (var writer = await StartWithRetryAsync(writerDefinition))
             {
-                using var payload = new MemoryStream(Encoding.UTF8.GetBytes("content from the first container"));
-                await writer.WriteFileAsync(filePath, payload, XunitCancellationToken);
+                await WriteThroughMountAsync(writer, filePath, "content from the first container");
             }
 
             var readerDefinition = CreateHttpServerDefinition();
             readerDefinition.Mounts.AddVolume(volume, mountPath);
             await using (var reader = await StartWithRetryAsync(readerDefinition))
             {
-                await using var stream = await reader.OpenReadAsync(filePath, XunitCancellationToken);
-                using var streamReader = new StreamReader(stream);
-                Assert.Equal("content from the first container", await streamReader.ReadToEndAsync(XunitCancellationToken));
+                Assert.Equal("content from the first container", await ReadThroughMountAsync(reader, filePath));
             }
         }, XunitCancellationToken);
+    }
+
+    /// <summary>Writes a file inside a mount from within the container. The copy commands cannot be used for this:
+    /// on Windows containers <c>docker cp</c> writes into the container's own layer instead of the mounted volume, so
+    /// the content never reaches the volume.</summary>
+    private async Task WriteThroughMountAsync(TemporaryContainer container, string path, string content)
+    {
+        var exec = await container.ExecAsync(options =>
+        {
+            if (UseWindowsContainerImages)
+            {
+                options.Command.Add("powershell");
+                options.Command.Add("-NoProfile");
+                options.Command.Add("-Command");
+                options.Command.Add($"Set-Content -Path {path} -Value '{content}' -NoNewline");
+            }
+            else
+            {
+                options.Command.Add("sh");
+                options.Command.Add("-c");
+                options.Command.Add($"printf %s '{content}' > {path}");
+            }
+        }, XunitCancellationToken);
+
+        Assert.Equal(0, exec.ExitCode);
+    }
+
+    /// <summary>Reads a file inside a mount from within the container. See <see cref="WriteThroughMountAsync"/> for why the copy commands are not used.</summary>
+    private async Task<string> ReadThroughMountAsync(TemporaryContainer container, string path)
+    {
+        var exec = await container.ExecAsync(options =>
+        {
+            if (UseWindowsContainerImages)
+            {
+                options.Command.Add("powershell");
+                options.Command.Add("-NoProfile");
+                options.Command.Add("-Command");
+                options.Command.Add($"Get-Content -Raw {path}");
+            }
+            else
+            {
+                options.Command.Add("cat");
+                options.Command.Add(path);
+            }
+        }, XunitCancellationToken);
+
+        Assert.Equal(0, exec.ExitCode);
+        return exec.StandardOutput.Trim();
     }
 
     /// <summary>Shared assertion that a read-only volume mount rejects writes (called from the runtimes that support volumes).</summary>

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiCreateRequestBuilderTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiCreateRequestBuilderTests.cs
@@ -22,6 +22,7 @@ public sealed class DockerApiCreateRequestBuilderTests
         definition.Ports.Add(15432, 5432);
         definition.Mounts.AddBindMount("/host", "/container", readOnly: true);
         definition.Mounts.AddVolume("volume-name", "/var/lib/data");
+        definition.Mounts.AddVolume("config-volume", "/etc/app", readOnly: true);
         definition.Mounts.AddTmpfs("/tmpfs");
         definition.Network.Network = "my-network";
         definition.Network.Alias = "my-alias";
@@ -49,7 +50,8 @@ public sealed class DockerApiCreateRequestBuilderTests
         Assert.Equal("15432", payload.HostConfig.PortBindings["5432/tcp"]![0]!.HostPort);
         var mounts = Assert.IsType<List<DockerApiModels.Mount>>(payload.HostConfig.Mounts);
         Assert.Single(mounts, mount => mount.Type == "bind" && mount.Source == "/host" && mount.Target == "/container" && mount.ReadOnly);
-        Assert.Single(mounts, mount => mount.Type == "volume" && mount.Source == "volume-name" && mount.Target == "/var/lib/data");
+        Assert.Single(mounts, mount => mount.Type == "volume" && mount.Source == "volume-name" && mount.Target == "/var/lib/data" && !mount.ReadOnly);
+        Assert.Single(mounts, mount => mount.Type == "volume" && mount.Source == "config-volume" && mount.Target == "/etc/app" && mount.ReadOnly);
         Assert.Equal(string.Empty, payload.HostConfig.Tmpfs!["/tmpfs"]);
         Assert.True(payload.HostConfig.ReadonlyRootfs);
         Assert.Equal(536870912, payload.HostConfig.Memory);

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiRuntimeTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiRuntimeTests.cs
@@ -6,6 +6,25 @@ namespace Meziantou.Framework.TemporaryContainers.Tests;
 
 public sealed class DockerApiRuntimeTests
 {
+    /// <summary>The Docker Engine API has its own volume endpoints, which no other test exercises. It is skipped when the daemon does not answer.</summary>
+    [Fact]
+    public async Task Volumes_CreateExistsAndDelete()
+    {
+        var runtime = new DockerApiRuntime();
+        global::Xunit.Assert.SkipUnless(await runtime.IsSupportedAsync(XunitCancellationToken), "The Docker Engine API is not available on this system.");
+
+        await using var volume = new VolumeDefinition { Runtime = runtime }.CreateVolume();
+        volume.Definition.Labels.Add("owner", "meziantou");
+
+        Assert.False(await volume.ExistsAsync(XunitCancellationToken));
+
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+        Assert.True(await volume.ExistsAsync(XunitCancellationToken));
+
+        await volume.DeleteAsync(XunitCancellationToken);
+        Assert.False(await volume.ExistsAsync(XunitCancellationToken));
+    }
+
     [Fact]
     public async Task ReadMultiplexedLogsAsync_SplitsFramesIntoLines()
     {

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
@@ -13,4 +13,13 @@ public sealed class DockerContainerTests() : ContainerRuntimeTestsBase(Container
 
     [Fact]
     public Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout() => AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync();
+
+    [Fact]
+    public Task Volume_IsCreatedWithTheContainerAndRemovedOnDemand() => AssertVolumeLifecycleAsync();
+
+    [Fact]
+    public Task Volume_CarriesItsContentToTheNextContainer() => AssertVolumeSharedBetweenContainersAsync();
+
+    [Fact]
+    public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerCreateArgumentBuilderTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerCreateArgumentBuilderTests.cs
@@ -20,7 +20,7 @@ public sealed class DockerCreateArgumentBuilderTests
         definition.Resources.MemoryLimit = 536870912;
         definition.Command.Add("--appendonly");
 
-        var args = DockerCreateArgumentBuilder.Build(definition, "redis:8", "missing");
+        var args = DockerCreateArgumentBuilder.Build(definition, "redis:8", "missing", quotedMountFieldsSupported: true);
 
         Assert.Equal("create", args[0]);
         Assert.Contains("--name", args);
@@ -47,9 +47,45 @@ public sealed class DockerCreateArgumentBuilderTests
             ReuseId = "my-reuse-id",
         };
 
-        var args = DockerCreateArgumentBuilder.Build(definition, "redis:8", pullPolicyValue: null);
+        var args = DockerCreateArgumentBuilder.Build(definition, "redis:8", pullPolicyValue: null, quotedMountFieldsSupported: true);
 
         Assert.Contains($"{DockerCreateArgumentBuilder.ReuseLabel}=my-reuse-id", args);
+    }
+
+    [Fact]
+    public void MapsVolumeAndTmpfsMounts()
+    {
+        var definition = new ContainerDefinition(new RegistryImage("alpine"));
+        definition.Mounts.AddVolume("data", "/var/lib/data");
+        definition.Mounts.AddVolume("config", "/etc/app", readOnly: true);
+        definition.Mounts.AddTmpfs("/scratch");
+
+        var args = DockerCreateArgumentBuilder.Build(definition, "alpine", pullPolicyValue: null, quotedMountFieldsSupported: true);
+
+        Assert.Contains("type=volume,source=data,target=/var/lib/data", args);
+        Assert.Contains("type=volume,source=config,target=/etc/app,readonly", args);
+        Assert.Contains("--tmpfs", args);
+        Assert.Contains("/scratch", args);
+    }
+
+    [Fact]
+    public void QuotesMountFieldsContainingASeparator()
+    {
+        var definition = new ContainerDefinition(new RegistryImage("alpine"));
+        definition.Mounts.AddBindMount("""/host/a,b""", """/container/c"d""", readOnly: true);
+
+        var args = DockerCreateArgumentBuilder.Build(definition, "alpine", pullPolicyValue: null, quotedMountFieldsSupported: true);
+
+        Assert.Contains("""type=bind,"source=/host/a,b","target=/container/c""d",readonly""", args);
+    }
+
+    [Fact]
+    public void ThrowsWhenAMountFieldCannotBeQuoted()
+    {
+        var definition = new ContainerDefinition(new RegistryImage("alpine"));
+        definition.Mounts.AddBindMount("/host/a,b", "/container");
+
+        Assert.Throws<NotSupportedException>(() => DockerCreateArgumentBuilder.Build(definition, "alpine", pullPolicyValue: null, quotedMountFieldsSupported: false));
     }
 
     [Fact]
@@ -60,7 +96,7 @@ public sealed class DockerCreateArgumentBuilderTests
         definition.Entrypoint.Add("-c");
         definition.Command.Add("echo hi");
 
-        var args = DockerCreateArgumentBuilder.Build(definition, "alpine", pullPolicyValue: null);
+        var args = DockerCreateArgumentBuilder.Build(definition, "alpine", pullPolicyValue: null, quotedMountFieldsSupported: true);
 
         Assert.Contains("--entrypoint", args);
         Assert.Contains("/bin/sh", args);

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
@@ -54,7 +54,7 @@ public sealed class DockerRuntimeAdapterTests
         Assert.True(runtime.SupportsPause);
         Assert.True(runtime.SupportsRestart);
         Assert.True(runtime.LogsIncludeTimestamps);
-        Assert.Equal("rm -f abc", string.Join(' ', runtime.BuildRemoveArguments("abc")));
+        Assert.Equal("rm -f -v abc", string.Join(' ', runtime.BuildRemoveArguments("abc")));
         Assert.Equal("cp src abc:/dst", string.Join(' ', runtime.BuildCopyToContainerArguments("abc", "src", "/dst")));
         Assert.Equal("cp abc:/src dst", string.Join(' ', runtime.BuildCopyFromContainerArguments("abc", "/src", "dst")));
         Assert.Contains("--timestamps", runtime.BuildLogsArguments("abc"));
@@ -67,6 +67,7 @@ public sealed class DockerRuntimeAdapterTests
         var runtime = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Podman);
 
         Assert.Equal("version", string.Join(' ', runtime.BuildProbeArguments()));
+        Assert.Equal("rm -f -v abc", string.Join(' ', runtime.BuildRemoveArguments("abc")));
     }
 
     [Fact]
@@ -75,6 +76,27 @@ public sealed class DockerRuntimeAdapterTests
         var runtime = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Wslc);
 
         Assert.Equal("list -q", string.Join(' ', runtime.BuildProbeArguments()));
+
+        // wslc has no '-v' flag on 'rm', and no volume commands at all.
+        Assert.Equal("rm -f abc", string.Join(' ', runtime.BuildRemoveArguments("abc")));
+        Assert.Throws<NotSupportedException>(() => runtime.BuildCreateVolumeArguments(new VolumeDefinition(), "vol"));
+        Assert.Throws<NotSupportedException>(() => runtime.BuildDeleteVolumeArguments("vol"));
+        Assert.Throws<NotSupportedException>(() => runtime.BuildVolumeExistsArguments("vol"));
+    }
+
+    [Fact]
+    public void BuildsVolumeArguments()
+    {
+        var runtime = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Docker);
+        var definition = new VolumeDefinition { Driver = "local" };
+        definition.Labels.Add("owner", "meziantou");
+        definition.DriverOptions.Add("size", "10m");
+
+        Assert.Equal("volume create --driver local --label owner=meziantou --opt size=10m my-volume", string.Join(' ', runtime.BuildCreateVolumeArguments(definition, "my-volume")));
+
+        // '--force' is not used: podman would remove the containers still using the volume.
+        Assert.Equal("volume rm my-volume", string.Join(' ', runtime.BuildDeleteVolumeArguments("my-volume")));
+        Assert.Equal("volume inspect my-volume", string.Join(' ', runtime.BuildVolumeExistsArguments("my-volume")));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
@@ -10,4 +10,13 @@ public sealed class PodmanContainerTests() : ContainerRuntimeTestsBase(Container
 
     [Fact]
     public Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout() => AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync();
+
+    [Fact]
+    public Task Volume_IsCreatedWithTheContainerAndRemovedOnDemand() => AssertVolumeLifecycleAsync();
+
+    [Fact]
+    public Task Volume_CarriesItsContentToTheNextContainer() => AssertVolumeSharedBetweenContainersAsync();
+
+    [Fact]
+    public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/VolumeDefinitionTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/VolumeDefinitionTests.cs
@@ -1,0 +1,214 @@
+using Meziantou.Framework.TemporaryContainers.Internals;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+public sealed class VolumeDefinitionTests
+{
+    [Fact]
+    public void CreateVolume_GeneratesANameEveryRuntimeAccepts()
+    {
+        var first = new VolumeDefinition().CreateVolume().Name;
+        var second = new VolumeDefinition().CreateVolume().Name;
+
+        Assert.NotEqual(first, second);
+        Assert.StartsWith("meziantou-tc-", first);
+        Assert.All(first, c => Assert.True(char.IsAsciiLetterOrDigit(c) || c is '_' or '.' or '-', $"'{c}' is not accepted in a volume name."));
+    }
+
+    [Fact]
+    public void CreateVolume_DerivesADeterministicNameFromTheReuseId()
+    {
+        var definition = new VolumeDefinition { ReuseId = "my/reuse:id" };
+
+        var name = definition.CreateVolume().Name;
+
+        Assert.Equal(name, definition.CreateVolume().Name);
+        Assert.Equal("meziantou-tc-my-reuse-id", name);
+    }
+
+    [Fact]
+    public void CreateVolume_KeepsAnExplicitName()
+    {
+        var volume = new VolumeDefinition { Name = "my-volume" }.CreateVolume();
+
+        Assert.Equal("my-volume", volume.Name);
+    }
+
+    [Fact]
+    public void CreateVolume_DeepClonesDefinition()
+    {
+        var definition = new VolumeDefinition();
+        definition.Labels.Add("a", "1");
+        definition.DriverOptions.Add("size", "10m");
+
+        var volume = definition.CreateVolume();
+
+        definition.Labels.Add("b", "2");
+        definition.DriverOptions.Add("type", "tmpfs");
+
+        Assert.True(volume.Definition.Labels.Contains("a"));
+        Assert.False(volume.Definition.Labels.Contains("b"));
+        Assert.True(volume.Definition.DriverOptions.Contains("size"));
+        Assert.False(volume.Definition.DriverOptions.Contains("type"));
+    }
+
+    [Fact]
+    public void CopyConstructor_CopiesScalarProperties()
+    {
+        var original = new VolumeDefinition
+        {
+            Runtime = ContainerRuntime.Podman,
+            Name = "name",
+            Driver = "local",
+            ReuseId = "reuse",
+        };
+
+        var copy = new VolumeDefinition(original);
+
+        Assert.Equal(ContainerRuntime.Podman, copy.Runtime);
+        Assert.Equal("name", copy.Name);
+        Assert.Equal("local", copy.Driver);
+        Assert.Equal("reuse", copy.ReuseId);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_CreatesTheVolumeOnce()
+    {
+        var runtime = new RecordingRuntime();
+        var volume = new VolumeDefinition { Runtime = runtime }.CreateVolume();
+
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+
+        Assert.Equal([volume.Name], runtime.Created);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RemovesTheVolumeItCreated()
+    {
+        var runtime = new RecordingRuntime();
+        var volume = new VolumeDefinition { Runtime = runtime }.CreateVolume();
+
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+        await volume.DisposeAsync();
+
+        Assert.Equal([volume.Name], runtime.Deleted);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_KeepsAVolumeThatAlreadyExisted()
+    {
+        var runtime = new RecordingRuntime();
+        runtime.Volumes.Add("my-volume");
+        var volume = new VolumeDefinition { Runtime = runtime, Name = "my-volume" }.CreateVolume();
+
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+        await volume.DisposeAsync();
+
+        Assert.Empty(runtime.Created);
+        Assert.Empty(runtime.Deleted);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_KeepsAReusedVolume()
+    {
+        var runtime = new RecordingRuntime();
+        var volume = new VolumeDefinition { Runtime = runtime, ReuseId = "reuse" }.CreateVolume();
+
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+        await volume.DisposeAsync();
+
+        Assert.Equal([volume.Name], runtime.Created);
+        Assert.Empty(runtime.Deleted);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ReportsAVolumeThatSurvived()
+    {
+        var runtime = new RecordingRuntime { IgnoreDeletions = true };
+        await using var volume = new VolumeDefinition { Runtime = runtime }.CreateVolume();
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => volume.DeleteAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task StartAsync_CreatesTheMountedVolume()
+    {
+        var runtime = new RecordingRuntime();
+        await using var volume = new VolumeDefinition { Runtime = runtime }.CreateVolume();
+
+        var definition = new ContainerDefinition(ImageSource.FromExisting("sha256:test")) { Runtime = runtime };
+        definition.Mounts.AddVolume(volume, "/data");
+
+        await using var container = definition.CreateContainer();
+        await container.StartAsync(XunitCancellationToken);
+
+        Assert.Equal([volume.Name], runtime.Created);
+    }
+
+    [Fact]
+    public async Task StartAsync_RejectsAVolumeFromAnotherRuntime()
+    {
+        var containerRuntime = new RecordingRuntime();
+        await using var volume = new VolumeDefinition { Runtime = new RecordingRuntime() }.CreateVolume();
+
+        var definition = new ContainerDefinition(ImageSource.FromExisting("sha256:test")) { Runtime = containerRuntime };
+        definition.Mounts.AddVolume(volume, "/data");
+
+        await using var container = definition.CreateContainer();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => container.StartAsync(XunitCancellationToken));
+    }
+
+    /// <summary>A runtime that keeps its volumes in memory, so the ownership rules can be exercised without a daemon.</summary>
+    private sealed class RecordingRuntime : ContainerRuntime
+    {
+        public RecordingRuntime()
+            : base("Recording")
+        {
+        }
+
+        public HashSet<string> Volumes { get; } = new(StringComparer.Ordinal);
+
+        public List<string> Created { get; } = [];
+
+        public List<string> Deleted { get; } = [];
+
+        /// <summary>Mimics a runtime that reports success but leaves the volume behind, as it does when a container still uses it.</summary>
+        public bool IgnoreDeletions { get; set; }
+
+        public override Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        internal override Task CreateVolumeAsync(VolumeDefinition definition, string name, CancellationToken cancellationToken)
+        {
+            Created.Add(name);
+            Volumes.Add(name);
+            return Task.CompletedTask;
+        }
+
+        internal override Task DeleteVolumeAsync(string name, CancellationToken cancellationToken)
+        {
+            Deleted.Add(name);
+            if (!IgnoreDeletions)
+                Volumes.Remove(name);
+
+            return Task.CompletedTask;
+        }
+
+        internal override Task<bool> VolumeExistsAsync(string name, CancellationToken cancellationToken) => Task.FromResult(Volumes.Contains(name));
+
+        internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken) => Task.FromResult("id");
+
+        internal override Task StartAsync(string id, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        internal override Task DeleteAsync(string id, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        internal override Task<ContainerInfo> InspectAsync(string id, CancellationToken cancellationToken)
+            => Task.FromResult(new ContainerInfo { Id = id, Name = "name", State = ContainerState.Running });
+
+        internal override IAsyncEnumerable<LogEntry> GetLogsAsync(string id, CancellationToken cancellationToken) => AsyncEnumerable.Empty<LogEntry>();
+
+        internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition) => new Dictionary<int, int>();
+    }
+}


### PR DESCRIPTION
Volumes in `Meziantou.Framework.TemporaryContainers` were declarative only: a `VolumeMount` name was passed through to the runtime and nothing else happened. The library never created or deleted a volume, so a test had to manage the volume's lifetime itself, and `docker rm -f` ran without `-v`, leaking the image's anonymous volumes on every run.

## Volume lifecycle

- **`VolumeDefinition`** (`Runtime`, `Name`, `Driver`, `ReuseId`, `Labels`, `DriverOptions`, deep-copy ctor, `CreateVolume()`) and **`TemporaryVolume : IAsyncDisposable`** (`Name`, `EnsureCreatedAsync`, `ExistsAsync`, `DeleteAsync`), mirroring `ContainerDefinition` / `TemporaryContainer`. The name is resolved eagerly because Apple's `container volume create` takes it as a mandatory positional argument.
- `EnsureCreatedAsync` probes before creating, so it records ownership **only when it actually created the volume**. Pointing a definition at an existing volume adopts it and dispose leaves it alone — without that probe, `VolumeDefinition.Name = "my-precious-data"` would be destroyed on dispose, since `docker volume create <existing>` is idempotent. The same probe makes creation idempotent on podman and Apple, which reject an existing name.
- `DeleteAsync` re-probes and throws when the volume survived: every runtime reports "still in use" the same way it reports "already gone", so the outcome is confirmed rather than inferred from an exit code.
- `Mounts.AddVolume(TemporaryVolume, path, readOnly)` records the volume and the container creates it on start. A volume bound to a different engine is rejected — otherwise the mismatch surfaces as a mysteriously empty directory rather than an error.
- New volume verbs on `ContainerRuntime`, implemented for the docker/podman CLI, the Docker Engine API and Apple's CLI, and forwarded by `Auto`.

## Fixes along the way

- **`VolumeMount` gains `ReadOnly`**, like `BindMount`. This rewrites the record's primary constructor and `Deconstruct`, so it is binary-breaking and the package version goes to **1.1.0**. The existing 2-arg `AddVolume` is left untouched and a 3-arg overload added, to avoid a second break.
- Anonymous volumes are removed with the container (`rm -f -v`, `?force=1&v=1`). Named volumes are never touched by either flag.
- `--mount` fields containing `,` or `"` are CSV-quoted for docker, and rejected with a clear error on the runtimes whose parsers split on the comma, instead of silently emitting a corrupt descriptor. Both behaviours were checked against the real CLIs.
- Apple's `container` 1.1.0 supports `--tmpfs`, `--read-only`, `--network` and `--mount type=volume,…,readonly`, so those stale `NotSupportedException`s are gone and its mounts now use `--mount` like the other runtimes. Only `--network-alias` still throws — it genuinely does not exist.
- `docker volume rm` is used without `--force`: on docker it only hides the not-found error (already tolerated), while `podman volume rm --force` additionally removes the containers using the volume.

## Reviewer notes

- **`wslc` has no volume commands** and throws. `AutoContainerRuntime` yields `Wslc` first on Windows and caches the resolution, so `ContainerRuntime.Auto` will throw for volume operations on a Windows box with `wslc` even when Docker Desktop is installed. Noted in the readme.
- **Apple runtime limitation:** `container` 1.1.0 hangs indefinitely on any operation (`exec`, `cp`, even `delete -f`) against a container that mounts a volume a *deleted* container previously used, and the daemon degrades badly. `AppleContainerContainerTests` therefore runs the single-container volume lifecycle test but not the cross-container one. Documented in the readme.
- `OwnedVolumeMount` is internal and correctly absent from `ref/`; the rest of the `ref/` diff is the intended new public surface.

## Verification

- `dotnet build` in Release with `IsOfficialBuild=true` and `TreatWarningsAsErrors=true`; `ref/` regenerated and committed. `dotnet run ./eng/update-all.cs` produced no further changes. Dependent projects (`Trimmable`, `Http.Caching.Tests`) build.
- Full test suite on net10.0 and net11.0: **268 passed, 48 skipped** (podman and wslc are not installed on the dev machine), **4 failed** — the two `SqlServerContainerTests` × 2 TFMs, failing on `image … does not support required platforms` because there is no arm64 mssql image for Apple's runtime. Pre-existing on that machine and unrelated to this change.
- All volume tests pass on both TFMs, including the docker and Apple integration tests and the Docker Engine API volume endpoints. Docker volume count was identical before and after the run, and no Apple volumes were left behind.
