### PR TITLE
Retry an image pull that failed for a transient reason

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
@@ -56,13 +57,13 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 
     internal override bool SupportsRestart => false;
 
-    internal override async Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, CancellationToken cancellationToken)
+    internal override async Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, ILogger? logger, CancellationToken cancellationToken)
     {
         switch (source)
         {
             case RegistryImage registry:
                 if (pullPolicy is PullPolicy.Always)
-                    await Cli.RunBufferedAsync(["image", "pull", registry.Name], cancellationToken).ConfigureAwait(false);
+                    await PullImageAsync(["image", "pull", registry.Name], registry.Name, logger, cancellationToken).ConfigureAwait(false);
                 return registry.Name;
 
             case DockerfileImage dockerfile:

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Meziantou.Framework;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
@@ -38,7 +39,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         if (definition.ReuseId is { } reuseId && await FindReusableContainerAsync(reuseId, cancellationToken).ConfigureAwait(false) is { } reusedContainerId)
             return reusedContainerId;
 
-        var imageRef = await PrepareImageAsync(definition.Image, definition.PullPolicy, cancellationToken).ConfigureAwait(false);
+        var imageRef = await PrepareImageAsync(definition.Image, definition.PullPolicy, definition.Logging.Logger, cancellationToken).ConfigureAwait(false);
         var payload = DockerApiCreateRequestBuilder.Build(definition, imageRef);
         using var content = CreateJsonContent(payload, DockerApiJsonContext.Default.CreateContainerRequest);
         var endpoint = "/containers/create";
@@ -374,13 +375,13 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         return null;
     }
 
-    private async Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, CancellationToken cancellationToken)
+    private async Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, ILogger? logger, CancellationToken cancellationToken)
     {
         switch (source)
         {
             case RegistryImage registry:
-                if (pullPolicy is PullPolicy.Always || pullPolicy is PullPolicy.IfMissing && !await ImageExistsAsync(registry.Name, cancellationToken).ConfigureAwait(false))
-                    await PullImageAsync(registry.Name, cancellationToken).ConfigureAwait(false);
+                if (pullPolicy is PullPolicy.Always || pullPolicy is PullPolicy.IfMissing && !await ImageExistsAsync(registry.Name, logger, cancellationToken).ConfigureAwait(false))
+                    await PullImageAsync(registry.Name, logger, cancellationToken).ConfigureAwait(false);
 
                 return registry.Name;
 
@@ -437,13 +438,35 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         return tag;
     }
 
-    private async Task<bool> ImageExistsAsync(string imageName, CancellationToken cancellationToken)
+    private Task<bool> ImageExistsAsync(string imageName, ILogger? logger, CancellationToken cancellationToken)
+    {
+        return RetryStrategy.ExecuteAsync(
+            ct => ImageExistsCoreAsync(imageName, ct),
+            TransientError.IsTransient,
+            Log.CreateImageLookupRetryCallback(logger, imageName),
+            RetryStrategy.DefaultBaseDelay,
+            cancellationToken);
+    }
+
+    private async Task<bool> ImageExistsCoreAsync(string imageName, CancellationToken cancellationToken)
     {
         using var response = await SendAsync(HttpMethod.Get, "/images/" + Uri.EscapeDataString(imageName) + "/json", content: null, cancellationToken, allowedStatusCodes: [HttpStatusCode.NotFound]).ConfigureAwait(false);
         return response.StatusCode != HttpStatusCode.NotFound;
     }
 
-    private async Task PullImageAsync(string imageName, CancellationToken cancellationToken)
+    /// <summary>Pulls the image, running the whole pull again when the registry fails for a reason that a second attempt can resolve.</summary>
+    /// <remarks>A pull is idempotent, and the layers that were already fetched are cached by the daemon, so an attempt that follows a failure resumes instead of downloading everything again.</remarks>
+    private Task PullImageAsync(string imageName, ILogger? logger, CancellationToken cancellationToken)
+    {
+        return RetryStrategy.ExecuteAsync(
+            ct => PullImageCoreAsync(imageName, ct),
+            TransientError.IsTransient,
+            Log.CreateImagePullRetryCallback(logger, imageName),
+            RetryStrategy.DefaultBaseDelay,
+            cancellationToken);
+    }
+
+    private async Task PullImageCoreAsync(string imageName, CancellationToken cancellationToken)
     {
         var connection = await EnsureConnectionOrThrowAsync(cancellationToken).ConfigureAwait(false);
         var endpoint = "/images/create?fromImage=" + Uri.EscapeDataString(imageName);
@@ -463,8 +486,11 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         {
             var progress = JsonSerializer.Deserialize(line, DockerApiJsonContext.Default.PullProgress);
             var errorMessage = progress?.ErrorDetail?.Message ?? progress?.Error;
+
+            // The daemon answers a pull with a success as soon as it starts, so a failure is only ever reported here.
+            // It carries no status code, which is why the classification of a transient failure falls back to the text.
             if (!string.IsNullOrEmpty(errorMessage))
-                throw new InvalidOperationException("Unable to pull image '" + imageName + "': " + errorMessage);
+                throw new DockerApiException("Unable to pull image '" + imageName + "': " + errorMessage, statusCode: null);
         }
     }
 
@@ -509,7 +535,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         if (!string.IsNullOrEmpty(daemonMessage))
             message += ": " + daemonMessage;
 
-        return new InvalidOperationException(message);
+        return new DockerApiException(message, response.StatusCode);
     }
 
     internal static async IAsyncEnumerable<LogEntry> ReadMultiplexedLogsAsync(Stream stream, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 /// <summary>Runtime implementation for docker-compatible CLIs (docker, podman, and wslc).</summary>
@@ -39,13 +41,15 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
 
     internal override bool SupportsRestart => _flavor is not Flavor.Wslc;
 
-    internal override async Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, CancellationToken cancellationToken)
+    internal override async Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, ILogger? logger, CancellationToken cancellationToken)
     {
         switch (source)
         {
             case RegistryImage registry:
+                // PullPolicy.IfMissing is not handled here: it is passed to the create command as '--pull=missing',
+                // which is where a registry failure surfaces for that policy.
                 if (pullPolicy is PullPolicy.Always)
-                    await Cli.RunBufferedAsync(["pull", registry.Name], cancellationToken).ConfigureAwait(false);
+                    await PullImageAsync(["pull", registry.Name], registry.Name, logger, cancellationToken).ConfigureAwait(false);
                 return registry.Name;
 
             case DockerfileImage dockerfile:

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
@@ -114,7 +115,19 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
         }
     }
 
-    internal abstract Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, CancellationToken cancellationToken);
+    internal abstract Task<string> PrepareImageAsync(ImageSource source, PullPolicy pullPolicy, ILogger? logger, CancellationToken cancellationToken);
+
+    /// <summary>Runs the pull command of the runtime, running it again when the registry fails for a reason that a second attempt can resolve.</summary>
+    /// <remarks>A pull is idempotent, and the layers that were already fetched are cached by the runtime, so an attempt that follows a failure resumes instead of downloading everything again.</remarks>
+    private protected async Task PullImageAsync(IReadOnlyList<string> args, string imageName, ILogger? logger, CancellationToken cancellationToken)
+    {
+        await RetryStrategy.ExecuteAsync(
+            async ct => await Cli.RunBufferedAsync(args, ct).ConfigureAwait(false),
+            TransientError.IsTransient,
+            Log.CreateImagePullRetryCallback(logger, imageName),
+            RetryStrategy.DefaultBaseDelay,
+            cancellationToken).ConfigureAwait(false);
+    }
 
     internal abstract Task<string?> FindReusableContainerAsync(string reuseId, CancellationToken cancellationToken);
 
@@ -182,7 +195,7 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
 
         PrepareDefinitionForCreate(definition);
 
-        var imageRef = await PrepareImageAsync(definition.Image, definition.PullPolicy, cancellationToken).ConfigureAwait(false);
+        var imageRef = await PrepareImageAsync(definition.Image, definition.PullPolicy, definition.Logging.Logger, cancellationToken).ConfigureAwait(false);
         var args = BuildCreateArguments(definition, imageRef);
         try
         {

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/DockerApiException.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/DockerApiException.cs
@@ -1,0 +1,31 @@
+using System.Net;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Reports a Docker Engine API request that the daemon refused, or an operation that the daemon reported as failed in the body of a response whose status is a success.</summary>
+/// <remarks>It derives from <see cref="InvalidOperationException"/> because that is the exception these code paths have always thrown.</remarks>
+internal sealed class DockerApiException : InvalidOperationException
+{
+    public DockerApiException()
+    {
+    }
+
+    public DockerApiException(string message)
+        : base(message)
+    {
+    }
+
+    public DockerApiException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public DockerApiException(string message, HttpStatusCode? statusCode)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>The status of the response, or <see langword="null"/> when the daemon reported the failure in the body of a response whose status is a success.</summary>
+    public HttpStatusCode? StatusCode { get; }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/Log.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/Log.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+internal static partial class Log
+{
+    // The reason of the failure is deliberately left out of both messages: it comes from the daemon or from the
+    // standard error of a CLI, and a registry that echoes back a rejected credential would end up in the log.
+    [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "Pulling the image '{Image}' failed on attempt {Attempt}. Retrying in {Delay}.")]
+    public static partial void ImagePullRetry(ILogger logger, string image, int attempt, TimeSpan delay);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Looking up the image '{Image}' failed on attempt {Attempt}. Retrying in {Delay}.")]
+    public static partial void ImageLookupRetry(ILogger logger, string image, int attempt, TimeSpan delay);
+
+    public static Action<Exception, int, TimeSpan>? CreateImagePullRetryCallback(ILogger? logger, string image)
+    {
+        if (logger is not { } imageLogger)
+            return null;
+
+        return (_, attempt, delay) => ImagePullRetry(imageLogger, image, attempt, delay);
+    }
+
+    public static Action<Exception, int, TimeSpan>? CreateImageLookupRetryCallback(ILogger? logger, string image)
+    {
+        if (logger is not { } imageLogger)
+            return null;
+
+        return (_, attempt, delay) => ImageLookupRetry(imageLogger, image, attempt, delay);
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/RetryStrategy.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/RetryStrategy.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Runs an operation again when it fails for a reason that is likely to resolve on its own.</summary>
+internal static class RetryStrategy
+{
+    /// <summary>The number of times the operation is run, the first attempt included.</summary>
+    public const int MaxAttempts = 3;
+
+    /// <summary>The delay before the first retry. It doubles on every subsequent attempt.</summary>
+    public static readonly TimeSpan DefaultBaseDelay = TimeSpan.FromSeconds(1);
+
+    private const int MaxJitterPercentage = 25;
+
+    public static async Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> operation, Func<Exception, bool> isTransient, Action<Exception, int, TimeSpan>? onRetry, TimeSpan baseDelay, CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await operation(cancellationToken).ConfigureAwait(false);
+            }
+            // A cancellation asked for by the caller is never a transient failure, whatever the operation reports: the
+            // token is the one thing the caller expects to stop the retries instead of being waited out.
+            catch (Exception exception) when (attempt < MaxAttempts && !cancellationToken.IsCancellationRequested && isTransient(exception))
+            {
+                var delay = GetDelay(attempt, baseDelay);
+                onRetry?.Invoke(exception, attempt, delay);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public static async Task ExecuteAsync(Func<CancellationToken, Task> operation, Func<Exception, bool> isTransient, Action<Exception, int, TimeSpan>? onRetry, TimeSpan baseDelay, CancellationToken cancellationToken)
+    {
+        await ExecuteAsync(async ct =>
+        {
+            await operation(ct).ConfigureAwait(false);
+            return true;
+        }, isTransient, onRetry, baseDelay, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Computes the delay that follows <paramref name="attempt"/>: an exponential backoff, plus a jitter of up to 25% so that concurrent callers do not all come back at the same instant.</summary>
+    internal static TimeSpan GetDelay(int attempt, TimeSpan baseDelay)
+    {
+        if (baseDelay <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        var backoff = baseDelay * Math.Pow(2, attempt - 1);
+        var jitterPercentage = RandomNumberGenerator.GetInt32(0, MaxJitterPercentage + 1);
+        return backoff + backoff * (jitterPercentage / 100d);
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/TransientError.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/TransientError.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+/// <summary>Classifies the failures of a registry operation that are worth another attempt.</summary>
+internal static class TransientError
+{
+    // A registry failure rarely comes with a status code: the daemon reports most of them in the body of a response
+    // whose status is a success, and the CLIs only ever expose them through their standard error, with an exit code
+    // that is the same for every kind of failure. The messages below are the ones a second attempt can resolve.
+    // Anything else is treated as permanent, so an unknown manifest or a rejected credential still fails at once.
+    private static readonly string[] TransientMessages =
+    [
+        "toomanyrequests",
+        "too many requests",
+        "tls handshake timeout",
+        "i/o timeout",
+        "unexpected eof",
+        "connection reset by peer",
+        "connection refused",
+        "no route to host",
+        "temporary failure in name resolution",
+        "server misbehaving",
+        "timeout exceeded while awaiting headers",
+        "internal server error",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "unexpected http status: 408",
+        "unexpected http status: 429",
+        "unexpected http status: 500",
+        "unexpected http status: 502",
+        "unexpected http status: 503",
+        "unexpected http status: 504",
+    ];
+
+    public static bool IsTransient(Exception exception) => exception switch
+    {
+        DockerApiException { StatusCode: { } statusCode } => IsTransientStatusCode(statusCode),
+        DockerApiException => IsTransientMessage(exception.Message),
+        ContainerRuntimeException runtimeException => IsTransientMessage(runtimeException.StandardError) || IsTransientMessage(runtimeException.StandardOutput),
+        HttpRequestException or IOException or SocketException or TimeoutException => true,
+        _ => false,
+    };
+
+    public static bool IsTransientStatusCode(HttpStatusCode statusCode)
+        => statusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests or (>= HttpStatusCode.InternalServerError and <= (HttpStatusCode)599);
+
+    public static bool IsTransientMessage(string? message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return false;
+
+        foreach (var transientMessage in TransientMessages)
+        {
+            if (message.Contains(transientMessage, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using Meziantou.Framework.TemporaryContainers.Internals;
 
 namespace Meziantou.Framework.TemporaryContainers.Tests;
@@ -268,6 +270,163 @@ public sealed class DockerRuntimeAdapterTests
     public void TryParseLoadedImage_ReturnsNullWithoutAMarker(string output)
     {
         Assert.Null(ContainerImageOutputParser.TryParseLoadedImage(output));
+    }
+
+    [Fact]
+    public void IsTransient_DockerApiResponse_ServerErrorIsTransient()
+    {
+        Assert.True(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.ServiceUnavailable)));
+        Assert.True(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.InternalServerError)));
+        Assert.True(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.TooManyRequests)));
+        Assert.True(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.RequestTimeout)));
+    }
+
+    [Fact]
+    public void IsTransient_DockerApiResponse_ClientErrorIsPermanent()
+    {
+        Assert.False(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.NotFound)));
+        Assert.False(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.Unauthorized)));
+        Assert.False(TransientError.IsTransient(new DockerApiException("boom", HttpStatusCode.Conflict)));
+    }
+
+    [Fact]
+    public void IsTransient_InBandPullFailure_IsClassifiedFromItsMessage()
+    {
+        // The daemon reports a failed pull in the body of a response whose status is a success, so there is no status
+        // code to classify: these are the messages the pull stream actually carries.
+        Assert.True(TransientError.IsTransient(NoStatusCode("net/http: TLS handshake timeout")));
+        Assert.True(TransientError.IsTransient(NoStatusCode("toomanyrequests: You have reached your pull rate limit.")));
+        Assert.True(TransientError.IsTransient(NoStatusCode("received unexpected HTTP status: 503 Service Unavailable")));
+        Assert.True(TransientError.IsTransient(NoStatusCode("unexpected EOF")));
+
+        Assert.False(TransientError.IsTransient(NoStatusCode("manifest for busybox:nope not found: manifest unknown")));
+        Assert.False(TransientError.IsTransient(NoStatusCode("pull access denied, repository does not exist")));
+
+        static DockerApiException NoStatusCode(string message)
+            => new("Unable to pull image 'busybox:1.37': " + message, statusCode: null);
+    }
+
+    [Fact]
+    public void IsTransient_CliFailure_IsClassifiedFromItsStandardError()
+    {
+        // Every CLI exits with the same code whatever the registry answered, so the standard error is the only clue.
+        Assert.True(TransientError.IsTransient(CliFailure("Error response from daemon: toomanyrequests: too many requests")));
+        Assert.True(TransientError.IsTransient(CliFailure("Error response from daemon: net/http: TLS handshake timeout")));
+
+        Assert.False(TransientError.IsTransient(CliFailure("Error response from daemon: unauthorized: authentication required")));
+        Assert.False(TransientError.IsTransient(CliFailure("Error response from daemon: manifest unknown")));
+
+        static ContainerRuntimeException CliFailure(string standardError)
+            => new("The command failed.", ContainerRuntime.Docker, "docker pull busybox:1.37", exitCode: 1, standardOutput: "", standardError);
+    }
+
+    [Fact]
+    public void IsTransient_TransportFailures()
+    {
+        Assert.True(TransientError.IsTransient(new HttpRequestException("connection closed")));
+        Assert.True(TransientError.IsTransient(new IOException("the socket was closed")));
+        Assert.True(TransientError.IsTransient(new SocketException()));
+        Assert.True(TransientError.IsTransient(new TimeoutException()));
+
+        Assert.False(TransientError.IsTransient(new InvalidOperationException("boom")));
+        Assert.False(TransientError.IsTransient(new NotSupportedException("boom")));
+    }
+
+    [Fact]
+    public async Task RetryStrategy_ReturnsWithoutRetryingWhenTheFirstAttemptSucceeds()
+    {
+        var attempts = 0;
+        var result = await RetryStrategy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return Task.FromResult("ok");
+        }, TransientError.IsTransient, onRetry: null, TimeSpan.Zero, CancellationToken.None);
+
+        Assert.Equal("ok", result);
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task RetryStrategy_RetriesATransientFailureUntilItSucceeds()
+    {
+        var attempts = 0;
+        var result = await RetryStrategy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return attempts < 2 ? throw new IOException("boom") : Task.FromResult("ok");
+        }, TransientError.IsTransient, onRetry: null, TimeSpan.Zero, CancellationToken.None);
+
+        Assert.Equal("ok", result);
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task RetryStrategy_GivesUpAfterMaxAttemptsAndRethrowsTheLastFailure()
+    {
+        var attempts = 0;
+        var exception = await Assert.ThrowsAsync<IOException>(() => RetryStrategy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new IOException("boom " + attempts);
+        }, TransientError.IsTransient, onRetry: null, TimeSpan.Zero, CancellationToken.None));
+
+        Assert.Equal(RetryStrategy.MaxAttempts, attempts);
+        Assert.Equal("boom 3", exception.Message);
+    }
+
+    [Fact]
+    public async Task RetryStrategy_DoesNotRetryAPermanentFailure()
+    {
+        var attempts = 0;
+        await Assert.ThrowsAsync<DockerApiException>(() => RetryStrategy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new DockerApiException("manifest unknown", HttpStatusCode.NotFound);
+        }, TransientError.IsTransient, onRetry: null, TimeSpan.Zero, CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task RetryStrategy_DoesNotRetryWhenTheCallerCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var attempts = 0;
+        await Assert.ThrowsAsync<IOException>(() => RetryStrategy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new IOException("boom");
+        }, TransientError.IsTransient, onRetry: null, TimeSpan.Zero, cts.Token));
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task RetryStrategy_ReportsEveryRetry()
+    {
+        var reported = new List<int>();
+        await Assert.ThrowsAsync<IOException>(() => RetryStrategy.ExecuteAsync(_ => throw new IOException("boom"),
+            TransientError.IsTransient,
+            (_, attempt, _) => reported.Add(attempt),
+            TimeSpan.Zero,
+            CancellationToken.None));
+
+        Assert.Equal([1, 2], reported);
+    }
+
+    [Fact]
+    public void RetryStrategy_DelayGrowsExponentiallyAndCarriesAJitter()
+    {
+        var baseDelay = TimeSpan.FromSeconds(1);
+        foreach (var attempt in Enumerable.Range(1, RetryStrategy.MaxAttempts))
+        {
+            var backoff = baseDelay * Math.Pow(2, attempt - 1);
+            var delay = RetryStrategy.GetDelay(attempt, baseDelay);
+
+            Assert.InRange(delay, backoff, backoff * 1.25);
+        }
     }
 
     /// <summary>Writes a CLI that exits with <paramref name="exitCode"/> whatever it is asked to do, so the outcome of the probe can be forced.</summary>


### PR DESCRIPTION
## Why

A registry that answers with a rate limit, a 5xx, or a TLS handshake that times out fails the whole test run, even though the same pull would succeed a second later.

## What changed

New internals (all `internal`, so `ref/` is unchanged):

- `Internals/RetryStrategy.cs` — 3 attempts, 1s base delay, exponential backoff plus up to 25% jitter. A cancellation requested by the caller is never treated as transient, so the token stops the retries instead of being waited out. `baseDelay` is a parameter, which is what makes the loop testable without a fake clock.
- `Internals/TransientError.cs` — classifies the HTTP status (408/429/5xx), the transport exceptions (`HttpRequestException`, `IOException`, `SocketException`, `TimeoutException`), and the text of the registry message. It is a positive-match list: an unrecognised failure is permanent and fails on the first attempt.
- `Internals/DockerApiException.cs` — carries the status code, `null` when the daemon reported the failure inside a 200 response. It derives from `InvalidOperationException`, which is what these paths already threw, so existing `catch` clauses are unaffected.
- `Internals/Log.cs` — source-generated `[LoggerMessage]` warnings, following the pattern already used in `Meziantou.Framework.Http.ServerSideRequestForgery`.

Wired into `DockerApiRuntime.PullImageAsync` and `ImageExistsAsync`, and into the explicit CLI pull through a shared `ExecutableContainerRuntime.PullImageAsync` helper used by the docker/podman/wslc and Apple runtimes. The logger is threaded from `definition.Logging.Logger` through `PrepareImageAsync`, whose internal signature gained an `ILogger?` parameter.

## Notes for the reviewer

**Classifying on the message text is deliberate.** A registry failure rarely comes with a status code: the daemon answers a pull with a success as soon as it starts and reports the failure in the body of the progress stream (`errorDetail`), and every CLI exits with the same code whatever went wrong. This is where `net/http: TLS handshake timeout` and the Docker Hub rate limit actually land, and it is the case the upstream status-code classifier does not catch either.

**What is not retried, and why:**

- `create`, `start`, `exec`, and the copy paths — not idempotent, or not registry-bound.
- `BuildImageAsync` — a build pulls its base image too, but a retried build is much more expensive and its failures are usually deterministic.
- `PullPolicy.IfMissing` on the CLI runtimes — that policy never runs a pull. It is passed to the create command as `--pull=missing`, so a registry failure surfaces as a failed `create`. Covering it would mean retrying the create itself, which is not cleanly idempotent (reuse names, port allocation). There is a comment at the call site recording this.

**Logging leaves out the reason of the failure** (image name, attempt, and delay only): the reason comes from the daemon or from the standard error of a CLI, and a registry that echoes back a rejected credential would end up in the caller's log.

## Testing

- 12 new tests in `DockerRuntimeAdapterTests.cs`: the classification of the API status codes, the in-band pull messages, the CLI standard error and the transport exceptions; the retry loop (success, retry-then-succeed, give up after `MaxAttempts`, no retry on a permanent failure, no retry when the caller cancelled, every retry reported); and the backoff bounds.
- Docker was available locally, so the real integration suites ran as well: 74 `DockerContainerTests`/`DockerApiContainerTests`, 160 unit tests, and 18 Redis/PostgreSQL container tests. All pass on net10.0 and net11.0.
- Builds clean with `/p:TreatsWarningsAsErrors=true`, and with `-c Release /p:IsOfficialBuild=true` to run the IDE analyzers. `dotnet run ./eng/update-all.cs` reports no changes.
- Not run locally: the Apple container tests (the daemon wedges on this machine) and podman/wslc (not installed). The Apple change is a two-line delegation to the same shared helper the Docker CLI path uses.