### PR TITLE
Add PackageTags and improve descriptions for all packages

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/Meziantou.AspNetCore.Authentication.HttpBasic.csproj
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/Meziantou.AspNetCore.Authentication.HttpBasic.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>HTTP Basic authentication for ASP.NET Core with support for ASP.NET Core Identity</Description>
+    <PackageTags>aspnetcore, authentication, http-basic, basic-authentication, identity, security</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.4</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>A log viewer component for Blazor</Description>
+    <PackageTags>aspnetcore, blazor, components, logging, log-viewer, ui</PackageTags>
 
     <!-- StaticWebAssets are duplicated when multitargeting -->
     <NoWarn>$(NoWarn);NU5118</NoWarn>

--- a/src/Meziantou.AspNetCore.Components.WebAssembly/Meziantou.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Meziantou.AspNetCore.Components.WebAssembly/Meziantou.AspNetCore.Components.WebAssembly.csproj
@@ -7,6 +7,7 @@
     <!-- Microsoft.JSInterop, pulled in transitively, does not pass trim analysis (IL2065/IL2111) -->
     <SkipTrimmableValidation>true</SkipTrimmableValidation>
     <Description>Services for Blazor WebAssembly</Description>
+    <PackageTags>aspnetcore, blazor, webassembly, wasm, components</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj
+++ b/src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj
@@ -6,6 +6,7 @@
     <Version>3.0.5</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Components and services for Blazor</Description>
+    <PackageTags>aspnetcore, blazor, components, razor, ui</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj
+++ b/src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj
@@ -6,6 +6,7 @@
     <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>TagHelpers for Razor Pages</Description>
+    <PackageTags>aspnetcore, mvc, razor-pages, taghelper, html</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
     <Version>2.0.1</Version>
-    <Description>Auto register services and map routes</Description>
+    <Description>Source generator that automatically registers services and maps routes for applications using Meziantou.AspNetCore.ServiceDefaults</Description>
+    <PackageTags>aspnetcore, service-defaults, source-generator, dependency-injection, routing</PackageTags>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.6</Version>
-    <Description>Default configuration for meziantou applications</Description>
+    <Description>Opinionated ASP.NET Core defaults for OpenTelemetry, health checks, resilience, service discovery, and security</Description>
+    <PackageTags>aspnetcore, service-defaults, opentelemetry, health-checks, resilience, service-discovery, aspire</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj
+++ b/src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
-    <Description>Helpers for ASP.NET Core middleware diagnostics</Description>
+    <Description>Helpers for ASP.NET Core middleware pipeline diagnostics and default response cache-control headers</Description>
+    <PackageTags>aspnetcore, middleware, diagnostics, cache-control, http</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj
+++ b/src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <Version>2.0.2</Version>
     <Description>DNS proxy service with filtering and diagnostics UI</Description>
+    <PackageTags>dns, dns-proxy, dns-server, dns-filter, adblock, networking</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj
+++ b/src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj
@@ -5,7 +5,7 @@
     <IsTrimmable>true</IsTrimmable>
 
     <Description>Microsoft.Extension.Logging.ILogger implementation that writes to a file. Supports rolling files, retention, gzip compression, scopes, and JSON output.</Description>
-    <PackageTags>logger, file</PackageTags>
+    <PackageTags>logging, logger, file, rolling-file, ilogger, microsoft-extensions-logging</PackageTags>
     <Version>3.0.3</Version>
     <RootNamespace>Meziantou.Extensions.Logging</RootNamespace>
   </PropertyGroup>

--- a/src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj
+++ b/src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj
@@ -5,7 +5,7 @@
     <IsTrimmable>false</IsTrimmable>
 
     <Description>An in-memory implementation of Microsoft.Extension.Logging.ILogger</Description>
-    <PackageTags>logger</PackageTags>
+    <PackageTags>logging, logger, in-memory, ilogger, testing, microsoft-extensions-logging</PackageTags>
     <Version>2.0.5</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
@@ -5,7 +5,7 @@
     <IsTrimmable>false</IsTrimmable>
 
     <Description>Microsoft.Extension.Logging.ILogger implementation for xunit.v3</Description>
-    <PackageTags>xunit, xunit.v3, logger</PackageTags>
+    <PackageTags>xunit, xunit.v3, logging, logger, ilogger, testing</PackageTags>
     <Version>3.0.5</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.AnsiFormatting/Meziantou.Framework.AnsiFormatting.csproj
+++ b/src/Meziantou.Framework.AnsiFormatting/Meziantou.Framework.AnsiFormatting.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Utilities to process ANSI escape sequences and formatting</Description>
+    <PackageTags>ansi, escape-sequences, console, terminal, formatting, colors</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Assertions/Meziantou.Framework.Assertions.csproj
+++ b/src/Meziantou.Framework.Assertions/Meziantou.Framework.Assertions.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Meziantou.Framework.Assertions</RootNamespace>
     <Version>2.0.6</Version>
     <Description>Assertion helpers for .NET tests</Description>
+    <PackageTags>assertions, testing, unit-tests, assert, analyzer</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.AtlassianDataFormat.Tool/Meziantou.Framework.AtlassianDataFormat.Tool.csproj
+++ b/src/Meziantou.Framework.AtlassianDataFormat.Tool/Meziantou.Framework.AtlassianDataFormat.Tool.csproj
@@ -8,6 +8,7 @@
 
     <Version>1.0.2</Version>
     <Description>CLI to convert Atlassian Document Format (ADF) documents to Markdown using Meziantou.Framework.AtlassianDataFormat</Description>
+    <PackageTags>atlassian, adf, jira, confluence, markdown, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.AtlassianDataFormat/Meziantou.Framework.AtlassianDataFormat.csproj
+++ b/src/Meziantou.Framework.AtlassianDataFormat/Meziantou.Framework.AtlassianDataFormat.csproj
@@ -5,6 +5,7 @@
     <Version>1.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Parse the Atlassian Document Format (ADF) used by Jira, Confluence, and Bitbucket, and convert it to Markdown</Description>
+    <PackageTags>atlassian, adf, jira, confluence, bitbucket, markdown, parser</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Avatar/Meziantou.Framework.Avatar.csproj
+++ b/src/Meziantou.Framework.Avatar/Meziantou.Framework.Avatar.csproj
@@ -6,6 +6,7 @@
     <Version>2.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Generate deterministic avatar SVG images from names and bigrams</Description>
+    <PackageTags>avatar, identicon, initials, svg, image</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Bcrypt/Meziantou.Framework.Bcrypt.csproj
+++ b/src/Meziantou.Framework.Bcrypt/Meziantou.Framework.Bcrypt.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>BCrypt password hashing and verification helpers</Description>
+    <PackageTags>bcrypt, password, hashing, security, cryptography</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Bencode/Meziantou.Framework.Bencode.csproj
+++ b/src/Meziantou.Framework.Bencode/Meziantou.Framework.Bencode.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Bencode parser/writer and torrent file model</Description>
+    <PackageTags>bencode, torrent, bittorrent, parser, serialization</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.BloomFilters/Meziantou.Framework.BloomFilters.csproj
+++ b/src/Meziantou.Framework.BloomFilters/Meziantou.Framework.BloomFilters.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>High-performance in-memory Bloom filters and counting Bloom filters with atomic concurrent writes and segmented storage</Description>
+    <PackageTags>bloom-filter, counting-bloom-filter, probabilistic, data-structures, performance</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.ByteSize/Meziantou.Framework.ByteSize.csproj
+++ b/src/Meziantou.Framework.ByteSize/Meziantou.Framework.ByteSize.csproj
@@ -6,6 +6,7 @@
     <Version>4.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Class to parse and displaying values, such as file size, in Bytes</Description>
+    <PackageTags>byte-size, file-size, units, formatting, parsing</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.ChromiumTracing/Meziantou.Framework.ChromiumTracing.csproj
+++ b/src/Meziantou.Framework.ChromiumTracing/Meziantou.Framework.ChromiumTracing.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Classes to generate a tracing file that can be opened by Chromium browsers and other tools</Description>
+    <PackageTags>tracing, chromium, trace-event, perfetto, profiling, diagnostics</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.CodeDom/Meziantou.Framework.CodeDom.csproj
+++ b/src/Meziantou.Framework.CodeDom/Meziantou.Framework.CodeDom.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>A replacement for CodeDom to generate C# files</Description>
+    <PackageTags>codedom, code-generation, codegen, csharp</PackageTags>
     <Version>6.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.CodeOwners/Meziantou.Framework.CodeOwners.csproj
+++ b/src/Meziantou.Framework.CodeOwners/Meziantou.Framework.CodeOwners.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>CODEOWNERS file parser</Description>
+    <PackageTags>codeowners, github, gitlab, git, parser</PackageTags>
     <Version>6.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.CommandLine/Meziantou.Framework.CommandLine.csproj
+++ b/src/Meziantou.Framework.CommandLine/Meziantou.Framework.CommandLine.csproj
@@ -5,7 +5,8 @@
     <RootNamespace>Meziantou.Framework</RootNamespace>
     <Version>4.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
-    <Description>Basic command line parser</Description>
+    <Description>Command-line argument parsing, argument escaping, and interactive console prompts</Description>
+    <PackageTags>command-line, cli, arguments, parser, console, prompt</PackageTags>
     <DefineConstants>$(DefineConstants);CommandLineBuilder_PUBLIC</DefineConstants>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Csv/Meziantou.Framework.Csv.csproj
+++ b/src/Meziantou.Framework.Csv/Meziantou.Framework.Csv.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>CSV reader and writer</Description>
+    <PackageTags>csv, tsv, parser, reader, writer</PackageTags>
     <Version>5.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>false</IsTrimmable>
     <Version>2.0.11</Version>
     <Description>CLI tool to update dependencies in source repositories</Description>
+    <PackageTags>dependencies, scanner, nuget, npm, docker, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj
+++ b/src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj
@@ -5,6 +5,7 @@
     <IsTrimmable>false</IsTrimmable>
     <Version>3.0.11</Version>
     <Description>Find dependencies in source files. Support multiple package managers such as NuGet, npm, Docker, PyPi, and so on</Description>
+    <PackageTags>dependencies, scanner, nuget, npm, docker, pypi, dependency-update</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Meziantou.Framework.Diagnostics.ContextSnapshot.csproj
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Meziantou.Framework.Diagnostics.ContextSnapshot.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.4</Version>
     <Description>Create a snapshot of the current execution context to ease investigation</Description>
+    <PackageTags>diagnostics, snapshot, environment, troubleshooting</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj
+++ b/src/Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Locate and resolve external diff tools</Description>
+    <PackageTags>diff, diff-tool, merge-tool, testing</PackageTags>
     <Version>2.0.4</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj
+++ b/src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A DNS client supporting UDP, TCP, DNS over TLS, DNS over HTTPS, DNS over QUIC, DNSSEC, EDNS, IDN, and reverse lookups</Description>
+    <PackageTags>dns, dns-client, doh, dot, doq, dnssec, networking</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj
+++ b/src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>DNS filter list parser and matching engine supporting hosts files, domains-only lists, and AdGuard/Adblock DNS filtering syntax</Description>
+    <PackageTags>dns, filter, adblock, adguard, hosts, blocklist</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj
+++ b/src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj
@@ -5,6 +5,7 @@
     <Version>2.1.0</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>A DNS server library supporting UDP, TCP, DNS over TLS, DNS over HTTPS, and DNS over QUIC with ASP.NET Core hosting integration</Description>
+    <PackageTags>dns, dns-server, doh, dot, doq, aspnetcore, networking</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/Meziantou.Framework.EmbeddedConstantsGenerator.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>1.0.3</Version>
     <Description>MSBuild task for embedding text and binary files as C# constants</Description>
+    <PackageTags>msbuild, source-generator, constants, embedded-resources, codegen</PackageTags>
 
     <developmentDependency>true</developmentDependency>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
+++ b/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
     <Version>4.0.0</Version>
     <Description>Generate optimized enum helper methods</Description>
+    <PackageTags>enum, source-generator, roslyn, performance, codegen</PackageTags>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
     <Version>2.0.2</Version>
     <Description>Roslyn source generator and analyzer for custom fixed-length string structs</Description>
+    <PackageTags>string-builder, fixed-string, source-generator, analyzer, roslyn</PackageTags>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Meziantou.Framework.FixedStringBuilder/Meziantou.Framework.FixedStringBuilder.csproj
+++ b/src/Meziantou.Framework.FixedStringBuilder/Meziantou.Framework.FixedStringBuilder.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fixed-length string builder value types for low-allocation text operations</Description>
+    <PackageTags>string-builder, fixed-string, low-allocation, performance, struct</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj
+++ b/src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Meziantou.Framework</RootNamespace>
     <Version>3.0.4</Version>
     <Description>FullPath makes it easier to deal with paths</Description>
+    <PackageTags>path, file-system, io, full-path, normalization</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj
+++ b/src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>A globbing library for .NET. Can be used to match any string or with System.IO.Enumeration.</Description>
+    <PackageTags>glob, globbing, pattern-matching, wildcard, file-system</PackageTags>
     <Version>5.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Html.Tool/Meziantou.Framework.Html.Tool.csproj
+++ b/src/Meziantou.Framework.Html.Tool/Meziantou.Framework.Html.Tool.csproj
@@ -8,6 +8,7 @@
     <ToolCommandName>meziantou.html</ToolCommandName>
     <Version>2.0.6</Version>
     <Description>CLI to edit HTML files</Description>
+    <PackageTags>html, xpath, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Html/Meziantou.Framework.Html.csproj
+++ b/src/Meziantou.Framework.Html/Meziantou.Framework.Html.csproj
@@ -5,6 +5,7 @@
     <Version>3.0.2</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>HTML parser for .NET</Description>
+    <PackageTags>html, parser, dom, xpath, scraping</PackageTags>
     <DefineConstants>$(DefineConstants);HTML_PUBLIC</DefineConstants>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.HtmlSanitizer/Meziantou.Framework.HtmlSanitizer.csproj
+++ b/src/Meziantou.Framework.HtmlSanitizer/Meziantou.Framework.HtmlSanitizer.csproj
@@ -6,6 +6,7 @@
     <Version>3.1.1</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Provide helpers to sanitize HTML fragment</Description>
+    <PackageTags>html, sanitizer, sanitize, xss, security</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.HtmlToMarkdown.Tool/Meziantou.Framework.HtmlToMarkdown.Tool.csproj
+++ b/src/Meziantou.Framework.HtmlToMarkdown.Tool/Meziantou.Framework.HtmlToMarkdown.Tool.csproj
@@ -8,6 +8,7 @@
 
     <Version>1.0.2</Version>
     <Description>CLI to convert HTML to Markdown using Meziantou.Framework.HtmlToMarkdown</Description>
+    <PackageTags>html, markdown, converter, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.HtmlToMarkdown/Meziantou.Framework.HtmlToMarkdown.csproj
+++ b/src/Meziantou.Framework.HtmlToMarkdown/Meziantou.Framework.HtmlToMarkdown.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.5</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Convert HTML fragments to Markdown</Description>
+    <PackageTags>html, markdown, converter, conversion</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide In-memory persistence provider for Meziantou.Framework.Http.Caching</Description>
+    <PackageTags>http, caching, in-memory, httpclient</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj
+++ b/src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide Redis persistence provider for Meziantou.Framework.Http.Caching</Description>
+    <PackageTags>http, caching, redis, httpclient</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj
+++ b/src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide SQLite persistence provider for Meziantou.Framework.Http.Caching</Description>
+    <PackageTags>http, caching, sqlite, httpclient</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj
+++ b/src/Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide types to cache http response as described in RFC 7234</Description>
+    <PackageTags>http, caching, http-cache, rfc7234, httpclient</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj
+++ b/src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj
@@ -6,6 +6,7 @@
     <Version>2.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Provide an HttpClientHandler to upgrade request from http to https if an HSTS policy is set for the domain</Description>
+    <PackageTags>http, https, hsts, security, httpclient</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Htpasswd/Meziantou.Framework.Http.Htpasswd.csproj
+++ b/src/Meziantou.Framework.Http.Htpasswd/Meziantou.Framework.Http.Htpasswd.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Parser and validator for Apache htpasswd files</Description>
+    <PackageTags>htpasswd, apache, authentication, password, http</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj
+++ b/src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>HTTP record and replay for testing, using DelegatingHandler with HAR format support</Description>
+    <PackageTags>http, record, replay, har, httpclient, testing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/Meziantou.Framework.Http.ServerSideRequestForgery.csproj
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/Meziantou.Framework.Http.ServerSideRequestForgery.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Protects outbound SocketsHttpHandler requests against SSRF by validating schemes and resolved IP addresses.</Description>
+    <PackageTags>ssrf, security, http, httpclient, validation</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http/Meziantou.Framework.Http.csproj
+++ b/src/Meziantou.Framework.Http/Meziantou.Framework.Http.csproj
@@ -5,7 +5,8 @@
     <RootNamespace>Meziantou.Framework.Http</RootNamespace>
     <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
-    <Description>Provide methods to ease work with http stuff</Description>
+    <Description>Helpers to work with HTTP, such as parsing RFC 8288 Link header values</Description>
+    <PackageTags>http, link-header, rfc8288, httpclient, headers</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj
+++ b/src/Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>HAR 1.2 (HTTP Archive) format parser and writer</Description>
+    <PackageTags>har, http-archive, http, parser, serialization</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj
+++ b/src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj
@@ -6,6 +6,7 @@
     <Version>2.1.0</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Allow to create mocks for HttpClient</Description>
+    <PackageTags>httpclient, mock, http, testing, unit-tests</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.HumanReadable</RootNamespace>
     <Description>One-way serializer to a human readable format</Description>
+    <PackageTags>serializer, human-readable, snapshot-testing, diagnostics</PackageTags>
     <Version>4.0.3</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of objects using inline snapshots</Description>
+    <PackageTags>snapshot-testing, inline-snapshot, approval-tests, testing, assertions</PackageTags>
     <DefineConstants>$(DefineConstants);MEZIANTOU_INLINE_SNAPSHOT_TESTING</DefineConstants>
 
     <Version>6.0.7</Version>

--- a/src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj
+++ b/src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Json</RootNamespace>
     <Description>An implementation of JSONPath (RFC 9535) for System.Text.Json and custom object models.</Description>
+    <PackageTags>jsonpath, rfc9535, json, system-text-json, query</PackageTags>
     <Version>3.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj
+++ b/src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Detect known LLM and agentic execution contexts</Description>
+    <PackageTags>llm, ai, agent, detection, environment</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Language.Json/Meziantou.Framework.Language.Json.csproj
+++ b/src/Meziantou.Framework.Language.Json/Meziantou.Framework.Language.Json.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Language.Json</RootNamespace>
     <Description>Immutable JSON concrete syntax tree with diagnostics, trivia, source locations, and editing helpers.</Description>
+    <PackageTags>json, syntax-tree, cst, parser, diagnostics</PackageTags>
     <Version>2.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Language.Regex/Meziantou.Framework.Language.Regex.csproj
+++ b/src/Meziantou.Framework.Language.Regex/Meziantou.Framework.Language.Regex.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Language.Regex</RootNamespace>
     <Description>Immutable, round-trip regular-expression pattern concrete syntax tree for .NET, JavaScript, PCRE/Perl, and POSIX ERE/BRE, with diagnostics, trivia, source locations, and editing helpers.</Description>
+    <PackageTags>regex, syntax-tree, cst, parser, pcre</PackageTags>
     <Version>1.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Language.Shell/Meziantou.Framework.Language.Shell.csproj
+++ b/src/Meziantou.Framework.Language.Shell/Meziantou.Framework.Language.Shell.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Language.Shell</RootNamespace>
     <Description>Immutable, round-trip shell script concrete syntax tree for bash, sh, zsh, PowerShell, PowerShell Core, and cmd, with diagnostics, trivia, source locations, and editing helpers.</Description>
+    <PackageTags>shell, bash, powershell, syntax-tree, cst, parser</PackageTags>
     <Version>1.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Language.Xml/Meziantou.Framework.Language.Xml.csproj
+++ b/src/Meziantou.Framework.Language.Xml/Meziantou.Framework.Language.Xml.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Language.Xml</RootNamespace>
     <Description>Immutable XML syntax tree with diagnostics, editing helpers, and XPath navigation.</Description>
+    <PackageTags>xml, syntax-tree, cst, parser, xpath</PackageTags>
     <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -5,6 +5,7 @@
     <Version>2.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
+    <PackageTags>metadata, tags, id3, mp3, flac, ogg, mp4</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj
+++ b/src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj
@@ -5,6 +5,7 @@
     <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>An NTP client for querying NTP servers to retrieve accurate network time (supports NTPv3 and NTPv4)</Description>
+    <PackageTags>ntp, sntp, time, clock, networking</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj
+++ b/src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj
@@ -5,6 +5,7 @@
     <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>An NTP server that responds to NTP time queries (supports NTPv3 and NTPv4)</Description>
+    <PackageTags>ntp, sntp, time, server, networking</PackageTags>
   </PropertyGroup>
 
   <!-- The wire format is defined once, in the client project, and shared as source. These types are

--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/Meziantou.Framework.NuGetPackageValidation.Tool.csproj
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/Meziantou.Framework.NuGetPackageValidation.Tool.csproj
@@ -8,6 +8,7 @@
     <ToolCommandName>meziantou.validate-nuget-package</ToolCommandName>
     <Version>2.0.6</Version>
     <Description>CLI tool to validate NuGet packages follows best-practices</Description>
+    <PackageTags>nuget, package, validation, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.5</Version>
     <Description>Provide rules to validate a NuGet package follows best practices</Description>
+    <PackageTags>nuget, package, validation, best-practices</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.ObjectMethodExecutor/Meziantou.Framework.ObjectMethodExecutor.csproj
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/Meziantou.Framework.ObjectMethodExecutor.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.1</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Provide helpers to execute a synchronous or asynchronous method using reflection</Description>
+    <PackageTags>reflection, method-invocation, async, performance</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj
+++ b/src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.1.0</Version>
     <Description>In-memory OpenTelemetry collector receiver for Meziantou.Framework.OpenTelemetryCollector</Description>
+    <PackageTags>opentelemetry, otlp, collector, in-memory, testing</PackageTags>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>3.0.0</Version>
     <Description>OpenTelemetry OTLP collector endpoint abstractions for HTTP and gRPC with configurable receiver mappings</Description>
+    <PackageTags>opentelemetry, otlp, collector, telemetry, grpc, http</PackageTags>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.PooledMemoryStream/Meziantou.Framework.PooledMemoryStream.csproj
+++ b/src/Meziantou.Framework.PooledMemoryStream/Meziantou.Framework.PooledMemoryStream.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A pooled, recyclable MemoryStream backed by a shared pool of fixed-size byte arrays, implementing IBufferWriter&lt;byte&gt;.</Description>
+    <PackageTags>memorystream, pooling, buffer, ibufferwriter, performance</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.PostgreSqlServer/Meziantou.Framework.PostgreSqlServer.csproj
+++ b/src/Meziantou.Framework.PostgreSqlServer/Meziantou.Framework.PostgreSqlServer.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.0</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>A PostgreSQL wire-protocol server library with callback-based authentication and query handling</Description>
+    <PackageTags>postgresql, postgres, server, wire-protocol, testing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.4</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
+    <PackageTags>process, fluent, cli, diagnostics</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.PublicApiGenerator.MSBuild/Meziantou.Framework.PublicApiGenerator.MSBuild.csproj
+++ b/src/Meziantou.Framework.PublicApiGenerator.MSBuild/Meziantou.Framework.PublicApiGenerator.MSBuild.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.8</Version>
     <Description>MSBuild task to generate compilable C# public API stubs from built .NET assemblies.</Description>
+    <PackageTags>public-api, api-approval, api-diff, msbuild, build</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj
+++ b/src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.8</Version>
     <Description>CLI to generate compilable C# public API stubs from .NET assemblies.</Description>
+    <PackageTags>public-api, api-approval, api-diff, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj
+++ b/src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.5</Version>
     <Description>Generate compilable C# public API stubs from .NET assemblies.</Description>
+    <PackageTags>public-api, api-approval, api-diff, reflection, testing</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj
+++ b/src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>QR and barcode generation with SVG, PNG, and console renderers</Description>
+    <PackageTags>qrcode, barcode, svg, png, console</PackageTags>
     <NoWarn>$(NoWarn);CA1814</NoWarn>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.RelativeDate/Meziantou.Framework.RelativeDate.csproj
+++ b/src/Meziantou.Framework.RelativeDate/Meziantou.Framework.RelativeDate.csproj
@@ -6,6 +6,7 @@
     <Version>4.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Format a DateTime or DateTimeOffset using a relative format (e.g. 5 minutes ago)</Description>
+    <PackageTags>date, relative-date, humanize, formatting, time</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
+++ b/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
@@ -9,6 +9,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <Description>Generate code to access resx files using strongly-typed properties and methods</Description>
+    <PackageTags>resx, resources, source-generator, localization, roslyn</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.RobotsTxt/Meziantou.Framework.RobotsTxt.csproj
+++ b/src/Meziantou.Framework.RobotsTxt/Meziantou.Framework.RobotsTxt.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.4</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>robots.txt parser following RFC 9309 with Google path-wildcard extensions</Description>
+    <PackageTags>robots-txt, rfc9309, crawler, parser, seo</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
     <Version>1.0.11</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
+    <PackageTags>roslyn, analyzer, source-generator, codegen, compiler</PackageTags>
 
     <developmentDependency>true</developmentDependency>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
+++ b/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks);netstandard2.0</TargetFrameworks>
     <Description>RecurrenceRule (RFC 5545) and Cron expression parser and evaluator</Description>
+    <PackageTags>cron, rrule, recurrence, rfc5545, icalendar, scheduling</PackageTags>
     <Version>4.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.SensitiveData/Meziantou.Framework.SensitiveData.csproj
+++ b/src/Meziantou.Framework.SensitiveData/Meziantou.Framework.SensitiveData.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Represent sensitive data which should be difficult to accidentally disclose, even accounting for some types of application bugs.</Description>
+    <PackageTags>security, sensitive-data, secrets, memory, protection</PackageTags>
     <Version>2.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <RootNamespace>Meziantou.Framework</RootNamespace>

--- a/src/Meziantou.Framework.SimpleQueryLanguage/Meziantou.Framework.SimpleQueryLanguage.csproj
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Meziantou.Framework.SimpleQueryLanguage.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Parser and evaluator for expressions such as "author:meziantou AND status:opened"</Description>
+    <PackageTags>query-language, search, filtering, parser, dsl</PackageTags>
     <Version>2.0.2</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.SingleInstance/Meziantou.Framework.SingleInstance.csproj
+++ b/src/Meziantou.Framework.SingleInstance/Meziantou.Framework.SingleInstance.csproj
@@ -5,6 +5,7 @@
     <Version>3.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>SingleInstance allows to ensure only one instance of an application runs. Following instances can notify the main instance before closing.</Description>
+    <PackageTags>single-instance, mutex, ipc, application, desktop</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Slug/Meziantou.Framework.Slug.csproj
+++ b/src/Meziantou.Framework.Slug/Meziantou.Framework.Slug.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Compute a slug from any string value</Description>
+    <PackageTags>slug, slugify, url, text, normalization</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of SixLabors.ImageSharp images using file-based snapshots</Description>
+    <PackageTags>snapshot-testing, imagesharp, image, testing</PackageTags>
     <Version>2.0.8</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting.Roslyn/Meziantou.Framework.SnapshotTesting.Roslyn.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.Roslyn/Meziantou.Framework.SnapshotTesting.Roslyn.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of Roslyn objects (source generator results, syntax trees, and diagnostics) using file-based snapshots</Description>
+    <PackageTags>snapshot-testing, roslyn, source-generator, testing</PackageTags>
     <Version>1.0.4</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of SkiaSharp images using file-based snapshots</Description>
+    <PackageTags>snapshot-testing, skiasharp, image, testing</PackageTags>
     <Version>1.0.5</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting.Tool/Meziantou.Framework.SnapshotTesting.Tool.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.Tool/Meziantou.Framework.SnapshotTesting.Tool.csproj
@@ -6,6 +6,7 @@
     <IsTrimmable>false</IsTrimmable>
     <Version>2.0.6</Version>
     <Description>CLI tool to approve Meziantou.Framework.SnapshotTesting snapshots</Description>
+    <PackageTags>snapshot-testing, testing, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of objects using file-based snapshots</Description>
+    <PackageTags>snapshot-testing, approval-tests, testing, assertions</PackageTags>
     <Version>3.1.4</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.StronglyTypedId.Interfaces/Meziantou.Framework.StronglyTypedId.Interfaces.csproj
+++ b/src/Meziantou.Framework.StronglyTypedId.Interfaces/Meziantou.Framework.StronglyTypedId.Interfaces.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>4.0.0</Version>
     <Description>Provide optional interfaces for the Meziantou.Framework.StronglyTypedId source generator</Description>
+    <PackageTags>strongly-typed-id, interfaces, source-generator</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
+++ b/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
@@ -6,6 +6,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <Description>Source Generator to generate strongly-typed id with all needed helpers such as converters for System.Text.Json, Newtonsoft.Json, or MongoDB.</Description>
+    <PackageTags>strongly-typed-id, source-generator, roslyn, ddd, codegen</PackageTags>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddAnnotationsToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.SyntaxHighlighting/Meziantou.Framework.SyntaxHighlighting.csproj
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Meziantou.Framework.SyntaxHighlighting.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Syntax highlighting engine for .NET</Description>
+    <PackageTags>syntax-highlighting, highlighter, code, html, console</PackageTags>
     <Version>1.0.2</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.TdsServer/Meziantou.Framework.TdsServer.csproj
+++ b/src/Meziantou.Framework.TdsServer/Meziantou.Framework.TdsServer.csproj
@@ -5,6 +5,7 @@
     <Version>2.0.5</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>A TDS server library for SQL Server protocol connections with query response serialization and ASP.NET Core hosting integration</Description>
+    <PackageTags>tds, sql-server, server, wire-protocol, testing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Templating.Html/Meziantou.Framework.Templating.Html.csproj
+++ b/src/Meziantou.Framework.Templating.Html/Meziantou.Framework.Templating.Html.csproj
@@ -5,6 +5,7 @@
     <Version>4.0.4</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>HTML Template parser and evaluator. Provide a few syntax extensions to encode values or handle attached files for emails.</Description>
+    <PackageTags>template, template-engine, html, email, rendering</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Templating.Tool/Meziantou.Framework.Templating.Tool.csproj
+++ b/src/Meziantou.Framework.Templating.Tool/Meziantou.Framework.Templating.Tool.csproj
@@ -7,6 +7,7 @@
 
     <Version>2.0.7</Version>
     <Description>CLI to render templates using Meziantou.Framework.Templating</Description>
+    <PackageTags>template, template-engine, cli, dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Templating/Meziantou.Framework.Templating.csproj
+++ b/src/Meziantou.Framework.Templating/Meziantou.Framework.Templating.csproj
@@ -5,6 +5,7 @@
     <Version>4.0.4</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Template parser and evaluator. The template syntax is customizable. The code sections use C#.</Description>
+    <PackageTags>template, template-engine, csharp, rendering, codegen</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj
+++ b/src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj
@@ -5,6 +5,7 @@
     <Version>1.0.8</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Manage temporary containers for integration tests using the Docker Engine API, or the docker, podman, apple/container, or wslc CLI.</Description>
+    <PackageTags>docker, podman, containers, integration-tests, testing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj
+++ b/src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj
@@ -6,6 +6,7 @@
     <Version>3.0.4</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>TemporaryDirectory and TemporaryFile allow to create a disposable directory or file to store temporary data</Description>
+    <PackageTags>temporary-file, temporary-directory, io, disposable, testing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj
+++ b/src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj
@@ -6,6 +6,7 @@
     <Version>3.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Text diffing library supporting line, word, and character-level comparison with configurable options</Description>
+    <PackageTags>diff, text-diff, comparison, patch</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj
+++ b/src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>true</IsTrimmable>
     <Description>Types and extension methods to help with threading</Description>
+    <PackageTags>threading, concurrency, async, synchronization, collections</PackageTags>
     <Version>3.1.1</Version>
     <RootNamespace>Meziantou.Framework</RootNamespace>
   </PropertyGroup>

--- a/src/Meziantou.Framework.TypeConverter/Meziantou.Framework.TypeConverter.csproj
+++ b/src/Meziantou.Framework.TypeConverter/Meziantou.Framework.TypeConverter.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>false</IsTrimmable>
     <Description>Convert objects to other types using all standard .NET ways to convert objects</Description>
+    <PackageTags>type-converter, conversion, reflection, culture</PackageTags>
     <Version>4.0.1</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
+++ b/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
@@ -5,6 +5,7 @@
     <Version>4.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Async-first undo/redo framework based on the command pattern, with transactions and action merging.</Description>
+    <PackageTags>undo, redo, command-pattern, transactions, async</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Unicode/Meziantou.Framework.Unicode.csproj
+++ b/src/Meziantou.Framework.Unicode/Meziantou.Framework.Unicode.csproj
@@ -6,6 +6,7 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Unicode helpers for confusable character normalization and character metadata.</Description>
+    <PackageTags>unicode, confusables, homoglyph, normalization, text</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj
+++ b/src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>A .NET library for managing Linux Control Groups v2 (cgroups v2). Provides APIs to create/delete cgroups, manage process membership, and configure resource limits for CPU, memory, I/O, PIDs, and more.</Description>
+    <PackageTags>linux, unix, cgroups, cgroups-v2, resources</PackageTags>
     <Version>2.0.1</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Uri/Meziantou.Framework.Uri.csproj
+++ b/src/Meziantou.Framework.Uri/Meziantou.Framework.Uri.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>true</IsTrimmable>
-    <Description>Helpers to manipulate Uri</Description>
+    <Description>Helpers to manipulate URIs, including an implementation of the WHATWG URL Pattern API</Description>
+    <PackageTags>uri, url, urlpattern, whatwg, parsing</PackageTags>
     <Version>2.0.5</Version>
     <RootNamespace>Meziantou.Framework</RootNamespace>
   </PropertyGroup>

--- a/src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj
+++ b/src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj
@@ -6,6 +6,7 @@
     <Version>3.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Stopwatch without any allocation</Description>
+    <PackageTags>stopwatch, timing, performance, allocation-free, struct</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.ValueStringBuilder/Meziantou.Framework.ValueStringBuilder.csproj
+++ b/src/Meziantou.Framework.ValueStringBuilder/Meziantou.Framework.ValueStringBuilder.csproj
@@ -6,6 +6,7 @@
     <Version>3.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A high-performance value-type string builder with pooled buffers</Description>
+    <PackageTags>string-builder, low-allocation, performance, pooling, struct</PackageTags>
     <DefineConstants>$(DefineConstants);PUBLIC_VALUESTRINGBUILDER</DefineConstants>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj
+++ b/src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj
@@ -5,6 +5,7 @@
     <Version>3.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Provide a SemanticVersion class to parse, compare, format semantic versions</Description>
+    <PackageTags>semver, semantic-versioning, version, parsing, comparison</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj
+++ b/src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <Version>4.0.0</Version>
     <Description>Collection of Commands, Markup extensions, and DependencyProperty for WPF</Description>
+    <PackageTags>wpf, xaml, mvvm, commands, markup-extension</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Win32.AccessToken/Meziantou.Framework.Win32.AccessToken.csproj
+++ b/src/Meziantou.Framework.Win32.AccessToken/Meziantou.Framework.Win32.AccessToken.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Version>3.0.3</Version>
     <Description>Allow to manipulate Windows Access Tokens</Description>
+    <PackageTags>windows, win32, access-token, privileges, security</PackageTags>
 
     <MeziantouPolyfill_ExcludedPolyfills>T:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute</MeziantouPolyfill_ExcludedPolyfills>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Win32.Amsi/Meziantou.Framework.Win32.Amsi.csproj
+++ b/src/Meziantou.Framework.Win32.Amsi/Meziantou.Framework.Win32.Amsi.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>false</IsTrimmable>
     <Description>.NET wrapper for the Antimalware Scan Interface (AMSI)</Description>
+    <PackageTags>windows, win32, amsi, antimalware, security</PackageTags>
     <Version>3.0.2</Version>
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Version>4.0.3</Version>
     <Description>Allow to access the Windows Change Journal to quickly detect changed files</Description>
+    <PackageTags>windows, win32, change-journal, usn-journal, ntfs, file-system</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj
+++ b/src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>true</IsTrimmable>
     <Description>C# wrapper around CredWrite/CredRead/CredDelete/CredUIPromptForWindowsCredentials/CredUICmdLinePromptForCredentials functions to store and retrieve from Windows Credential Store</Description>
+    <PackageTags>windows, win32, credentials, credential-manager, security</PackageTags>
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Version>3.0.2</Version>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj
+++ b/src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>4.0.1</Version>
     <Description>Provide an OpenFolderDialog that uses Vista+ design</Description>
+    <PackageTags>windows, win32, dialog, folder-picker, ui</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj
+++ b/src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Version>4.0.1</Version>
     <Description>.NET wrapper for Windows Job Objects</Description>
+    <PackageTags>windows, win32, job-objects, process, resources</PackageTags>
 
     <MeziantouPolyfill_ExcludedPolyfills>T:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute</MeziantouPolyfill_ExcludedPolyfills>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Win32.Lsa/Meziantou.Framework.Win32.Lsa.csproj
+++ b/src/Meziantou.Framework.Win32.Lsa/Meziantou.Framework.Win32.Lsa.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Version>3.0.2</Version>
     <Description>.NET wrapper to get or set private data stored in Local Security Authority (LSA)</Description>
+    <PackageTags>windows, win32, lsa, secrets, security</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/Meziantou.Framework.Win32.MarkOfTheWeb.csproj
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/Meziantou.Framework.Win32.MarkOfTheWeb.csproj
@@ -5,6 +5,7 @@
     <IsTrimmable>false</IsTrimmable>
     <Version>2.0.1</Version>
     <Description>.NET wrapper to get or set Mark of the Web, a metadata identifier used by Microsoft Windows to mark files downloaded from the Internet as potentially unsafe</Description>
+    <PackageTags>windows, win32, mark-of-the-web, zone-identifier, security</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Win32.PerceivedType/Meziantou.Framework.Win32.PerceivedType.csproj
+++ b/src/Meziantou.Framework.Win32.PerceivedType/Meziantou.Framework.Win32.PerceivedType.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>false</IsTrimmable>
-    <Description>Wrapper for Windows Perceived types</Description>
+    <Description>Determine the perceived type of a file (text, image, audio, video, and so on) from its extension using Windows APIs</Description>
+    <PackageTags>windows, win32, perceived-type, file-type, shell</PackageTags>
     <Version>3.0.1</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>false</IsTrimmable>
     <Description>.NET wrapper for Windows Projected File System (ProjFS)</Description>
+    <PackageTags>windows, win32, projfs, virtual-file-system, file-system</PackageTags>
     <Version>3.0.3</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Win32.RecentDocuments/Meziantou.Framework.Win32.RecentDocuments.csproj
+++ b/src/Meziantou.Framework.Win32.RecentDocuments/Meziantou.Framework.Win32.RecentDocuments.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>.NET wrapper for Windows Recent Documents</Description>
+    <PackageTags>windows, win32, recent-documents, shell, jumplist</PackageTags>
     <Version>2.0.1</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Win32.RestartManager/Meziantou.Framework.Win32.RestartManager.csproj
+++ b/src/Meziantou.Framework.Win32.RestartManager/Meziantou.Framework.Win32.RestartManager.csproj
@@ -5,6 +5,7 @@
     <IsTrimmable>false</IsTrimmable>
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Description>C# wrapper for Windows RestartManager</Description>
+    <PackageTags>windows, win32, restart-manager, file-lock, process</PackageTags>
     <Version>4.0.2</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
+++ b/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
@@ -4,6 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <Description>A high-performance .NET YAML library providing parsing and serialization of object graphs, NativeAOT ready.</Description>
+    <PackageTags>yaml, parser, serialization, nativeaot, performance</PackageTags>
     <Version>1.0.8</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework/Meziantou.Framework.csproj
+++ b/src/Meziantou.Framework/Meziantou.Framework.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IsTrimmable>true</IsTrimmable>
 
-    <Description>Lots of utility classes</Description>
+    <Description>A collection of utility types and extension methods for .NET: collections, strings, dates, reflection, IO, and more</Description>
+    <PackageTags>utilities, extensions, helpers, collections, dotnet</PackageTags>
     <Version>6.0.4</Version>
     <DefineConstants>$(DefineConstants);PUBLIC_IO_UTILITIES;PUBLIC_STRING_EXTENSIONS;PUBLIC_MARKDOWN_BUILDER;PUBLIC_EXECUTABLE_FINDER;PUBLIC_SAFEHANDLEVALUE;PUBLIC_EXPRESSIONEXTENSIONS;PUBLIC_CIRCULARBUFFER;PUBLIC_APPEND_ONLY_COLLECTION;PUBLIC_REFLECTION_UTILITIES</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
## What

Every packable project under `src/` now sets both `Description` and `PackageTags`.

- **`PackageTags` added to 123 projects** that had none. Only `Meziantou.Xunit`, `Meziantou.Extensions.Logging.FileLogger`, `Meziantou.Extensions.Logging.InMemory` and `Meziantou.Extensions.Logging.Xunit.v3` had any; the logging ones were broadened. Tags follow the existing convention (`, `-separated, lowercase) and are placed on the line right after `<Description>`.
- **8 descriptions rewritten** where the existing text did not tell a reader what the package does, using each package's readme/source as the source of truth:
  - `Meziantou.Framework` — "Lots of utility classes" → collections/strings/dates/reflection/IO summary
  - `Meziantou.Framework.Uri` — now mentions the WHATWG URL Pattern API
  - `Meziantou.Framework.Http` — "ease work with http stuff" → RFC 8288 `Link` header parsing
  - `Meziantou.Framework.CommandLine` — adds argument escaping and interactive prompts
  - `Meziantou.AspNetCore`, `Meziantou.AspNetCore.ServiceDefaults`, `Meziantou.AspNetCore.ServiceDefaults.AutoRegister`, `Meziantou.Framework.Win32.PerceivedType`

## Why

Tags drive search on NuGet.org, and most packages shipped without any. Setting them everywhere also makes the packages pass this repository's own `TagsMustBeSetValidationRule`.

## Notes for reviewers

- The 7 non-packable projects (`*.Analyzer`, `*.CodeFix`, `*.CodeFixes`, `StronglyTypedId.Annotations`, `Yaml.SourceGenerator`) are untouched — they ship inside their parent package.
- Metadata only: no code, no `ref/` changes, no version bumps.

## Verification

- `dotnet run ./eng/update-all.cs` — clean, produced no further file changes.
- `dotnet build Meziantou.Framework.slnx -p:TreatWarningsAsErrors=true` — build succeeded, 0 warnings, 0 errors.
- `dotnet pack` on `Meziantou.Framework.Csv` confirms the tags reach the nuspec: `<tags>csv, tsv, parser, reader, writer</tags>`.
- The test suite was not run: the change is package metadata only and no test reads `Description`/`PackageTags`. All test projects compiled as part of the build.