### PR TITLE
Wait for a required container runtime to finish starting

### DIFF
--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Text.Json;
 using Meziantou.Extensions.Logging.Xunit.v3;
@@ -17,6 +18,9 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     private const string WindowsTempDirectory = "C:/Windows/Temp";
     private const string LinuxHttpServerCommand = "mkdir -p /www; printf 'hello from container' > /www/index.html; echo SERVER READY; exec httpd -f -p 8080 -h /www";
     private const string WindowsHttpServerCommand = "$content='hello from container'; New-Item -ItemType Directory -Path C:/www -Force | Out-Null; Set-Content -Path C:/www/index.html -Value $content -NoNewline; $listener=[System.Net.HttpListener]::new(); $listener.Prefixes.Add('http://+:8080/'); $listener.Start(); Write-Output 'SERVER READY'; while ($true) { $context=$listener.GetContext(); $bytes=[System.Text.Encoding]::UTF8.GetBytes($content); $context.Response.ContentLength64=$bytes.Length; $context.Response.OutputStream.Write($bytes, 0, $bytes.Length); $context.Response.OutputStream.Close(); }";
+
+    // A runtime that boots on demand needs a few probes before it answers, but a genuinely missing one must still fail fast enough to be readable.
+    private static readonly TimeSpan RuntimeStartupTimeout = TimeSpan.FromMinutes(2);
 
     private bool _useWindowsContainerImages;
 
@@ -43,20 +47,35 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     /// <summary>Checking that the runtime answers is asynchronous, so the skip gate cannot live in the constructor.</summary>
     public async ValueTask InitializeAsync()
     {
-        var isSupported = await Runtime.IsSupportedAsync(XunitCancellationToken);
         if (IsRuntimeRequired)
         {
-            global::Xunit.Assert.True(isSupported, $"The '{Runtime}' container runtime must be available in this environment, but it did not answer.");
+            global::Xunit.Assert.True(await WaitUntilRuntimeAnswersAsync(XunitCancellationToken), $"The '{Runtime}' container runtime must be available in this environment, but it did not answer.");
         }
         else
         {
-            global::Xunit.Assert.SkipUnless(isSupported, $"The '{Runtime}' container runtime is not available on this system.");
+            global::Xunit.Assert.SkipUnless(await Runtime.IsSupportedAsync(XunitCancellationToken), $"The '{Runtime}' container runtime is not available on this system.");
         }
 
         _useWindowsContainerImages = DetectUseWindowsContainerImages(Runtime);
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    /// <summary>Waits for a required runtime to answer. It can still be starting when the first test of the class runs: wslc boots its WSL virtual machine on demand and the probe fails until it is up, so a single failed probe would report a broken setup for what is only a cold start.</summary>
+    private async Task<bool> WaitUntilRuntimeAnswersAsync(CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
+        {
+            if (await Runtime.IsSupportedAsync(cancellationToken))
+                return true;
+
+            if (stopwatch.Elapsed >= RuntimeStartupTimeout)
+                return false;
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+    }
 
     private static bool DetectUseWindowsContainerImages(ContainerRuntime runtime)
     {


### PR DESCRIPTION
## What

When a `ContainerRuntimeTestsBase` subclass declares the runtime **required** (`IsRuntimeRequired`), retry `IsSupportedAsync` for up to 2 minutes instead of failing on the first non-zero probe.

## Why

`WslcContainerTests.Lifecycle_RestartStopAndDelete` failed on `windows-2025-vs2026, Release, TemporaryContainers` ([run 34006142726](https://github.com/meziantou/Meziantou.Framework/actions/runs/34006142726/job/101413735869)) with:

> The 'Wslc' container runtime must be available in this environment, but it did not answer.

The trx from that job's artifact shows it was not a broken CI setup:

| test | start | outcome |
|---|---|---|
| `Lifecycle_RestartStopAndDelete` | 02:32:02 | **Failed** (7.1s) |
| `GetLogsAsync_StreamsReadyMessage` | 02:32:09 | Passed |
| …7 more Wslc tests | … | Passed |

The failure is the *first* Wslc test of the net10.0 run, and all 8 tests after it passed. `wslc` boots its WSL virtual machine on demand, so `wslc list -q` (the probe behind `ContainerRuntime.IsSupportedAsync`) exits non-zero until the VM is up. In the net11.0 run earlier in the same job the first Wslc test took 22s but survived the cold start; by the net10.0 run 7 minutes later the VM had shut down and the cold start lost the race.

## Notes for reviewers

- Test-only change; the library's `IsSupportedAsync` keeps its current fail-fast semantics, so a caller asking "is this runtime available?" still gets a quick answer.
- The skip path is untouched: a runtime that is not required still skips immediately, and a genuinely broken CI setup still fails the tests — 2 minutes later.

## Verification

- `dotnet build -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- Temporarily forced `IsRuntimeRequired => true` with a 5s budget to exercise both new branches, then reverted: the Wslc test failed at 5.02s with the same message (the retry loop honors the deadline), and a Docker test passed at 3.1s (success on the first probe).
- `WslcContainerTests`, both TFMs: 18/18 skipped as before (no wslc on macOS).
- `DockerContainerTests`, both TFMs: 30/30 passed.
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.

The retry could not be exercised against a real cold-starting wslc locally, since wslc only exists on the Windows agents; CI on this PR is what confirms it end to end.