### PR TITLE
Fall back to the instance type when the data flow value has no type

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -36,7 +36,13 @@ internal static partial class LocalDataFlowAnalysis
             if (value is null || value == operation)
                 return operation.Type;
 
-            operation = value.UnwrapImplicitConversions();
+            // Some values have no type, such as the null literal of "Type type = null;". The type of the
+            // current operation is more accurate than no type at all.
+            var unwrappedValue = value.UnwrapImplicitConversions();
+            if (unwrappedValue.Type is null)
+                return operation.Type;
+
+            operation = unwrappedValue;
         }
     }
 

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -820,6 +820,47 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void GetActualType_ReturnsTheDeclaredTypeWhenTheValueHasNoType()
+    {
+        var compilation = CreateCompilation("""
+            using System;
+            public class Sample
+            {
+                public void M()
+                {
+                    Type type = null;
+                    object boxed = type;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.Equal("System.Type", boxed.GetActualType(default)?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)));
+    }
+
+    [Fact]
+    public void GetActualType_ReturnsTheAssignedTypeWhenTheValueHasNoType()
+    {
+        var compilation = CreateCompilation("""
+            using System;
+            public class Sample
+            {
+                public void M()
+                {
+                    object value = default(int);
+                    value = null;
+                    object boxed = value;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.Equal(SpecialType.System_Object, boxed.GetActualType(default)?.SpecialType);
+    }
+
+    [Fact]
     public void GetActualType_WithoutDataFlowAnalysis_OnlyUnwrapsConversions()
     {
         var compilation = CreateCompilation("""


### PR DESCRIPTION
## What changed

`LocalDataFlowAnalysis.GetActualType` now stops the data flow walk when the value it finds has no type, and returns the type of the current operation instead.

## Why

Some values have no type — the null literal of `Type type = null;` is the common one. The walk moved onto that untyped operation, the next `GetFlowValue` found nothing more, and the method returned the untyped operation's `Type`, i.e. `null`. Falling back to the type of the instance itself (`System.Type` here) is more accurate than no type at all.

## Notes for reviewers

- `TryGetConstantValue` is untouched, so `null` constants still resolve through the same walk.
- Two tests added to `RoslynHelperTests`: the initializer case (`Type type = null;`) and the later-assignment case (`value = null;` after `object value = default(int);`, which falls back to the local's declared type).
- The first assertion compares against a display format that omits the nullable annotation, since the flow state annotates the type as `System.Type?`.
- All four Roslyn test projects pass (320/320, 320/320, 320/320, 322/322 — 7 `GetActualType` tests per TFM, up from 5). `dotnet run ./eng/update-all.cs` exits 0 with no generated-file changes, and a Release `/p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` build is clean.