### PR TITLE
Require the docker, Docker API and podman container tests on the CI agents

### DIFF
--- a/.github/actions/setup-wslc/action.yml
+++ b/.github/actions/setup-wslc/action.yml
@@ -31,8 +31,8 @@ runs:
         }
 
         if (-not $wslc) {
-          # Reported as a warning so the missing runtime surfaces where it is meaningful: the version step of
-          # the debug job, and the Wslc tests themselves
+          # Reported as a warning so the missing runtime surfaces where it is meaningful: the Wslc tests
+          # themselves, which fail instead of skipping on the CI agents
           Write-Host "::warning::wslc.exe was not found. Searched: $($candidates -join ', ') and $env:ProgramFiles\WindowsApps"
           Get-AppxPackage -Name "*WindowsSubsystemForLinux*" | Format-List -Property Name, Version, InstallLocation | Out-String | Write-Host
           Get-ChildItem -LiteralPath (Join-Path $env:ProgramFiles "WSL") -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name | Out-String | Write-Host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,17 +459,6 @@ jobs:
               path: |
                 **/*.coverage
 
-  # Debug job: reports which wslc the Windows agents provide, independently of the test run
-  debug_wslc:
-    runs-on: windows-2025-vs2026
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Setup wslc
-        uses: ./.github/actions/setup-wslc
-      - name: wslc version
-        run: wslc version
-
   test_trimming:
     runs-on: ubuntu-26.04
     timeout-minutes: 60
@@ -641,7 +630,7 @@ jobs:
   final_status_check:
     runs-on: ubuntu-slim
     if: always()
-    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, debug_wslc, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
+    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
     steps:
       - name: Check previous jobs status
         env:

--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -182,6 +182,7 @@ namespace Meziantou.Framework.TemporaryContainers
     {
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Auto { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Docker { get => throw null; }
+        public static Meziantou.Framework.TemporaryContainers.ContainerRuntime DockerApi { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Podman { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime AppleContainer { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Wslc { get => throw null; }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
@@ -15,6 +15,9 @@ public abstract class ContainerRuntime
     /// <summary>Use the <c>docker</c> CLI.</summary>
     public static ContainerRuntime Docker { get; } = new DockerContainerRuntime(nameof(Docker), DockerContainerRuntime.Flavor.Docker);
 
+    /// <summary>Use the Docker Engine API, over the unix socket or the named pipe of the daemon, without going through the <c>docker</c> CLI.</summary>
+    public static ContainerRuntime DockerApi { get; } = new DockerApiRuntime();
+
     /// <summary>Use the <c>podman</c> CLI.</summary>
     public static ContainerRuntime Podman { get; } = new DockerContainerRuntime(nameof(Podman), DockerContainerRuntime.Flavor.Podman);
 

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
@@ -5,7 +5,6 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 internal sealed class AutoContainerRuntime : ContainerRuntime
 {
-    private readonly DockerApiRuntime _dockerApiRuntime = new();
     private ContainerRuntime? _resolvedRuntime;
 
     public AutoContainerRuntime()
@@ -45,7 +44,7 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
     /// <summary>The runtime resolved by a previous operation. The container resolves the runtime before it runs anything, so the members that cannot await do not have to resolve it themselves.</summary>
     private ContainerRuntime ResolvedRuntime => _resolvedRuntime ?? throw CreateUnavailableRuntimeException(this);
 
-    private IEnumerable<ContainerRuntime> GetAllCandidates()
+    private static IEnumerable<ContainerRuntime> GetAllCandidates()
     {
         if (OperatingSystem.IsWindows())
             yield return Wslc;
@@ -53,7 +52,7 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
         if (OperatingSystem.IsMacOS())
             yield return AppleContainer;
 
-        yield return _dockerApiRuntime;
+        yield return DockerApi;
         yield return Docker;
         yield return Podman;
     }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
@@ -16,5 +16,6 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 [JsonSerializable(typeof(DockerApiModels.AuthConfigFile))]
 [JsonSerializable(typeof(DockerApiModels.CredentialHelperGetResponse))]
 [JsonSerializable(typeof(DockerApiModels.RegistryAuthHeader))]
+[JsonSerializable(typeof(DockerApiModels.ContainerPathStat))]
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 internal sealed partial class DockerApiJsonContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiModels.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiModels.cs
@@ -145,4 +145,17 @@ internal static class DockerApiModels
         public string? Password { get; set; }
         public string? IdentityToken { get; set; }
     }
+
+    /// <summary>The metadata the daemon reports for a container path in the <c>X-Docker-Container-Path-Stat</c> header.</summary>
+    internal sealed class ContainerPathStat
+    {
+        public string? Name { get; set; }
+        public long Size { get; set; }
+        public uint Mode { get; set; }
+        public string? LinkTarget { get; set; }
+
+        /// <summary>The mode is a Go <c>os.FileMode</c>, whose highest bit marks a directory.</summary>
+        [JsonIgnore]
+        public bool IsDirectory => (Mode & 0x8000_0000) != 0;
+    }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,6 +13,8 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 internal sealed class DockerApiRuntime : ContainerRuntime
 {
+    private static readonly char[] ContainerPathSeparators = ['/', '\\'];
+
     private readonly DockerRegistryAuthProvider _authProvider;
     private DockerApiConnection? _connection;
 
@@ -51,12 +54,14 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
     internal override async Task StartAsync(string id, CancellationToken cancellationToken)
     {
-        using var response = await SendAsync(HttpMethod.Post, "/containers/" + Uri.EscapeDataString(id) + "/start", content: null, cancellationToken).ConfigureAwait(false);
+        // An adopted container is already running, and the daemon reports that with '304 Not Modified' instead of a success status.
+        using var response = await SendAsync(HttpMethod.Post, "/containers/" + Uri.EscapeDataString(id) + "/start", content: null, cancellationToken, allowedStatusCode: HttpStatusCode.NotModified).ConfigureAwait(false);
     }
 
     internal override async Task StopAsync(string id, CancellationToken cancellationToken)
     {
-        using var response = await SendAsync(HttpMethod.Post, "/containers/" + Uri.EscapeDataString(id) + "/stop", content: null, cancellationToken).ConfigureAwait(false);
+        // Same as StartAsync: a container that already exited is reported with '304 Not Modified'.
+        using var response = await SendAsync(HttpMethod.Post, "/containers/" + Uri.EscapeDataString(id) + "/stop", content: null, cancellationToken, allowedStatusCode: HttpStatusCode.NotModified).ConfigureAwait(false);
     }
 
     internal override async Task RestartAsync(string id, CancellationToken cancellationToken)
@@ -81,12 +86,12 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
     internal override async Task DeleteAsync(string id, CancellationToken cancellationToken)
     {
-        using var response = await SendAsync(HttpMethod.Delete, "/containers/" + Uri.EscapeDataString(id) + "?force=1", content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
+        using var response = await SendAsync(HttpMethod.Delete, "/containers/" + Uri.EscapeDataString(id) + "?force=1", content: null, cancellationToken, allowedStatusCode: HttpStatusCode.NotFound).ConfigureAwait(false);
     }
 
     internal override async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken)
     {
-        using var response = await SendAsync(HttpMethod.Get, "/containers/" + Uri.EscapeDataString(id) + "/json", content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
+        using var response = await SendAsync(HttpMethod.Get, "/containers/" + Uri.EscapeDataString(id) + "/json", content: null, cancellationToken, allowedStatusCode: HttpStatusCode.NotFound).ConfigureAwait(false);
         return response.StatusCode != HttpStatusCode.NotFound;
     }
 
@@ -152,24 +157,108 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         return new ExecResult(inspectExecResult.ExitCode, standardOutput, standardError);
     }
 
-    internal override Task<Stream> OpenReadAsync(string id, string path, CancellationToken cancellationToken)
+    internal override async Task<Stream> OpenReadAsync(string id, string path, CancellationToken cancellationToken)
     {
-        throw new NotSupportedException("The Docker API runtime does not support reading files from containers.");
+        using var response = await SendAsync(HttpMethod.Get, BuildArchiveEndpoint(id, path), content: null, cancellationToken, completionOption: HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        await using var archive = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await DockerApiTarArchive.ReadSingleFileAsync(archive, path, cancellationToken).ConfigureAwait(false);
     }
 
-    internal override Task WriteFileAsync(string id, string path, Stream content, CancellationToken cancellationToken)
+    internal override async Task WriteFileAsync(string id, string path, Stream content, CancellationToken cancellationToken)
     {
-        throw new NotSupportedException("The Docker API runtime does not support writing files to containers.");
+        await using var archive = await DockerApiTarArchive.CreateForFileAsync(GetContainerPathName(path), content, cancellationToken).ConfigureAwait(false);
+        await PutArchiveAsync(id, GetContainerParentPath(path), archive, cancellationToken).ConfigureAwait(false);
     }
 
-    internal override Task CopyToContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
+    internal override async Task CopyToContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
     {
-        throw new NotSupportedException("The Docker API runtime does not support copying files to containers.");
+        // 'docker cp' copies into an existing directory under the name of the source, and renames the source to the destination otherwise.
+        var destinationIsDirectory = await StatPathAsync(id, destination, cancellationToken).ConfigureAwait(false) is { IsDirectory: true };
+        var targetDirectory = destinationIsDirectory ? destination : GetContainerParentPath(destination);
+        var entryName = GetContainerPathName(destinationIsDirectory ? source : destination);
+
+        if (Directory.Exists(source))
+        {
+            await using var directoryArchive = await DockerApiTarArchive.CreateForDirectoryAsync(source, entryName + "/", additionalFile: null, cancellationToken).ConfigureAwait(false);
+            await PutArchiveAsync(id, targetDirectory, directoryArchive, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await using var file = File.OpenRead(source);
+        await using var archive = await DockerApiTarArchive.CreateForFileAsync(entryName, file, cancellationToken).ConfigureAwait(false);
+        await PutArchiveAsync(id, targetDirectory, archive, cancellationToken).ConfigureAwait(false);
     }
 
-    internal override Task CopyFromContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
+    internal override async Task CopyFromContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
     {
-        throw new NotSupportedException("The Docker API runtime does not support copying files from containers.");
+        var sourceIsDirectory = await StatPathAsync(id, source, cancellationToken).ConfigureAwait(false) is { IsDirectory: true };
+        using var response = await SendAsync(HttpMethod.Get, BuildArchiveEndpoint(id, source), content: null, cancellationToken, completionOption: HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        await using var archive = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (sourceIsDirectory)
+        {
+            // A destination directory that does not exist yet takes the place of the copied one, so the archive's own top-level directory is dropped.
+            var destinationExists = Directory.Exists(destination);
+            Directory.CreateDirectory(destination);
+            await DockerApiTarArchive.ExtractToDirectoryAsync(archive, destination, stripFirstSegment: !destinationExists, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // Same as CopyToContainerAsync, the other way around: an existing directory receives the file under its own name.
+        var targetFile = Directory.Exists(destination) ? Path.Combine(destination, GetContainerPathName(source)) : destination;
+        if (Path.GetDirectoryName(Path.GetFullPath(targetFile)) is { } parent)
+            Directory.CreateDirectory(parent);
+
+        await using var content = await DockerApiTarArchive.ReadSingleFileAsync(archive, source, cancellationToken).ConfigureAwait(false);
+        await using var file = File.Create(targetFile);
+        await content.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task PutArchiveAsync(string id, string directory, Stream archive, CancellationToken cancellationToken)
+    {
+        using var content = new StreamContent(archive);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-tar");
+        using var response = await SendAsync(HttpMethod.Put, BuildArchiveEndpoint(id, directory), content, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads the metadata the daemon reports for a container path. Returns <see langword="null"/> when the path does not exist.</summary>
+    private async Task<DockerApiModels.ContainerPathStat?> StatPathAsync(string id, string path, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(HttpMethod.Head, BuildArchiveEndpoint(id, path), content: null, cancellationToken, allowedStatusCode: HttpStatusCode.NotFound).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return null;
+
+        if (!response.Headers.TryGetValues("X-Docker-Container-Path-Stat", out var values) || values.FirstOrDefault() is not { Length: > 0 } encoded)
+            return null;
+
+        var buffer = new byte[encoded.Length];
+        if (!Convert.TryFromBase64String(encoded, buffer, out var written))
+            return null;
+
+        return JsonSerializer.Deserialize(buffer.AsSpan(0, written), DockerApiJsonContext.Default.ContainerPathStat);
+    }
+
+    private static string BuildArchiveEndpoint(string id, string path)
+        => "/containers/" + Uri.EscapeDataString(id) + "/archive?path=" + Uri.EscapeDataString(path);
+
+    /// <summary>The last segment of a container path. <see cref="Path"/> cannot do it: it splits on the separators of the host, and the path of a Windows container reaches a Linux host unchanged.</summary>
+    private static string GetContainerPathName(string path)
+    {
+        var trimmed = path.TrimEnd(ContainerPathSeparators);
+        var separatorIndex = trimmed.LastIndexOfAny(ContainerPathSeparators);
+        return separatorIndex < 0 ? trimmed : trimmed[(separatorIndex + 1)..];
+    }
+
+    /// <summary>The directory a container path lives in. See <see cref="GetContainerPathName"/> for why <see cref="Path"/> is not used.</summary>
+    private static string GetContainerParentPath(string path)
+    {
+        var trimmed = path.TrimEnd(ContainerPathSeparators);
+        return trimmed.LastIndexOfAny(ContainerPathSeparators) switch
+        {
+            < 0 => ".",
+            0 => "/",
+            var separatorIndex => trimmed[..separatorIndex],
+        };
     }
 
     internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition)
@@ -212,8 +301,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
                 return existing.ImageId;
 
             case DockerfileImage dockerfile:
-                _ = dockerfile;
-                throw new NotSupportedException("The Docker API runtime does not support Dockerfile image builds.");
+                return await BuildImageAsync(dockerfile, cancellationToken).ConfigureAwait(false);
 
             case ArchiveImage archive:
                 _ = archive;
@@ -224,9 +312,47 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         }
     }
 
+    private async Task<string> BuildImageAsync(DockerfileImage dockerfile, CancellationToken cancellationToken)
+    {
+        var tag = "meziantou-tc/" + Guid.NewGuid().ToString("N") + ":latest";
+        var contextDirectory = Path.GetFullPath(dockerfile.ContextDirectory);
+        var dockerfileName = Path.GetRelativePath(contextDirectory, Path.GetFullPath(dockerfile.DockerfilePath)).Replace('\\', '/');
+
+        // The daemon only ever sees the build context, so a Dockerfile stored outside of it is added to the archive under a name of our own.
+        (string SourcePath, string EntryName)? additionalFile = null;
+        if (Path.IsPathRooted(dockerfileName) || dockerfileName.StartsWith("../", StringComparison.Ordinal))
+        {
+            dockerfileName = "Dockerfile.meziantou-tc-" + Guid.NewGuid().ToString("N");
+            additionalFile = (dockerfile.DockerfilePath, dockerfileName);
+        }
+
+        await using var context = await DockerApiTarArchive.CreateForDirectoryAsync(contextDirectory, entryPrefix: "", additionalFile, cancellationToken).ConfigureAwait(false);
+        using var content = new StreamContent(context);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-tar");
+
+        var endpoint = "/build?rm=1&dockerfile=" + Uri.EscapeDataString(dockerfileName) + "&t=" + Uri.EscapeDataString(tag);
+        using var response = await SendAsync(HttpMethod.Post, endpoint, content, cancellationToken, completionOption: HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+
+        // The daemon answers as soon as the build starts, so a failure is only reported in the stream of messages that follows.
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var reader = new StreamReader(stream);
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+        {
+            if (line.Length is 0)
+                continue;
+
+            var progress = JsonSerializer.Deserialize(line, DockerApiJsonContext.Default.PullProgress);
+            var errorMessage = progress?.ErrorDetail?.Message ?? progress?.Error;
+            if (!string.IsNullOrEmpty(errorMessage))
+                throw new InvalidOperationException("Unable to build the image from '" + dockerfile.DockerfilePath + "': " + errorMessage);
+        }
+
+        return tag;
+    }
+
     private async Task<bool> ImageExistsAsync(string imageName, CancellationToken cancellationToken)
     {
-        using var response = await SendAsync(HttpMethod.Get, "/images/" + Uri.EscapeDataString(imageName) + "/json", content: null, cancellationToken, allowNotFound: true).ConfigureAwait(false);
+        using var response = await SendAsync(HttpMethod.Get, "/images/" + Uri.EscapeDataString(imageName) + "/json", content: null, cancellationToken, allowedStatusCode: HttpStatusCode.NotFound).ConfigureAwait(false);
         return response.StatusCode != HttpStatusCode.NotFound;
     }
 
@@ -255,7 +381,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         }
     }
 
-    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string endpoint, HttpContent? content, CancellationToken cancellationToken, bool allowNotFound = false, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string endpoint, HttpContent? content, CancellationToken cancellationToken, HttpStatusCode? allowedStatusCode = null, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
     {
         var connection = await EnsureConnectionOrThrowAsync(cancellationToken).ConfigureAwait(false);
         using var request = new HttpRequestMessage(method, BuildEndpoint(connection, endpoint))
@@ -265,7 +391,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
         var response = await connection.HttpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
 
-        if (response.IsSuccessStatusCode || allowNotFound && response.StatusCode == HttpStatusCode.NotFound)
+        if (response.IsSuccessStatusCode || response.StatusCode == allowedStatusCode)
             return response;
 
         throw await CreateRequestExceptionAsync(response, method.Method, request.RequestUri?.AbsolutePath ?? endpoint, cancellationToken).ConfigureAwait(false);

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiTarArchive.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiTarArchive.cs
@@ -1,0 +1,202 @@
+using System.Formats.Tar;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Builds and reads the tar payloads the Docker Engine API exchanges: the build context of <c>POST /build</c>, and the body of <c>GET</c> and <c>PUT /containers/{id}/archive</c>.</summary>
+internal static class DockerApiTarArchive
+{
+    private const UnixFileMode RegularFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+    private const UnixFileMode DirectoryEntryMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+    /// <summary>Creates an archive holding <paramref name="content"/> as its only file entry.</summary>
+    /// <param name="entryName">The name the file takes inside the archive, which is the name it takes in the container.</param>
+    /// <param name="content">The content of the file.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The archive, positioned at its beginning.</returns>
+    public static async Task<Stream> CreateForFileAsync(string entryName, Stream content, CancellationToken cancellationToken)
+    {
+        // The tar entry declares its length up front, so a stream whose length cannot be read is buffered first.
+        MemoryStream? buffer = null;
+        try
+        {
+            if (!content.CanSeek)
+            {
+                buffer = new MemoryStream();
+                await content.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+                buffer.Position = 0;
+            }
+
+            var archive = new MemoryStream();
+            try
+            {
+                await using (var writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
+                {
+                    await WriteFileEntryAsync(writer, entryName, buffer ?? content, cancellationToken).ConfigureAwait(false);
+                }
+
+                archive.Position = 0;
+                return archive;
+            }
+            catch
+            {
+                await archive.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+        finally
+        {
+            if (buffer is not null)
+                await buffer.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Creates an archive of <paramref name="directory"/> and everything below it.</summary>
+    /// <param name="directory">The directory to archive.</param>
+    /// <param name="entryPrefix">A directory name every entry is placed under, or an empty string to archive the content of <paramref name="directory"/> at the root. When it is not empty, it must end with a slash.</param>
+    /// <param name="additionalFile">A file to add to the archive under a name of the caller's choosing, on top of the content of <paramref name="directory"/>.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The archive, positioned at its beginning. It is backed by a temporary file that is deleted when the stream is disposed.</returns>
+    public static async Task<Stream> CreateForDirectoryAsync(string directory, string entryPrefix, (string SourcePath, string EntryName)? additionalFile, CancellationToken cancellationToken)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), "MezTC_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            await using (var file = File.Create(tempFile))
+            await using (var writer = new TarWriter(file, TarEntryFormat.Pax, leaveOpen: true))
+            {
+                if (entryPrefix.Length > 0)
+                    await WriteDirectoryEntryAsync(writer, entryPrefix, cancellationToken).ConfigureAwait(false);
+
+                // .dockerignore is not applied: it is a client-side filter the daemon never sees, so the whole context is sent.
+                foreach (var path in Directory.EnumerateFileSystemEntries(directory, "*", SearchOption.AllDirectories))
+                {
+                    var entryName = entryPrefix + Path.GetRelativePath(directory, path).Replace('\\', '/');
+                    if (Directory.Exists(path))
+                    {
+                        await WriteDirectoryEntryAsync(writer, entryName + "/", cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    await using var content = File.OpenRead(path);
+                    await WriteFileEntryAsync(writer, entryName, content, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (additionalFile is var (sourcePath, additionalEntryName))
+                {
+                    await using var content = File.OpenRead(sourcePath);
+                    await WriteFileEntryAsync(writer, additionalEntryName, content, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return new TemporaryFileStream(tempFile);
+        }
+        catch
+        {
+            File.Delete(tempFile);
+            throw;
+        }
+    }
+
+    /// <summary>Reads the content of the single file entry of an archive returned by <c>GET /containers/{id}/archive</c>.</summary>
+    /// <param name="archive">The archive returned by the daemon.</param>
+    /// <param name="containerPath">The path that was requested, used to report a path that turned out not to be a file.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The content of the file, positioned at its beginning.</returns>
+    public static async Task<Stream> ReadSingleFileAsync(Stream archive, string containerPath, CancellationToken cancellationToken)
+    {
+        await using var reader = new TarReader(archive, leaveOpen: true);
+        while (await reader.GetNextEntryAsync(copyData: false, cancellationToken).ConfigureAwait(false) is { } entry)
+        {
+            // Only the entries that carry content have a data stream, so this skips the directories of the archive.
+            if (entry.DataStream is not { } data)
+                continue;
+
+            var content = new MemoryStream();
+            try
+            {
+                await data.CopyToAsync(content, cancellationToken).ConfigureAwait(false);
+                content.Position = 0;
+                return content;
+            }
+            catch
+            {
+                await content.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        throw new FileNotFoundException($"The path '{containerPath}' does not point to a file in the container.", containerPath);
+    }
+
+    /// <summary>Extracts an archive returned by <c>GET /containers/{id}/archive</c> below <paramref name="destinationDirectory"/>.</summary>
+    /// <param name="archive">The archive returned by the daemon.</param>
+    /// <param name="destinationDirectory">The directory the entries are written to.</param>
+    /// <param name="stripFirstSegment">Drops the leading directory of every entry, which is how <c>docker cp</c> gives a copied directory the name of a destination that does not exist yet.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes once every entry is written.</returns>
+    public static async Task ExtractToDirectoryAsync(Stream archive, string destinationDirectory, bool stripFirstSegment, CancellationToken cancellationToken)
+    {
+        await using var reader = new TarReader(archive, leaveOpen: true);
+        while (await reader.GetNextEntryAsync(copyData: false, cancellationToken).ConfigureAwait(false) is { } entry)
+        {
+            var entryName = entry.Name.Replace('\\', '/').TrimStart('/');
+            if (stripFirstSegment)
+            {
+                var separatorIndex = entryName.IndexOf('/', StringComparison.Ordinal);
+                entryName = separatorIndex < 0 ? "" : entryName[(separatorIndex + 1)..];
+            }
+
+            entryName = entryName.TrimEnd('/');
+            if (entryName.Length == 0)
+                continue;
+
+            var destination = GetSafeDestinationPath(destinationDirectory, entryName);
+            if (entry.EntryType is TarEntryType.Directory)
+            {
+                Directory.CreateDirectory(destination);
+                continue;
+            }
+
+            if (entry.DataStream is not { } data)
+                continue;
+
+            if (Path.GetDirectoryName(destination) is { } parent)
+                Directory.CreateDirectory(parent);
+
+            await using var file = File.Create(destination);
+            await data.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WriteFileEntryAsync(TarWriter writer, string entryName, Stream content, CancellationToken cancellationToken)
+    {
+        var entry = new PaxTarEntry(TarEntryType.RegularFile, entryName)
+        {
+            DataStream = content,
+            Mode = RegularFileMode,
+        };
+
+        await writer.WriteEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteDirectoryEntryAsync(TarWriter writer, string entryName, CancellationToken cancellationToken)
+    {
+        var entry = new PaxTarEntry(TarEntryType.Directory, entryName)
+        {
+            Mode = DirectoryEntryMode,
+        };
+
+        await writer.WriteEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Resolves an entry name below <paramref name="directory"/>. The names come from the container, so an entry that escapes the destination is rejected instead of overwriting a file of the host.</summary>
+    private static string GetSafeDestinationPath(string directory, string entryName)
+    {
+        var root = Path.GetFullPath(directory);
+        var destination = Path.GetFullPath(Path.Combine(root, entryName.Replace('/', Path.DirectorySeparatorChar)));
+        if (destination != root && !destination.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException($"The archive entry '{entryName}' points outside of '{directory}'.");
+
+        return destination;
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj
+++ b/src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>1.0.8</Version>
     <IsTrimmable>true</IsTrimmable>
-    <Description>Manage temporary containers for integration tests using the docker, podman, apple/container, or wslc CLI.</Description>
+    <Description>Manage temporary containers for integration tests using the Docker Engine API, or the docker, podman, apple/container, or wslc CLI.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.TemporaryContainers/readme.md
+++ b/src/Meziantou.Framework.TemporaryContainers/readme.md
@@ -1,8 +1,8 @@
 # Meziantou.Framework.TemporaryContainers
 
-Manage temporary containers for integration tests by driving a container runtime CLI, so no daemon SDK is required.
+Manage temporary containers for integration tests by driving a container runtime CLI or the Docker Engine API, so no daemon SDK is required.
 
-Supported runtimes (auto-detected, or set `ContainerDefinition.Runtime`): `docker`, `podman`, Apple's `container` (macOS), and `wslc` (Windows/WSL).
+Supported runtimes (auto-detected, or set `ContainerDefinition.Runtime`): the Docker Engine API, `docker`, `podman`, Apple's `container` (macOS), and `wslc` (Windows/WSL).
 
 ```c#
 var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8"));

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -1,7 +1,6 @@
 using System.Net.Sockets;
 using System.Text.Json;
 using Meziantou.Extensions.Logging.Xunit.v3;
-using Meziantou.Framework.TemporaryContainers.Internals;
 using Meziantou.Xunit;
 using Microsoft.Extensions.Logging;
 
@@ -87,7 +86,7 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     {
         string? commandName;
         // The Docker API runtime talks to the daemon the docker CLI talks to, so the CLI is what reports its OS.
-        if (runtime == ContainerRuntime.Docker || runtime is DockerApiRuntime)
+        if (runtime == ContainerRuntime.Docker || runtime == ContainerRuntime.DockerApi)
         {
             commandName = "docker";
         }
@@ -566,7 +565,7 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     /// <summary>Shared pause/unpause assertion for runtimes that support it (called from the relevant subclasses).</summary>
     protected async Task AssertPauseUnpauseAsync()
     {
-        global::Xunit.Assert.SkipUnless(!UseWindowsContainerImages || (Runtime != ContainerRuntime.Docker && Runtime is not DockerApiRuntime), "docker pause is not implemented for Windows process-isolated containers");
+        global::Xunit.Assert.SkipUnless(!UseWindowsContainerImages || (Runtime != ContainerRuntime.Docker && Runtime != ContainerRuntime.DockerApi), "docker pause is not implemented for Windows process-isolated containers");
 
         await using var container = await StartWithRetryAsync(CreateHttpServerDefinition());
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using System.Text.Json;
 using Meziantou.Extensions.Logging.Xunit.v3;
+using Meziantou.Framework.TemporaryContainers.Internals;
 using Meziantou.Xunit;
 using Microsoft.Extensions.Logging;
 
@@ -85,7 +86,8 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     private static bool TryGetRuntimeExecutable(ContainerRuntime runtime, out string executable)
     {
         string? commandName;
-        if (runtime == ContainerRuntime.Docker)
+        // The Docker API runtime talks to the daemon the docker CLI talks to, so the CLI is what reports its OS.
+        if (runtime == ContainerRuntime.Docker || runtime is DockerApiRuntime)
         {
             commandName = "docker";
         }
@@ -564,7 +566,7 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     /// <summary>Shared pause/unpause assertion for runtimes that support it (called from the relevant subclasses).</summary>
     protected async Task AssertPauseUnpauseAsync()
     {
-        global::Xunit.Assert.SkipUnless(!UseWindowsContainerImages || Runtime != ContainerRuntime.Docker, "docker pause is not implemented for Windows process-isolated containers");
+        global::Xunit.Assert.SkipUnless(!UseWindowsContainerImages || (Runtime != ContainerRuntime.Docker && Runtime is not DockerApiRuntime), "docker pause is not implemented for Windows process-isolated containers");
 
         await using var container = await StartWithRetryAsync(CreateHttpServerDefinition());
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiContainerTests.cs
@@ -1,0 +1,23 @@
+using Meziantou.Framework.TemporaryContainers.Internals;
+using Meziantou.Xunit;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+// Each test starts its own container. Running them all at once saturates the CI agents and makes the container
+// runtimes fail transiently (image pull races, port collisions), so this class does not run in parallel.
+[TestClass(DisableParallelization = true)]
+public sealed class DockerApiContainerTests() : ContainerRuntimeTestsBase(DockerApi)
+{
+    /// <summary>The runtime is not exposed by <see cref="ContainerRuntime"/>, and it caches the connection it probes, so every test shares a single instance instead of reconnecting.</summary>
+    private static readonly ContainerRuntime DockerApi = new DockerApiRuntime();
+
+    // The Linux CI agents ship the Docker daemon, so a socket that does not answer there means the CI setup regressed. Skipping would hide it.
+    // The Windows agents are left out on purpose: their Docker Engine is flaky enough that requiring it would fail runs for reasons unrelated to the change under test.
+    protected override bool IsRuntimeRequired => OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions();
+
+    [Fact]
+    public Task PauseAndUnpause() => AssertPauseUnpauseAsync();
+
+    [Fact]
+    public Task StartAsync_ContainerExitsBeforeTheReadyMessage_ReportsWhatTheContainerPrinted() => AssertStartFailureReportsContainerOutputAsync();
+}

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiContainerTests.cs
@@ -1,4 +1,3 @@
-using Meziantou.Framework.TemporaryContainers.Internals;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.TemporaryContainers.Tests;
@@ -6,11 +5,8 @@ namespace Meziantou.Framework.TemporaryContainers.Tests;
 // Each test starts its own container. Running them all at once saturates the CI agents and makes the container
 // runtimes fail transiently (image pull races, port collisions), so this class does not run in parallel.
 [TestClass(DisableParallelization = true)]
-public sealed class DockerApiContainerTests() : ContainerRuntimeTestsBase(DockerApi)
+public sealed class DockerApiContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.DockerApi)
 {
-    /// <summary>The runtime is not exposed by <see cref="ContainerRuntime"/>, and it caches the connection it probes, so every test shares a single instance instead of reconnecting.</summary>
-    private static readonly ContainerRuntime DockerApi = new DockerApiRuntime();
-
     // The Linux CI agents ship the Docker daemon, so a socket that does not answer there means the CI setup regressed. Skipping would hide it.
     // The Windows agents are left out on purpose: their Docker Engine is flaky enough that requiring it would fail runs for reasons unrelated to the change under test.
     protected override bool IsRuntimeRequired => OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions();

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
@@ -1,3 +1,5 @@
+using Meziantou.Xunit;
+
 namespace Meziantou.Framework.TemporaryContainers.Tests;
 
 // Each test starts its own container. Running them all at once saturates the CI agents and makes the container
@@ -5,6 +7,10 @@ namespace Meziantou.Framework.TemporaryContainers.Tests;
 [TestClass(DisableParallelization = true)]
 public sealed class DockerContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.Docker)
 {
+    // The Linux CI agents ship the Docker daemon, so a missing docker there means the CI setup regressed. Skipping would hide it.
+    // The Windows agents are left out on purpose: their docker is flaky enough that requiring it would fail runs for reasons unrelated to the change under test.
+    protected override bool IsRuntimeRequired => OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions();
+
     [Fact]
     public Task PauseAndUnpause() => AssertPauseUnpauseAsync();
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
@@ -1,3 +1,5 @@
+using Meziantou.Xunit;
+
 namespace Meziantou.Framework.TemporaryContainers.Tests;
 
 // Each test starts its own container. Running them all at once saturates the CI agents and makes the container
@@ -5,6 +7,9 @@ namespace Meziantou.Framework.TemporaryContainers.Tests;
 [TestClass(DisableParallelization = true)]
 public sealed class PodmanContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.Podman)
 {
+    // The Linux CI agents ship podman, so a missing podman there means the CI setup regressed. Skipping would hide it.
+    protected override bool IsRuntimeRequired => OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions();
+
     [Fact]
     public Task PauseAndUnpause() => AssertPauseUnpauseAsync();
 


### PR DESCRIPTION
## What changed

**Removed the `debug_wslc` job.** It reported which `wslc` the Windows agents provide while that runtime was being brought up. The `Wslc` tests cover it now, so the job is gone from `ci.yml` along with its entry in `final_status_check`'s `needs` list, and the comment in `setup-wslc/action.yml` that pointed at it is updated.

**Gated docker, Docker API and podman the way wslc already is.** `WslcContainerTests` overrides `IsRuntimeRequired` so an unavailable runtime *fails* instead of skipping — a broken CI setup cannot silently turn the suite into a no-op. The docker and podman suites had no such gate, and the Docker Engine API runtime had no integration test at all, only log-parsing unit tests.

- `DockerContainerTests` and `PodmanContainerTests` now require their runtime on the Linux CI agents.
- New `DockerApiContainerTests` runs the shared suite against the Docker Engine API runtime, required on the Linux CI agents.

The `ubuntu-26.04` runner images ship Docker 29.4.2 (client + server) and Podman 5.7.0 on **both** x64 and arm64, so unlike wslc no setup step is needed — only the gate was missing.

The Windows agents are deliberately left out. Their docker fails intermittently for reasons unrelated to the change under test (the retry workflow usually turns those runs green on the second attempt), so requiring it there would only add red.

## Docker Engine API runtime fixes

Running the shared suite against that runtime for the first time exposed three real defects:

| | |
|---|---|
| **`start`/`stop` failed on a container already in the requested state** | The daemon reports that with `304 Not Modified`, which was treated as an error, so adopting a reused container threw. `SendAsync`'s `allowNotFound` flag becomes a general `allowedStatusCode`. |
| **Dockerfile builds threw `NotSupportedException`** | Now `POST /build` with a tar of the build context, including the case of a Dockerfile stored outside of it. |
| **All four file operations threw `NotSupportedException`** | Now `GET`/`PUT /containers/{id}/archive`, with a `HEAD` to stat the target so the copy-into-a-directory vs. rename semantics of `docker cp` are matched. |

New `DockerApiTarArchive` does the tar work with `System.Formats.Tar`, and rejects archive entries that escape the destination directory.

This matters beyond CI: `ContainerRuntime.Auto` prefers the API runtime over the CLI on Linux, so `Auto` with a `DockerfileImage`, or `OpenReadAsync`, was throwing there.

## Notes for the reviewer

- **No public API change** — everything is `internal`, so `ref/` is untouched.
- Two gaps left in place, both flagged rather than papered over: `ArchiveImage` (`docker load`) is still unsupported by the API runtime, since nothing in the suite covers it and implementing it would mean untested code; and `POST /build` does not send `X-Registry-Config`, so a Dockerfile whose base image lives in a private registry will not authenticate through this path.
- `.dockerignore` is not applied to the build context. It is a client-side filter the daemon never sees, so the whole context directory is sent. This is noted in a comment in `DockerApiTarArchive`.

## Verification

Run locally on arm64 macOS against Docker Desktop and Apple `container`:

- `DockerApiContainerTests`: **22/22** (11 tests x 2 TFMs).
- `AppleContainerContainerTests`: **22/22**.
- Full `Meziantou.Framework.TemporaryContainers.Tests` suite: 212 passed, 2 failed, 29 skipped. The 2 failures are the `SqlServerContainerTests` connection-string tests, the known local baseline on this machine (the mssql image has no arm64 variant); that same test also hung the net11.0 host at the 10-minute dump timeout, so the two classes above were re-run separately to cover both TFMs. Podman and wslc skip locally, neither is installed.
- `dotnet run ./eng/update-all.cs`: no changes.
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.

Podman and wslc could not be exercised locally; CI is the first place those gates are tested.
