### PR TITLE
Add an IncludeRoslynHelpers property to consume the Roslyn sources

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -44,6 +44,13 @@
                       SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
+  <!-- Compile the Meziantou.Framework.Roslyn sources and configure the ROSLYN_* constants -->
+  <ItemGroup Condition="'$(IncludeRoslynHelpers)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)src/Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)src/Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" Condition="'$(IncludeRoslynHelpers)' == 'true'" />
+
   <Target Name="ConfigurePolyfill" AfterTargets="ResolveLockFileAnalyzers" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <MeziantouPolyfill_ExcludedPolyfills Condition="@(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.Windows.CsWin32'))">T:System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute|T:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute</MeziantouPolyfill_ExcludedPolyfills>

--- a/src/Meziantou.Framework.Assertions.Analyzer/Meziantou.Framework.Assertions.Analyzer.csproj
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Meziantou.Framework.Assertions.Analyzer.csproj
@@ -7,6 +7,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,10 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
@@ -7,6 +7,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,11 +24,7 @@
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs" Link="AssertionsAnalyzerHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs" Link="AssertionCodeFixHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs" Link="RuleIdentifiers.cs" />
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj
+++ b/src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj
@@ -7,18 +7,14 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../Meziantou.Framework.Roslyn/EmbeddedAttribute.cs" LinkBase="Roslyn" />
-    <Compile Include="../Meziantou.Framework.Roslyn/LanguageVersionExtensions.cs" LinkBase="Roslyn" />
     <Compile Include="../Meziantou.Framework.FastEnumGenerator/FastEnumAnalyzerCommon.cs" Link="FastEnumAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.FastEnumGenerator/FastEnumInvocationMatch.cs" Link="FastEnumInvocationMatch.cs" />
     <Compile Include="../Meziantou.Framework.FastEnumGenerator/FastEnumMethodKind.cs" Link="FastEnumMethodKind.cs" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
+++ b/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
@@ -10,6 +10,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,11 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
     <Compile Include="../Meziantou.Framework/Collections/ImmutableEquatableArray.cs" LinkBase="Collections" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj
+++ b/src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj
@@ -7,13 +7,10 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj
+++ b/src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj
@@ -7,16 +7,13 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="../Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs" Link="FullPathAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs" Link="FullPathContext.cs" />
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
+++ b/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
@@ -8,6 +8,7 @@
     <Description>Source Generator to generate strongly-typed id with all needed helpers such as converters for System.Text.Json, Newtonsoft.Json, or MongoDB.</Description>
     <PackageTags>strongly-typed-id, source-generator, roslyn, ddd, codegen</PackageTags>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddAnnotationsToPackage</TargetsForTfmSpecificContentInPackage>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,10 +26,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../Meziantou.Framework.StronglyTypedId.Annotations/Meziantou.Framework.StronglyTypedId.Annotations.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1" PrivateAssets="all" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
@@ -5,13 +5,12 @@
     <NoWarn>$(NoWarn);RS1041</NoWarn>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_YAML_SOURCE_GENERATOR</DefineConstants>
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
-    <Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
-
     <EmbeddedResource Include="../Meziantou.Framework.Yaml/Serialization/YamlThrowHelper.cs" LogicalName="Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.cs" />
   </ItemGroup>
 
@@ -26,7 +25,4 @@
     <Compile Include="../Meziantou.Framework.Yaml/YamlSnakeCaseLowerNamingPolicy.cs" Link="YamlSnakeCaseLowerNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlSnakeCaseUpperNamingPolicy.cs" Link="YamlSnakeCaseUpperNamingPolicy.cs" />
   </ItemGroup>
-
-  <Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
-
 </Project>

--- a/tests/Meziantou.Framework.Roslyn.Tests/Directory.Build.props
+++ b/tests/Meziantou.Framework.Roslyn.Tests/Directory.Build.props
@@ -7,11 +7,7 @@
 
     <!-- The sources are shipped as content files, so warnings are disabled by default. Enable them here to validate the sources. -->
     <DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS</DefineConstants>
+
+    <IncludeRoslynHelpers>true</IncludeRoslynHelpers>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)../../src/Meziantou.Framework.Roslyn/**/*.cs" LinkBase="RoslynSources" />
-  </ItemGroup>
-
-  <Import Project="$(MSBuildThisFileDirectory)../../src/Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
 </Project>


### PR DESCRIPTION
## What

Projects that use the `Meziantou.Framework.Roslyn` source helpers had to repeat two things in every csproj:

```xml
<Compile Include="../Meziantou.Framework.Roslyn/**/*.cs" LinkBase="Roslyn" />
...
<Import Project="../Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets" />
```

`Directory.Build.targets` now does both when `IncludeRoslynHelpers` is set, so each consumer is a single property:

```xml
<IncludeRoslynHelpers>true</IncludeRoslynHelpers>
```

## Why

The two halves are easy to separate by accident. The `Import` is what defines the `ROSLYN_*` and `CSHARP*_OR_GREATER` constants from the referenced `Microsoft.CodeAnalysis.*` version — forgetting it compiles the sources anyway, just with every version-gated block silently switched off.

## Notes for the reviewer

- **Why targets and not props.** `Directory.Build.props` is imported before the project body in SDK-style projects, so an `IncludeRoslynHelpers` set in a csproj would not be visible there. `Directory.Build.targets` is imported after the body. The folder-level `tests/Meziantou.Framework.Roslyn.Tests/Directory.Build.props` sets the property just as well, since it is still evaluated before the final import.
- **`Meziantou.Framework.FastEnumGenerator.CodeFixes` now compiles all the sources** instead of just `EmbeddedAttribute.cs` and `LanguageVersionExtensions.cs`. It already references both `Microsoft.CodeAnalysis.CSharp` and `.CSharp.Workspaces`, so the rest compiles; this keeps the opt-in uniform.
- **Cosmetic:** the test project's link folder went from `RoslynSources` to `Roslyn` so all consumers share one convention. IDE display only.
- The `Meziantou.Framework.Roslyn` NuGet package itself is unchanged — external consumers still get the sources as `contentFiles` plus the `buildTransitive` targets.

## Verification

- `dotnet build Meziantou.Framework.slnx -p:TreatsWarningsAsErrors=true` — succeeded, 0 warnings.
- Checked the mechanism actually fires rather than silently no-op'ing: after `_MeziantouFrameworkRoslynDefineConstants`, `DefineConstants` contains the full `ROSLYN_*` / `CSHARP*_OR_GREATER` set, and the Roslyn sources appear in `Compile`.
- Tests, 0 failures: Roslyn.Tests (328 / 328 / 328 / 330 across the four Roslyn-version variants), FastEnumGenerator GeneratorTests 120 / Tests 108 / InterceptorTests 38, StronglyTypedId.GeneratorTests 196, Assertions.Analyzer.Tests 212, FullPath.Analyzer.Tests 122.
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.