### PR TITLE
Pin RespectNullableAnnotations in the HTTP recording serializer context

### DIFF
--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingSerializerContext.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingSerializerContext.cs
@@ -6,5 +6,9 @@ namespace Meziantou.Framework.Http.Recording;
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    PropertyNameCaseInsensitive = true)]
+    PropertyNameCaseInsensitive = true,
+    // The store validates the entries itself so it can name the file and the index of the faulty entry. Honoring the
+    // nullable annotations would let the deserializer reject a null value first with a message blaming a truncated
+    // file, and the diagnostic would depend on whether the host application enabled the switch.
+    RespectNullableAnnotations = false)]
 internal sealed partial class HttpRecordingSerializerContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingStoreHelpers.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingStoreHelpers.cs
@@ -47,7 +47,8 @@ internal static class HttpRecordingStoreHelpers
                 throw new InvalidDataException($"The recording file '{filePath}' contains a null entry at index {i}.");
             }
 
-            // 'required' is not a null check: a JSON document can set these to null and deserialization accepts it.
+            // 'required' is not a null check: a JSON document can set these to null and the deserializer accepts it,
+            // as 'HttpRecordingSerializerContext' keeps 'RespectNullableAnnotations' off so this check owns the message.
             if (string.IsNullOrEmpty(entry.Method))
             {
                 throw new InvalidDataException($"The entry at index {i} in the recording file '{filePath}' has no HTTP method.");


### PR DESCRIPTION
## Summary

Unblocks #3001 (`Meziantou.NET.Sdk` 1.0.163 → 1.0.165), which fails on every `shard-2` job with `JsonHttpRecordingStoreTests.LoadAsync_EntryWithoutMethod_ThrowsNamingTheIndex`.

SDK 1.0.165 added these to `common/Common.targets`:

```xml
<RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault" Value="true" />
<RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault" Value="true" />
```

`HttpRecordingEntry.Method` is a non-nullable `required string`, so a recording file containing `{"method": null, ...}` is now rejected by the deserializer *before* `HttpRecordingStoreHelpers.ValidateEntries` runs. The store then reports

> The recording file '…' is not valid JSON. It may have been truncated by an interrupted save.

which is misleading — the file is perfectly well-formed JSON, one entry just has no method.

These are process-wide `AppContext` switches baked into the **host application's** `runtimeconfig.json`, so without this change the error message a consumer sees depends on whether their app enabled the switch.

## What changed

- `HttpRecordingSerializerContext`: added `RespectNullableAnnotations = false` to `[JsonSourceGenerationOptions]`, so the library's own validation always owns the diagnostic regardless of the host's configuration.
- `HttpRecordingStoreHelpers.ValidateEntries`: updated the existing comment to point at that pin, so it is not "fixed" later.

The HAR store is unaffected — `HarRequest.Method` and its siblings are already nullable.

No behavior change on `main` as it stands (1.0.163 does not set the switch); this makes the intent explicit and keeps the diagnostic stable once the bump lands.

## Validation

- Reproduced the failure on the `renovate/meziantou-dependencies` branch, then confirmed the fix there: `Meziantou.Framework.Http.Recording.Tests` **170/170 pass** (85 × net10.0/net11.0) in Debug and Release with `/p:TreatWarningsAsErrors=true`.
- Same test project passes on this branch (1.0.163), Release, warnings as errors.
- Release build with `/p:IsOfficialBuild=true`: 0 warnings, 0 errors, no `ref/` changes.
- `dotnet run ./eng/update-all.cs`: no generated files changed.
- Verified all 8 failing jobs on #3001 fail on this single test only.