### PR TITLE
Benchmark the assertion library and speed up its hot paths

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/AssertionsBenchmarks/AssertionsBenchmarks.csproj" />
     <Project Path="benchmarks/BloomFiltersBenchmarks/BloomFiltersBenchmarks.csproj" />
     <Project Path="benchmarks/DependencyScanningBenchmarks/DependencyScanningBenchmarks.csproj" />
     <Project Path="benchmarks/FastEnumGeneratorBenchmarks/FastEnumGeneratorBenchmarks.csproj" />

--- a/benchmarks/AssertionsBenchmarks/AssertionsBenchmarks.csproj
+++ b/benchmarks/AssertionsBenchmarks/AssertionsBenchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Meziantou.NET.Sdk">
+
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+   </PropertyGroup>
+
+   <ItemGroup>
+     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+   </ItemGroup>
+
+   <ItemGroup>
+     <ProjectReference Include="../../src/Meziantou.Framework.Assertions/Meziantou.Framework.Assertions.csproj" />
+   </ItemGroup>
+
+</Project>

--- a/benchmarks/AssertionsBenchmarks/CollectionAssertionBenchmark.cs
+++ b/benchmarks/AssertionsBenchmarks/CollectionAssertionBenchmark.cs
@@ -1,0 +1,88 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.Assertions;
+
+namespace AssertionsBenchmarks;
+
+/// <summary>Measures the success path of the collection assertions.</summary>
+[MemoryDiagnoser]
+public class CollectionAssertionBenchmark
+{
+    [Params(8, 1000)]
+    public int Size { get; set; }
+
+    private int[] _expectedArray = null!;
+    private int[] _actualArray = null!;
+    private List<int> _expectedList = null!;
+    private List<int> _actualList = null!;
+    private string[] _expectedStrings = null!;
+    private string[] _actualStrings = null!;
+    private IEnumerable<int> _expectedLazy = null!;
+    private IEnumerable<int> _actualLazy = null!;
+    private int[] _singleItem = null!;
+    private int[] _empty = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _expectedArray = Enumerable.Range(0, Size).ToArray();
+        _actualArray = Enumerable.Range(0, Size).ToArray();
+        _expectedList = [.. _expectedArray];
+        _actualList = [.. _actualArray];
+        _expectedStrings = [.. _expectedArray.Select(value => value.ToString(CultureInfo.InvariantCulture))];
+        _actualStrings = [.. _actualArray.Select(value => value.ToString(CultureInfo.InvariantCulture))];
+        _expectedLazy = Lazy(_expectedArray);
+        _actualLazy = Lazy(_actualArray);
+        _singleItem = [1];
+        _empty = [];
+
+        static IEnumerable<int> Lazy(int[] values)
+        {
+            foreach (var value in values)
+            {
+                yield return value;
+            }
+        }
+    }
+
+    [Benchmark]
+    public void EqualArrays() => Assert.Equal(_expectedArray, _actualArray);
+
+    [Benchmark]
+    public void EqualLists() => Assert.Equal(_expectedList, _actualList);
+
+    [Benchmark]
+    public void EqualStringArrays() => Assert.Equal(_expectedStrings, _actualStrings);
+
+    [Benchmark]
+    public void EqualLazyEnumerables() => Assert.Equal(_expectedLazy, _actualLazy);
+
+    [Benchmark]
+    public void EqualSpans() => Assert.Equal<int>(_expectedArray.AsSpan(), _actualArray.AsSpan());
+
+    [Benchmark]
+    public void EqualNonGeneric() => Assert.Equal((System.Collections.IEnumerable)_expectedArray, (System.Collections.IEnumerable)_actualArray);
+
+    [Benchmark]
+    public void EqualUnordered() => Assert.EqualUnordered(_expectedArray, _actualArray);
+
+    [Benchmark]
+    public void ContainsLast() => Assert.Contains(Size - 1, (IEnumerable<int>)_actualArray);
+
+    [Benchmark]
+    public void Distinct() => Assert.Distinct((IEnumerable<int>)_actualArray);
+
+    [Benchmark]
+    public void AllPredicate() => Assert.All(_actualArray, value => value >= 0);
+
+    [Benchmark]
+    public void HasCount() => Assert.HasCount(Size, (IEnumerable<int>)_actualArray);
+
+    [Benchmark]
+    public void SingleItem() => Assert.Single((IEnumerable<int>)_singleItem);
+
+    [Benchmark]
+    public void Empty() => Assert.Empty((IEnumerable<int>)_empty);
+
+    [Benchmark]
+    public void NotEmpty() => Assert.NotEmpty((IEnumerable<int>)_actualArray);
+}

--- a/benchmarks/AssertionsBenchmarks/EquivalentBenchmark.cs
+++ b/benchmarks/AssertionsBenchmarks/EquivalentBenchmark.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.Assertions;
+
+namespace AssertionsBenchmarks;
+
+/// <summary>Measures the success path of the structural comparison used by <c>Assert.Equivalent</c>.</summary>
+[MemoryDiagnoser]
+public class EquivalentBenchmark
+{
+    private readonly string _expectedText = "Meziantou";
+    private readonly string _actualText = new(['M', 'e', 'z', 'i', 'a', 'n', 't', 'o', 'u']);
+
+    private Customer _expectedCustomer = null!;
+    private Customer _actualCustomer = null!;
+    private int[] _expectedArray = null!;
+    private int[] _actualArray = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _expectedCustomer = CreateCustomer();
+        _actualCustomer = CreateCustomer();
+        _expectedArray = Enumerable.Range(0, 100).ToArray();
+        _actualArray = Enumerable.Range(0, 100).ToArray();
+
+        static Customer CreateCustomer() => new()
+        {
+            Id = 42,
+            Name = "Meziantou",
+            CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Address = new Address { Street = "1 rue de la Paix", City = "Paris", ZipCode = "75000" },
+            Tags = ["a", "b", "c"],
+        };
+    }
+
+    [Benchmark]
+    public void EquivalentScalar() => Assert.Equivalent(42, 42);
+
+    [Benchmark]
+    public void EquivalentString() => Assert.Equivalent(_expectedText, _actualText);
+
+    [Benchmark]
+    public void EquivalentObject() => Assert.Equivalent(_expectedCustomer, _actualCustomer);
+
+    [Benchmark]
+    public void EquivalentCollection() => Assert.Equivalent(_expectedArray, _actualArray);
+
+    private sealed class Customer
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public Address? Address { get; set; }
+        public string[]? Tags { get; set; }
+    }
+
+    private sealed class Address
+    {
+        public string? Street { get; set; }
+        public string? City { get; set; }
+        public string? ZipCode { get; set; }
+    }
+}

--- a/benchmarks/AssertionsBenchmarks/FailureBenchmark.cs
+++ b/benchmarks/AssertionsBenchmarks/FailureBenchmark.cs
@@ -1,0 +1,66 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.Assertions;
+
+namespace AssertionsBenchmarks;
+
+/// <summary>Measures the failure path, which builds the assertion message.</summary>
+[MemoryDiagnoser]
+public class FailureBenchmark
+{
+    private readonly bool _condition = bool.Parse(bool.FalseString);
+    private int[] _expectedArray = null!;
+    private int[] _actualArray = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _expectedArray = Enumerable.Range(0, 100).ToArray();
+        _actualArray = Enumerable.Range(0, 100).ToArray();
+        _actualArray[50] = -1;
+    }
+
+    [Benchmark]
+    public string FalseCondition()
+    {
+        try
+        {
+            Assert.True(_condition);
+        }
+        catch (AssertionException ex)
+        {
+            return ex.Message;
+        }
+
+        return null!;
+    }
+
+    [Benchmark]
+    public string NotEqualStrings()
+    {
+        try
+        {
+            Assert.Equal("The quick brown fox", "The quick brown cat");
+        }
+        catch (AssertionException ex)
+        {
+            return ex.Message;
+        }
+
+        return null!;
+    }
+
+    [Benchmark]
+    public string NotEqualCollections()
+    {
+        try
+        {
+            Assert.Equal(_expectedArray, _actualArray);
+        }
+        catch (AssertionException ex)
+        {
+            return ex.Message;
+        }
+
+        return null!;
+    }
+}

--- a/benchmarks/AssertionsBenchmarks/Program.cs
+++ b/benchmarks/AssertionsBenchmarks/Program.cs
@@ -1,0 +1,4 @@
+using BenchmarkDotNet.Running;
+using AssertionsBenchmarks;
+
+BenchmarkSwitcher.FromAssembly(typeof(ValueAssertionBenchmark).Assembly).Run(args);

--- a/benchmarks/AssertionsBenchmarks/ValueAssertionBenchmark.cs
+++ b/benchmarks/AssertionsBenchmarks/ValueAssertionBenchmark.cs
@@ -1,0 +1,118 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.Assertions;
+
+namespace AssertionsBenchmarks;
+
+/// <summary>Measures the success path of the scalar assertions.</summary>
+[MemoryDiagnoser]
+public class ValueAssertionBenchmark
+{
+    private const int OperationsPerInvoke = 1000;
+
+    private readonly bool _condition = bool.Parse(bool.TrueString);
+    private readonly string _left = "The quick brown fox jumps over the lazy dog";
+    private readonly string _right = "The quick brown fox jumps over the lazy dog";
+    private readonly object _boxedLeft = 42;
+    private readonly object _boxedRight = 42;
+    private readonly Uri _uri = new("https://www.meziantou.net/");
+    private readonly Uri _sameUri = new("https://www.meziantou.net/");
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void True()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.True(_condition);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void NotNull()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.NotNull(_left);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualInt32()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal(42, 42);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualString()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal(_left, _right);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualStringAsObject()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal((object)_left, (object)_right);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualBoxedInt32()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal(_boxedLeft, _boxedRight);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualReferenceType()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal(_uri, _sameUri);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualDouble()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal(1.5, 1.5);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void NotEqualInt32()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.NotEqual(42, 1);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void EqualStringIgnoreLineEndings()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.Equal(_left, _right, ignoreCase: false, ignoreLineEndingDifferences: true);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void StartsWith()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            Assert.StartsWith("The quick", _right);
+        }
+    }
+}

--- a/src/Meziantou.Framework.Assertions/Assert.Distinct.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Distinct.cs
@@ -64,7 +64,8 @@ public partial class Assert
             }
             else
             {
-                firstIndexes ??= FirstIndexLookup<T>.Create(actualSnapshot.Items, duplicateIndex, comparer);
+                // Sizing the lookup for the whole sequence, when its length is known, avoids growing it repeatedly.
+                firstIndexes ??= FirstIndexLookup<T>.Create(actualSnapshot.Items, duplicateIndex, comparer, TryGetKnownCount(actual, out var knownCount) ? knownCount : duplicateIndex);
                 firstIndex = firstIndexes.Add(item, duplicateIndex);
             }
 
@@ -112,7 +113,7 @@ public partial class Assert
             }
             else
             {
-                firstIndexes ??= FirstIndexLookup<T>.Create(actualSnapshot.Items, duplicateIndex, comparer);
+                firstIndexes ??= FirstIndexLookup<T>.Create(actualSnapshot.Items, duplicateIndex, comparer, duplicateIndex);
                 firstIndex = firstIndexes.Add(item, duplicateIndex);
             }
 
@@ -173,9 +174,9 @@ public partial class Assert
             _indexes = new Dictionary<NullableKey<T>, int>(capacity, NullableKeyComparer<T>.Create(comparer));
         }
 
-        public static FirstIndexLookup<T> Create(IReadOnlyList<T> items, int count, IEqualityComparer<T> comparer)
+        public static FirstIndexLookup<T> Create(IReadOnlyList<T> items, int count, IEqualityComparer<T> comparer, int capacity)
         {
-            var lookup = new FirstIndexLookup<T>(comparer, count);
+            var lookup = new FirstIndexLookup<T>(comparer, capacity);
             for (var index = 0; index < count; index++)
             {
                 lookup.Add(items[index], index);

--- a/src/Meziantou.Framework.Assertions/Assert.Equal.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equal.cs
@@ -142,6 +142,47 @@ public partial class Assert
         }
     }
 
+    private static bool IsDefaultComparer<T>(IEqualityComparer<T>? comparer)
+    {
+        return comparer is null || object.ReferenceEquals(comparer, EqualityComparer<T>.Default);
+    }
+
+    private static bool TryGetSpan<T>(IEnumerable<T> source, out ReadOnlySpan<T> span)
+    {
+        switch (source)
+        {
+            case T[] array:
+                span = array;
+                return true;
+
+            case List<T> list:
+                span = CollectionsMarshal.AsSpan(list);
+                return true;
+
+            default:
+                span = default;
+                return false;
+        }
+    }
+
+    /// <summary>Compares two spans the way <see cref="EqualityComparer{T}.Default"/> would, element by element.</summary>
+    private static bool DefaultComparerSpansEqual<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual)
+    {
+        if (expected.Length != actual.Length)
+            return false;
+
+        if (BitwiseEquatable<T>.IsSupported)
+            return BitwiseSequenceEqual(expected, actual);
+
+        for (var i = 0; i < expected.Length; i++)
+        {
+            if (!EqualityComparer<T>.Default.Equals(expected[i], actual[i]))
+                return false;
+        }
+
+        return true;
+    }
+
     private static bool BitwiseSequenceEqual<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual)
     {
         if (expected.IsEmpty)
@@ -213,6 +254,11 @@ public partial class Assert
 
     private static void EqualCollections<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? comparer, string? message, string? actualExpression, string? expectedExpression)
     {
+        // Arrays and lists are the common case. Comparing them in place skips the snapshots, which only exist to
+        // describe the failure, and lets the comparison be vectorized. Anything else falls through to the general path.
+        if (IsDefaultComparer(comparer) && TryGetSpan(expected, out var expectedSpan) && TryGetSpan(actual, out var actualSpan) && DefaultComparerSpansEqual(expectedSpan, actualSpan))
+            return;
+
         using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
         using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         comparer ??= EqualityComparer<T>.Default;

--- a/src/Meziantou.Framework.Assertions/Assert.Equivalent.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equivalent.cs
@@ -16,26 +16,59 @@ public partial class Assert
 
     public static void Equivalent(object? expected, object? actual, EquivalentOptions? options, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        var failure = GetStructuralDifference(expected, actual, new StructuralPath(), new HashSet<StructuralReferencePair>(), [], StructuralComparisonOptions.Create(options));
+        var comparisonOptions = StructuralComparisonOptions.Create(options);
+
+        // Comparing two values that are not walked structurally needs none of the state the walk carries, so the
+        // common case of a scalar or a string allocates nothing.
+        if (TryCompareStructuralLeaves(expected, actual, comparisonOptions, out var areEquivalent))
+        {
+            if (areEquivalent)
+                return;
+
+            throw new AssertionException(ErrorFormatter.Format(new EquivalentAssertionError(expected, actual, StructuralPath.Root, "Values differ.", message, actualExpression, expectedExpression)));
+        }
+
+        var failure = GetStructuralDifference(expected, actual, new StructuralPath(), new HashSet<StructuralReferencePair>(), [], comparisonOptions);
         if (failure is null)
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new EquivalentAssertionError(failure.Value.ExpectedValue, failure.Value.ActualValue, failure.Value.Path, failure.Value.Reason, message, actualExpression, expectedExpression)));
     }
 
-    private static StructuralDifference? GetStructuralDifference(object? expected, object? actual, StructuralPath path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
+    /// <summary>Compares the values when neither of them needs to be walked, and reports whether it could.</summary>
+    private static bool TryCompareStructuralLeaves(object? expected, object? actual, StructuralComparisonOptions options, out bool areEquivalent)
     {
         if (object.ReferenceEquals(expected, actual))
-            return null;
+        {
+            areEquivalent = true;
+            return true;
+        }
 
         if (expected is null || actual is null)
-            return ValuesEqual(expected, actual) ? null : new StructuralDifference(path.ToString(), expected, actual, "Values differ.");
+        {
+            areEquivalent = ValuesEqual(expected, actual);
+            return true;
+        }
 
+        if (IsSimpleStructuralValue(expected.GetType()) || IsSimpleStructuralValue(actual.GetType()))
+        {
+            areEquivalent = StructuralValuesEqual(expected, actual, options);
+            return true;
+        }
+
+        areEquivalent = false;
+        return false;
+    }
+
+    private static StructuralDifference? GetStructuralDifference(object? expected, object? actual, StructuralPath path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
+    {
+        if (TryCompareStructuralLeaves(expected, actual, options, out var areEquivalent))
+            return areEquivalent ? null : new StructuralDifference(path.ToString(), expected, actual, "Values differ.");
+
+        Debug.Assert(expected is not null);
+        Debug.Assert(actual is not null);
         var expectedType = expected.GetType();
         var actualType = actual.GetType();
-        if (IsSimpleStructuralValue(expectedType) || IsSimpleStructuralValue(actualType))
-            return StructuralValuesEqual(expected, actual, options) ? null : new StructuralDifference(path.ToString(), expected, actual, "Values differ.");
-
         if (!expectedType.IsValueType && !actualType.IsValueType)
         {
             var pair = new StructuralReferencePair(expected, actual);
@@ -236,6 +269,8 @@ public partial class Assert
     /// </summary>
     private sealed class StructuralPath
     {
+        public const string Root = "$";
+
         private readonly List<StructuralPathSegment> _segments = [];
 
         public int Depth => _segments.Count;
@@ -248,7 +283,7 @@ public partial class Assert
 
         public override string ToString()
         {
-            var builder = new StringBuilder("$");
+            var builder = new StringBuilder(Root);
             foreach (var segment in _segments)
             {
                 if (segment.MemberName is null)


### PR DESCRIPTION
## What

Adds a `AssertionsBenchmarks` project for `Meziantou.Framework.Assertions`, and fixes the three costs it exposed on the assertion *success* path.

## Why

There was no benchmark coverage for the assertion library. The scalar assertions turned out to be in great shape already — `Assert.True`, `Assert.NotNull`, `Assert.Equal(int, int)` all run at ~0.23 ns with zero allocation, and arrays already take the vectorized span overload. The collection and structural assertions were paying for work only the failure message needs.

### `EqualCollections` allocated snapshots it did not need

`CollectionSnapshot` exists to describe a failure, but it was built up front and both sides were walked through virtual `TryGetItem` calls. Arrays and `List<T>` now compare in place through a span, reusing the vectorized `BitwiseSequenceEqual` the span overload already had. Any other source falls through to the general path unchanged, and the failure path is untouched.

| | before | after |
|---|---|---|
| `Equal(List<int>, List<int>)`, 1000 items | 1932 ns / 48 B | **81 ns / 0 B** |
| `Equal(List<int>, List<int>)`, 8 items | 23.5 ns / 48 B | **3.4 ns / 0 B** |

### `Equivalent` allocated its walk state before looking at its arguments

Every call built a `StructuralPath`, a `HashSet` and two `List`s, even to compare two integers. Leaf comparisons (reference equality, null, primitives, strings, `Guid`, dates…) now short-circuit before any of that state exists.

| | before | after |
|---|---|---|
| `Equivalent(42, 42)` | 19.0 ns / 200 B | **8.1 ns / 48 B** |
| `Equivalent(string, string)` | 7.7 ns / 88 B | **4.7 ns / 0 B** |

The 48 B left on the scalar case is the caller boxing the two `int` arguments, not the assertion.

### The `Distinct` lookup was sized to the linear-scan threshold

It started at 64 entries — the point where the linear scan gives up — and then grew repeatedly. It now uses the sequence length when that is known without enumerating.

| | before | after |
|---|---|---|
| `Distinct(IEnumerable<int>)`, 1000 items | 9455 ns / 59288 B | **4419 ns / 22240 B** |

## Notes for the reviewer

- All three changes only short-circuit on success; every failure still falls through to the original code, so assertion messages are unchanged. The `Equivalent` leaf failure builds its path as `"$"`, which is exactly what `StructuralPath.ToString()` returned for an empty path.
- `ref/Meziantou.Framework.Assertions.cs` is unchanged — everything added is private.
- **BenchmarkDotNet 0.15.8 does not recognize `net11.0`** (`NotImplementedException: GetRuntimeVersion not implemented for NotRecognized`), so the benchmarks have to be run with `-f net10.0`:

  ```
  dotnet run -c Release -f net10.0 --project benchmarks/AssertionsBenchmarks/AssertionsBenchmarks.csproj -- --filter '*' --memory
  ```

- Numbers above come from paired `--job short` runs on an M-series Mac; ambient drift between runs was around 10-15%, well below every delta reported.

## Verification

- `dotnet test tests/Meziantou.Framework.Assertions.Tests` — 864 tests pass (432 on each of net10.0 and net11.0).
- Release build with `/p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true`: clean, no `ref/` change.
- `dotnet run ./eng/update-all.cs` run; it added the new project to the generated `Meziantou.Framework.slnx`.

## Follow-ups found but not done here

- `EqualUnordered` has no ordered fast path — 6.5 µs / 22 KB for two identical 1000-item lists, because it always builds a counting dictionary. It also does a second hash lookup per item that `CollectionsMarshal.GetValueRefOrAddDefault` would remove.
- `Equivalent` on objects (419 ns / 624 B for a 5-property object) is dominated by `PropertyInfo.GetValue`; cached getter delegates would cut most of it.
- The non-generic `Equal(IEnumerable, IEnumerable)` boxes every element — 8.4 µs / 48 KB for 1000 ints.
- `Contains`, `All`, `Single`, `Empty` and `NotEmpty` still allocate a 24 B snapshot on the success path and could use the same span fast path.