### PR TITLE
Install Apple's container runtime on the macOS CI agents

### DIFF
--- a/.github/actions/setup-apple-container/action.yml
+++ b/.github/actions/setup-apple-container/action.yml
@@ -82,10 +82,25 @@ runs:
           exit 0
         }
 
-        # Same command as AppleContainerRuntime.BuildProbeArguments, so this answers exactly the question the tests ask.
+        # Same command as AppleContainerRuntime.BuildProbeArguments.
         container ls -q
         if ($LASTEXITCODE -ne 0) {
           Write-Host "::warning::The Apple container service started but 'container ls -q' failed with exit code $LASTEXITCODE."
+          "available=false" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        # A service that answers is not proof the runtime works: on GitHub-hosted macOS agents 'container ls -q'
+        # succeeds and only the virtual machine fails to boot, with 'Virtualization is not available on this
+        # hardware'. Booting a container is what the tests actually need, so that is what decides availability.
+        # renovate: datasource=docker depName=busybox
+        $image = "busybox:1.37"
+        container run --rm $image true
+        if ($LASTEXITCODE -ne 0) {
+          # Stopping the service makes the probe fail, which is what turns the container tests back into skips.
+          # Left running, they would run and fail on every test that starts a container.
+          Write-Host "::warning::The Apple container service answers but no container can boot on this agent. Stopping the service so the runtime probe fails and the container tests skip."
+          container system stop
           "available=false" >> $env:GITHUB_OUTPUT
           exit 0
         }

--- a/.github/actions/setup-apple-container/action.yml
+++ b/.github/actions/setup-apple-container/action.yml
@@ -1,0 +1,93 @@
+name: 'Setup Apple container'
+description: 'Installs Apple''s container runtime on macOS agents and starts the API service it needs to answer'
+
+outputs:
+  available:
+    description: 'true when the container CLI answers the same probe the library uses, false when the runtime could not be installed or started'
+    value: ${{ steps.start-service.outputs.available }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Apple container
+      id: install
+      shell: pwsh
+      run: |
+        # GitHub runs pwsh steps with $ErrorActionPreference = 'stop', and PowerShell 7.4 turns a non-zero exit code
+        # from a native command into an error on top of that. Both are relaxed here so the failures below reach their
+        # '::warning::' instead of taking the step down.
+        $ErrorActionPreference = "Continue"
+        $PSNativeCommandUseErrorActionPreference = $false
+
+        # The installer package is attached to each release and its file name carries the version, so it cannot be
+        # downloaded through the version-less '/releases/latest/download/' redirect. Renovate keeps the pin fresh.
+        # renovate: datasource=github-releases depName=apple/container
+        $version = "1.3.1"
+        $url = "https://github.com/apple/container/releases/download/$version/container-$version-installer-signed.pkg"
+        $package = Join-Path ([System.IO.Path]::GetTempPath()) "container-$version-installer-signed.pkg"
+
+        # Every failure below is reported as a warning rather than thrown: the container tests skip when the runtime
+        # does not answer, and the debug_apple_container job is where a broken setup is meant to surface. Failing here
+        # would take down the whole test matrix leg over a runtime that is optional on macOS.
+        try {
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $package
+
+          sudo installer -pkg $package -target /
+          if ($LASTEXITCODE -ne 0) { throw "installer exited with code $LASTEXITCODE" }
+        }
+        catch {
+          Write-Host "::warning::Could not install Apple container $version. $_"
+          "installed=false" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        # The package installs under /usr/local, which the agents already have on PATH, but a change to the package
+        # layout should leave a readable message instead of an unexplained 'command not found'.
+        if (-not (Get-Command container -ErrorAction SilentlyContinue)) {
+          if (Test-Path -LiteralPath "/usr/local/bin/container") {
+            Add-Content -LiteralPath $env:GITHUB_PATH -Value "/usr/local/bin"
+          }
+          else {
+            Write-Host "::warning::'container' is not on PATH and /usr/local/bin/container does not exist after installing the package."
+            "installed=false" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+        }
+
+        "installed=true" >> $env:GITHUB_OUTPUT
+
+    - name: Start the Apple container service
+      id: start-service
+      shell: pwsh
+      run: |
+        # GitHub runs pwsh steps with $ErrorActionPreference = 'stop', and PowerShell 7.4 turns a non-zero exit code
+        # from a native command into an error on top of that. Both are relaxed here so the failures below reach their
+        # '::warning::' instead of taking the step down.
+        $ErrorActionPreference = "Continue"
+        $PSNativeCommandUseErrorActionPreference = $false
+
+        if ("${{ steps.install.outputs.installed }}" -ne "true") {
+          "available=false" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        container --version
+
+        # Without '--enable-kernel-install' the first start prompts for the default Linux kernel and hangs the job.
+        container system start --enable-kernel-install --timeout 120
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::warning::'container system start' failed with exit code $LASTEXITCODE. Apple's runtime boots a virtual machine per container, which GitHub-hosted macOS agents cannot do (no nested virtualization)."
+          "available=false" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        # Same command as AppleContainerRuntime.BuildProbeArguments, so this answers exactly the question the tests ask.
+        container ls -q
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::warning::The Apple container service started but 'container ls -q' failed with exit code $LASTEXITCODE."
+          "available=false" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        "available=true" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,8 +425,8 @@ jobs:
             uses: ./.github/actions/setup-wslc
 
           # Apple's runtime is not preinstalled on the macOS agents, so without this step the AppleContainer tests
-          # skip. The action never fails the job: whether the agents can run the runtime at all is reported by the
-          # debug_apple_container job.
+          # skip. The action never fails the job, and it leaves the runtime running only when a container actually
+          # booted, so agents that cannot run one keep skipping instead of failing.
           - name: Setup Apple container
             if: startsWith(matrix.runs-on, 'macos') && matrix.test-group.id == 'TemporaryContainers' && steps.build-project.outputs.has-project == 'true'
             uses: ./.github/actions/setup-apple-container
@@ -478,9 +478,9 @@ jobs:
         run: wslc version
 
   # Debug job: reports whether the macOS agents can actually run Apple's container runtime, independently of the
-  # test run. Apple boots a virtual machine per container and GitHub-hosted macOS agents are themselves virtual
-  # machines without nested virtualization (actions/runner-images#13565), so this is expected to report that the
-  # runtime is unavailable. The job does not fail on that outcome: it exists to tell us the day it changes.
+  # test run. The runtime installs and its service starts there, but a container cannot boot: the agents are
+  # themselves virtual machines and Apple's framework reports 'Virtualization is not available on this hardware'
+  # (actions/runner-images#13565). The job does not fail on that outcome; it exists to tell us the day it changes.
   debug_apple_container:
     runs-on: macos-26
     timeout-minutes: 30
@@ -489,16 +489,13 @@ jobs:
       - name: Setup Apple container
         id: setup
         uses: ./.github/actions/setup-apple-container
-      - name: Run a container
-        if: steps.setup.outputs.available == 'true'
-        run: container run --rm busybox:1.37 echo "hello from container"
       - name: Report the outcome
         run: |
           if ("${{ steps.setup.outputs.available }}" -eq "true") {
-            $message = "Apple's container runtime answered on ${{ runner.os }} ${{ runner.arch }}. AppleContainerContainerTests can be made required."
+            $message = "Apple's container runtime booted a container on ${{ runner.os }} ${{ runner.arch }}. AppleContainerContainerTests now runs there and can be made required."
           }
           else {
-            $message = "Apple's container runtime did not answer on ${{ runner.os }} ${{ runner.arch }}, so AppleContainerContainerTests skips. The warnings above name the step that failed."
+            $message = "Apple's container runtime cannot run a container on ${{ runner.os }} ${{ runner.arch }}, so AppleContainerContainerTests skips. The warnings above name the step that failed."
           }
 
           Write-Host $message

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,13 @@ jobs:
             if: startsWith(matrix.runs-on, 'windows') && matrix.test-group.id == 'TemporaryContainers' && steps.build-project.outputs.has-project == 'true'
             uses: ./.github/actions/setup-wslc
 
+          # Apple's runtime is not preinstalled on the macOS agents, so without this step the AppleContainer tests
+          # skip. The action never fails the job: whether the agents can run the runtime at all is reported by the
+          # debug_apple_container job.
+          - name: Setup Apple container
+            if: startsWith(matrix.runs-on, 'macos') && matrix.test-group.id == 'TemporaryContainers' && steps.build-project.outputs.has-project == 'true'
+            uses: ./.github/actions/setup-apple-container
+
       - name: Build
         if: steps.build-project.outputs.has-project == 'true'
         run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} /bl ${{ matrix.additionalArguments }}
@@ -469,6 +476,33 @@ jobs:
         uses: ./.github/actions/setup-wslc
       - name: wslc version
         run: wslc version
+
+  # Debug job: reports whether the macOS agents can actually run Apple's container runtime, independently of the
+  # test run. Apple boots a virtual machine per container and GitHub-hosted macOS agents are themselves virtual
+  # machines without nested virtualization (actions/runner-images#13565), so this is expected to report that the
+  # runtime is unavailable. The job does not fail on that outcome: it exists to tell us the day it changes.
+  debug_apple_container:
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup Apple container
+        id: setup
+        uses: ./.github/actions/setup-apple-container
+      - name: Run a container
+        if: steps.setup.outputs.available == 'true'
+        run: container run --rm busybox:1.37 echo "hello from container"
+      - name: Report the outcome
+        run: |
+          if ("${{ steps.setup.outputs.available }}" -eq "true") {
+            $message = "Apple's container runtime answered on ${{ runner.os }} ${{ runner.arch }}. AppleContainerContainerTests can be made required."
+          }
+          else {
+            $message = "Apple's container runtime did not answer on ${{ runner.os }} ${{ runner.arch }}, so AppleContainerContainerTests skips. The warnings above name the step that failed."
+          }
+
+          Write-Host $message
+          $message >> $env:GITHUB_STEP_SUMMARY
 
   test_trimming:
     runs-on: ubuntu-26.04
@@ -641,7 +675,7 @@ jobs:
   final_status_check:
     runs-on: ubuntu-slim
     if: always()
-    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, debug_wslc, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
+    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, debug_wslc, debug_apple_container, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
     steps:
       - name: Check previous jobs status
         env:

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,18 @@
         "using the <c>(?<depName>[^<]+):(?<currentValue>[^<@]+)</c> image"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      // Apple ships 'container' as an installer package whose file name carries the version, so the download URL
+      // cannot go through the version-less '/releases/latest/download/' redirect and the version has to be pinned.
+      "customType": "regex",
+      "description": "Apple's container runtime installed on the macOS CI agents",
+      "managerFilePatterns": [
+        "/^\\.github/actions/setup-apple-container/action\\.yml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\$version = \"(?<currentValue>[^\"]+)\""
+      ]
     }
   ],
   "packageRules": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,7 +28,8 @@
         "/^\\.github/actions/setup-apple-container/action\\.yml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\$version = \"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\$version = \"(?<currentValue>[^\"]+)\"",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\$image = \"[^\":]+:(?<currentValue>[^\"]+)\""
       ]
     }
   ],

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
@@ -6,10 +6,11 @@ namespace Meziantou.Framework.TemporaryContainers.Tests;
 public sealed class AppleContainerContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.AppleContainer)
 {
     // Unlike WslcContainerTests, this class does not make the runtime required on CI. The macOS agents install it
-    // (.github/actions/setup-apple-container), but Apple boots a virtual machine per container and the GitHub-hosted
-    // macOS agents are themselves virtual machines without nested virtualization, so the service cannot start there
-    // (actions/runner-images#13565). The debug_apple_container job reports the day that changes; requiring the
-    // runtime here before then would only turn the macOS legs red.
+    // (.github/actions/setup-apple-container) and its service does start there, so the 'container ls -q' probe
+    // behind IsSupportedAsync answers; only booting the virtual machine a container needs fails, with
+    // 'Virtualization is not available on this hardware' (actions/runner-images#13565). The setup action therefore
+    // stops the service when no container can boot, which is what keeps these tests skipping rather than failing.
+    // The debug_apple_container job reports the day that changes.
 
     [Fact]
     public async Task PauseAsync_IsNotSupported()

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
@@ -5,6 +5,12 @@ namespace Meziantou.Framework.TemporaryContainers.Tests;
 [TestClass(DisableParallelization = true)]
 public sealed class AppleContainerContainerTests() : ContainerRuntimeTestsBase(ContainerRuntime.AppleContainer)
 {
+    // Unlike WslcContainerTests, this class does not make the runtime required on CI. The macOS agents install it
+    // (.github/actions/setup-apple-container), but Apple boots a virtual machine per container and the GitHub-hosted
+    // macOS agents are themselves virtual machines without nested virtualization, so the service cannot start there
+    // (actions/runner-images#13565). The debug_apple_container job reports the day that changes; requiring the
+    // runtime here before then would only turn the macOS legs red.
+
     [Fact]
     public async Task PauseAsync_IsNotSupported()
     {


### PR DESCRIPTION
## What

The `AppleContainer` tests silently skipped on every CI run. Apple's `container` is not preinstalled on the macOS agents, so `AppleContainerRuntime.IsSupportedAsync` never answered and `AppleContainerContainerTests` was skipped wholesale — the runtime was only ever exercised locally.

- **`.github/actions/setup-apple-container`** (new composite action) — downloads the signed release package, installs it, runs `container system start --enable-kernel-install`, probes with `container ls -q` (the exact command `AppleContainerRuntime.BuildProbeArguments` uses), and then boots a real container as the availability check.
- **`build_and_test`** — runs the action for `macos-*` on the `TemporaryContainers` group, mirroring the `Setup wslc` step next to it.
- **`debug_apple_container`** (new job) — mirrors `debug_wslc`: installs the runtime and writes the verdict to the step summary.
- **`renovate.json5`** — custom manager to keep the pinned `apple/container` version and smoke-test image fresh.
- **`AppleContainerContainerTests`** — comment recording why `IsRuntimeRequired` is *not* overridden here.

## What CI actually showed (and why the second commit exists)

I opened this expecting the runtime to fail to install or start, per [actions/runner-images#13565](https://github.com/actions/runner-images/issues/13565). **That was wrong**, and the first CI run on this PR is what corrected it. On `macos-26`:

- the package installs;
- `container system start` **succeeds** (22s);
- `container ls -q` **succeeds** — so `IsSupportedAsync` returns `true`;
- the image pulls, the kernel downloads, and only the last step fails:

```
[6/6] Starting container
Error: failed to bootstrap container (cause: "internalError: ... Error Domain=VZErrorDomain
Code=2 "Virtualization is not available on this hardware.""
```

This is **worse** than the runtime being absent. Because the probe answers, `AppleContainerContainerTests` would have *run and failed* on every test that starts a container, instead of skipping as it did before this branch — the exact CI breakage this PR set out to avoid.

The second commit fixes it: booting a container, not answering the probe, now decides availability. When no container can boot, the action stops the service so the probe fails again and the tests go back to skipping. The runtime is left running **only when it actually works** — which is also the moment `IsRuntimeRequired` becomes worth turning on.

## Why the tests are not made required yet

Unlike `WslcContainerTests`, this does **not** flip `IsRuntimeRequired`. Given the evidence above, requiring the runtime today would just turn the macOS legs red. `debug_apple_container` exists to report the day GitHub's agents gain the ability to boot a VM, at which point making the tests required is a one-line follow-up.

## Notes for the reviewer

- **The action never fails the job.** Every failure path emits a `::warning::` and sets `available=false`.
- **`container system stop` on failure is deliberate**, not cleanup for its own sake — it is what keeps `IsSupportedAsync` returning `false` so the tests skip. Worth a look, since it is the load-bearing line of the whole change.
- **PowerShell error handling.** GitHub runs `pwsh` steps with `$ErrorActionPreference = 'stop'`, and PowerShell 7.4+ escalates a non-zero native exit code into a terminating error. Both are relaxed at the top of each step — otherwise the failures above would fail the job, the opposite of the warn-don't-fail design.
- **Why the version is pinned.** The installer package file name carries the version (`container-1.3.1-installer-signed.pkg`), so it cannot be fetched through the version-less `/releases/latest/download/` redirect. Hence the pin plus the Renovate custom manager.
- `--enable-kernel-install` is required: without it the first start prompts for the default Linux kernel and hangs the job.

## Verification

- `dotnet run ./eng/update-all.cs` — exit 0, no generated-file drift.
- `dotnet build ... /p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet test --filter-class "*AppleContainer*" /p:TreatsWarningsAsErrors=true` — **total 32 / failed 0 / skipped 0** (16 tests × net10.0 + net11.0), against the real Apple runtime on macOS.
- `container run --rm busybox:1.37 true` returns 0 locally, confirming the new gate discriminates correctly (it returns 1 on the CI agents).
- Both YAML files parse; each Renovate `matchString` matches exactly one pin, with no overlap.
