### PR TITLE
Remove the redundant SixLabors.ImageSharp IncludeAssets override

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,12 +15,6 @@
              Visible="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="SixLabors.ImageSharp">
-      <IncludeAssets>compile;runtime</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' and '@(ProjectReference->WithMetadataValue(`Filename`, `Meziantou.Framework.FullPath`))' != '' and '@(ProjectReference->WithMetadataValue(`Filename`, `Meziantou.Framework.FullPath.Analyzer`))' == ''">
     <ProjectReference Include="$(MSBuildThisFileDirectory)src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj"
                       OutputItemType="Analyzer"


### PR DESCRIPTION
## What changed

Removed this `ItemGroup` from `Directory.Build.targets`:

```xml
<ItemGroup>
  <PackageReference Update="SixLabors.ImageSharp">
    <IncludeAssets>compile;runtime</IncludeAssets>
  </PackageReference>
</ItemGroup>
```

## Why

`Meziantou.NET.Sdk` 1.0.162 — the version already pinned in `global.json`, and the latest published version of all six `Meziantou.NET.Sdk*` packages — applies this rule globally. `common/Common.targets` sets `DefaultPackageIncludeAssets` to `runtime;compile` for every `PackageReference` that does not already specify `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, and whose package id does not match `DefaultPackageIncludeAssetsExcludedPackagePattern` (`^(?i:(Meziantou|Microsoft)\.|xunit)`).

`SixLabors.ImageSharp` is not covered by that pattern, so the repository-level override was redundant.

No `global.json` change was needed.

## What a reviewer should know

The override existed to keep ImageSharp's `build` assets out of the build. ImageSharp 4.x ships `build/SixLabors.ImageSharp.targets`, which runs a `ValidateLicenseTask` before `CoreCompile` with `ContinueOnError` set only for `Debug*` configurations — so if those assets came back, Release builds would start failing on license validation.

That behaviour is unchanged. After the removal and a forced `dotnet restore`, `project.assets.json` still resolves the package as:

- `"include": "Runtime, Compile"` on the dependency
- `"build": { "build/_._": {} }` on the target entry

so the license targets remain excluded.

## Verification

- `dotnet build src/Meziantou.Framework.SnapshotTesting.ImageSharp -c Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings, 0 errors.
- `dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests -c Release /p:TreatWarningsAsErrors=true` — 382 passed, 0 failed, 0 skipped (191 per TFM across net10.0 and net11.0).
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.
- No `ref/` drift.
