### PR TITLE
Support the remaining analysis contexts in DiagnosticReporter

### DIFF
--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.g.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.g.cs
@@ -402,4 +402,316 @@ internal static partial class ContextExtensions
 
     public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, location, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, location, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, attribute, messageArgs);
+
+    public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, location, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, location, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, attribute, messageArgs);
+
+    public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, location, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, location, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, attribute, messageArgs);
+
+    public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxToken syntaxToken, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxToken, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxNode syntaxNode, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxNode, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ISymbol symbol, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, symbol, reportOptions, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, location, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, Location location, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, location, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, attribute, messageArgs);
+
+    public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
 }

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.tt
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.tt
@@ -16,7 +16,7 @@ namespace Meziantou.Framework.Roslyn;
 
 internal static partial class ContextExtensions
 {
-<# foreach (string type in new string[] { "SyntaxNodeAnalysisContext", "SymbolAnalysisContext", "OperationAnalysisContext", "OperationBlockAnalysisContext", "CompilationAnalysisContext" }) { #>
+<# foreach (string type in new string[] { "SyntaxNodeAnalysisContext", "SymbolAnalysisContext", "OperationAnalysisContext", "OperationBlockAnalysisContext", "CompilationAnalysisContext", "SemanticModelAnalysisContext", "SyntaxTreeAnalysisContext", "CodeBlockAnalysisContext", "AdditionalFileAnalysisContext" }) { #>
     public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
@@ -51,6 +51,34 @@ internal readonly struct DiagnosticReporter
         CancellationToken = context.CancellationToken;
     }
 
+    public DiagnosticReporter(SemanticModelAnalysisContext context)
+    {
+        _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
+        CancellationToken = context.CancellationToken;
+    }
+
+    public DiagnosticReporter(SyntaxTreeAnalysisContext context)
+    {
+        _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
+        CancellationToken = context.CancellationToken;
+    }
+
+    public DiagnosticReporter(CodeBlockAnalysisContext context)
+    {
+        _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
+        CancellationToken = context.CancellationToken;
+    }
+
+    public DiagnosticReporter(AdditionalFileAnalysisContext context)
+    {
+        _reportDiagnostic = context.ReportDiagnostic;
+        Options = context.Options;
+        CancellationToken = context.CancellationToken;
+    }
+
     /// <summary>
     /// Gets or sets a filter evaluated before a diagnostic is reported by any <see cref="DiagnosticReporter"/>. When the filter returns <see langword="false"/>, the diagnostic is not reported.
     /// </summary>
@@ -77,4 +105,8 @@ internal readonly struct DiagnosticReporter
     public static implicit operator DiagnosticReporter(OperationBlockAnalysisContext context) => new(context);
     public static implicit operator DiagnosticReporter(SyntaxNodeAnalysisContext context) => new(context);
     public static implicit operator DiagnosticReporter(CompilationAnalysisContext context) => new(context);
+    public static implicit operator DiagnosticReporter(SemanticModelAnalysisContext context) => new(context);
+    public static implicit operator DiagnosticReporter(SyntaxTreeAnalysisContext context) => new(context);
+    public static implicit operator DiagnosticReporter(CodeBlockAnalysisContext context) => new(context);
+    public static implicit operator DiagnosticReporter(AdditionalFileAnalysisContext context) => new(context);
 }

--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
 
     <developmentDependency>true</developmentDependency>

--- a/src/Meziantou.Framework.Roslyn/readme.md
+++ b/src/Meziantou.Framework.Roslyn/readme.md
@@ -70,6 +70,8 @@ DiagnosticReporter.CanReportDiagnostic = (diagnostic, options, cancellationToken
     => diagnostic.Location.SourceTree?.IsGeneratedCode(options, cancellationToken) is not true;
 ````
 
+`DiagnosticReporter` converts implicitly from every analysis context that can report a diagnostic: `SyntaxNodeAnalysisContext`, `SymbolAnalysisContext`, `OperationAnalysisContext`, `OperationBlockAnalysisContext`, `CompilationAnalysisContext`, `SemanticModelAnalysisContext`, `SyntaxTreeAnalysisContext`, `CodeBlockAnalysisContext` and `AdditionalFileAnalysisContext`. The `ReportDiagnostic` extension methods are available on all of them.
+
 The delegate gets the `Diagnostic` about to be reported, so the descriptor is available with `diagnostic.Descriptor` and the syntax tree with `diagnostic.Location.SourceTree`. The `AnalyzerOptions` and the `CancellationToken` are the ones of the context the diagnostic is reported from.
 
 The filter is meant to be set once, when the analyzer is initialized. As all types of this package are embedded, it only applies to the assembly that consumes the package. Diagnostics reported directly on a Roslyn context, such as `SymbolAnalysisContext.ReportDiagnostic(Diagnostic)`, don't go through the reporter and are not filtered.

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 using Meziantou.Framework.Roslyn;
 
 namespace Meziantou.Framework.Roslyn.Tests;
@@ -232,11 +233,14 @@ public sealed class RoslynHelperTests
 
         Assert.Equal(
             [
+                "Message CodeBlockAnalysisContext",
                 "Message CompilationAnalysisContext",
                 "Message OperationAnalysisContext",
                 "Message OperationBlockAnalysisContext",
+                "Message SemanticModelAnalysisContext",
                 "Message SymbolAnalysisContext",
                 "Message SyntaxNodeAnalysisContext",
+                "Message SyntaxTreeAnalysisContext",
             ],
             diagnostics.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture)).Distinct(StringComparer.Ordinal).OrderBy(message => message, StringComparer.Ordinal));
     }
@@ -346,8 +350,25 @@ public sealed class RoslynHelperTests
             [
                 "Message context-kept",
                 "Message reporter-kept",
+                "Message tree-kept",
             ],
             diagnostics.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture)).OrderBy(message => message, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task DiagnosticReporter_ReportsTheDiagnosticsOfAnAdditionalFileAnalysisContext()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample;
+            """);
+
+        var diagnostics = await compilation
+            .WithAnalyzers([new AdditionalFileAnalyzer()], new AnalyzerOptions([new TestAdditionalText("sample.txt", "content")]))
+            .GetAnalyzerDiagnosticsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ["Message sample.txt"],
+            diagnostics.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture)));
     }
 
     [Fact]
@@ -2297,6 +2318,7 @@ public sealed class RoslynHelperTests
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, SyntaxKind.ClassDeclaration);
+            context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
         }
 
         private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
@@ -2309,10 +2331,54 @@ public sealed class RoslynHelperTests
             context.ReportDiagnostic(Descriptor, declaration, "context-kept");
             context.ReportDiagnostic(Descriptor, declaration, "context-dropped");
         }
+
+        private static void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
+        {
+            var location = context.Tree.GetRoot(context.CancellationToken).GetLocation();
+
+            context.ReportDiagnostic(Descriptor, location, "tree-kept");
+            context.ReportDiagnostic(Descriptor, location, "tree-dropped");
+        }
     }
 #pragma warning restore RS1041
 #pragma warning restore RS1038
 #pragma warning restore RS1036
+
+    // RS1036/RS1038/RS1041 only apply to analyzers shipped in an analyzer package. This one only exists to exercise the extension methods.
+#pragma warning disable RS1036 // A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>'
+#pragma warning disable RS1038 // This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces
+#pragma warning disable RS1041 // This compiler extension should not be implemented in an assembly with target framework
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class AdditionalFileAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Descriptor = new("MFTEST005", "Title", "Message {0}", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterAdditionalFileAction(AnalyzeAdditionalFile);
+        }
+
+        private static void AnalyzeAdditionalFile(AdditionalFileAnalysisContext context)
+        {
+            var location = Location.Create(context.AdditionalFile.Path, new TextSpan(0, 0), new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 0)));
+
+            context.ReportDiagnostic(Descriptor, location, Path.GetFileName(context.AdditionalFile.Path));
+        }
+    }
+#pragma warning restore RS1041
+#pragma warning restore RS1038
+#pragma warning restore RS1036
+
+    private sealed class TestAdditionalText(string path, string text) : AdditionalText
+    {
+        public override string Path { get; } = path;
+
+        public override SourceText GetText(CancellationToken cancellationToken = default) => SourceText.From(text);
+    }
 
     // RS1036/RS1038/RS1041 only apply to analyzers shipped in an analyzer package. This one only exists to exercise the extension methods.
 #pragma warning disable RS1036 // A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>'
@@ -2372,6 +2438,9 @@ public sealed class RoslynHelperTests
             context.RegisterOperationAction(operationContext => ReportWhenOptionsMatch(operationContext, operationContext.Options, operationContext.Operation.Syntax.GetLocation(), nameof(OperationAnalysisContext)), OperationKind.Invocation);
             context.RegisterOperationBlockAction(operationBlockContext => ReportWhenOptionsMatch(operationBlockContext, operationBlockContext.Options, operationBlockContext.OperationBlocks[0].Syntax.GetLocation(), nameof(OperationBlockAnalysisContext)));
             context.RegisterCompilationAction(compilationContext => ReportWhenOptionsMatch(compilationContext, compilationContext.Options, location: null, nameof(CompilationAnalysisContext)));
+            context.RegisterSemanticModelAction(semanticModelContext => ReportWhenOptionsMatch(semanticModelContext, semanticModelContext.Options, semanticModelContext.SemanticModel.SyntaxTree.GetRoot(semanticModelContext.CancellationToken).GetLocation(), nameof(SemanticModelAnalysisContext)));
+            context.RegisterSyntaxTreeAction(syntaxTreeContext => ReportWhenOptionsMatch(syntaxTreeContext, syntaxTreeContext.Options, syntaxTreeContext.Tree.GetRoot(syntaxTreeContext.CancellationToken).GetLocation(), nameof(SyntaxTreeAnalysisContext)));
+            context.RegisterCodeBlockAction(codeBlockContext => ReportWhenOptionsMatch(codeBlockContext, codeBlockContext.Options, codeBlockContext.CodeBlock.GetLocation(), nameof(CodeBlockAnalysisContext)));
         }
 
         private static void ReportWhenOptionsMatch(DiagnosticReporter reporter, AnalyzerOptions options, Location? location, string contextName)


### PR DESCRIPTION
## What

`DiagnosticReporter` now converts implicitly from every Roslyn analysis context that can report a diagnostic. Four were missing:

- `SemanticModelAnalysisContext`
- `SyntaxTreeAnalysisContext`
- `CodeBlockAnalysisContext`
- `AdditionalFileAnalysisContext`

The `ReportDiagnostic` extension methods are generated for them too (`ContextExtensions.tt`, +312 lines in the generated file).

## Why

Only `SyntaxNodeAnalysisContext`, `SymbolAnalysisContext`, `OperationAnalysisContext`, `OperationBlockAnalysisContext` and `CompilationAnalysisContext` were supported. An analyzer reporting from one of the other four had to call `ReportDiagnostic` directly on the context, which bypasses the global `DiagnosticReporter.CanReportDiagnostic` filter. Consumers ended up writing their own extension method plus a duplicate of the filtering logic to work around it.

## Notes for the reviewer

- The set of contexts was determined by reflecting over `Microsoft.CodeAnalysis.Common`: the ones exposing `ReportDiagnostic` + `Options` + `CancellationToken` are exactly the five already supported plus these four. `CompilationStartAnalysisContext`, `SymbolStartAnalysisContext`, `OperationBlockStartAnalysisContext`, `CodeBlockStartAnalysisContext<T>` and `SuppressionAnalysisContext` have no `ReportDiagnostic` and are correctly excluded.
- No `ROSLYN_*` guard is needed: all four types are present as far back as Roslyn 3.11 (verified against 3.11.0, 4.0.0, 4.0.1, 4.1.0, 4.2.0 and 4.8.0).
- `ContextExtensions.g.cs` is regenerated by `dotnet run ./eng/update-all.cs`.
- Package version bumped to 1.0.11, following the per-feature convention.

## Tests

- `DiagnosticFilterAnalyzer` now also reports from a `SyntaxTreeAnalysisContext`, asserting those diagnostics go through the global filter.
- `AnalyzerOptionsAnalyzer` registers semantic-model, syntax-tree and code-block actions, asserting each reporter exposes its context's `AnalyzerOptions`.
- New `AdditionalFileAnalyzer` test covers the additional-file path with a `TestAdditionalText`.

## Verification

- `dotnet build` of the src project plus `dotnet test` on all four test projects (Roslyn 4.8 / 5.0 / 5.3 / 5.6) with `/p:TreatsWarningsAsErrors=true`: 316 / 316 / 316 / 318 passing, 0 warnings.
- Package tests: 14/14.
- `dotnet run ./eng/update-all.cs` exits 0 with no files left to update.
- `git diff --check` clean.
