### PR TITLE
Fix flaky DnsProxy tests caused by a fixed port and shared environment variables

### DIFF
--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyHandlerTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyHandlerTests.cs
@@ -56,8 +56,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(upstream.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(upstream.Url);
 
         var response = await QueryAsync(factory, "signed.example", dnssecOk: true);
 
@@ -79,8 +78,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(upstream.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(upstream.Url);
 
         _ = await QueryAsync(factory, "unsigned.example", dnssecOk: false);
 
@@ -98,8 +96,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(upstream.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(upstream.Url);
 
         var response = await QueryAsync(factory, "payload.example", dnssecOk: false, udpPayloadSize: 512);
 
@@ -112,8 +109,7 @@ public sealed class DnsProxyHandlerTests
     {
         await using var upstream = FakeUpstream.Start(context => context.CreateResponse());
 
-        using var scope = EnvironmentScope.ForUpstreams(upstream.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(upstream.Url);
 
         var response = await QueryAsync(factory, "badvers.example", dnssecOk: false, ednsVersion: 1);
 
@@ -133,8 +129,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(upstream.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(upstream.Url);
 
         var response = await QueryAsync(factory, "opt.example", dnssecOk: true);
 
@@ -160,8 +155,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(broken.Url, healthy.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(broken.Url, healthy.Url);
 
         var response = await QueryAsync(factory, "failover.example", dnssecOk: false);
 
@@ -189,8 +183,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(nxdomain.Url, second.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(nxdomain.Url, second.Url);
 
         var response = await QueryAsync(factory, "missing.example", dnssecOk: false);
 
@@ -208,8 +201,7 @@ public sealed class DnsProxyHandlerTests
             return response;
         });
 
-        using var scope = EnvironmentScope.ForUpstreams(broken.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(broken.Url);
 
         var response = await QueryAsync(factory, "allbroken.example", dnssecOk: false);
 
@@ -221,8 +213,7 @@ public sealed class DnsProxyHandlerTests
     {
         await using var upstream = FakeUpstream.Start(context => context.CreateResponse());
 
-        using var scope = EnvironmentScope.ForUpstreams(upstream.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams(upstream.Url);
 
         var query = BuildQuery(["first.example", "second.example"], dnssecOk: false, udpPayloadSize: 1232, ednsVersion: 0);
         var response = await SendAsync(factory, query);
@@ -242,8 +233,7 @@ public sealed class DnsProxyHandlerTests
 
         await using var filterList = FakeFilterList.Start("||rewritten.example^$dnsrewrite=203.0.113.99");
 
-        using var scope = EnvironmentScope.ForUpstreams([upstream.Url], filterList.Url);
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        await using var factory = DnsProxyApplicationFactory.ForUpstreams([upstream.Url], filterList.Url);
         await WaitForFilterRulesAsync(factory);
 
         var response = await QueryAsync(factory, "rewritten.example", dnssecOk: false);
@@ -498,37 +488,30 @@ public sealed class DnsProxyHandlerTests
     }
 
     /// <summary>
-    /// Points every configured upstream at the given fake servers and keeps the proxy offline, restoring the previous
-    /// environment on dispose.
+    /// Applies the test configuration to a single host instead of the process-wide environment variables, so
+    /// concurrently running tests cannot observe each other's settings.
     /// </summary>
-    private sealed class EnvironmentScope : IDisposable
+    private sealed class DnsProxyApplicationFactory : WebApplicationFactory<DnsProxyProgram>
     {
         private const int ConfiguredUpstreamCount = 6;
         private const string UnreachableFilterUrl = "http://127.0.0.1:1/filters.txt";
 
-        private readonly Dictionary<string, string?> _previousValues = [];
+        private readonly Dictionary<string, string> _settings;
 
-        private EnvironmentScope(Dictionary<string, string?> values)
+        private DnsProxyApplicationFactory(Dictionary<string, string> settings) => _settings = settings;
+
+        public static DnsProxyApplicationFactory ForUpstreams(params string[] upstreamUrls) => ForUpstreams(upstreamUrls, filterListUrl: null);
+
+        public static DnsProxyApplicationFactory ForUpstreams(string[] upstreamUrls, string? filterListUrl)
         {
-            foreach (var (name, value) in values)
+            var settings = new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                _previousValues[name] = Environment.GetEnvironmentVariable(name);
-                Environment.SetEnvironmentVariable(name, value);
-            }
-        }
-
-        public static EnvironmentScope ForUpstreams(params string[] upstreamUrls) => ForUpstreams(upstreamUrls, filterListUrl: null);
-
-        public static EnvironmentScope ForUpstreams(string[] upstreamUrls, string? filterListUrl)
-        {
-            var values = new Dictionary<string, string?>(StringComparer.Ordinal)
-            {
-                ["DnsProxy__DnsPort"] = "0",
-                ["DnsProxy__HttpPort"] = "0",
-                ["DnsProxy__FilterRefreshInterval"] = "01:00:00",
-                ["DnsProxy__Filters__0__Url"] = filterListUrl ?? UnreachableFilterUrl,
-                ["DnsProxy__Filters__0__Format"] = "AdBlock",
-                ["DnsProxy__Filters__1__Url"] = UnreachableFilterUrl,
+                ["DnsProxy:DnsPort"] = "0",
+                ["DnsProxy:HttpPort"] = "0",
+                ["DnsProxy:FilterRefreshInterval"] = "01:00:00",
+                ["DnsProxy:Filters:0:Url"] = filterListUrl ?? UnreachableFilterUrl,
+                ["DnsProxy:Filters:0:Format"] = "AdBlock",
+                ["DnsProxy:Filters:1:Url"] = UnreachableFilterUrl,
             };
 
             // appsettings.json declares six upstreams; every one of them must point at a fake server, otherwise a
@@ -536,19 +519,19 @@ public sealed class DnsProxyHandlerTests
             for (var i = 0; i < ConfiguredUpstreamCount; i++)
             {
                 var url = upstreamUrls[Math.Min(i, upstreamUrls.Length - 1)];
-                values[$"DnsProxy__Upstreams__{i}__Url"] = url;
-                values[$"DnsProxy__Upstreams__{i}__Name"] = $"Fake {i}";
-                values[$"DnsProxy__Upstreams__{i}__Priority"] = i.ToString(CultureInfo.InvariantCulture);
+                settings[$"DnsProxy:Upstreams:{i}:Url"] = url;
+                settings[$"DnsProxy:Upstreams:{i}:Name"] = $"Fake {i}";
+                settings[$"DnsProxy:Upstreams:{i}:Priority"] = i.ToString(CultureInfo.InvariantCulture);
             }
 
-            return new EnvironmentScope(values);
+            return new DnsProxyApplicationFactory(settings);
         }
 
-        public void Dispose()
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            foreach (var (name, value) in _previousValues)
+            foreach (var (name, value) in _settings)
             {
-                Environment.SetEnvironmentVariable(name, value);
+                builder.UseSetting(name, value);
             }
         }
     }

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
@@ -13,72 +13,46 @@ namespace Meziantou.Framework.DnsProxy.Tests;
 [Collection("DnsProxyEnvironment")]
 public sealed partial class DnsProxyIntegrationTests
 {
-    [Fact(DisableParallelization = true)]
+    [Fact]
     public async Task Proxy_StartsWithCustomConfiguration_AndProcessesRequests()
     {
         const int DnsPort = 0;
         const int HttpPort = 5080;
         const string FilterRefreshInterval = "00:10:00";
-        const string DnsPortVariableName = "DnsProxy__DnsPort";
-        const string HttpPortVariableName = "DnsProxy__HttpPort";
-        const string FilterRefreshIntervalVariableName = "DnsProxy__FilterRefreshInterval";
-        const string Upstream0UrlVariableName = "DnsProxy__Upstreams__0__Url";
-        const string Upstream1UrlVariableName = "DnsProxy__Upstreams__1__Url";
-        const string Upstream2UrlVariableName = "DnsProxy__Upstreams__2__Url";
-        const string BootstrapDnsServersVariableName = "DnsProxy__BootstrapDnsServers__0";
 
-        var previousDnsPort = Environment.GetEnvironmentVariable(DnsPortVariableName);
-        var previousHttpPort = Environment.GetEnvironmentVariable(HttpPortVariableName);
-        var previousFilterRefreshInterval = Environment.GetEnvironmentVariable(FilterRefreshIntervalVariableName);
-        var previousUpstream0Url = Environment.GetEnvironmentVariable(Upstream0UrlVariableName);
-        var previousUpstream1Url = Environment.GetEnvironmentVariable(Upstream1UrlVariableName);
-        var previousUpstream2Url = Environment.GetEnvironmentVariable(Upstream2UrlVariableName);
-        var previousBootstrapDnsServers = Environment.GetEnvironmentVariable(BootstrapDnsServersVariableName);
-
-        Environment.SetEnvironmentVariable(DnsPortVariableName, DnsPort.ToString(CultureInfo.InvariantCulture));
-        Environment.SetEnvironmentVariable(HttpPortVariableName, HttpPort.ToString(CultureInfo.InvariantCulture));
-        Environment.SetEnvironmentVariable(FilterRefreshIntervalVariableName, FilterRefreshInterval);
-        Environment.SetEnvironmentVariable(Upstream0UrlVariableName, "https://1.1.1.1/dns-query");
-        Environment.SetEnvironmentVariable(Upstream1UrlVariableName, "https://9.9.9.9/dns-query");
-        Environment.SetEnvironmentVariable(Upstream2UrlVariableName, "https://dns.nextdns.io/dns-query");
-        Environment.SetEnvironmentVariable(BootstrapDnsServersVariableName, "1.1.1.1");
-
-        try
+        using var baseFactory = new WebApplicationFactory<DnsProxyProgram>();
+        using var factory = baseFactory.WithWebHostBuilder(builder =>
         {
-            await using var factory = new WebApplicationFactory<DnsProxyProgram>();
-            var webClient = factory.CreateClient();
-            var html = await webClient.GetStringAsync("/", XunitCancellationToken);
+            builder.UseSetting("DnsProxy:DnsPort", DnsPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:HttpPort", HttpPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:FilterRefreshInterval", FilterRefreshInterval);
+            builder.UseSetting("DnsProxy:Upstreams:0:Url", "https://1.1.1.1/dns-query");
+            builder.UseSetting("DnsProxy:Upstreams:1:Url", "https://9.9.9.9/dns-query");
+            builder.UseSetting("DnsProxy:Upstreams:2:Url", "https://dns.nextdns.io/dns-query");
+            builder.UseSetting("DnsProxy:BootstrapDnsServers:0", "1.1.1.1");
+        });
+        var webClient = factory.CreateClient();
+        var html = await webClient.GetStringAsync("/", XunitCancellationToken);
 
-            Assert.Contains($"<span class='mono'>DnsPort</span>: {DnsPort}", html);
-            Assert.Contains($"<span class='mono'>HttpPort</span>: {HttpPort}", html);
-            Assert.Contains($"<span class='mono'>FilterRefreshInterval</span>: {FilterRefreshInterval}", html);
+        Assert.Contains($"<span class='mono'>DnsPort</span>: {DnsPort}", html);
+        Assert.Contains($"<span class='mono'>HttpPort</span>: {HttpPort}", html);
+        Assert.Contains($"<span class='mono'>FilterRefreshInterval</span>: {FilterRefreshInterval}", html);
 
-            var query = CreateAQuery("localhost", id: 0x1234);
-            using var request = new HttpRequestMessage(HttpMethod.Post, "/dns-query")
-            {
-                Content = new ByteArrayContent(query),
-            };
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
-            using var response = await webClient.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-            var responseBytes = await response.Content.ReadAsByteArrayAsync();
-            AssertDnsResponseHasARecord(responseBytes, expectedId: 0x1234, expectedAddress: IPAddress.Parse("127.0.0.1"));
-
-            var htmlAfterQuery = await webClient.GetStringAsync("/");
-            Assert.Contains("localhost A", htmlAfterQuery);
-            Assert.Contains("CustomRecord", htmlAfterQuery);
-        }
-        finally
+        var query = CreateAQuery("localhost", id: 0x1234);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/dns-query")
         {
-            Environment.SetEnvironmentVariable(DnsPortVariableName, previousDnsPort);
-            Environment.SetEnvironmentVariable(HttpPortVariableName, previousHttpPort);
-            Environment.SetEnvironmentVariable(FilterRefreshIntervalVariableName, previousFilterRefreshInterval);
-            Environment.SetEnvironmentVariable(Upstream0UrlVariableName, previousUpstream0Url);
-            Environment.SetEnvironmentVariable(Upstream1UrlVariableName, previousUpstream1Url);
-            Environment.SetEnvironmentVariable(Upstream2UrlVariableName, previousUpstream2Url);
-            Environment.SetEnvironmentVariable(BootstrapDnsServersVariableName, previousBootstrapDnsServers);
-        }
+            Content = new ByteArrayContent(query),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
+        using var response = await webClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var responseBytes = await response.Content.ReadAsByteArrayAsync();
+        AssertDnsResponseHasARecord(responseBytes, expectedId: 0x1234, expectedAddress: IPAddress.Parse("127.0.0.1"));
+
+        var htmlAfterQuery = await webClient.GetStringAsync("/");
+        Assert.Contains("localhost A", htmlAfterQuery);
+        Assert.Contains("CustomRecord", htmlAfterQuery);
     }
 
     [Fact]
@@ -258,7 +232,23 @@ public sealed partial class DnsProxyIntegrationTests
     [Fact]
     public async Task DisableFilteringEndpoint_WithoutAntiforgeryToken_IsRejected()
     {
-        await using var factory = new WebApplicationFactory<DnsProxyProgram>();
+        const int DnsPort = 0;
+        const int HttpPort = 5080;
+
+        using var baseFactory = new WebApplicationFactory<DnsProxyProgram>();
+        using var factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            // The default DnsPort is a fixed port, so relying on it would make the test fail with
+            // "Address already in use" whenever another host binds it, such as the same test running
+            // in the process of another target framework.
+            builder.UseSetting("DnsProxy:DnsPort", DnsPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:HttpPort", HttpPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:Filters:0:Url", "");
+            builder.UseSetting("DnsProxy:Filters:1:Url", "");
+            builder.UseSetting("DnsProxy:Upstreams:0:Endpoint", "");
+            builder.UseSetting("DnsProxy:Upstreams:1:Endpoint", "");
+            builder.UseSetting("DnsProxy:Upstreams:2:Endpoint", "");
+        });
         var webClient = factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false,


### PR DESCRIPTION
## Why

[This CI job](https://github.com/meziantou/Meziantou.Framework/actions/runs/34009425576/job/101423249460) (`ubuntu-26.04-arm, Release, Dns`) failed on attempt 1 with a single failing test out of 874:

```
DnsProxyIntegrationTests.DisableFilteringEndpoint_WithoutAntiforgeryToken_IsRejected
  SocketException : Address already in use
    at DnsUdpListener.StartAsync(...) src/Meziantou.Framework.DnsServer/Listeners/DnsUdpListener.cs:47
```

That test built a bare `WebApplicationFactory<Program>()` without overriding any setting, so the host bound the default `DnsPort` from `appsettings.json` — a fixed 5053 — on `127.0.0.1` and `::1`. Every other host-starting test in the project sets it to 0. `tests/Directory.Build.props` only disables `TestTfmsInParallel` on Windows CI, so elsewhere the net10.0 and net11.0 test processes run concurrently and both raced for 5053.

While verifying, a second flake showed up, failing 3/3 local runs on net10.0 before any change: `Proxy_StartsWithCustomConfiguration_AndProcessesRequests` configured its host through the process-wide `DnsProxy__*` environment variables, and `DnsProxyHandlerTests.EnvironmentScope` restored those same variables concurrently. Tests of different classes run in parallel under the repo's `parallelAlgorithm: aggressive` setup, so the host read the `appsettings.json` defaults instead of the values the test had just set. It passed when run alone.

## What changed

- `DisableFilteringEndpoint_WithoutAntiforgeryToken_IsRejected` now sets `DnsProxy:DnsPort` to 0, plus empty filters and upstreams so it no longer reaches the network, matching its sibling tests.
- `Proxy_StartsWithCustomConfiguration_AndProcessesRequests` configures its host with `WithWebHostBuilder`/`UseSetting`; the environment variable save/restore block and `DisableParallelization` are gone.
- `DnsProxyHandlerTests.EnvironmentScope` is replaced by a `DnsProxyApplicationFactory` applying the same settings per host through `ConfigureWebHost`, which also drops a line at each of its 10 call sites.

No test binds a fixed port or mutates process-wide state any more.

## Notes for reviewers

- `[Fact(DisableParallelization = true)]` on the handler tests is now redundant, but I left it in place rather than widen the change.
- Test behaviour is otherwise unchanged: the same configuration keys and values are applied, just through host settings rather than environment variables.

## Verification

- `Meziantou.Framework.DnsProxy.Tests` with `-p:TreatWarningsAsErrors=true`: 3 consecutive runs, 122/122 passing on both target frameworks (121/122 with a failure on every run before the change).
- Full `Dns` CI group: DnsClient 268 passed / 2 skipped, DnsFilter 324, DnsProxy 122, DnsServer 158, no failures.
- `dotnet run ./eng/update-all.cs` exits 0 with no file changes.