### PR TITLE
Run the wslc container tests on the Windows CI agents

### DIFF
--- a/.github/actions/setup-wslc/action.yml
+++ b/.github/actions/setup-wslc/action.yml
@@ -1,0 +1,43 @@
+name: 'Setup wslc'
+description: 'Installs the pre-release WSL, which ships the wslc container CLI, and puts wslc.exe on the PATH'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install the pre-release WSL
+      shell: pwsh
+      run: |
+        # wslc ships inside WSL itself, and only the pre-release channel carries it (WSL 2.9.3 or higher)
+        wsl --update --pre-release
+        if ($LASTEXITCODE -ne 0) { throw "wsl --update --pre-release failed with exit code $LASTEXITCODE" }
+
+        wsl --version
+
+    - name: Locate wslc.exe
+      shell: pwsh
+      run: |
+        # The runner captured its PATH before WSL was updated, so a freshly installed wslc.exe does not
+        # resolve yet. Find it and publish its directory to the jobs that come next.
+        $candidates = @(
+          Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\wslc.exe"
+          Join-Path $env:ProgramFiles "WSL\wslc.exe"
+          Join-Path $env:SystemRoot "System32\wslc.exe"
+        )
+
+        $wslc = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+        if (-not $wslc) {
+          $wslc = Get-ChildItem -LiteralPath (Join-Path $env:ProgramFiles "WindowsApps") -Filter "wslc.exe" -Recurse -ErrorAction SilentlyContinue
+            | Select-Object -First 1 -ExpandProperty FullName
+        }
+
+        if (-not $wslc) {
+          # Reported as a warning so the missing runtime surfaces where it is meaningful: the version step of
+          # the debug job, and the Wslc tests themselves
+          Write-Host "::warning::wslc.exe was not found. Searched: $($candidates -join ', ') and $env:ProgramFiles\WindowsApps"
+          Get-AppxPackage -Name "*WindowsSubsystemForLinux*" | Format-List -Property Name, Version, InstallLocation | Out-String | Write-Host
+          Get-ChildItem -LiteralPath (Join-Path $env:ProgramFiles "WSL") -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name | Out-String | Write-Host
+          exit 0
+        }
+
+        Write-Host "Found wslc: $wslc"
+        Add-Content -LiteralPath $env:GITHUB_PATH -Value (Split-Path -Parent $wslc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,18 +419,10 @@ jobs:
                 Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
               }
 
-          # wslc ships with WSL, and only the pre-release channel provides it. The Wslc tests fail instead of
-          # skipping on Windows agents, so this step is what keeps them running.
-          - name: Install WSL containers (wslc)
+          # The Wslc tests fail instead of skipping on Windows agents, so this step is what keeps them running
+          - name: Setup wslc
             if: startsWith(matrix.runs-on, 'windows') && matrix.test-group.id == 'TemporaryContainers' && steps.build-project.outputs.has-project == 'true'
-            run: |
-              wsl --update --pre-release
-              if ($LASTEXITCODE -ne 0) { throw "wsl --update --pre-release failed with exit code $LASTEXITCODE" }
-
-              # Diagnostics only: a missing wslc must surface as a Wslc test failure, not as a broken setup step
-              try { wsl --version } catch { Write-Host "::warning::wsl --version failed: $_" }
-              try { wslc version } catch { Write-Host "::warning::wslc version failed: $_" }
-              exit 0
+            uses: ./.github/actions/setup-wslc
 
       - name: Build
         if: steps.build-project.outputs.has-project == 'true'
@@ -472,10 +464,9 @@ jobs:
     runs-on: windows-2025-vs2026
     timeout-minutes: 30
     steps:
-      - name: Install WSL containers (wslc)
-        run: wsl --update --pre-release
-      - name: WSL version
-        run: wsl --version
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup wslc
+        uses: ./.github/actions/setup-wslc
       - name: wslc version
         run: wslc version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,19 @@ jobs:
                 Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
               }
 
+          # wslc ships with WSL, and only the pre-release channel provides it. The Wslc tests fail instead of
+          # skipping on Windows agents, so this step is what keeps them running.
+          - name: Install WSL containers (wslc)
+            if: startsWith(matrix.runs-on, 'windows') && matrix.test-group.id == 'TemporaryContainers' && steps.build-project.outputs.has-project == 'true'
+            run: |
+              wsl --update --pre-release
+              if ($LASTEXITCODE -ne 0) { throw "wsl --update --pre-release failed with exit code $LASTEXITCODE" }
+
+              # Diagnostics only: a missing wslc must surface as a Wslc test failure, not as a broken setup step
+              try { wsl --version } catch { Write-Host "::warning::wsl --version failed: $_" }
+              try { wslc version } catch { Write-Host "::warning::wslc version failed: $_" }
+              exit 0
+
       - name: Build
         if: steps.build-project.outputs.has-project == 'true'
         run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} /bl ${{ matrix.additionalArguments }}
@@ -453,6 +466,18 @@ jobs:
               retention-days: 3
               path: |
                 **/*.coverage
+
+  # Debug job: reports which wslc the Windows agents provide, independently of the test run
+  debug_wslc:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 30
+    steps:
+      - name: Install WSL containers (wslc)
+        run: wsl --update --pre-release
+      - name: WSL version
+        run: wsl --version
+      - name: wslc version
+        run: wslc version
 
   test_trimming:
     runs-on: ubuntu-26.04
@@ -625,7 +650,7 @@ jobs:
   final_status_check:
     runs-on: ubuntu-slim
     if: always()
-    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
+    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, debug_wslc, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
     steps:
       - name: Check previous jobs status
         env:

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -16,6 +16,12 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 
     internal override string ExecutableName => "container";
 
+    // 'container' is not a distinctive name: WSL containers installs a container.exe alias for wslc, which answers
+    // the probe below and would then be driven with Apple's CLI dialect. Apple's runtime only exists on macOS, so
+    // nothing else can legitimately claim the name there.
+    public override Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default)
+        => OperatingSystem.IsMacOS() ? base.IsSupportedAsync(cancellationToken) : Task.FromResult(false);
+
     // 'container --version' is answered by the CLI itself, so the probe has to go through the API server: listing the
     // containers is the cheapest command that does.
     internal override IReadOnlyList<string> BuildProbeArguments() => ["ls", "-q"];

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
@@ -82,11 +82,26 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
         foreach (var line in lookup.StandardOutput.Split('\n'))
         {
             var trimmed = line.Trim();
-            if (IsContainerId(trimmed))
-                return trimmed;
+            if (!IsContainerId(trimmed))
+                continue;
+
+            return _flavor is Flavor.Wslc
+                ? await ExpandContainerIdAsync(trimmed, cancellationToken).ConfigureAwait(false)
+                : trimmed;
         }
 
         return null;
+    }
+
+    /// <summary>Expands a truncated id to the one the runtime reports for the container. 'wslc list -q' only prints the short id, where docker has '--no-trunc', and an adopted container has to report the same id as the run that created it.</summary>
+    private async Task<string> ExpandContainerIdAsync(string id, CancellationToken cancellationToken)
+    {
+        var result = await Cli.RunBufferedAsync(BuildInspectArguments(id), cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        if (result.ExitCode != 0)
+            return id;
+
+        var info = ParseInspect(result.StandardOutput);
+        return string.IsNullOrEmpty(info.Id) ? id : info.Id;
     }
 
     internal override IReadOnlyList<string> BuildCreateArguments(ContainerDefinition definition, string imageRef)

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -1015,9 +1015,11 @@ public sealed class DnsServerIntegrationTests
             builder.WebHost.UseUrls("http://127.0.0.1:0");
             builder.AddDnsServer(options =>
             {
-                for (var i = 0; i < 4; i++)
+                // The ports are reserved in one go: 4 separate calls can hand back the same port twice, and the
+                // duplicate listener then fails the startup with a SocketException instead of the expected one.
+                foreach (var port in GetAvailableUdpPorts(4))
                 {
-                    options.AddUdpListener(GetAvailableUdpPort(), IPAddress.Loopback);
+                    options.AddUdpListener(port, IPAddress.Loopback);
                 }
             });
             builder.Services.AddHostedService<FailingHostedService>();

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
@@ -11,4 +11,7 @@ public sealed class AppleContainerContainerTests() : ContainerRuntimeTestsBase(C
         await using var container = await StartWithRetryAsync(CreateHttpServerDefinition());
         await Assert.ThrowsAsync<NotSupportedException>(() => container.PauseAsync(XunitCancellationToken));
     }
+
+    [Fact]
+    public Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout() => AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -37,10 +37,21 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
 
     protected ContainerRuntime Runtime { get; }
 
+    /// <summary>Gets a value indicating whether the runtime must be available in the current environment. When it is, an unavailable runtime fails the tests instead of skipping them, so a broken setup cannot silently turn the suite into a no-op.</summary>
+    protected virtual bool IsRuntimeRequired => false;
+
     /// <summary>Checking that the runtime answers is asynchronous, so the skip gate cannot live in the constructor.</summary>
     public async ValueTask InitializeAsync()
     {
-        global::Xunit.Assert.SkipUnless(await Runtime.IsSupportedAsync(XunitCancellationToken), $"The '{Runtime}' container runtime is not available on this system.");
+        var isSupported = await Runtime.IsSupportedAsync(XunitCancellationToken);
+        if (IsRuntimeRequired)
+        {
+            global::Xunit.Assert.True(isSupported, $"The '{Runtime}' container runtime must be available in this environment, but it did not answer.");
+        }
+        else
+        {
+            global::Xunit.Assert.SkipUnless(isSupported, $"The '{Runtime}' container runtime is not available on this system.");
+        }
 
         _useWindowsContainerImages = DetectUseWindowsContainerImages(Runtime);
     }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -500,12 +500,14 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
         }
     }
 
-    [Fact]
-    public async Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout()
+    /// <summary>Shared assertion that a failing runtime command reports what the runtime printed (called from the
+    /// relevant subclasses). It is not run for every runtime: wslc has no copy command, so the adapter streams the
+    /// file itself and a missing source fails as a <see cref="FileNotFoundException"/> before any command runs.</summary>
+    protected async Task AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync()
     {
         await using var container = await StartWithRetryAsync(CreateHttpServerDefinition());
 
-        // The source is missing on the host, so every runtime rejects the copy before it touches the container.
+        // The source is missing on the host, so the runtime rejects the copy before it touches the container.
         // Asking for a missing path *inside* the container is not equivalent: 'container copy' never returns for
         // apple/container, which hangs the test host rather than failing.
         var missingSource = Path.Combine(Path.GetTempPath(), "MezTC-missing-" + Guid.NewGuid().ToString("N"));

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
@@ -10,4 +10,7 @@ public sealed class DockerContainerTests() : ContainerRuntimeTestsBase(Container
 
     [Fact]
     public Task StartAsync_ContainerExitsBeforeTheReadyMessage_ReportsWhatTheContainerPrinted() => AssertStartFailureReportsContainerOutputAsync();
+
+    [Fact]
+    public Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout() => AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
@@ -7,4 +7,7 @@ public sealed class PodmanContainerTests() : ContainerRuntimeTestsBase(Container
 {
     [Fact]
     public Task PauseAndUnpause() => AssertPauseUnpauseAsync();
+
+    [Fact]
+    public Task FailedCommand_ReportsWhatTheRuntimeComplainedAbout() => AssertFailedCommandReportsWhatTheRuntimeComplainedAboutAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/WslcContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/WslcContainerTests.cs
@@ -1,6 +1,12 @@
+using Meziantou.Xunit;
+
 namespace Meziantou.Framework.TemporaryContainers.Tests;
 
 // Each test starts its own container. Running them all at once saturates the CI agents and makes the container
 // runtimes fail transiently (image pull races, port collisions), so this class does not run in parallel.
 [TestClass(DisableParallelization = true)]
-public sealed class WslcContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.Wslc);
+public sealed class WslcContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.Wslc)
+{
+    // The Windows CI agents install WSL, so a missing wslc there means the CI setup regressed. Skipping would hide it.
+    protected override bool IsRuntimeRequired => OperatingSystem.IsWindows() && TestEnvironment.IsOnGitHubActions();
+}


### PR DESCRIPTION
## What

- `ContainerRuntimeTestsBase` gains an opt-in `IsRuntimeRequired` gate. When a runtime is declared mandatory, an unavailable runtime **fails** the tests instead of skipping them.
- `WslcContainerTests` opts in on GitHub Actions Windows only (`OperatingSystem.IsWindows() && TestEnvironment.IsOnGitHubActions()`).
- CI installs WSL from the pre-release channel (`wsl --update --pre-release`) on the Windows leg of the `TemporaryContainers` test group, so the tests have a runtime to drive.
- New `debug_wslc` job reports `wsl --version` and `wslc version` on `windows-2025-vs2026`, independently of the test run.

## Why

The Wslc tests were collected on all four matrix legs but always skipped: the suite gate skips when the runtime does not answer, and no hosted agent ships `wslc`. A runtime that silently never runs looks exactly like one that passes, so the suite gave no signal on Windows. Every other runtime and every local run keep the previous skip behavior.

## Notes for reviewers

- **This may go red on the first run, by design.** GitHub's hosted Windows runners have historically lacked nested virtualization, which WSL2 (and therefore `wslc`) needs. If the pre-release install does not produce a working `wslc`, the 10 Wslc tests fail on the Windows leg and `debug_wslc` fails — that is the signal this PR is meant to produce, and the debug job's output distinguishes "wslc not installed" from "WSL2 cannot start here".
- The install step's `wsl --version` / `wslc version` calls are deliberately non-fatal (try/catch + `exit 0`) so a missing `wslc` surfaces as test failures rather than a broken setup step. The `debug_wslc` job's `wslc version` step, in contrast, does fail the job.
- `debug_wslc` was added to `final_status_check`'s `needs` so it cannot fail unnoticed. Happy to drop that if you'd rather keep it purely informational.

## Verification

- Build clean with `/p:TreatsWarningsAsErrors=true`, 0 warnings.
- Forced the required path locally (temporarily dropping the Windows condition, `GITHUB_ACTIONS=true`): 20 failures instead of 20 skips, confirming the tests do fail when `wslc` is missing. Reverted afterwards.
- Full `Meziantou.Framework.TemporaryContainers.Tests` run on macOS/arm64: 266 total, 220 passed, 42 skipped, 4 failed — the known SqlServer-on-arm64 baseline, unchanged by this PR.
- `dotnet run ./eng/update-all.cs` — exit 0, no generated-file changes.
- The CI behavior itself could not be verified locally.