### PR TITLE
Iterate on interface members in GetAllMembers

### DIFF
--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
     <PackageTags>roslyn, analyzer, source-generator, codegen, compiler</PackageTags>
 

--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -32,9 +32,13 @@ internal static partial class TypeSymbolExtensions
     }
 
     /// <summary>
-    /// Enumerates the members of <paramref name="symbol"/>, of its base types and of all the interfaces it implements.
+    /// Enumerates the members of <paramref name="symbol"/> and of its base types.
     /// </summary>
-    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol)
+    /// <param name="symbol">The type whose members are enumerated.</param>
+    /// <param name="includeInterfaceMembers">
+    /// <see langword="true"/> to also enumerate the members of all the interfaces implemented by <paramref name="symbol"/>; otherwise, <see langword="false"/>.
+    /// </param>
+    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, bool includeInterfaceMembers = true)
     {
         var type = symbol;
         while (type is not null)
@@ -45,7 +49,7 @@ internal static partial class TypeSymbolExtensions
             type = type.BaseType;
         }
 
-        if (symbol is not null)
+        if (includeInterfaceMembers && symbol is not null)
         {
             foreach (var @interface in symbol.AllInterfaces)
             {
@@ -56,9 +60,14 @@ internal static partial class TypeSymbolExtensions
     }
 
     /// <summary>
-    /// Enumerates the members named <paramref name="name"/> of <paramref name="symbol"/>, of its base types and of all the interfaces it implements.
+    /// Enumerates the members named <paramref name="name"/> of <paramref name="symbol"/> and of its base types.
     /// </summary>
-    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, string name)
+    /// <param name="symbol">The type whose members are enumerated.</param>
+    /// <param name="name">The name of the members to enumerate.</param>
+    /// <param name="includeInterfaceMembers">
+    /// <see langword="true"/> to also enumerate the members of all the interfaces implemented by <paramref name="symbol"/>; otherwise, <see langword="false"/>.
+    /// </param>
+    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, string name, bool includeInterfaceMembers = true)
     {
         var type = symbol;
         while (type is not null)
@@ -69,7 +78,7 @@ internal static partial class TypeSymbolExtensions
             type = type.BaseType;
         }
 
-        if (symbol is not null)
+        if (includeInterfaceMembers && symbol is not null)
         {
             foreach (var @interface in symbol.AllInterfaces)
             {

--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -31,25 +31,51 @@ internal static partial class TypeSymbolExtensions
         return allInterfaces.Add(namedType);
     }
 
+    /// <summary>
+    /// Enumerates the members of <paramref name="symbol"/>, of its base types and of all the interfaces it implements.
+    /// </summary>
     public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol)
     {
-        while (symbol is not null)
+        var type = symbol;
+        while (type is not null)
         {
-            foreach (var member in symbol.GetMembers())
+            foreach (var member in type.GetMembers())
                 yield return member;
 
-            symbol = symbol.BaseType;
+            type = type.BaseType;
+        }
+
+        if (symbol is not null)
+        {
+            foreach (var @interface in symbol.AllInterfaces)
+            {
+                foreach (var member in @interface.GetMembers())
+                    yield return member;
+            }
         }
     }
 
+    /// <summary>
+    /// Enumerates the members named <paramref name="name"/> of <paramref name="symbol"/>, of its base types and of all the interfaces it implements.
+    /// </summary>
     public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, string name)
     {
-        while (symbol is not null)
+        var type = symbol;
+        while (type is not null)
         {
-            foreach (var member in symbol.GetMembers(name))
+            foreach (var member in type.GetMembers(name))
                 yield return member;
 
-            symbol = symbol.BaseType;
+            type = type.BaseType;
+        }
+
+        if (symbol is not null)
+        {
+            foreach (var @interface in symbol.AllInterfaces)
+            {
+                foreach (var member in @interface.GetMembers(name))
+                    yield return member;
+            }
         }
     }
 

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -1437,6 +1437,78 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void GetAllMembers_ReturnsMembersFromImplementedInterfaces()
+    {
+        var compilation = CreateCompilation("""
+            public interface IBase
+            {
+                void BaseInterfaceOnly();
+            }
+
+            public interface ISample : IBase
+            {
+                void SampleInterfaceOnly();
+            }
+
+            public class Sample : ISample
+            {
+                public void BaseInterfaceOnly() { }
+                public void SampleInterfaceOnly() { }
+            }
+            """);
+        var type = GetRequiredType(compilation, "Sample");
+        var baseInterface = GetRequiredType(compilation, "IBase");
+        var sampleInterface = GetRequiredType(compilation, "ISample");
+
+        var members = type.GetAllMembers().ToArray();
+
+        Assert.Contains(GetRequiredMethod(baseInterface, "BaseInterfaceOnly"), members);
+        Assert.Contains(GetRequiredMethod(sampleInterface, "SampleInterfaceOnly"), members);
+    }
+
+    [Fact]
+    public void GetAllMembers_ReturnsMembersFromBaseInterfaces()
+    {
+        var compilation = CreateCompilation("""
+            public interface IBase
+            {
+                void BaseInterfaceOnly();
+            }
+
+            public interface ISample : IBase;
+            """);
+        var type = GetRequiredType(compilation, "ISample");
+        var baseInterface = GetRequiredType(compilation, "IBase");
+        var baseInterfaceOnly = GetRequiredMethod(baseInterface, "BaseInterfaceOnly");
+
+        Assert.Contains(baseInterfaceOnly, type.GetAllMembers());
+    }
+
+    [Fact]
+    public void GetAllMembers_WithName_ReturnsMatchingMembersFromInterfaces()
+    {
+        var compilation = CreateCompilation("""
+            public interface IBase
+            {
+                void BaseInterfaceOnly();
+            }
+
+            public interface ISample : IBase;
+
+            public class Sample : ISample
+            {
+                public void BaseInterfaceOnly() { }
+            }
+            """);
+        var type = GetRequiredType(compilation, "Sample");
+        var baseInterface = GetRequiredType(compilation, "IBase");
+        var baseInterfaceOnly = GetRequiredMethod(baseInterface, "BaseInterfaceOnly");
+
+        Assert.Contains(baseInterfaceOnly, type.GetAllMembers("BaseInterfaceOnly"));
+        Assert.DoesNotContain(baseInterfaceOnly, type.GetAllMembers("Unknown"));
+    }
+
+    [Fact]
     public void InheritsFrom_ReturnsTrueForBaseTypesAndConstrainedTypeParameters()
     {
         var compilation = CreateCompilation("""

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -1509,6 +1509,38 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void GetAllMembers_WithoutInterfaceMembers_OnlyReturnsMembersFromBaseTypes()
+    {
+        var compilation = CreateCompilation("""
+            public interface ISample
+            {
+                void InterfaceOnly();
+            }
+
+            public class Base
+            {
+                public void BaseOnly() { }
+            }
+
+            public class Sample : Base, ISample
+            {
+                public void InterfaceOnly() { }
+            }
+            """);
+        var type = GetRequiredType(compilation, "Sample");
+        var baseType = GetRequiredType(compilation, "Base");
+        var sampleInterface = GetRequiredType(compilation, "ISample");
+        var baseOnly = GetRequiredMethod(baseType, "BaseOnly");
+        var interfaceOnly = GetRequiredMethod(sampleInterface, "InterfaceOnly");
+
+        var members = type.GetAllMembers(includeInterfaceMembers: false).ToArray();
+
+        Assert.Contains(baseOnly, members);
+        Assert.DoesNotContain(interfaceOnly, members);
+        Assert.DoesNotContain(interfaceOnly, type.GetAllMembers("InterfaceOnly", includeInterfaceMembers: false));
+    }
+
+    [Fact]
     public void InheritsFrom_ReturnsTrueForBaseTypesAndConstrainedTypeParameters()
     {
         var compilation = CreateCompilation("""


### PR DESCRIPTION
## What changed

`TypeSymbolExtensions.GetAllMembers` (both the parameterless overload and the one taking a member name) now yields the members of every interface in `AllInterfaces`, after walking the base type chain as before.

`Meziantou.Framework.Roslyn` is bumped from `1.0.12` to `1.0.13`.

## Why

The previous implementation only walked `BaseType`, so members declared on implemented interfaces were never returned.

For an interface symbol the gap was larger: `BaseType` is `null` on interfaces, so `GetAllMembers` on `ISample : IBase` returned only `ISample`'s own members and never anything from `IBase`.

## Notes for reviewers

- `AllInterfaces` is already transitive and deduplicated by Roslyn, and interface members are distinct symbols from the class members that implement them, so no duplicates are introduced.
- Type parameters also benefit: `T` in `where T : ISample` now yields the constraint interfaces' members.
- The enumeration order is unchanged for existing callers — base chain first, interfaces appended at the end.
- Three tests were added to `RoslynHelperTests`: a class implementing an interface hierarchy, an interface deriving from a base interface, and the `name` overload (with a negative case).

## Verification

- All four Roslyn test project variants pass with `/p:TreatsWarningsAsErrors=true` (322/322, 322/322, 322/322, 324/324).
- All 8 projects consuming this shared source package (analyzers, code fixes, source generators) build clean with warnings as errors.
- `dotnet run ./eng/update-all.cs` succeeds and produces no generated-file changes.