### PR TITLE
Clean up the containers a run left behind

### DIFF
--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -19,6 +19,29 @@ namespace Meziantou.Framework.TemporaryContainers
         public void Deconstruct(out string Source, out string Target, out bool ReadOnly) => throw null;
     }
 
+    public sealed class ContainerCleanupOptions
+    {
+        public Meziantou.Framework.TemporaryContainers.ContainerCleanupScope Scope { get => throw null; set { } }
+        public System.TimeSpan MinimumAge { get => throw null; set { } }
+        public bool IncludeContainers { get => throw null; set { } }
+        public bool IncludeVolumes { get => throw null; set { } }
+        public bool IncludeReusedResources { get => throw null; set { } }
+    }
+
+    public sealed class ContainerCleanupResult
+    {
+        public System.Collections.Generic.IReadOnlyList<string> RemovedContainers { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<string> RemovedVolumes { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<System.Exception> Errors { get => throw null; }
+        public int RemovedCount { get => throw null; }
+    }
+
+    public enum ContainerCleanupScope
+    {
+        Orphaned = 0,
+        All = 1
+    }
+
     public sealed class ContainerCommandCollection : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }
@@ -173,6 +196,21 @@ namespace Meziantou.Framework.TemporaryContainers
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }
 
+    public sealed class ContainerReaper : System.IAsyncDisposable
+    {
+        public string SessionId { get => throw null; }
+        public string ContainerId { get => throw null; }
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
+    }
+
+    public sealed class ContainerReaperOptions
+    {
+        public Meziantou.Framework.TemporaryContainers.ImageSource Image { get => throw null; set { } }
+        public string? SocketPath { get => throw null; set { } }
+        public System.TimeSpan ConnectionTimeout { get => throw null; set { } }
+        public System.TimeSpan ReconnectionTimeout { get => throw null; set { } }
+    }
+
     public sealed class ContainerResourceOptions
     {
         public long? MemoryLimit { get => throw null; set { } }
@@ -188,8 +226,12 @@ namespace Meziantou.Framework.TemporaryContainers
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Podman { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime AppleContainer { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Wslc { get => throw null; }
+        public System.Threading.Tasks.Task<Meziantou.Framework.TemporaryContainers.ContainerCleanupResult> CleanupAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public System.Threading.Tasks.Task<Meziantou.Framework.TemporaryContainers.ContainerCleanupResult> CleanupAsync(Meziantou.Framework.TemporaryContainers.ContainerCleanupOptions options, System.Threading.CancellationToken cancellationToken = null) => throw null;
         public virtual System.Threading.Tasks.Task<bool> IsSupportedAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public override string ToString() => throw null;
+        public System.Threading.Tasks.Task<Meziantou.Framework.TemporaryContainers.ContainerReaper> StartReaperAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public System.Threading.Tasks.Task<Meziantou.Framework.TemporaryContainers.ContainerReaper> StartReaperAsync(Meziantou.Framework.TemporaryContainers.ContainerReaperOptions options, System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
     public sealed class ContainerRuntimeException : System.Exception

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupOptions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupOptions.cs
@@ -1,0 +1,21 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>Configures what <see cref="ContainerRuntime.CleanupAsync(ContainerCleanupOptions, CancellationToken)"/> removes.</summary>
+public sealed class ContainerCleanupOptions
+{
+    /// <summary>Gets or sets which resources are removed. Defaults to <see cref="ContainerCleanupScope.Orphaned"/>.</summary>
+    public ContainerCleanupScope Scope { get; set; } = ContainerCleanupScope.Orphaned;
+
+    /// <summary>Gets or sets the minimum age a resource must have to be removed. Defaults to <see cref="TimeSpan.Zero"/>, which removes a resource whatever its age.</summary>
+    /// <remarks>A resource created by a version of the library that did not record a creation time is never removed when this is set.</remarks>
+    public TimeSpan MinimumAge { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether containers are removed. Defaults to <see langword="true"/>.</summary>
+    public bool IncludeContainers { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether volumes are removed. Defaults to <see langword="true"/>. Volumes are removed after the containers, so a volume a removed container used is no longer in use.</summary>
+    public bool IncludeVolumes { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether the resources created with a <see cref="ContainerDefinition.ReuseId"/> are removed. Defaults to <see langword="false"/>: such a resource outlives the run that created it on purpose, and another run may be using it right now.</summary>
+    public bool IncludeReusedResources { get; set; }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupResult.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupResult.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>What a cleanup removed, and what it could not remove.</summary>
+public sealed class ContainerCleanupResult
+{
+    internal ContainerCleanupResult(IReadOnlyList<string> removedContainers, IReadOnlyList<string> removedVolumes, IReadOnlyList<Exception> errors)
+    {
+        RemovedContainers = removedContainers;
+        RemovedVolumes = removedVolumes;
+        Errors = errors;
+    }
+
+    /// <summary>Gets the ids of the removed containers.</summary>
+    public IReadOnlyList<string> RemovedContainers { get; }
+
+    /// <summary>Gets the names of the removed volumes.</summary>
+    public IReadOnlyList<string> RemovedVolumes { get; }
+
+    /// <summary>Gets the failures met while removing the resources. A cleanup does not stop on the first failure, so a resource that cannot be removed does not keep the others alive.</summary>
+    public IReadOnlyList<Exception> Errors { get; }
+
+    /// <summary>Gets the total number of removed resources.</summary>
+    public int RemovedCount => RemovedContainers.Count + RemovedVolumes.Count;
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupScope.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupScope.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>Selects which of the resources created by this library a cleanup removes.</summary>
+public enum ContainerCleanupScope
+{
+    /// <summary>Only the resources whose creating process is no longer running on this machine. A resource created on another machine, or by a process that is still alive, is left alone.</summary>
+    Orphaned,
+
+    /// <summary>Every resource created by this library, whatever created it, except the ones the current process created.</summary>
+    All,
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupScope.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerCleanupScope.cs
@@ -7,5 +7,6 @@ public enum ContainerCleanupScope
     Orphaned,
 
     /// <summary>Every resource created by this library, whatever created it, except the ones the current process created.</summary>
+    /// <remarks>Another run using the same daemon right now is not spared: its containers are removed while it uses them. Only use this when nothing else is running against the daemon.</remarks>
     All,
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerDefinition.cs
@@ -58,6 +58,8 @@ public class ContainerDefinition
         Network = new ContainerNetworkOptions(other.Network);
         Resources = new ContainerResourceOptions(other.Resources);
         Logging = new ContainerLoggingOptions(other.Logging);
+        SessionOwned = other.SessionOwned;
+        Identity = other.Identity;
     }
 
     /// <summary>Gets or sets the image the container is created from.</summary>
@@ -124,6 +126,12 @@ public class ContainerDefinition
 
     /// <summary>Gets the logging options.</summary>
     public ContainerLoggingOptions Logging { get; }
+
+    /// <summary>Whether the container belongs to the current run. The reaper container is the only one that does not: it must outlive the session it watches, so it is not labelled with it and does not remove itself.</summary>
+    internal bool SessionOwned { get; set; } = true;
+
+    /// <summary>The run recorded in the labels of the container. Defaults to the current one; the tests use it to create a container that looks like the leftover of a run that is over.</summary>
+    internal Internals.SessionIdentity? Identity { get; set; }
 
     /// <summary>Creates a <see cref="TemporaryContainer"/> from a deep copy of this definition. Later changes to this definition do not affect the returned container.</summary>
     /// <returns>A new container.</returns>

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerReaper.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerReaper.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using Meziantou.Framework.TemporaryContainers.Internals;
+
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A watchdog container that removes the containers and volumes of the current session when this process goes away, including when it is killed and cannot run its own cleanup.</summary>
+/// <remarks>Dispose the instance to stop the watchdog. A clean disposal removes the watchdog before it can remove anything, so the resources the process still owns are left to their own disposal.</remarks>
+public sealed class ContainerReaper : IAsyncDisposable
+{
+    private const int ReaperPort = 8080;
+
+    // The watchdog answers as soon as it is reachable; the timeout only matters when it never becomes reachable.
+    private static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly TemporaryContainer _container;
+    private readonly TcpClient _client;
+    private bool _disposed;
+
+    private ContainerReaper(TemporaryContainer container, TcpClient client, string sessionId)
+    {
+        _container = container;
+        _client = client;
+        SessionId = sessionId;
+    }
+
+    /// <summary>Gets the session the watchdog removes the resources of.</summary>
+    public string SessionId { get; }
+
+    /// <summary>Gets the id of the watchdog container.</summary>
+    public string ContainerId => _container.Id;
+
+    internal static async Task<ContainerReaper> StartAsync(ContainerRuntime runtime, ContainerReaperOptions options, CancellationToken cancellationToken)
+    {
+        var definition = new ContainerDefinition(options.Image)
+        {
+            Runtime = runtime,
+
+            // The watchdog watches the session; being part of it would make it remove itself in the middle of its own
+            // sweep. It still carries the other library labels, so a leftover watchdog is collected by a later cleanup.
+            SessionOwned = false,
+        };
+
+        definition.Environment.Add("RYUK_PORT", ReaperPort.ToString(CultureInfo.InvariantCulture));
+        definition.Environment.Add("RYUK_CONNECTION_TIMEOUT", FormatDuration(options.ConnectionTimeout));
+        definition.Environment.Add("RYUK_RECONNECTION_TIMEOUT", FormatDuration(options.ReconnectionTimeout));
+        definition.Mounts.AddBindMount(options.SocketPath ?? GetDefaultSocketPath(), "/var/run/docker.sock");
+        definition.Ports.Add(new ContainerPort(ReaperPort));
+        definition.WaitStrategies.Add(Wait.ForPort(ReaperPort));
+
+        var container = definition.CreateContainer();
+        try
+        {
+            await container.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            var client = await ConnectAsync(container.GetMappedPort(ReaperPort), cancellationToken).ConfigureAwait(false);
+            return new ContainerReaper(container, client, SessionIdentity.Current.SessionId);
+        }
+        catch
+        {
+            await container.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <summary>Connects to the watchdog and registers the session, retrying until it answers.</summary>
+    /// <remarks>The port forwarder of the runtime accepts connections as soon as the port is published, and resets them until the container is actually reachable, so a single attempt says nothing about the watchdog being up.</remarks>
+    private static async Task<TcpClient> ConnectAsync(int port, CancellationToken cancellationToken)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (true)
+        {
+            var client = new TcpClient();
+            try
+            {
+                await client.ConnectAsync("127.0.0.1", port, cancellationToken).ConfigureAwait(false);
+                await SendFilterAsync(client, cancellationToken).ConfigureAwait(false);
+                return client;
+            }
+            catch (Exception ex) when (ex is IOException or SocketException or InvalidOperationException && elapsed.Elapsed < HandshakeTimeout)
+            {
+                client.Dispose();
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                client.Dispose();
+                throw;
+            }
+        }
+    }
+
+    /// <summary>Registers the resources to remove. The watchdog reads one URL-encoded query string per line and answers each one with an acknowledgement.</summary>
+    private static async Task SendFilterAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        var stream = client.GetStream();
+        var filter = "label=" + Uri.EscapeDataString(ResourceLabels.SessionId + "=" + SessionIdentity.Current.SessionId) + "\n";
+        await stream.WriteAsync(Encoding.UTF8.GetBytes(filter), cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        var buffer = new byte[64];
+        var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        if (read == 0)
+            throw new IOException("The reaper closed the connection without answering.");
+
+        var response = Encoding.UTF8.GetString(buffer, 0, read).Trim();
+        if (!string.Equals(response, "ACK", StringComparison.Ordinal))
+            throw new InvalidOperationException($"The reaper did not acknowledge the filter. It answered '{response}'.");
+    }
+
+    private static string GetDefaultSocketPath()
+    {
+        var dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST");
+        if (dockerHost is not null && dockerHost.StartsWith("unix://", StringComparison.OrdinalIgnoreCase))
+        {
+            var path = dockerHost["unix://".Length..];
+            if (!string.IsNullOrWhiteSpace(path))
+                return Uri.UnescapeDataString(path);
+        }
+
+        // Docker Desktop for Windows exposes the Linux socket at the same path; the leading slash keeps the CLI from
+        // reading it as a Windows path.
+        return OperatingSystem.IsWindows() ? "//var/run/docker.sock" : "/var/run/docker.sock";
+    }
+
+    /// <summary>Formats a duration the way Go parses it, which is what the watchdog expects. Sub-second values are written in milliseconds so they do not end up as "0s".</summary>
+    private static string FormatDuration(TimeSpan value)
+        => value.Ticks % TimeSpan.TicksPerSecond == 0
+            ? ((long)value.TotalSeconds).ToString(CultureInfo.InvariantCulture) + "s"
+            : ((long)value.TotalMilliseconds).ToString(CultureInfo.InvariantCulture) + "ms";
+
+    /// <summary>Stops the watchdog. The watchdog container is removed first, so it cannot remove the resources that are still in use.</summary>
+    /// <returns>A task that completes once the watchdog is stopped.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        try
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort cleanup: ignore failures during disposal.
+        }
+
+        _client.Dispose();
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerReaperOptions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerReaperOptions.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>Configures the watchdog container started by <see cref="ContainerRuntime.StartReaperAsync(ContainerReaperOptions, CancellationToken)"/>.</summary>
+public sealed class ContainerReaperOptions
+{
+    /// <summary>Gets or sets the image of the watchdog. Defaults to <c>testcontainers/ryuk</c>, whose protocol this implementation speaks.</summary>
+    public ImageSource Image { get; set; } = ImageSource.FromRegistry("testcontainers/ryuk:0.14.0");
+
+    /// <summary>Gets or sets the path of the daemon socket on the host, which is mounted into the watchdog so it can remove the resources. Defaults to the socket of <c>DOCKER_HOST</c> when it designates one, and to the default docker socket otherwise.</summary>
+    public string? SocketPath { get; set; }
+
+    /// <summary>Gets or sets how long the watchdog waits for this process to connect before it gives up and removes the resources. Defaults to one minute.</summary>
+    public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>Gets or sets how long the watchdog waits, after this process is gone, before it removes the resources. Defaults to ten seconds.</summary>
+    public TimeSpan ReconnectionTimeout { get; set; } = TimeSpan.FromSeconds(10);
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.Cleanup.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.Cleanup.cs
@@ -1,0 +1,133 @@
+using Meziantou.Framework.TemporaryContainers.Internals;
+
+namespace Meziantou.Framework.TemporaryContainers;
+
+public partial class ContainerRuntime
+{
+    /// <summary>Removes the containers and volumes this library left behind, for instance by a run that was interrupted before it could dispose them.</summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The removed resources.</returns>
+    /// <exception cref="InvalidOperationException">The runtime is not available.</exception>
+    public Task<ContainerCleanupResult> CleanupAsync(CancellationToken cancellationToken = default)
+        => CleanupAsync(new ContainerCleanupOptions(), cancellationToken);
+
+    /// <summary>Removes the containers and volumes this library left behind, for instance by a run that was interrupted before it could dispose them.</summary>
+    /// <param name="options">What to remove. By default, only the resources whose creating process is gone.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The removed resources.</returns>
+    /// <exception cref="InvalidOperationException">The runtime is not available.</exception>
+    /// <remarks>The resources of the current process are never removed, whatever the scope: a cleanup at the beginning of a test run cannot break the containers that run is about to use.</remarks>
+    public async Task<ContainerCleanupResult> CleanupAsync(ContainerCleanupOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        await EnsureSupportedAsync(cancellationToken).ConfigureAwait(false);
+        var runtime = await GetEffectiveRuntimeAsync(cancellationToken).ConfigureAwait(false);
+
+        var removedContainers = new List<string>();
+        var removedVolumes = new List<string>();
+        var errors = new List<Exception>();
+        var now = DateTimeOffset.UtcNow;
+
+        if (options.IncludeContainers)
+        {
+            foreach (var container in await ListSafeAsync(runtime.ListManagedContainersAsync, errors, cancellationToken).ConfigureAwait(false))
+            {
+                if (!ShouldRemove(container, options, now))
+                    continue;
+
+                try
+                {
+                    await runtime.DeleteAsync(container.Id, cancellationToken).ConfigureAwait(false);
+                    removedContainers.Add(container.Id);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    errors.Add(ex);
+                }
+            }
+        }
+
+        // Volumes come last: a volume a container still references cannot be removed, and the containers that
+        // referenced these volumes have just been removed.
+        if (options.IncludeVolumes && runtime.SupportsVolumes)
+        {
+            foreach (var volume in await ListSafeAsync(runtime.ListManagedVolumesAsync, errors, cancellationToken).ConfigureAwait(false))
+            {
+                if (!ShouldRemove(volume, options, now))
+                    continue;
+
+                try
+                {
+                    await runtime.DeleteVolumeAsync(volume.Id, cancellationToken).ConfigureAwait(false);
+
+                    // The runtimes report "still in use" the same way they report "already gone", so the outcome is
+                    // confirmed rather than inferred from an exit code.
+                    if (await runtime.VolumeExistsAsync(volume.Id, cancellationToken).ConfigureAwait(false))
+                        errors.Add(new InvalidOperationException($"The volume '{volume.Id}' could not be removed. It is probably still used by a container."));
+                    else
+                        removedVolumes.Add(volume.Id);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    errors.Add(ex);
+                }
+            }
+        }
+
+        return new ContainerCleanupResult(removedContainers, removedVolumes, errors);
+    }
+
+    /// <summary>Lists the containers created by this library, whichever process created them.</summary>
+    internal virtual Task<IReadOnlyList<ManagedResource>> ListManagedContainersAsync(CancellationToken cancellationToken)
+        => throw CreateNotSupportedException();
+
+    /// <summary>Lists the volumes created by this library, whichever process created them.</summary>
+    internal virtual Task<IReadOnlyList<ManagedResource>> ListManagedVolumesAsync(CancellationToken cancellationToken)
+        => throw CreateNotSupportedException();
+
+    internal virtual bool SupportsVolumes => true;
+
+    /// <summary>Runs a listing without letting a failure on one kind of resource abort the whole cleanup.</summary>
+    private static async Task<IReadOnlyList<ManagedResource>> ListSafeAsync(Func<CancellationToken, Task<IReadOnlyList<ManagedResource>>> list, List<Exception> errors, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await list(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            errors.Add(ex);
+            return [];
+        }
+    }
+
+    internal static bool ShouldRemove(ManagedResource resource, ContainerCleanupOptions options, DateTimeOffset now)
+    {
+        var labels = resource.Labels;
+        if (!labels.ContainsKey(ResourceLabels.Managed))
+            return false;
+
+        // The containers of the current run are what the caller is about to use.
+        if (labels.TryGetValue(ResourceLabels.SessionId, out var sessionId) && string.Equals(sessionId, SessionIdentity.Current.SessionId, StringComparison.Ordinal))
+            return false;
+
+        if (!options.IncludeReusedResources && labels.ContainsKey(ResourceLabels.ReuseId))
+            return false;
+
+        if (options.MinimumAge > TimeSpan.Zero)
+        {
+            if (!labels.TryGetValue(ResourceLabels.CreatedAt, out var createdAtText) ||
+                !long.TryParse(createdAtText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var createdAtMilliseconds))
+            {
+                // An age that cannot be read is not an age above the threshold.
+                return false;
+            }
+
+            if (now - DateTimeOffset.FromUnixTimeMilliseconds(createdAtMilliseconds) < options.MinimumAge)
+                return false;
+        }
+
+        return options.Scope is ContainerCleanupScope.All || ResourceOwnership.IsOwnerGone(labels);
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.Reaper.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.Reaper.cs
@@ -1,0 +1,32 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+public partial class ContainerRuntime
+{
+    /// <summary>Starts a watchdog container that removes the containers and volumes created by this process once the process is gone, even when it is killed before it can dispose them.</summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The watchdog. Keep it alive for as long as the containers it watches, and dispose it to stop it.</returns>
+    /// <exception cref="NotSupportedException">The runtime does not expose a socket the watchdog can drive.</exception>
+    public Task<ContainerReaper> StartReaperAsync(CancellationToken cancellationToken = default)
+        => StartReaperAsync(new ContainerReaperOptions(), cancellationToken);
+
+    /// <summary>Starts a watchdog container that removes the containers and volumes created by this process once the process is gone, even when it is killed before it can dispose them.</summary>
+    /// <param name="options">The watchdog configuration.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The watchdog. Keep it alive for as long as the containers it watches, and dispose it to stop it.</returns>
+    /// <exception cref="NotSupportedException">The runtime does not expose a socket the watchdog can drive.</exception>
+    /// <remarks>The watchdog only removes the resources this process created; the resources of a run that has a <see cref="ContainerDefinition.ReuseId"/> are not part of a session and are left alone.</remarks>
+    public async Task<ContainerReaper> StartReaperAsync(ContainerReaperOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        await EnsureSupportedAsync(cancellationToken).ConfigureAwait(false);
+        var runtime = await GetEffectiveRuntimeAsync(cancellationToken).ConfigureAwait(false);
+        if (!runtime.SupportsReaper)
+            throw new NotSupportedException($"The '{runtime}' runtime does not support the reaper: it has no docker-compatible socket to drive.");
+
+        return await ContainerReaper.StartAsync(runtime, options, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Whether the runtime is driven by a docker-compatible socket, which the watchdog needs to remove the resources.</summary>
+    internal virtual bool SupportsReaper => false;
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
@@ -3,7 +3,7 @@ using Meziantou.Framework.TemporaryContainers.Internals;
 namespace Meziantou.Framework.TemporaryContainers;
 
 /// <summary>Identifies the container runtime CLI used to manage containers.</summary>
-public abstract class ContainerRuntime
+public abstract partial class ContainerRuntime
 {
     private readonly string _name;
 

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -114,7 +114,7 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
         if (definition.Resources.CpuLimit is { } cpu)
             AddOption(args, "--cpus", cpu.ToString(CultureInfo.InvariantCulture));
 
-        foreach (var (labelName, labelValue) in definition.Labels)
+        foreach (var (labelName, labelValue) in ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, definition.Identity))
         {
             args.Add("--label");
             args.Add($"{labelName}={labelValue}");
@@ -157,7 +157,7 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
             throw new NotSupportedException("Apple's container runtime does not support volume drivers.");
 
         var args = new List<string> { "volume", "create" };
-        foreach (var (labelName, labelValue) in definition.Labels)
+        foreach (var (labelName, labelValue) in ResourceLabels.Build(definition.Labels, definition.ReuseId, sessionOwned: true, definition.Identity))
         {
             args.Add("--label");
             args.Add($"{labelName}={labelValue}");
@@ -171,6 +171,53 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 
         args.Add(name);
         return args;
+    }
+
+    // Apple's CLI has no label filter, so everything is listed and filtered here. Both listings report the same shape
+    // as 'inspect', labels included, which spares an inspect per resource.
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedContainersAsync(CancellationToken cancellationToken)
+    {
+        var result = await Cli.RunBufferedAsync(["ls", "-a", "--format", "json"], cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        return ParseManagedResources(result.StandardOutput);
+    }
+
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedVolumesAsync(CancellationToken cancellationToken)
+    {
+        var result = await Cli.RunBufferedAsync(["volume", "ls", "--format", "json"], cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        return ParseManagedResources(result.StandardOutput);
+    }
+
+    internal static IReadOnlyList<ManagedResource> ParseManagedResources(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return [];
+
+        AppleInspectResult[]? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize(output, AppleInspectJsonContext.Default.AppleInspectResultArray);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (parsed is null)
+            return [];
+
+        var resources = new List<ManagedResource>();
+        foreach (var item in parsed)
+        {
+            var labels = item.Configuration?.Labels;
+            if (labels is null || !labels.ContainsKey(ResourceLabels.Managed))
+                continue;
+
+            var id = item.Id ?? item.Configuration?.Id;
+            if (!string.IsNullOrEmpty(id))
+                resources.Add(new ManagedResource(id, labels));
+        }
+
+        return resources;
     }
 
     internal override IReadOnlyList<string> BuildDeleteVolumeArguments(string name) => ["volume", "delete", name];

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
@@ -60,6 +60,22 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
     internal override async Task<ContainerRuntime> GetEffectiveRuntimeAsync(CancellationToken cancellationToken)
         => await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
 
+    internal override bool SupportsVolumes => ResolvedRuntime.SupportsVolumes;
+
+    internal override bool SupportsReaper => ResolvedRuntime.SupportsReaper;
+
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedContainersAsync(CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.ListManagedContainersAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedVolumesAsync(CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.ListManagedVolumesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     internal override bool SupportsPause => ResolvedRuntime.SupportsPause;
 
     internal override bool SupportsRestart => ResolvedRuntime.SupportsRestart;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiCreateRequestBuilder.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiCreateRequestBuilder.cs
@@ -6,9 +6,7 @@ internal static class DockerApiCreateRequestBuilder
 {
     public static DockerApiModels.CreateContainerRequest Build(ContainerDefinition definition, string imageRef)
     {
-        var labels = definition.Labels.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
-        if (definition.ReuseId is { } reuseId)
-            labels[DockerCreateArgumentBuilder.ReuseLabel] = reuseId;
+        var labels = ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, definition.Identity);
 
         var hostConfig = new DockerApiModels.HostConfig
         {

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
@@ -12,6 +12,7 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 [JsonSerializable(typeof(DockerInspectResult))]
 [JsonSerializable(typeof(DockerApiModels.CreateContainerRequest))]
 [JsonSerializable(typeof(DockerApiModels.VolumeCreateRequest))]
+[JsonSerializable(typeof(DockerApiModels.VolumeListResponse))]
 [JsonSerializable(typeof(DockerApiModels.ExecCreateRequest))]
 [JsonSerializable(typeof(DockerApiModels.ExecStartRequest))]
 [JsonSerializable(typeof(DockerApiModels.AuthConfigFile))]

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiModels.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiModels.cs
@@ -80,6 +80,17 @@ internal static class DockerApiModels
         public NetworkingConfig? NetworkingConfig { get; set; }
     }
 
+    internal sealed class VolumeListResponse
+    {
+        public List<VolumeSummary>? Volumes { get; set; }
+    }
+
+    internal sealed class VolumeSummary
+    {
+        public string? Name { get; set; }
+        public Dictionary<string, string>? Labels { get; set; }
+    }
+
     internal sealed class VolumeCreateRequest
     {
         public string? Name { get; set; }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -31,6 +31,8 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
     internal override bool SupportsRestart => true;
 
+    internal override bool SupportsReaper => true;
+
     internal override async Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
     {
         if (definition.ReuseId is { } reuseId && await FindReusableContainerAsync(reuseId, cancellationToken).ConfigureAwait(false) is { } reusedContainerId)
@@ -40,10 +42,25 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         var payload = DockerApiCreateRequestBuilder.Build(definition, imageRef);
         using var content = CreateJsonContent(payload, DockerApiJsonContext.Default.CreateContainerRequest);
         var endpoint = "/containers/create";
-        if (!string.IsNullOrEmpty(definition.Name))
-            endpoint += "?name=" + Uri.EscapeDataString(definition.Name);
 
-        using var response = await SendAsync(HttpMethod.Post, endpoint, content, cancellationToken).ConfigureAwait(false);
+        // A reused container gets a deterministic name so the daemon itself rejects a second creation: two processes
+        // that start at the same time would otherwise both find nothing and both create one.
+        var name = definition.Name is { Length: > 0 } definitionName
+            ? definitionName
+            : definition.ReuseId is { } namedReuseId ? ResourceNaming.GetReuseName(namedReuseId) : null;
+
+        if (name is not null)
+            endpoint += "?name=" + Uri.EscapeDataString(name);
+
+        using var response = await SendAsync(HttpMethod.Post, endpoint, content, cancellationToken, allowedStatusCodes: definition.ReuseId is null ? null : [HttpStatusCode.Conflict]).ConfigureAwait(false);
+        if (response.StatusCode is HttpStatusCode.Conflict)
+        {
+            // Another process created the container between the lookup and the creation. Adopting it is the whole
+            // point of a reuse identifier.
+            return await FindReusableContainerAsync(definition.ReuseId!, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Unable to create the container: the name '{name}' is already used by a container that does not belong to this library.");
+        }
+
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         var createResponse = JsonSerializer.Deserialize(stream, DockerApiJsonContext.Default.CreateContainerResponse);
         if (string.IsNullOrWhiteSpace(createResponse?.Id))
@@ -104,7 +121,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
             Name = name,
             Driver = definition.Driver,
             DriverOpts = definition.DriverOptions.Count > 0 ? definition.DriverOptions.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal) : null,
-            Labels = definition.Labels.Count > 0 ? definition.Labels.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal) : null,
+            Labels = ResourceLabels.Build(definition.Labels, definition.ReuseId, sessionOwned: true, definition.Identity),
         };
 
         using var content = CreateJsonContent(payload, DockerApiJsonContext.Default.VolumeCreateRequest);
@@ -295,9 +312,50 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         return info.Ports;
     }
 
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedContainersAsync(CancellationToken cancellationToken)
+    {
+        var endpoint = "/containers/json?all=1&filters=" + Uri.EscapeDataString(BuildManagedLabelFilter());
+        using var response = await SendAsync(HttpMethod.Get, endpoint, content: null, cancellationToken).ConfigureAwait(false);
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var containers = JsonSerializer.Deserialize(stream, DockerApiJsonContext.Default.ContainerSummaryArray);
+        if (containers is null)
+            return [];
+
+        var resources = new List<ManagedResource>(containers.Length);
+        foreach (var container in containers)
+        {
+            if (!string.IsNullOrEmpty(container.Id))
+                resources.Add(new ManagedResource(container.Id, container.Labels ?? new Dictionary<string, string>(StringComparer.Ordinal)));
+        }
+
+        return resources;
+    }
+
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedVolumesAsync(CancellationToken cancellationToken)
+    {
+        var endpoint = "/volumes?filters=" + Uri.EscapeDataString(BuildManagedLabelFilter());
+        using var response = await SendAsync(HttpMethod.Get, endpoint, content: null, cancellationToken).ConfigureAwait(false);
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var volumes = JsonSerializer.Deserialize(stream, DockerApiJsonContext.Default.VolumeListResponse);
+        if (volumes?.Volumes is null)
+            return [];
+
+        var resources = new List<ManagedResource>(volumes.Volumes.Count);
+        foreach (var volume in volumes.Volumes)
+        {
+            if (!string.IsNullOrEmpty(volume.Name))
+                resources.Add(new ManagedResource(volume.Name, volume.Labels ?? new Dictionary<string, string>(StringComparer.Ordinal)));
+        }
+
+        return resources;
+    }
+
+    private static string BuildManagedLabelFilter()
+        => "{\"label\":[\"" + ResourceLabels.Managed + "\"]}";
+
     private async Task<string?> FindReusableContainerAsync(string reuseId, CancellationToken cancellationToken)
     {
-        var labelFilter = JsonEncodedText.Encode(DockerCreateArgumentBuilder.ReuseLabel + "=" + reuseId).ToString();
+        var labelFilter = JsonEncodedText.Encode(ResourceLabels.ReuseId + "=" + reuseId).ToString();
         var filters = "{\"label\":[\"" + labelFilter + "\"]}";
 
         var endpoint = "/containers/json?all=1&filters=" + Uri.EscapeDataString(filters);

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerInfoParser.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerInfoParser.cs
@@ -14,6 +14,32 @@ internal static class DockerContainerInfoParser
         return ParseInspectResult(parsed[0]);
     }
 
+    /// <summary>Reads an inspect output that may describe several containers. A malformed or empty output means no container, which is what a listing on an empty daemon reports.</summary>
+    public static IReadOnlyList<ContainerInfo> ParseInspectOutputs(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return [];
+
+        DockerInspectResult[]? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize(output, DockerInspectJsonContext.Default.DockerInspectResultArray);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (parsed is null)
+            return [];
+
+        var results = new List<ContainerInfo>(parsed.Length);
+        foreach (var result in parsed)
+            results.Add(ParseInspectResult(result));
+
+        return results;
+    }
+
     public static ContainerInfo ParseInspectResult(DockerInspectResult result)
     {
         var ports = new Dictionary<int, int>();

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
@@ -71,11 +71,11 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
         IReadOnlyList<string> lookupArgs;
         if (_flavor is Flavor.Wslc)
         {
-            lookupArgs = ["list", "-a", "-q", "--filter", $"label={DockerCreateArgumentBuilder.ReuseLabel}={reuseId}"];
+            lookupArgs = ["list", "-a", "-q", "--filter", $"label={ResourceLabels.ReuseId}={reuseId}"];
         }
         else
         {
-            lookupArgs = ["ps", "-a", "--no-trunc", "--filter", $"label={DockerCreateArgumentBuilder.ReuseLabel}={reuseId}", "--format", "{{.ID}}"];
+            lookupArgs = ["ps", "-a", "--no-trunc", "--filter", $"label={ResourceLabels.ReuseId}={reuseId}", "--format", "{{.ID}}"];
         }
 
         var lookup = await Cli.RunBufferedAsync(lookupArgs, cancellationToken, allowNonZero: true).ConfigureAwait(false);
@@ -201,7 +201,7 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
             args.Add(driver);
         }
 
-        foreach (var (labelName, labelValue) in definition.Labels)
+        foreach (var (labelName, labelValue) in ResourceLabels.Build(definition.Labels, definition.ReuseId, sessionOwned: true, definition.Identity))
         {
             args.Add("--label");
             args.Add($"{labelName}={labelValue}");
@@ -230,6 +230,88 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
         EnsureVolumesSupported();
         return ["volume", "inspect", name];
     }
+
+    internal override bool SupportsVolumes => _flavor is not Flavor.Wslc;
+
+    internal override bool SupportsReaper => _flavor is not Flavor.Wslc;
+
+    internal IReadOnlyList<string> BuildListManagedContainersArguments()
+        => _flavor is Flavor.Wslc
+            ? ["list", "-a", "-q", "--filter", $"label={ResourceLabels.Managed}"]
+            : ["ps", "-a", "--no-trunc", "--filter", $"label={ResourceLabels.Managed}", "--format", "{{.ID}}"];
+
+    internal IReadOnlyList<string> BuildListManagedVolumesArguments()
+    {
+        EnsureVolumesSupported();
+        return ["volume", "ls", "--filter", $"label={ResourceLabels.Managed}", "--format", "{{.Name}}"];
+    }
+
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedContainersAsync(CancellationToken cancellationToken)
+    {
+        var list = await Cli.RunBufferedAsync(BuildListManagedContainersArguments(), cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        var ids = new List<string>();
+        foreach (var line in list.StandardOutput.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (IsContainerId(trimmed))
+                ids.Add(trimmed);
+        }
+
+        if (ids.Count == 0)
+            return [];
+
+        var resources = new List<ManagedResource>(ids.Count);
+        foreach (var batch in GetInspectBatches(ids))
+        {
+            // A container removed in the meantime makes the command fail while the others are still reported, so the
+            // exit code is ignored and whatever was printed is parsed.
+            var inspectArgs = new List<string> { "inspect" };
+            inspectArgs.AddRange(batch);
+            var inspect = await Cli.RunBufferedAsync(inspectArgs, cancellationToken, allowNonZero: true).ConfigureAwait(false);
+            foreach (var info in DockerContainerInfoParser.ParseInspectOutputs(inspect.StandardOutput))
+            {
+                if (!string.IsNullOrEmpty(info.Id))
+                    resources.Add(new ManagedResource(info.Id, info.Labels));
+            }
+        }
+
+        return resources;
+    }
+
+    /// <summary>Groups the resources to inspect. docker and podman inspect a whole batch at once; wslc only documents a single argument, so it is asked one at a time.</summary>
+    private IEnumerable<IReadOnlyList<string>> GetInspectBatches(List<string> names)
+    {
+        if (_flavor is not Flavor.Wslc)
+        {
+            yield return names;
+            yield break;
+        }
+
+        foreach (var name in names)
+            yield return [name];
+    }
+
+    internal override async Task<IReadOnlyList<ManagedResource>> ListManagedVolumesAsync(CancellationToken cancellationToken)
+    {
+        var list = await Cli.RunBufferedAsync(BuildListManagedVolumesArguments(), cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        var names = new List<string>();
+        foreach (var line in list.StandardOutput.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (!string.IsNullOrEmpty(trimmed))
+                names.Add(trimmed);
+        }
+
+        if (names.Count == 0)
+            return [];
+
+        var inspectArgs = new List<string> { "volume", "inspect" };
+        inspectArgs.AddRange(names);
+        var inspect = await Cli.RunBufferedAsync(inspectArgs, cancellationToken, allowNonZero: true).ConfigureAwait(false);
+        return DockerVolumeInspectResult.Parse(inspect.StandardOutput);
+    }
+
+
 
     private void EnsureVolumesSupported()
     {

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerCreateArgumentBuilder.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerCreateArgumentBuilder.cs
@@ -2,14 +2,14 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 internal static class DockerCreateArgumentBuilder
 {
-    public const string ReuseLabel = "meziantou.tc.reuse";
-
     /// <param name="quotedMountFieldsSupported">Whether the runtime parses the <c>--mount</c> descriptor as a CSV record, which is the only way to express a value containing a comma. Docker does; podman and wslc split on the comma instead.</param>
     public static List<string> Build(ContainerDefinition definition, string imageRef, string? pullPolicyValue, bool quotedMountFieldsSupported)
     {
         var args = new List<string> { "create" };
 
-        AddOption(args, "--name", definition.Name);
+        // A reused container gets a deterministic name so the daemon itself rejects a second creation: two processes
+        // that start at the same time would otherwise both find nothing and both create one.
+        AddOption(args, "--name", definition.Name ?? (definition.ReuseId is { } reuseId ? ResourceNaming.GetReuseName(reuseId) : null));
         AddOption(args, "--hostname", definition.Hostname);
         AddOption(args, "--user", definition.User);
         AddOption(args, "--workdir", definition.WorkingDirectory);
@@ -27,16 +27,10 @@ internal static class DockerCreateArgumentBuilder
         AddOption(args, "--network", definition.Network.Network);
         AddOption(args, "--network-alias", definition.Network.Alias);
 
-        foreach (var (name, value) in definition.Labels)
+        foreach (var (name, value) in ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, definition.Identity))
         {
             args.Add("--label");
             args.Add($"{name}={value}");
-        }
-
-        if (definition.ReuseId is { } reuseId)
-        {
-            args.Add("--label");
-            args.Add($"{ReuseLabel}={reuseId}");
         }
 
         foreach (var (name, value) in definition.Environment)

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerInspectJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerInspectJsonContext.cs
@@ -3,5 +3,6 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 [JsonSerializable(typeof(DockerInspectResult[]))]
+[JsonSerializable(typeof(DockerVolumeInspectResult[]))]
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 internal sealed partial class DockerInspectJsonContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerVolumeInspectResult.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerVolumeInspectResult.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+internal sealed class DockerVolumeInspectResult
+{
+    public string? Name { get; set; }
+    public Dictionary<string, string>? Labels { get; set; }
+
+    /// <summary>Reads the output of a <c>volume inspect</c> command. A malformed or empty output means no volume, which is what a cleanup on an empty daemon reports.</summary>
+    public static IReadOnlyList<ManagedResource> Parse(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return [];
+
+        DockerVolumeInspectResult[]? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize(output, DockerInspectJsonContext.Default.DockerVolumeInspectResultArray);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (parsed is null)
+            return [];
+
+        var resources = new List<ManagedResource>(parsed.Length);
+        foreach (var volume in parsed)
+        {
+            if (!string.IsNullOrEmpty(volume.Name))
+                resources.Add(new ManagedResource(volume.Name, volume.Labels ?? new Dictionary<string, string>(StringComparer.Ordinal)));
+        }
+
+        return resources;
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
@@ -184,8 +184,20 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
 
         var imageRef = await PrepareImageAsync(definition.Image, definition.PullPolicy, cancellationToken).ConfigureAwait(false);
         var args = BuildCreateArguments(definition, imageRef);
-        var createResult = await Cli.RunBufferedAsync(args, cancellationToken).ConfigureAwait(false);
-        return createResult.StandardOutput.Trim();
+        try
+        {
+            var createResult = await Cli.RunBufferedAsync(args, cancellationToken).ConfigureAwait(false);
+            return createResult.StandardOutput.Trim();
+        }
+        catch (ContainerRuntimeException) when (definition.ReuseId is not null)
+        {
+            // Another process created the container between the lookup and the creation, and the runtime refused the
+            // name it already uses. Adopting it is the whole point of a reuse identifier.
+            if (await FindReusableContainerAsync(definition.ReuseId, cancellationToken).ConfigureAwait(false) is { } concurrentId)
+                return concurrentId;
+
+            throw;
+        }
     }
 
     internal override async Task StartAsync(string id, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/ManagedResource.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/ManagedResource.cs
@@ -1,0 +1,6 @@
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>A container or a volume the library created, as reported by a runtime listing.</summary>
+/// <param name="Id">The container id or the volume name.</param>
+/// <param name="Labels">The labels the resource carries.</param>
+internal sealed record ManagedResource(string Id, IReadOnlyDictionary<string, string> Labels);

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/ResourceLabels.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/ResourceLabels.cs
@@ -1,0 +1,63 @@
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>The labels the library stamps on every container and volume it creates, so a later run can tell its own leftovers from the resources it must not touch.</summary>
+internal static class ResourceLabels
+{
+    public const string Prefix = "meziantou.tc.";
+
+    /// <summary>Marks a resource as created by this library. Every cleanup starts from this label.</summary>
+    public const string Managed = Prefix + "managed";
+
+    /// <summary>The session that created the resource. A session is one process run.</summary>
+    public const string SessionId = Prefix + "session";
+
+    /// <summary>The machine that created the resource. A daemon can be shared, so the owner process only means something on the machine that recorded it.</summary>
+    public const string Host = Prefix + "host";
+
+    /// <summary>The id of the process that created the resource.</summary>
+    public const string ProcessId = Prefix + "pid";
+
+    /// <summary>The start time of the process that created the resource, in milliseconds since the Unix epoch.</summary>
+    public const string ProcessStartTime = Prefix + "pid-start";
+
+    /// <summary>The creation time of the resource, in milliseconds since the Unix epoch.</summary>
+    public const string CreatedAt = Prefix + "created";
+
+    /// <summary>The <see cref="ContainerDefinition.ReuseId"/> the resource was created with. Such a resource outlives the process that created it on purpose.</summary>
+    public const string ReuseId = Prefix + "reuse";
+
+    /// <summary>Builds the labels a new resource is created with: the ones the caller asked for, plus the identity of the run that creates it.</summary>
+    /// <param name="userLabels">The labels of the definition.</param>
+    /// <param name="reuseId">The reuse identifier, when the resource is meant to be reused across runs.</param>
+    /// <param name="sessionOwned">Whether the resource belongs to the run that creates it. A resource that does not is never removed by the reaper of that session.</param>
+    /// <param name="identity">The run to record. Defaults to the current one.</param>
+    /// <returns>The labels to apply.</returns>
+    public static Dictionary<string, string> Build(ContainerLabelCollection userLabels, string? reuseId, bool sessionOwned = true, SessionIdentity? identity = null)
+    {
+        identity ??= SessionIdentity.Current;
+
+        // The library labels are added last: a definition cannot overwrite them, which would make its resources
+        // invisible to the cleanup or, worse, make somebody else's resources look like ours.
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, value) in userLabels)
+            labels[name] = value;
+
+        labels[Managed] = "1";
+        labels[Host] = identity.Host;
+        labels[ProcessId] = identity.ProcessId;
+        labels[ProcessStartTime] = identity.ProcessStartTime;
+        labels[CreatedAt] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+
+        if (reuseId is not null)
+        {
+            // A reused resource outlives the run that created it on purpose, so it is not tied to that run's session.
+            labels[ReuseId] = reuseId;
+        }
+        else if (sessionOwned)
+        {
+            labels[SessionId] = identity.SessionId;
+        }
+
+        return labels;
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/ResourceOwnership.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/ResourceOwnership.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Reads the ownership labels of a resource to tell whether the run that created it is still alive.</summary>
+internal static class ResourceOwnership
+{
+    // Both sides of the comparison come from the operating system, but they travel through a millisecond timestamp and,
+    // on some platforms, through a value the kernel only reports at second precision.
+    private static readonly TimeSpan StartTimeTolerance = TimeSpan.FromSeconds(5);
+
+    private enum OwnerStatus
+    {
+        /// <summary>No process with this id is running.</summary>
+        Gone,
+
+        /// <summary>A process with this id is running, and its start time is known.</summary>
+        Running,
+
+        /// <summary>A process with this id may be running, but nothing more can be said about it.</summary>
+        Unknown,
+    }
+
+    /// <summary>Determines whether the process that created a resource is still running.</summary>
+    /// <param name="labels">The labels of the resource.</param>
+    /// <returns><see langword="true"/> when the owner is known to be gone; <see langword="false"/> when it is still running, or when the labels do not identify it well enough to tell.</returns>
+    public static bool IsOwnerGone(IReadOnlyDictionary<string, string> labels)
+    {
+        // A daemon can be shared between machines, and a process id only means something on the machine that recorded
+        // it. A resource created elsewhere is therefore never reported as orphaned.
+        if (!labels.TryGetValue(ResourceLabels.Host, out var host) || !string.Equals(host, SessionIdentity.Current.Host, StringComparison.Ordinal))
+            return false;
+
+        if (!labels.TryGetValue(ResourceLabels.ProcessId, out var processIdText) ||
+            !int.TryParse(processIdText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var processId))
+        {
+            return false;
+        }
+
+        var status = GetOwnerStatus(processId, out var startTime);
+        if (status is OwnerStatus.Gone)
+            return true;
+
+        if (status is OwnerStatus.Unknown)
+            return false;
+
+        // The process id is in use again. Whether it belongs to the owner is decided by the start time; without one in
+        // the labels, the resource is left alone rather than removed from under a process that may well be the owner.
+        if (!labels.TryGetValue(ResourceLabels.ProcessStartTime, out var ownerStartTimeText) ||
+            !long.TryParse(ownerStartTimeText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ownerStartTimeMilliseconds))
+        {
+            return false;
+        }
+
+        var ownerStartTime = DateTimeOffset.FromUnixTimeMilliseconds(ownerStartTimeMilliseconds);
+        return (startTime - ownerStartTime).Duration() > StartTimeTolerance;
+    }
+
+    private static OwnerStatus GetOwnerStatus(int processId, out DateTimeOffset startTime)
+    {
+        startTime = default;
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+
+            // A process that already exited can still be looked up on Unix, where it stays around as a zombie until
+            // its parent reaps it.
+            if (process.HasExited)
+                return OwnerStatus.Gone;
+
+            startTime = new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+            return OwnerStatus.Running;
+        }
+        catch (ArgumentException)
+        {
+            // No process with this id is running.
+            return OwnerStatus.Gone;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or PlatformNotSupportedException or Win32Exception)
+        {
+            // The process exists but cannot be inspected, for instance because it belongs to another user. Removing
+            // the resources of what may be a live run is worse than leaving them behind.
+            return OwnerStatus.Unknown;
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/SessionIdentity.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/SessionIdentity.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Identifies the run that created a resource: the process, on the machine it ran on.</summary>
+/// <param name="SessionId">An identifier of the run, regenerated every time the library is loaded.</param>
+/// <param name="Host">The machine the run happened on.</param>
+/// <param name="ProcessId">The id of the process.</param>
+/// <param name="ProcessStartTime">The start time of the process, in milliseconds since the Unix epoch, or an empty string when it could not be read. Process ids are reused, so the start time is what tells the owner apart from an unrelated process that inherited its id.</param>
+internal sealed record SessionIdentity(string SessionId, string Host, string ProcessId, string ProcessStartTime)
+{
+    /// <summary>The identity of the current run.</summary>
+    public static SessionIdentity Current { get; } = new(
+        Guid.NewGuid().ToString("N"),
+        Environment.MachineName,
+        Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
+        GetCurrentProcessStartTime());
+
+    private static string GetCurrentProcessStartTime()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero).ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or PlatformNotSupportedException or NotSupportedException)
+        {
+            // Without a start time the owner can still be identified by its process id, only less reliably.
+            return "";
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/VolumeDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/VolumeDefinition.cs
@@ -34,6 +34,7 @@ public sealed class VolumeDefinition
         ReuseId = other.ReuseId;
         Labels = new ContainerLabelCollection(other.Labels);
         DriverOptions = new VolumeDriverOptionCollection(other.DriverOptions);
+        Identity = other.Identity;
     }
 
     /// <summary>Gets or sets the container runtime to use.</summary>
@@ -61,6 +62,9 @@ public sealed class VolumeDefinition
 
     /// <summary>Gets the driver-specific options.</summary>
     public VolumeDriverOptionCollection DriverOptions { get; }
+
+    /// <summary>The run recorded in the labels of the volume. Defaults to the current one; the tests use it to create a volume that looks like the leftover of a run that is over.</summary>
+    internal Internals.SessionIdentity? Identity { get; set; }
 
     /// <summary>Creates a <see cref="TemporaryVolume"/> from a deep copy of this definition. Later changes to this definition do not affect the returned volume.</summary>
     /// <returns>A new volume.</returns>

--- a/src/Meziantou.Framework.TemporaryContainers/readme.md
+++ b/src/Meziantou.Framework.TemporaryContainers/readme.md
@@ -58,6 +58,69 @@ The volume is only removed when the library created it. A `VolumeDefinition.Name
 
 Runtime differences: `wslc` has no volume commands; Apple's `container` has no volume driver, its mount descriptors cannot contain a comma, and (as of 1.1.0) it hangs on a container that mounts a volume a deleted container used, so a volume there is best kept to a single container.
 
+## Cleaning up leftovers
+
+Every container and volume the library creates is labelled with the run that created it, so a later run can tell its own leftovers from the resources it must not touch. Disposal already removes them; the labels are what makes a run that was interrupted (a debugger stopped, a killed test host) recoverable.
+
+```c#
+// Removes the containers and volumes whose creating process is gone. Nothing else is touched:
+// not the resources of a live process, not those created on another machine, not the reused ones.
+var result = await ContainerRuntime.Auto.CleanupAsync();
+Console.WriteLine($"{result.RemovedCount} leftovers removed");
+```
+
+Call it once when a test run starts (an xUnit assembly fixture, a `[ModuleInitializer]`, a script). `ContainerCleanupOptions` widens or narrows what it removes:
+
+```c#
+await ContainerRuntime.Docker.CleanupAsync(new ContainerCleanupOptions
+{
+    Scope = ContainerCleanupScope.All,          // every resource of this library, not only the orphaned ones
+    MinimumAge = TimeSpan.FromHours(1),         // ... that is at least one hour old
+    IncludeVolumes = false,                     // ... and only containers
+    IncludeReusedResources = true,              // ... including the containers kept alive by a ReuseId
+});
+```
+
+The resources of the current process are never removed, whatever the scope, so a cleanup at the beginning of a run cannot take down the containers that run is about to use.
+
+### Removing the containers as soon as the process dies
+
+A cleanup only runs when a later run calls it. To have the leftovers removed right away, even when the process is killed, start a reaper: a watchdog container that holds a connection to this process and removes what the process created once that connection is gone.
+
+```c#
+// Keep it alive for as long as the containers it watches.
+await using var reaper = await ContainerRuntime.Docker.StartReaperAsync();
+```
+
+It is opt-in: it starts a container of its own ([`testcontainers/ryuk`](https://github.com/testcontainers/moby-ryuk), configurable through `ContainerReaperOptions`) and mounts the daemon socket into it. It needs a docker-compatible socket, so it works with the Docker Engine API, `docker`, and `podman`, but not with Apple's `container` or `wslc`. Disposing it stops the watchdog without removing anything, so a run that ends normally disposes its containers itself.
+
+The containers kept alive by a `ReuseId` are not part of a session: neither the reaper nor the default cleanup removes them.
+
+## Sharing a container between test processes
+
+Set the same `ReuseId` in every process. The first one creates the container, the others adopt it, and it is not removed on dispose:
+
+```c#
+var definition = ContainerDefinition.CreatePostgreSql();
+definition.ReuseId = "my-integration-tests";
+
+await using var container = definition.CreateContainer();
+await container.StartAsync(); // creates the container, or adopts the one another process created
+```
+
+The container is named after the reuse identifier, so two processes that start at the same time cannot both create one: the runtime rejects the second name and that process adopts the container the first one created. An adopted container keeps the ports it was created with, so `GetMappedPort` reports the same host port in every process.
+
+Nothing removes a reused container on its own. Remove it when it is no longer needed with `CleanupAsync` and `IncludeReusedResources`, for instance the ones that have been around for a day:
+
+```c#
+await ContainerRuntime.Auto.CleanupAsync(new ContainerCleanupOptions
+{
+    Scope = ContainerCleanupScope.All,
+    IncludeReusedResources = true,
+    MinimumAge = TimeSpan.FromDays(1),
+});
+```
+
 ## Database helpers
 
 `CreateRedis`, `CreatePostgreSql`, `CreateMongoDb`, and `CreateSqlServer` return pre-configured definitions whose container exposes `GetConnectionString()`.

--- a/src/Meziantou.Framework.TemporaryContainers/readme.md
+++ b/src/Meziantou.Framework.TemporaryContainers/readme.md
@@ -81,7 +81,7 @@ await ContainerRuntime.Docker.CleanupAsync(new ContainerCleanupOptions
 });
 ```
 
-The resources of the current process are never removed, whatever the scope, so a cleanup at the beginning of a run cannot take down the containers that run is about to use.
+The resources of the current process are never removed, whatever the scope, so a cleanup at the beginning of a run cannot take down the containers that run is about to use. The runs of *other* processes are only spared by the default scope: `ContainerCleanupScope.All` removes the containers another run started against the same daemon while it is still using them, so keep it for a daemon nothing else is running against.
 
 ### Removing the containers as soon as the process dies
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerContainerTests.cs
@@ -22,4 +22,7 @@ public sealed class AppleContainerContainerTests() : ContainerRuntimeTestsBase(C
 
     [Fact]
     public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
+
+    [Fact]
+    public Task Cleanup_RemovesTheVolumeOfARunThatIsOver() => AssertCleanupRemovesOrphanedVolumeAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
@@ -71,7 +71,11 @@ public sealed class AppleContainerRuntimeAdapterTests
         definition.Labels.Add("owner", "meziantou");
         definition.DriverOptions.Add("size", "10m");
 
-        Assert.Equal("volume create --label owner=meziantou --opt size=10m my-volume", string.Join(' ', runtime.BuildCreateVolumeArguments(definition, "my-volume")));
+        // The library also stamps the labels that identify the run, whose values change from one run to the next.
+        var createArguments = string.Join(' ', runtime.BuildCreateVolumeArguments(definition, "my-volume"));
+        Assert.StartsWith("volume create --label owner=meziantou --label ", createArguments);
+        Assert.Contains($"--label {ResourceLabels.Managed}=1", createArguments);
+        Assert.EndsWith("--opt size=10m my-volume", createArguments);
         Assert.Equal("volume delete my-volume", string.Join(' ', runtime.BuildDeleteVolumeArguments("my-volume")));
         Assert.Equal("volume inspect my-volume", string.Join(' ', runtime.BuildVolumeExistsArguments("my-volume")));
     }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerCleanupTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerCleanupTests.cs
@@ -1,0 +1,206 @@
+using Meziantou.Framework.TemporaryContainers.Internals;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+public sealed class ContainerCleanupTests
+{
+    private static readonly SessionIdentity DeadRun = SessionIdentity.Current with { SessionId = "dead-session", ProcessStartTime = "0" };
+
+    [Fact]
+    public void ShouldRemove_IgnoresAResourceThisLibraryDidNotCreate()
+    {
+        var resource = new ManagedResource("id", new Dictionary<string, string>(StringComparer.Ordinal) { ["app"] = "something-else" });
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { Scope = ContainerCleanupScope.All }));
+    }
+
+    [Fact]
+    public void ShouldRemove_KeepsTheResourcesOfTheCurrentRun()
+    {
+        var resource = CreateResource(SessionIdentity.Current);
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { Scope = ContainerCleanupScope.Orphaned }));
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { Scope = ContainerCleanupScope.All }));
+    }
+
+    [Fact]
+    public void ShouldRemove_RemovesTheResourcesOfARunWhoseProcessIdWasReused()
+    {
+        // The process id is the one of this process, which is running, but the start time is not: the id belongs to
+        // another process now, so the run that created the resource is over.
+        var resource = CreateResource(DeadRun);
+
+        Assert.True(ShouldRemove(resource, new ContainerCleanupOptions()));
+    }
+
+    [Fact]
+    public void ShouldRemove_KeepsTheResourcesOfAnotherMachine()
+    {
+        var resource = CreateResource(DeadRun with { Host = "another-machine" });
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { Scope = ContainerCleanupScope.Orphaned }));
+        Assert.True(ShouldRemove(resource, new ContainerCleanupOptions { Scope = ContainerCleanupScope.All }));
+    }
+
+    [Fact]
+    public void ShouldRemove_KeepsTheResourcesOfARunningProcess()
+    {
+        var resource = CreateResource(SessionIdentity.Current with { SessionId = "another-session" });
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { Scope = ContainerCleanupScope.Orphaned }));
+    }
+
+    [Fact]
+    public void ShouldRemove_KeepsTheReusedResourcesUnlessTheyAreAskedFor()
+    {
+        var resource = CreateResource(DeadRun, reuseId: "shared-database");
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions()));
+        Assert.True(ShouldRemove(resource, new ContainerCleanupOptions { IncludeReusedResources = true }));
+    }
+
+    [Fact]
+    public void ShouldRemove_KeepsTheResourcesThatAreNotOldEnough()
+    {
+        var resource = CreateResource(DeadRun);
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { MinimumAge = TimeSpan.FromHours(1) }));
+    }
+
+    [Fact]
+    public void ShouldRemove_RemovesTheResourcesThatAreOldEnough()
+    {
+        var resource = CreateResource(DeadRun);
+
+        Assert.True(ShouldRemove(resource, new ContainerCleanupOptions { MinimumAge = TimeSpan.FromHours(1) }, DateTimeOffset.UtcNow.AddHours(2)));
+    }
+
+    [Fact]
+    public void ShouldRemove_KeepsTheResourcesWhoseAgeIsUnknownWhenAnAgeIsRequired()
+    {
+        var labels = CreateResource(DeadRun).Labels.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
+        labels.Remove(ResourceLabels.CreatedAt);
+        var resource = new ManagedResource("id", labels);
+
+        Assert.False(ShouldRemove(resource, new ContainerCleanupOptions { MinimumAge = TimeSpan.FromSeconds(1) }, DateTimeOffset.UtcNow.AddHours(2)));
+        Assert.True(ShouldRemove(resource, new ContainerCleanupOptions()));
+    }
+
+    [Fact]
+    public void ContainersOfTheCurrentRunCarryTheSessionLabels()
+    {
+        var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8"));
+        definition.Labels.Add("app", "mine");
+
+        var labels = ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, definition.Identity);
+
+        Assert.Equal("mine", labels["app"]);
+        Assert.Equal("1", labels[ResourceLabels.Managed]);
+        Assert.Equal(SessionIdentity.Current.SessionId, labels[ResourceLabels.SessionId]);
+        Assert.Equal(SessionIdentity.Current.Host, labels[ResourceLabels.Host]);
+        Assert.Equal(SessionIdentity.Current.ProcessId, labels[ResourceLabels.ProcessId]);
+        Assert.DoesNotContain(ResourceLabels.ReuseId, labels);
+    }
+
+    [Fact]
+    public void ADefinitionCannotOverwriteTheLibraryLabels()
+    {
+        var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8"));
+        definition.Labels.Add(ResourceLabels.SessionId, "somebody-elses-session");
+
+        var labels = ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, definition.Identity);
+
+        Assert.Equal(SessionIdentity.Current.SessionId, labels[ResourceLabels.SessionId]);
+    }
+
+    [Fact]
+    public void AReusedContainerIsNotPartOfTheSession()
+    {
+        var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8")) { ReuseId = "shared-database" };
+
+        var labels = ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, definition.Identity);
+
+        // The container is shared with the runs that come after this one, so the reaper of this session must not take it down with it.
+        Assert.DoesNotContain(ResourceLabels.SessionId, labels);
+        Assert.Equal("shared-database", labels[ResourceLabels.ReuseId]);
+    }
+
+    [Fact]
+    public void DockerVolumeInspectOutputIsReadAsManagedResources()
+    {
+        var output = """
+            [
+                {"Name":"meziantou-tc-1","Labels":{"meziantou.tc.managed":"1","meziantou.tc.session":"abc"}},
+                {"Name":"other-volume","Labels":null}
+            ]
+            """;
+
+        var resources = DockerVolumeInspectResult.Parse(output);
+
+        Assert.Equal(2, resources.Count);
+        Assert.Equal("meziantou-tc-1", resources[0].Id);
+        Assert.Equal("abc", resources[0].Labels[ResourceLabels.SessionId]);
+        Assert.Empty(resources[1].Labels);
+    }
+
+    [Fact]
+    public void DockerVolumeInspectOutputThatIsNotJsonIsReadAsNoResource()
+    {
+        Assert.Empty(DockerVolumeInspectResult.Parse("Error: no such volume"));
+        Assert.Empty(DockerVolumeInspectResult.Parse(""));
+    }
+
+    [Fact]
+    public void DockerInspectOutputIsReadAsSeveralContainers()
+    {
+        var output = """
+            [
+                {"Id":"1111","Name":"/first","Config":{"Labels":{"meziantou.tc.managed":"1"}}},
+                {"Id":"2222","Name":"/second","Config":{"Labels":{}}}
+            ]
+            """;
+
+        var results = DockerContainerInfoParser.ParseInspectOutputs(output);
+
+        Assert.Equal(["1111", "2222"], results.Select(result => result.Id));
+        Assert.Equal("1", results[0].Labels[ResourceLabels.Managed]);
+        Assert.Empty(DockerContainerInfoParser.ParseInspectOutputs("Error: No such object"));
+    }
+
+    [Fact]
+    public void AppleListOutputOnlyReportsTheResourcesThisLibraryCreated()
+    {
+        var output = """
+            [
+                {"configuration":{"id":"buildkit","labels":{"com.apple.container.plugin":"builder"}},"id":"buildkit","status":{"state":"stopped"}},
+                {"configuration":{"id":"mine","labels":{"meziantou.tc.managed":"1","meziantou.tc.session":"abc"}},"id":"mine","status":{"state":"running"}}
+            ]
+            """;
+
+        var resource = Assert.Single(AppleContainerRuntime.ParseManagedResources(output));
+
+        Assert.Equal("mine", resource.Id);
+        Assert.Equal("abc", resource.Labels[ResourceLabels.SessionId]);
+    }
+
+    [Fact]
+    public void AppleVolumeListOutputIsReadAsManagedResources()
+    {
+        var output = """
+            [{"configuration":{"creationDate":"2026-09-06T20:38:43Z","driver":"local","labels":{"meziantou.tc.managed":"1"},"name":"meziantou-tc-probe"},"id":"meziantou-tc-probe"}]
+            """;
+
+        var resource = Assert.Single(AppleContainerRuntime.ParseManagedResources(output));
+
+        Assert.Equal("meziantou-tc-probe", resource.Id);
+    }
+
+    private static ManagedResource CreateResource(SessionIdentity identity, string? reuseId = null)
+    {
+        var definition = new ContainerDefinition(ImageSource.FromRegistry("redis:8")) { ReuseId = reuseId };
+        return new ManagedResource("id", ResourceLabels.Build(definition.Labels, definition.ReuseId, definition.SessionOwned, identity));
+    }
+
+    private static bool ShouldRemove(ManagedResource resource, ContainerCleanupOptions options, DateTimeOffset? now = null)
+        => ContainerRuntime.ShouldRemove(resource, options, now ?? DateTimeOffset.UtcNow);
+}

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -749,13 +749,16 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
         Assert.False(await container.ExistsAsync(XunitCancellationToken), "The cleanup left behind the container of a run that is over.");
     }
 
+    // The scope is deliberately left to its default: a ContainerCleanupScope.All sweep removes the resources of every
+    // other run against this daemon, and the test hosts of the two target frameworks run at the same time. That the
+    // current run is spared whatever the scope is asserted by ContainerCleanupTests instead.
     [Fact]
     public async Task Cleanup_KeepsTheContainersOfTheCurrentRun()
     {
         await using var container = CreateHttpServerDefinition().CreateContainer();
         await container.EnsureCreatedAsync(XunitCancellationToken);
 
-        await Runtime.CleanupAsync(new ContainerCleanupOptions { Scope = ContainerCleanupScope.All }, XunitCancellationToken);
+        await Runtime.CleanupAsync(XunitCancellationToken);
 
         Assert.True(await container.ExistsAsync(XunitCancellationToken), "The cleanup removed a container the current run is using.");
     }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net.Sockets;
 using System.Text.Json;
 using Meziantou.Extensions.Logging.Xunit.v3;
+using Meziantou.Framework.TemporaryContainers.Internals;
 using Meziantou.Xunit;
 using Microsoft.Extensions.Logging;
 
@@ -736,6 +737,77 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
             Assert.NotEqual(0, exec.ExitCode);
         }, XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Cleanup_RemovesTheContainerOfARunThatIsOver()
+    {
+        await using var container = CreateOrphanedDefinition().CreateContainer();
+        await container.EnsureCreatedAsync(XunitCancellationToken);
+
+        await Runtime.CleanupAsync(XunitCancellationToken);
+
+        Assert.False(await container.ExistsAsync(XunitCancellationToken), "The cleanup left behind the container of a run that is over.");
+    }
+
+    [Fact]
+    public async Task Cleanup_KeepsTheContainersOfTheCurrentRun()
+    {
+        await using var container = CreateHttpServerDefinition().CreateContainer();
+        await container.EnsureCreatedAsync(XunitCancellationToken);
+
+        await Runtime.CleanupAsync(new ContainerCleanupOptions { Scope = ContainerCleanupScope.All }, XunitCancellationToken);
+
+        Assert.True(await container.ExistsAsync(XunitCancellationToken), "The cleanup removed a container the current run is using.");
+    }
+
+    /// <summary>Shared assertion that the cleanup removes the volume of a run that is over (called from the runtimes that support volumes).</summary>
+    protected async Task AssertCleanupRemovesOrphanedVolumeAsync()
+    {
+        await using var volume = new VolumeDefinition { Runtime = Runtime, Identity = CreateDeadRunIdentity() }.CreateVolume();
+        await volume.EnsureCreatedAsync(XunitCancellationToken);
+        Assert.True(await volume.ExistsAsync(XunitCancellationToken));
+
+        await Runtime.CleanupAsync(XunitCancellationToken);
+
+        Assert.False(await volume.ExistsAsync(XunitCancellationToken), "The cleanup left behind the volume of a run that is over.");
+    }
+
+    /// <summary>Shared assertion that the reaper starts, acknowledges the session, and removes nothing when it is stopped cleanly (called from the runtimes driven by a docker-compatible socket).</summary>
+    protected async Task AssertReaperLifecycleAsync()
+    {
+        global::Xunit.Assert.SkipWhen(UseWindowsContainerImages, "The reaper image only runs on Linux containers.");
+
+        await using var container = CreateHttpServerDefinition().CreateContainer();
+        await container.EnsureCreatedAsync(XunitCancellationToken);
+
+        string reaperContainerId;
+        await using (var reaper = await Runtime.StartReaperAsync(XunitCancellationToken))
+        {
+            reaperContainerId = reaper.ContainerId;
+            Assert.NotEmpty(reaperContainerId);
+            Assert.True(await Runtime.ExistsAsync(reaperContainerId, XunitCancellationToken), "The reaper container is not running.");
+        }
+
+        Assert.False(await Runtime.ExistsAsync(reaperContainerId, XunitCancellationToken), "Disposing the reaper left its container behind.");
+
+        // A reaper that is stopped cleanly must not remove what the run still owns.
+        Assert.True(await container.ExistsAsync(XunitCancellationToken), "Disposing the reaper removed a container of the current run.");
+    }
+
+    /// <summary>A definition whose container looks like the leftover of a run that is over: the process id is the one of this process, but the start time is not, which is exactly what a reused process id looks like.</summary>
+    private ContainerDefinition CreateOrphanedDefinition()
+    {
+        var definition = CreateHttpServerDefinition();
+        definition.Identity = CreateDeadRunIdentity();
+        return definition;
+    }
+
+    private static SessionIdentity CreateDeadRunIdentity()
+        => SessionIdentity.Current with
+        {
+            SessionId = Guid.NewGuid().ToString("N"),
+            ProcessStartTime = "0",
+        };
 
     protected ContainerDefinition CreateHttpServerDefinition()
     {

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiContainerTests.cs
@@ -25,4 +25,10 @@ public sealed class DockerApiContainerTests() : ContainerRuntimeTestsBase(Contai
 
     [Fact]
     public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
+
+    [Fact]
+    public Task Cleanup_RemovesTheVolumeOfARunThatIsOver() => AssertCleanupRemovesOrphanedVolumeAsync();
+
+    [Fact]
+    public Task Reaper_WatchesTheSessionAndStopsWithIt() => AssertReaperLifecycleAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiCreateRequestBuilderTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiCreateRequestBuilderTests.cs
@@ -40,7 +40,7 @@ public sealed class DockerApiCreateRequestBuilderTests
         Assert.Equal("1000:1000", payload.User);
         Assert.Equal("/work", payload.WorkingDir);
         Assert.Equal("labelvalue", payload.Labels!["label"]);
-        Assert.Equal("reuse-id", payload.Labels[DockerCreateArgumentBuilder.ReuseLabel]);
+        Assert.Equal("reuse-id", payload.Labels[ResourceLabels.ReuseId]);
         Assert.Contains("KEY=VALUE", payload.Env!);
         Assert.Equal("/bin/sh", Assert.Single(payload.Entrypoint!));
         Assert.Equal(["-c", "echo hi"], payload.Cmd);

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerContainerTests.cs
@@ -28,4 +28,10 @@ public sealed class DockerContainerTests() : ContainerRuntimeTestsBase(Container
 
     [Fact]
     public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
+
+    [Fact]
+    public Task Cleanup_RemovesTheVolumeOfARunThatIsOver() => AssertCleanupRemovesOrphanedVolumeAsync();
+
+    [Fact]
+    public Task Reaper_WatchesTheSessionAndStopsWithIt() => AssertReaperLifecycleAsync();
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerCreateArgumentBuilderTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerCreateArgumentBuilderTests.cs
@@ -49,7 +49,7 @@ public sealed class DockerCreateArgumentBuilderTests
 
         var args = DockerCreateArgumentBuilder.Build(definition, "redis:8", pullPolicyValue: null, quotedMountFieldsSupported: true);
 
-        Assert.Contains($"{DockerCreateArgumentBuilder.ReuseLabel}=my-reuse-id", args);
+        Assert.Contains($"{ResourceLabels.ReuseId}=my-reuse-id", args);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
@@ -85,6 +85,20 @@ public sealed class DockerRuntimeAdapterTests
     }
 
     [Fact]
+    public void BuildsListArgumentsForTheCleanup()
+    {
+        var docker = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Docker);
+        var wslc = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Wslc);
+
+        Assert.Equal($"ps -a --no-trunc --filter label={ResourceLabels.Managed} --format {{{{.ID}}}}", string.Join(' ', docker.BuildListManagedContainersArguments()));
+        Assert.Equal($"volume ls --filter label={ResourceLabels.Managed} --format {{{{.Name}}}}", string.Join(' ', docker.BuildListManagedVolumesArguments()));
+
+        // wslc has no '--format' for its listing and no volume commands at all.
+        Assert.Equal($"list -a -q --filter label={ResourceLabels.Managed}", string.Join(' ', wslc.BuildListManagedContainersArguments()));
+        Assert.Throws<NotSupportedException>(() => wslc.BuildListManagedVolumesArguments());
+    }
+
+    [Fact]
     public void BuildsVolumeArguments()
     {
         var runtime = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Docker);
@@ -92,7 +106,11 @@ public sealed class DockerRuntimeAdapterTests
         definition.Labels.Add("owner", "meziantou");
         definition.DriverOptions.Add("size", "10m");
 
-        Assert.Equal("volume create --driver local --label owner=meziantou --opt size=10m my-volume", string.Join(' ', runtime.BuildCreateVolumeArguments(definition, "my-volume")));
+        // The library also stamps the labels that identify the run, whose values change from one run to the next.
+        var createArguments = string.Join(' ', runtime.BuildCreateVolumeArguments(definition, "my-volume"));
+        Assert.StartsWith("volume create --driver local --label owner=meziantou --label ", createArguments);
+        Assert.Contains($"--label {ResourceLabels.Managed}=1", createArguments);
+        Assert.EndsWith("--opt size=10m my-volume", createArguments);
 
         // '--force' is not used: podman would remove the containers still using the volume.
         Assert.Equal("volume rm my-volume", string.Join(' ', runtime.BuildDeleteVolumeArguments("my-volume")));

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/PodmanContainerTests.cs
@@ -24,4 +24,7 @@ public sealed class PodmanContainerTests() : ContainerRuntimeTestsBase(Container
 
     [Fact]
     public Task Volume_ReadOnlyMountRejectsWrites() => AssertReadOnlyVolumeMountAsync();
+
+    [Fact]
+    public Task Cleanup_RemovesTheVolumeOfARunThatIsOver() => AssertCleanupRemovesOrphanedVolumeAsync();
 }


### PR DESCRIPTION
## Why

A run that is interrupted before it can dispose its containers — a stopped debugger, a killed test host — leaves them running. Nothing distinguished those from the containers another run is using, so they piled up. (This repo's own Apple `container` runtime currently holds leftovers dating back to July.)

## What changed

**Identity labels.** Every container and volume the library creates now carries the run that created it: `meziantou.tc.managed`, `session`, `host`, `pid`, `pid-start` and `created`. They are stamped last, so a definition cannot overwrite them. The existing `meziantou.tc.reuse` label moved into the same place.

**`ContainerRuntime.CleanupAsync`** — removes the leftovers of a run that is over, on every runtime:

```c#
var result = await ContainerRuntime.Auto.CleanupAsync();
```

By default it only removes resources whose creating process is gone *from this machine*. The process start time is compared alongside the id, so a reused process id does not make a live run's containers look orphaned; a resource created on another machine, or by a process that cannot be inspected, is left alone. The resources of the current process are never removed, whatever the scope, so a cleanup at the start of a run cannot take down the containers that run is about to use. `ContainerCleanupOptions` widens it: `Scope`, `MinimumAge`, containers/volumes, reused resources. Containers are removed before volumes, and a volume that could not be removed is reported rather than claimed as removed.

**`ContainerRuntime.StartReaperAsync`** — opt-in watchdog for the runtimes driven by a docker-compatible socket (Docker Engine API, `docker`, `podman`):

```c#
await using var reaper = await ContainerRuntime.Docker.StartReaperAsync();
```

It starts a `testcontainers/ryuk` container with the daemon socket mounted, registers the session, and holds the connection. When the process dies — including `kill -9` — ryuk removes what that session created. Disposing it stops the watchdog without removing anything. The watchdog itself is deliberately not part of the session (it would remove itself mid-sweep) but keeps the other labels, so a leftover watchdog is collected by a later `CleanupAsync`.

**Reuse across processes.** A container with a `ReuseId` is shared with later runs, so it is not part of a session: neither the reaper nor the default cleanup removes it. It now also gets a deterministic name, which closes the race where two processes starting at the same time both found nothing and both created a container — the runtime rejects the second name and that process adopts the first one (both the CLI and the Docker API paths handle the conflict).

## Notes for the reviewer

- Listing is per-runtime: docker/podman filter on the label and inspect the batch, `wslc` inspects one at a time (its CLI only documents a single argument) and has no volumes, the Docker API filters server-side, and Apple's CLI has no label filter so `ls --format json` is filtered in-process — its listing reports labels directly, which spares an inspect per resource.
- Behaviour change to be aware of: containers created before this change carry no labels and are therefore invisible to `CleanupAsync`; they need one manual pass.
- `ContainerDefinition.Identity` / `VolumeDefinition.Identity` are internal seams used by the tests to create a resource that looks like the leftover of a run that is over.

## Verification

- `dotnet run ./eng/update-all.cs` reports nothing further to change; `ref/` regenerated.
- Release build with `IsOfficialBuild=true` and `TreatsWarningsAsErrors=true`: no warnings.
- `dotnet test -f net10.0` on the whole project: 205 tests, 2 failed, 28 skipped. The two failures are `SqlServerContainerTests` — the mssql image has no arm64 variant, which is the known baseline on the machine this was developed on and unrelated to this change. Docker, Docker API and Apple `container` classes pass (53/53).
- New tests: the orphan filter, label stamping and the listing parsers as unit tests; container and volume cleanup as integration tests on every runtime; a reaper lifecycle test on docker and the Docker API.
- Checked by hand end to end: a process that starts a reaper and a container, then gets `kill -9`, loses its container ~10s later, and the exited watchdog is collected by the next `CleanupAsync`.