### PR TITLE
Update Meziantou.NET.Sdk to 1.0.166 and pin the JSON serialization options

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "4.1.82",
-    "Meziantou.NET.Sdk": "1.0.165",
-    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.165",
-    "Meziantou.NET.Sdk.Razor": "1.0.165",
-    "Meziantou.NET.Sdk.Test": "1.0.165",
-    "Meziantou.NET.Sdk.Web": "1.0.165",
-    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.165"
+    "Meziantou.NET.Sdk": "1.0.166",
+    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.166",
+    "Meziantou.NET.Sdk.Razor": "1.0.166",
+    "Meziantou.NET.Sdk.Test": "1.0.166",
+    "Meziantou.NET.Sdk.Web": "1.0.166",
+    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.166"
   }
 }

--- a/src/Meziantou.Framework.ChromiumTracing/ChromiumTracingWriter.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/ChromiumTracingWriter.cs
@@ -235,7 +235,13 @@ public sealed partial class ChromiumTracingWriter : IAsyncDisposable
         return options;
     }
 
-    [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, WriteIndented = false, IgnoreReadOnlyProperties = false, GenerationMode = JsonSourceGenerationMode.Default)]
+    [JsonSourceGenerationOptions(
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+        IgnoreReadOnlyProperties = false,
+        GenerationMode = JsonSourceGenerationMode.Default,
+        RespectNullableAnnotations = true,
+        RespectRequiredConstructorParameters = true)]
     [JsonSerializable(typeof(ChromiumTracingAsyncBeginEvent))]
     [JsonSerializable(typeof(ChromiumTracingAsyncEndEvent))]
     [JsonSerializable(typeof(ChromiumTracingAsyncInstantEvent))]

--- a/src/Meziantou.Framework.Http.Caching.InMemory/InMemorySerializationContext.cs
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/InMemorySerializationContext.cs
@@ -3,7 +3,12 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.Http.Caching.InMemory;
 
 [JsonSerializable(typeof(InMemoryHttpCachePersistenceData))]
-[JsonSourceGenerationOptions(WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault, PropertyNameCaseInsensitive = false)]
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    PropertyNameCaseInsensitive = false,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class InMemorySerializationContext : JsonSerializerContext
 {
 }

--- a/src/Meziantou.Framework.Http.Caching.Redis/RedisSerializationContext.cs
+++ b/src/Meziantou.Framework.Http.Caching.Redis/RedisSerializationContext.cs
@@ -4,7 +4,12 @@ namespace Meziantou.Framework.Http.Caching.Redis;
 
 [JsonSerializable(typeof(HttpCachePersistenceEntry))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
-[JsonSourceGenerationOptions(WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault, PropertyNameCaseInsensitive = false)]
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    PropertyNameCaseInsensitive = false,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class RedisSerializationContext : JsonSerializerContext
 {
 }

--- a/src/Meziantou.Framework.Http.Caching.Sqlite/SqliteSerializationContext.cs
+++ b/src/Meziantou.Framework.Http.Caching.Sqlite/SqliteSerializationContext.cs
@@ -4,7 +4,12 @@ namespace Meziantou.Framework.Http.Caching.Sqlite;
 
 [JsonSerializable(typeof(HttpCachePersistenceEntry))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
-[JsonSourceGenerationOptions(WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault, PropertyNameCaseInsensitive = false)]
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    PropertyNameCaseInsensitive = false,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class SqliteSerializationContext : JsonSerializerContext
 {
 }

--- a/src/Meziantou.Framework.Http.Caching/SerializationContext.cs
+++ b/src/Meziantou.Framework.Http.Caching/SerializationContext.cs
@@ -3,7 +3,12 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.Http.Caching;
 
 [JsonSerializable(typeof(SerializedResponseMessage))]
-[JsonSourceGenerationOptions(WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault, PropertyNameCaseInsensitive = false)]
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    PropertyNameCaseInsensitive = false,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class SerializationContext : JsonSerializerContext
 {
 }

--- a/src/Meziantou.Framework.Http.Recording/HttpRecordingSerializerContext.cs
+++ b/src/Meziantou.Framework.Http.Recording/HttpRecordingSerializerContext.cs
@@ -10,5 +10,6 @@ namespace Meziantou.Framework.Http.Recording;
     // The store validates the entries itself so it can name the file and the index of the faulty entry. Honoring the
     // nullable annotations would let the deserializer reject a null value first with a message blaming a truncated
     // file, and the diagnostic would depend on whether the host application enabled the switch.
-    RespectNullableAnnotations = false)]
+    RespectNullableAnnotations = false,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class HttpRecordingSerializerContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.HttpArchive/HarSerializerContext.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarSerializerContext.cs
@@ -6,5 +6,7 @@ namespace Meziantou.Framework.HttpArchive;
 [JsonSourceGenerationOptions(
     WriteIndented = false,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    PropertyNameCaseInsensitive = true)]
+    PropertyNameCaseInsensitive = true,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class HarSerializerContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
@@ -221,7 +221,9 @@ internal static partial class Program
     [JsonSourceGenerationOptions(
        GenerationMode = JsonSourceGenerationMode.Serialization | JsonSourceGenerationMode.Metadata,
        WriteIndented = true,
-       DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
+       DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+       RespectNullableAnnotations = true,
+       RespectRequiredConstructorParameters = true)]
     [JsonSerializable(typeof(Result))]
     private sealed partial class ResultContext : JsonSerializerContext
     {

--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
@@ -483,6 +483,7 @@ internal sealed partial class SymbolsValidationRule : NuGetPackageValidationRule
     private sealed record CompilerData(string? Version);
 
     [JsonSerializable(typeof(SourceLinkJson))]
+    [JsonSourceGenerationOptions(RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true)]
     private sealed partial class SourceLinkContext : JsonSerializerContext
     {
     }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleInspectJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleInspectJsonContext.cs
@@ -3,5 +3,8 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 [JsonSerializable(typeof(AppleInspectResult[]))]
-[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class AppleInspectJsonContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiJsonContext.cs
@@ -19,5 +19,8 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 [JsonSerializable(typeof(DockerApiModels.CredentialHelperGetResponse))]
 [JsonSerializable(typeof(DockerApiModels.RegistryAuthHeader))]
 [JsonSerializable(typeof(DockerApiModels.ContainerPathStat))]
-[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class DockerApiJsonContext : JsonSerializerContext;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerInspectJsonContext.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerInspectJsonContext.cs
@@ -4,5 +4,8 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 [JsonSerializable(typeof(DockerInspectResult[]))]
 [JsonSerializable(typeof(DockerVolumeInspectResult[]))]
-[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    RespectNullableAnnotations = true,
+    RespectRequiredConstructorParameters = true)]
 internal sealed partial class DockerInspectJsonContext : JsonSerializerContext;

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
@@ -494,6 +494,7 @@ public sealed partial class WriterTests
     private sealed class UnserializableArgument;
 
     [JsonSerializable(typeof(CustomPayload))]
+    [JsonSourceGenerationOptions(RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true)]
     private sealed partial class CustomJsonContext : JsonSerializerContext
     {
     }


### PR DESCRIPTION
Bumps the six `Meziantou.NET.Sdk*` MSBuild SDKs from 1.0.165 to 1.0.166 and fixes the warnings the new version introduces.

## The new warnings

1.0.166 adds two Meziantou.Analyzer rules:

- `MA0222` — Set RespectNullableAnnotations on
- `MA0223` — Set RespectRequiredConstructorParameters on

They fire on every `JsonSerializerContext` that does not pin both options on its `[JsonSourceGenerationOptions]`, including the contexts that carried no such attribute at all (there the diagnostic points at the class declaration). That is 100 warnings over the 13 contexts in the repo, and since the SDK turns warnings into errors for CI, Release and AI-agent builds, they break the build.

## The fix

Both options are pinned to `true` on every context.

Since 1.0.165 the SDK writes the matching `System.Text.Json.Serialization.RespectNullableAnnotationsDefault` and `RespectRequiredConstructorParametersDefault` runtime switches into the host application's runtimeconfig, so `true` is what these contexts are already built and tested against. Stating it on the context keeps a library from deserializing differently depending on who consumes it, which is the point of the rules.

The change is behavior-neutral here: every reference-typed property in the HAR, Docker and Apple inspect, Docker API, ChromiumTracing and HTTP cache persistence models is already nullable-annotated, and none of them take required constructor parameters.

`HttpRecordingSerializerContext` is the one deviation and keeps `RespectNullableAnnotations = false`, for the reason it was turned off in #3004: the store validates the entries itself so it can name the file and the index of the faulty entry, and honoring the annotations would let the deserializer preempt that with a message blaming a truncated file. Its entries use `required` properties rather than constructor parameters, so the `RespectRequiredConstructorParameters` added there is inert.

No public API changed, so `ref/` is untouched.

## Verification

- `dotnet run ./eng/update-all.cs` — exit 0, no generated-file changes.
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` over all 290 projects — clean, zero warnings and errors.
- Tests, all `-c Release /p:TreatsWarningsAsErrors=true`: ChromiumTracing 80/80, Http.Caching 502/508 (6 pre-existing skips), Http.Recording 170/170, HttpArchive 150/150, NuGetPackageValidation 138/138, NuGetPackageValidation.Tool 34/34.
- TemporaryContainers, the suite that actually exercises the changed deserialization paths: `total: 412 / failed: 4 / succeeded: 352 / skipped: 56`. The 4 failures are the known local baseline on arm64 macOS — `SqlServerContainerTests` × 2 tests × 2 TFMs, failing with `image ... does not support required platforms` because the mssql image has no arm64 variant. No deserialization errors anywhere in the run.