### PR TITLE
Retry the WSL update in the setup-wslc action

### DIFF
--- a/.github/actions/setup-wslc/action.yml
+++ b/.github/actions/setup-wslc/action.yml
@@ -8,8 +8,28 @@ runs:
       shell: pwsh
       run: |
         # wslc ships inside WSL itself, and only the pre-release channel carries it (WSL 2.9.3 or higher)
-        wsl --update --pre-release
-        if ($LASTEXITCODE -ne 0) { throw "wsl --update --pre-release failed with exit code $LASTEXITCODE" }
+        # The update service intermittently answers with a transient error (e.g. Forbidden (403),
+        # Wsl/UpdatePackage/0x80190193), so retry a few times before giving up.
+        $maxAttempts = 3
+        $baseDelaySeconds = 5
+
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          Write-Host "Updating WSL (attempt $attempt/$maxAttempts)"
+          wsl --update --pre-release
+          $exitCode = $LASTEXITCODE
+
+          if ($exitCode -eq 0) {
+            break
+          }
+
+          if ($attempt -eq $maxAttempts) {
+            throw "wsl --update --pre-release failed with exit code $exitCode"
+          }
+
+          $delaySeconds = [int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1))
+          Write-Host "Retrying WSL update in $delaySeconds second(s)."
+          Start-Sleep -Seconds $delaySeconds
+        }
 
         wsl --version
 


### PR DESCRIPTION
## What

Wraps `wsl --update --pre-release` in `.github/actions/setup-wslc` in a 3-attempt retry loop with exponential backoff (5s, then 10s), instead of hard-failing on the first non-zero exit code.

## Why

The `build_and_test (windows-2025-vs2026, Debug, invariant, TemporaryContainers)` leg of [run 34011990562](https://github.com/meziantou/Meziantou.Framework/actions/runs/34011990562/job/101429396519) failed in the **`Setup wslc`** step, before any test ran:

```
Checking for updates.
Forbidden (403).
Error code: Wsl/UpdatePackage/0x80190193
wsl --update --pre-release failed with exit code -1
```

The Microsoft WSL update service refused the download. The other two Windows TemporaryContainers legs passed on the same run and the same runner image, which is the signature of a per-agent infrastructure flake rather than anything in the code under test.

## Notes for reviewers

- **The step still throws once the attempts are exhausted.** This is deliberate. The following `Locate wslc.exe` step only emits a `::warning::` and exits 0 when `wslc.exe` is missing, so swallowing the update failure would leave the step green with the runtime absent — and the Wslc tests are written to fail rather than skip on the CI agents (see commit 2ecd22e24). A genuinely broken install must stay loud.
- The retry shape matches the one already used for the NuGet push in `ci.yml`.
- This only helps if the 403 is transient. If the endpoint starts refusing these runners persistently, the job still fails after ~15s of retries, just with a clearer log; seeing it hit all three legs at once would mean a different problem.

## Verification

Workflow-only change — no C# touched, so no build or test run is affected by it. What was verified:

- YAML parses; both steps intact.
- The PowerShell body parses cleanly under `pwsh`.
- Simulated the retry loop against a stubbed `wsl` across three scenarios: success on the first attempt (one update call, no sleeps), transient failure recovering on attempt 3 (backoff 5s → 10s), and permanent failure (throws after 3 attempts).
- `dotnet run ./eng/update-all.cs` exits 0 and produces no file changes.