### PR TITLE
Lower the Yaml source generator requirement to Roslyn 5.0

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
     <EmbeddedResource Include="../Meziantou.Framework.Yaml/Serialization/YamlThrowHelper.cs" LogicalName="Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.cs" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -1385,16 +1385,19 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         return true;
     }
 
+    // SyntaxKind.UnionDeclaration was introduced in Roslyn 5.6. The generator compiles against an older
+    // Roslyn, so the value is used directly instead of naming the enum member. The generator still
+    // detects unions when it runs inside a compiler that supports them.
+    private const int UnionDeclarationRawKind = 9082;
+
     private static bool IsCSharpUnionDeclaration(INamedTypeSymbol type)
     {
         foreach (var syntaxReference in type.DeclaringSyntaxReferences)
         {
-#pragma warning disable RSEXPERIMENTAL006 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            if (syntaxReference.GetSyntax().IsKind(SyntaxKind.UnionDeclaration))
+            if (syntaxReference.GetSyntax().IsKind((SyntaxKind)UnionDeclarationRawKind))
             {
                 return true;
             }
-#pragma warning restore RSEXPERIMENTAL006 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
 
         return false;

--- a/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
+++ b/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
@@ -5,7 +5,7 @@
     <IsTrimmable>true</IsTrimmable>
     <Description>A high-performance .NET YAML library providing parsing and serialization of object graphs, NativeAOT ready.</Description>
     <PackageTags>yaml, parser, serialization, nativeaot, performance</PackageTags>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix https://github.com/meziantou/Meziantou.Framework/issues/3005

## What

Downgrades `Microsoft.CodeAnalysis.CSharp` in `Meziantou.Framework.Yaml.SourceGenerator` from **5.6.0 to 5.0.0**, and bumps `Meziantou.Framework.Yaml` to **1.0.10**.

## Why

The generator ships inside the `Meziantou.Framework.Yaml` package, so its Roslyn reference sets the floor on the compiler consumers need. Referencing 5.6.0 pushed that floor higher than the generator actually required.

## The one blocker, and how it's handled

Only a single 5.6-specific API was in use: `SyntaxKind.UnionDeclaration` (the experimental C# unions kind) in `IsCSharpUnionDeclaration`. It does not exist in 5.0.

The fix uses the kind value directly rather than naming the enum member:

```csharp
private const int UnionDeclarationRawKind = 9082;
...
if (syntaxReference.GetSyntax().IsKind((SyntaxKind)UnionDeclarationRawKind))
```

`CSharpExtensions.IsKind` reduces to `node.RawKind == (int)kind`, so this is exactly equivalent to the original call. Casting an integer that isn't a defined enum member is legal C# — enums are open and the compiler emits no check — so it builds against 5.0 while still matching real union declarations at runtime under a 5.6+ compiler. A compiler too old to parse unions will never hand the generator one, so no behaviour is lost on older Roslyn.

The now-unnecessary `RSEXPERIMENTAL006` pragma pair was removed with it.

### Reviewer note on the magic number

The value was verified rather than assumed: loading the 5.0, 5.3, 5.6 and 5.9 assemblies through a `MetadataLoadContext` and reading the enum shows `UnionDeclaration = 9082` in **both 5.6 and 5.9**, and absent in 5.0/5.3.

The residual risk is that this is an experimental kind and could in principle be renumbered in a future Roslyn preview, in which case union detection would silently stop matching rather than fail loudly. If that tradeoff isn't wanted, comparing `Kind().ToString()` to `"UnionDeclaration"` would survive renumbering at the cost of an allocation per call — happy to switch.

`Microsoft.CodeAnalysis.Analyzers` is deliberately left at 5.6.0: it is `PrivateAssets="all"` and contributes only authoring-time analyzers, so it places no floor on the consumer's Roslyn version.

Renovate will not revert this — the generator csproj is already in the disabled `roslyn-analyzers` rule in `renovate.json5`.

## Verification

- Generator builds clean for `net11.0` and `netstandard2.0`, Release + `IsOfficialBuild=true`, warnings-as-errors: **0 warnings, 0 errors**. No analyzer objected to the cast.
- Full Yaml suite: **1990 passed, 0 failed** (net10.0 + net11.0).
- Union tests specifically: **48 passed**, parameterized over `useSourceGeneration: true`/`false`, so the changed path is exercised end to end. Had detection broken, the source-generated cases would emit object-shaped YAML instead of the underlying case and fail.
- `dotnet run ./eng/update-all.cs` → exit 0, no files changed.
- `ref/Meziantou.Framework.Yaml.cs` unchanged — no public API impact.
- `dotnet pack` produces `Meziantou.Framework.Yaml.1.0.10.nupkg`; the packed generator's assembly references confirm `Microsoft.CodeAnalysis` and `Microsoft.CodeAnalysis.CSharp` at **5.0.0.0**, so the shipped artifact picked up the downgrade.

The net10.0 leg of the filtered union run exits code 9 ("no tests matched"); that is pre-existing and correct, since `YamlCSharpUnionTests` is wrapped in `#if NET11_0_OR_GREATER`.
