### PR TITLE
Return base interface members from GetAllMembers on an interface

### DIFF
--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.13</Version>
+    <Version>1.1.0</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
     <PackageTags>roslyn, analyzer, source-generator, codegen, compiler</PackageTags>
 

--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -37,8 +37,9 @@ internal static partial class TypeSymbolExtensions
     /// <param name="symbol">The type whose members are enumerated.</param>
     /// <param name="includeInterfaceMembers">
     /// <see langword="true"/> to also enumerate the members of all the interfaces implemented by <paramref name="symbol"/>; otherwise, <see langword="false"/>.
+    /// This parameter is ignored when <paramref name="symbol"/> is an interface as the members of its base interfaces are always enumerated.
     /// </param>
-    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, bool includeInterfaceMembers = true)
+    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, bool includeInterfaceMembers = false)
     {
         var type = symbol;
         while (type is not null)
@@ -49,7 +50,7 @@ internal static partial class TypeSymbolExtensions
             type = type.BaseType;
         }
 
-        if (includeInterfaceMembers && symbol is not null)
+        if (symbol is not null && (includeInterfaceMembers || symbol.TypeKind is TypeKind.Interface))
         {
             foreach (var @interface in symbol.AllInterfaces)
             {
@@ -66,8 +67,9 @@ internal static partial class TypeSymbolExtensions
     /// <param name="name">The name of the members to enumerate.</param>
     /// <param name="includeInterfaceMembers">
     /// <see langword="true"/> to also enumerate the members of all the interfaces implemented by <paramref name="symbol"/>; otherwise, <see langword="false"/>.
+    /// This parameter is ignored when <paramref name="symbol"/> is an interface as the members of its base interfaces are always enumerated.
     /// </param>
-    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, string name, bool includeInterfaceMembers = true)
+    public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol, string name, bool includeInterfaceMembers = false)
     {
         var type = symbol;
         while (type is not null)
@@ -78,7 +80,7 @@ internal static partial class TypeSymbolExtensions
             type = type.BaseType;
         }
 
-        if (includeInterfaceMembers && symbol is not null)
+        if (symbol is not null && (includeInterfaceMembers || symbol.TypeKind is TypeKind.Interface))
         {
             foreach (var @interface in symbol.AllInterfaces)
             {

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -1501,10 +1501,11 @@ public sealed class RoslynHelperTests
         var baseInterface = GetRequiredType(compilation, "IBase");
         var sampleInterface = GetRequiredType(compilation, "ISample");
 
-        var members = type.GetAllMembers().ToArray();
+        var members = type.GetAllMembers(includeInterfaceMembers: true).ToArray();
 
         Assert.Contains(GetRequiredMethod(baseInterface, "BaseInterfaceOnly"), members);
         Assert.Contains(GetRequiredMethod(sampleInterface, "SampleInterfaceOnly"), members);
+        Assert.DoesNotContain(GetRequiredMethod(baseInterface, "BaseInterfaceOnly"), type.GetAllMembers());
     }
 
     [Fact]
@@ -1523,6 +1524,43 @@ public sealed class RoslynHelperTests
         var baseInterfaceOnly = GetRequiredMethod(baseInterface, "BaseInterfaceOnly");
 
         Assert.Contains(baseInterfaceOnly, type.GetAllMembers());
+        Assert.Contains(baseInterfaceOnly, type.GetAllMembers(includeInterfaceMembers: false));
+        Assert.Contains(baseInterfaceOnly, type.GetAllMembers("BaseInterfaceOnly"));
+        Assert.Contains(baseInterfaceOnly, type.GetAllMembers("BaseInterfaceOnly", includeInterfaceMembers: false));
+    }
+
+    [Fact]
+    public void GetAllMembers_OnInterface_DoesNotReturnDuplicatedMembers()
+    {
+        var compilation = CreateCompilation("""
+            public interface IRoot
+            {
+                void RootOnly();
+            }
+
+            public interface ILeft : IRoot;
+
+            public interface IRight : IRoot;
+
+            public interface ISample : ILeft, IRight
+            {
+                void SampleOnly();
+            }
+            """);
+        var type = GetRequiredType(compilation, "ISample");
+        var rootInterface = GetRequiredType(compilation, "IRoot");
+        var rootOnly = GetRequiredMethod(rootInterface, "RootOnly");
+        var sampleOnly = GetRequiredMethod(type, "SampleOnly");
+
+        foreach (var includeInterfaceMembers in new[] { false, true })
+        {
+            var members = type.GetAllMembers(includeInterfaceMembers).ToArray();
+
+            Assert.Equal(1, members.Count(member => SymbolEqualityComparer.Default.Equals(member, rootOnly)));
+            Assert.Equal(1, members.Count(member => SymbolEqualityComparer.Default.Equals(member, sampleOnly)));
+            Assert.Equal(1, type.GetAllMembers("RootOnly", includeInterfaceMembers).Count(member => SymbolEqualityComparer.Default.Equals(member, rootOnly)));
+            Assert.Equal(1, type.GetAllMembers("SampleOnly", includeInterfaceMembers).Count(member => SymbolEqualityComparer.Default.Equals(member, sampleOnly)));
+        }
     }
 
     [Fact]
@@ -1545,8 +1583,9 @@ public sealed class RoslynHelperTests
         var baseInterface = GetRequiredType(compilation, "IBase");
         var baseInterfaceOnly = GetRequiredMethod(baseInterface, "BaseInterfaceOnly");
 
-        Assert.Contains(baseInterfaceOnly, type.GetAllMembers("BaseInterfaceOnly"));
-        Assert.DoesNotContain(baseInterfaceOnly, type.GetAllMembers("Unknown"));
+        Assert.Contains(baseInterfaceOnly, type.GetAllMembers("BaseInterfaceOnly", includeInterfaceMembers: true));
+        Assert.DoesNotContain(baseInterfaceOnly, type.GetAllMembers("Unknown", includeInterfaceMembers: true));
+        Assert.DoesNotContain(baseInterfaceOnly, type.GetAllMembers("BaseInterfaceOnly"));
     }
 
     [Fact]


### PR DESCRIPTION
## What

`TypeSymbolExtensions.GetAllMembers` had two problems for interface receivers:

- It enumerated inherited members by walking `BaseType`, but **an interface's `BaseType` is `null`**. An interface therefore only ever yielded its own members. Its base interfaces were reachable solely through the `AllInterfaces` branch, gated behind `includeInterfaceMembers`.
- `includeInterfaceMembers` defaulted to `true`, so members of *implemented* interfaces were opted in by default for classes and structs.

After this change:

- An interface **always** enumerates its base interfaces, regardless of `includeInterfaceMembers`. Those are its base types; the flag is about interfaces a type *implements*.
- `includeInterfaceMembers` now defaults to **`false`**, making implemented-interface members opt-in.

Both overloads (`GetAllMembers(bool)` and `GetAllMembers(string, bool)`) are updated identically, and the XML docs record that the parameter is ignored for interfaces.

## No duplicates

Worth stating explicitly, since always walking `AllInterfaces` for an interface looks like it should double up:

- An interface's `BaseType` is `null`, so the base-type walk runs exactly one iteration — the interface's own members — and stops.
- `AllInterfaces` never contains the type itself (that is precisely why `GetAllInterfacesIncludingSelf` has to add it) and is already de-duplicated, so diamond inheritance does not repeat a shared base interface.

`GetAllMembers_OnInterface_DoesNotReturnDuplicatedMembers` covers the diamond case (`ISample : ILeft, IRight`, both `: IRoot`) and asserts each member appears exactly once, across both overloads and both values of the parameter.

## Compatibility — please read before taking the bump

This is a **behavioural** change, not a source-breaking one: both signatures are unchanged, so existing call sites keep compiling. The failure mode is silent.

Callers that relied on the old `true` default to find members of implemented interfaces must now pass `includeInterfaceMembers: true`. The case that bites hardest is **explicit interface implementations**: on the implementing type such a member's `ISymbol.Name` is the mangled `IFoo.Member`, so `GetMembers("Member")` misses it and only the interface symbol carries the plain name. Verified against the compiler:

```
OWN=[IAsyncDisp.DisposeAsync|.ctor]  byName_default=0  byName_true=1
```

A consumer doing `symbol.GetAllMembers("DisposeAsync")` to detect `IAsyncDisposable` gets 1 result before this change and 0 after, with no compile error — a silent false negative. `Meziantou.Analyzer` has several call sites of exactly this shape and will need explicit `includeInterfaceMembers: true` when it takes this version.

The package is bumped **1.0.13 → 1.1.0** rather than the patch bump this repo has used until now, specifically so the behavioural change is visible in the version. Happy to drop it to 1.0.14 if you would rather keep the convention.

## Verification

- `Meziantou.Framework.Roslyn.Tests`, all four Roslyn variants, `/p:TreatsWarningsAsErrors=true`: 354/354 (4.8, 5.0, 5.3) and 356/356 (5.6), across net10.0 and net11.0.
- `Meziantou.Framework.Roslyn.PackageTests`: 14/14.
- The five source projects embedding these helpers (Yaml.SourceGenerator, StronglyTypedId, FastEnumGenerator, Assertions.Analyzer, FullPath.Analyzer) build clean.
- `dotnet run ./eng/update-all.cs`: no file changes.

No production code in this repo calls `GetAllMembers`, so the default change affects external consumers only.