### PR TITLE
Fix flaky CachedContent_CanBeEvictedUnderMemoryPressure test

### DIFF
--- a/tests/Meziantou.AspNetCore.Mvc.Tests/TagHelpersTests.cs
+++ b/tests/Meziantou.AspNetCore.Mvc.Tests/TagHelpersTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 
 namespace Meziantou.AspNetCore.Mvc.Tests;
 
@@ -188,7 +189,7 @@ public sealed class TagHelpersTests
     [Fact]
     public async Task CachedContent_CanBeEvictedUnderMemoryPressure()
     {
-        using var host = new TestHost();
+        using var host = new TestHost(watchFiles: false);
         host.Directory.CreateTextFile("app.js", "console.log(1)");
 
         var helper = host.CreateScriptTagHelper();
@@ -197,7 +198,7 @@ public sealed class TagHelpersTests
 
         Assert.NotEqual(0, host.Cache.Count);
 
-        // Compact never removes CacheItemPriority.NeverRemove entries
+        // Entries must not use CacheItemPriority.NeverRemove, which Compact never evicts
         host.Cache.Compact(1.0);
         Assert.Equal(0, host.Cache.Count);
     }
@@ -245,12 +246,12 @@ public sealed class TagHelpersTests
         private readonly PhysicalFileProvider _fileProvider;
         private readonly IWebHostEnvironment _environment;
 
-        public TestHost(MemoryCacheOptions? options = null)
+        public TestHost(MemoryCacheOptions? options = null, bool watchFiles = true)
         {
             Directory = TemporaryDirectory.Create();
             Cache = new MemoryCache(options ?? new MemoryCacheOptions());
             _fileProvider = new PhysicalFileProvider(Directory.FullPath);
-            _environment = new TestWebHostEnvironment(Directory.FullPath, _fileProvider);
+            _environment = new TestWebHostEnvironment(Directory.FullPath, watchFiles ? _fileProvider : new NonWatchingFileProvider(_fileProvider));
         }
 
         public TemporaryDirectory Directory { get; }
@@ -271,6 +272,25 @@ public sealed class TagHelpersTests
             Cache.Dispose();
             Directory.Dispose();
         }
+    }
+
+    // PhysicalFileProvider.Watch hands out a token that expires on its own: the watcher starts after the test has
+    // written the file, and macOS FSEvents replays that write to the newly created stream about 10ms later. Tests
+    // asserting on the cache content use this wrapper so no entry is evicted behind their back.
+    private sealed class NonWatchingFileProvider : IFileProvider
+    {
+        private readonly IFileProvider _fileProvider;
+
+        public NonWatchingFileProvider(IFileProvider fileProvider)
+        {
+            _fileProvider = fileProvider;
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath) => _fileProvider.GetDirectoryContents(subpath);
+
+        public IFileInfo GetFileInfo(string subpath) => _fileProvider.GetFileInfo(subpath);
+
+        public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
     }
 
     private sealed class TestWebHostEnvironment : IWebHostEnvironment


### PR DESCRIPTION
Fixes the flaky `TagHelpersTests.CachedContent_CanBeEvictedUnderMemoryPressure`, which failed on a macOS CI agent with:

```
Assert.NotEqual() assertion failed.
Expected expression: 0
Actual expression:   host.Cache.Count
```

## Root cause

On macOS, `PhysicalFileProvider.Watch(path)` returns a change token that fires **~11 ms later, 100% of the time**, when the watched file was written shortly before the watcher started — FSEvents replays the recent directory activity to the newly created stream.

Measured with a standalone repro:

| sequence | token fired |
| --- | --- |
| write → watch → read | 60/60 @ ~11 ms median |
| write → watch (no read) | 60/60 @ ~12 ms |
| write → 500 ms → watch → read | 0/60 |
| write → 500 ms → watch (no read) | 0/60 |

So the trigger is the write itself, not the subsequent read, and it stops once the write has aged out.

`InlineTagHelper.GetContentAsync` registers that token on the cache entry via `entry.AddExpirationToken(fileProvider.Watch(path))`. The entry is therefore evicted with `EvictionReason.TokenExpired` a few milliseconds after `ProcessAsync` returns, and `Assert.NotEqual(0, host.Cache.Count)` is racing it — usually winning by about a millisecond. Reproduced at the assertion level: **3 failures / 3000 iterations** under CPU load.

The production behaviour is correct; only the test's environment was moving underneath it. `InlineTagHelper` is unchanged.

## Fix

`TestHost` gains a `watchFiles` option backed by a small `NonWatchingFileProvider` decorator whose `Watch` returns `NullChangeToken.Singleton`. The entry then carries no expiration token at all, so the eviction is impossible **by construction** rather than merely unlikely — the same stress run goes to 0 failures / 3000.

Coverage is unchanged: the test asserts that a cached entry exists and that `Compact(1.0)` reclaims it. File-watch invalidation was never what it covered. Every other test in the class keeps the real `PhysicalFileProvider`.

Also fixes the comment above the `Compact` call, which read as contradictory — it claimed `Compact` never removes `NeverRemove` entries, directly above an assertion that the cache *is* emptied. It now states what the assertion actually guards.

## Note for reviewers

The other file-inlining tests in this class hit the same spurious invalidation; they just don't assert on cache state, so they are unaffected. Any future test that asserts on `Cache.Count` or on caching behaviour needs `watchFiles: false` too — the comment on the decorator says so.

## Verification

- Target test: 8 consecutive runs × both TFMs (16 executions) — all pass.
- Full project: 3 runs × 28 tests (14 tests × net10.0/net11.0) — all pass; counts confirm every test actually ran.
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` — succeeded with no warnings (the configuration where the IDE analyzers actually run for the new type).
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.
