### PR TITLE
Handle test parallelization per test instead of with global flags

### DIFF
--- a/.github/actions/setup-wslc/action.yml
+++ b/.github/actions/setup-wslc/action.yml
@@ -9,9 +9,12 @@ runs:
       run: |
         # wslc ships inside WSL itself, and only the pre-release channel carries it (WSL 2.9.3 or higher)
         # The update service intermittently answers with a transient error (e.g. Forbidden (403),
-        # Wsl/UpdatePackage/0x80190193), so retry a few times before giving up.
-        $maxAttempts = 3
+        # Wsl/UpdatePackage/0x80190193), so retry a few times before giving up. The service can answer with it
+        # for a minute or so while the other agents of the same run are served normally, so the attempts span
+        # roughly 65 seconds. The delay is capped as it would otherwise keep doubling.
+        $maxAttempts = 5
         $baseDelaySeconds = 5
+        $maxDelaySeconds = 30
 
         for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
           Write-Host "Updating WSL (attempt $attempt/$maxAttempts)"
@@ -26,7 +29,7 @@ runs:
             throw "wsl --update --pre-release failed with exit code $exitCode"
           }
 
-          $delaySeconds = [int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1))
+          $delaySeconds = [math]::Min([int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1)), $maxDelaySeconds)
           Write-Host "Retrying WSL update in $delaySeconds second(s)."
           Start-Sleep -Seconds $delaySeconds
         }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,11 +29,6 @@
     <DefineConstants Condition="$(InvariantGlobalization) == 'true'">$(DefineConstants);INVARIANT_GLOBALIZATION_MODE_ENABLED</DefineConstants>
   </PropertyGroup>
 
-  <!-- Keep the xUnit.net defaults instead of the full parallelization the SDK enables, as the CI agents are resource-constrained -->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <EnableXunitFullParallelization>false</EnableXunitFullParallelization>
-  </PropertyGroup>
-
   <!-- disable the nullable warnings when compiling for target that haven't annotation -->
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('$(LatestTargetFramework)'))">
     <NoWarn>$(NoWarn);nullable;IDE0370</NoWarn>

--- a/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
+++ b/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <!-- PromptTests redirects the process-wide Console, so its tests must not run in parallel with each other. -->
-    <XunitParallelizationMode>Collections</XunitParallelizationMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CommandLineTests/PromptTests.cs
+++ b/tests/Meziantou.Framework.CommandLineTests/PromptTests.cs
@@ -1,6 +1,8 @@
 namespace Meziantou.Framework.CommandLineTests;
 
-[Collection("PromptTests")]
+// UsingConsole redirects Console.In and Console.Out, which are process-wide, so no test of this class can run
+// beside another test.
+[TestClass(DisableParallelization = true)]
 public class PromptTests
 {
     [Fact]

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -53,7 +53,8 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(expected, Assert.IsType<ImmutableArray<string>>(variables[pathKey]));
     }
 
-    [Fact]
+    // Sets CONTEXTSNAPSHOT_TEST_* and snapshots the process environment, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public void SecretShapedEnvironmentVariablesAreRedactedByDefault()
     {
         Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_API_TOKEN", "super-secret");
@@ -74,7 +75,8 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
         }
     }
 
-    [Fact]
+    // Sets CONTEXTSNAPSHOT_TEST_API_TOKEN and snapshots the process environment, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public void EnvironmentVariableRedactionCanBeOverridden()
     {
         Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_API_TOKEN", "super-secret");

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -1,5 +1,8 @@
 namespace Meziantou.Framework.DiffEngine.Tests;
 
+// Almost every test overrides the DiffEngine_* and PATH environment variables, which are process-wide, so no
+// test of this class can run beside another test.
+[TestClass(DisableParallelization = true)]
 public sealed class DiffToolsTests
 {
     [Fact]

--- a/tests/Meziantou.Framework.DiffEngine.Tests/Meziantou.Framework.DiffEngine.Tests.csproj
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/Meziantou.Framework.DiffEngine.Tests.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Meziantou.NET.Sdk.Test">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-
-    <!-- The tests set environment variables, so they cannot run concurrently -->
-    <EnableXunitFullParallelization>false</EnableXunitFullParallelization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/XunitCollectionBehavior.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/XunitCollectionBehavior.cs
@@ -1,3 +1,0 @@
-#if GITHUB_ACTIONS
-[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.None)]
-#endif

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-
-    <!-- The tests swap the static ProcessWrapper.DefaultProcessFactory, so they cannot run concurrently -->
-    <EnableXunitFullParallelization>false</EnableXunitFullParallelization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -132,7 +132,8 @@ public class ProcessWrapperTests
         Assert.True(processResult.StartDate <= processResult.ExitDate);
     }
 
-    [Fact]
+    // Listens to the ProcessWrapper ActivitySource, which reports the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteAsync_EmitsActivity_WithProcessPathAndExitCode()
     {
         var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -151,7 +152,8 @@ public class ProcessWrapperTests
         Assert.False(string.IsNullOrWhiteSpace(processPath));
     }
 
-    [Fact]
+    // Listens to the ProcessWrapper ActivitySource, which reports the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteAsync_DoesNotChangeTheAmbientActivityOfTheCaller()
     {
         var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -485,7 +487,8 @@ public class ProcessWrapperTests
         Assert.Equal("\"my tool\" arg \"with spaces\" \"C:\\path with spaces\\\\\" \"with\\\"quote\" \"\"", command.ToString());
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ProcessResult_ToString_ReturnsCommandAndExitCode()
     {
         using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
@@ -508,7 +511,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ProcessResult_ToString_WithIncludeArguments_IncludesArguments()
     {
         using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
@@ -608,7 +612,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithCredentials_PropagatesToProcessStartInfo()
     {
         if (!OperatingSystem.IsWindows())
@@ -635,7 +640,8 @@ public class ProcessWrapperTests
         Assert.Equal("test-password", capturedStartInfo.PasswordInClearText);
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithCredentialsAndNetworkOnly_PropagatesToProcessStartInfo()
     {
         if (!OperatingSystem.IsWindows())
@@ -661,7 +667,8 @@ public class ProcessWrapperTests
         Assert.True(capturedStartInfo.UseCredentialsForNetworkingOnly);
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithSecureStringCredentials_PropagatesToProcessStartInfo()
     {
         if (!OperatingSystem.IsWindows())
@@ -791,7 +798,8 @@ public class ProcessWrapperTests
         Assert.Equal(1, ex.ExitCode);
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task Validation_FailIfNonZeroExitCode_DefaultLogVerbosity_IncludesProcessPathWithoutArguments()
     {
         using var fakeProcess = FakeProcess.Create(42, outputText: "", errorText: "");
@@ -814,7 +822,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task Validation_FailIfNonZeroExitCode_WithLogVerbosityIncludeArguments_IncludesArguments()
     {
         using var fakeProcess = FakeProcess.Create(42, outputText: "", errorText: "");
@@ -831,7 +840,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task Validation_FailIfNonZeroExitCode_WithDefaultLogVerbosityIncludeArguments_IncludesArguments()
     {
         using var fakeProcess = FakeProcess.Create(42, outputText: "", errorText: "");
@@ -850,7 +860,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Listens to the ProcessWrapper ActivitySource, which reports the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task Validation_FailIfNonZeroExitCode_SetsActivityStatusToError()
     {
         var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1365,7 +1376,8 @@ public class ProcessWrapperTests
     }
 
 #if NET11_0_OR_GREATER
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithKillOnParentExit_PropagatesToProcessStartInfo()
     {
         if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid())
@@ -1389,7 +1401,8 @@ public class ProcessWrapperTests
         Assert.True(capturedStartInfo.KillOnParentExit);
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithStartDetached_PropagatesToProcessStartInfo()
     {
         ProcessStartInfo? capturedStartInfo = null;
@@ -1410,7 +1423,8 @@ public class ProcessWrapperTests
         Assert.True(capturedStartInfo.StartDetached);
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithStartSuspended_PropagatesToProcessStartInfo()
     {
         if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
@@ -1434,7 +1448,8 @@ public class ProcessWrapperTests
         Assert.True(capturedStartInfo.StartSuspended);
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithPipeOperator_PreservesNet11StartInfoOptions()
     {
         var capturedStartInfos = new List<ProcessStartInfo>();
@@ -1507,7 +1522,8 @@ public class ProcessWrapperTests
         Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").StartAndForget());
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ProcessInstance_Signal_WhenSafeHandleIsUnavailable_Throws()
     {
         var fakeProcess = FakeProcess.CreatePending(0);
@@ -1716,7 +1732,8 @@ public class ProcessWrapperTests
         _ = Assert.Throws<ArgumentNullException>(() => command.WithInterceptor((IProcessStartInfoInterceptor)null!));
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_UsesCustomProcessFactory()
     {
         using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
@@ -1740,7 +1757,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteAsync_WithCustomProcessFactory_CancellationKillsProcess()
     {
         var fakeProcess = FakeProcess.CreatePending(0);
@@ -1759,7 +1777,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithPipeOperator_UsesCustomProcessFactory()
     {
         var downstreamProcess = FakeProcess.Create(0, outputText: "final output\n", errorText: "");
@@ -1776,7 +1795,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Swaps the process-wide ProcessWrapper.DefaultProcessFactory, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithInstanceProcessFactory_OverridesGlobalFactory()
     {
         var globalProcess = FakeProcess.Create(0, outputText: "global output\n", errorText: "");
@@ -1794,7 +1814,8 @@ public class ProcessWrapperTests
         });
     }
 
-    [Fact]
+    // Registers process-wide ProcessWrapper interceptors, which observe the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithGlobalProcessWrapperInterceptor_Applies()
     {
         await RunWithGlobalInterceptorsAsync(
@@ -1818,7 +1839,8 @@ public class ProcessWrapperTests
         Assert.Equal("instance-wrapper", processResult.Output.StandardOutput.First().Text);
     }
 
-    [Fact]
+    // Registers process-wide ProcessWrapper interceptors, which observe the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithGlobalProcessStartInfoInterceptor_Applies()
     {
         await RunWithGlobalInterceptorsAsync(
@@ -1842,7 +1864,8 @@ public class ProcessWrapperTests
         Assert.Equal("instance-startinfo", processResult.Output.StandardOutput.First().Text);
     }
 
-    [Fact]
+    // Registers process-wide ProcessWrapper interceptors, which observe the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_Interceptors_RunInExpectedOrder()
     {
         var events = new List<string>();
@@ -1861,7 +1884,8 @@ public class ProcessWrapperTests
         Assert.Equal(["global-wrapper", "instance-wrapper", "global-startinfo", "instance-startinfo"], events);
     }
 
-    [Fact]
+    // Registers process-wide ProcessWrapper interceptors, which observe the processes started by every other test, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task ExecuteBufferedAsync_WithPipeOperator_AppliesGlobalProcessStartInfoInterceptorsToEachStage()
     {
         var interceptor = new CountingProcessStartInfoInterceptor();

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
@@ -6,14 +6,23 @@ namespace Meziantou.Framework.ResxSourceGenerator.GeneratorTests;
 
 public class ResxGeneratorTests
 {
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    // Ambient UI culture is restored in a finally block, but a leak would be observed by anything running beside this test
+    [Fact(DisableParallelization = true), RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void FormatString()
     {
-        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-        Assert.Equal("Hello world!", Resource1.FormatHello("world"));
+        var previousUICulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+            Assert.Equal("Hello world!", Resource1.FormatHello("world"));
 
-        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr");
-        Assert.Equal("Bonjour le monde!", Resource1.FormatHello("le monde"));
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr");
+            Assert.Equal("Bonjour le monde!", Resource1.FormatHello("le monde"));
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUICulture;
+        }
     }
 
     [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
@@ -23,14 +32,23 @@ public class ResxGeneratorTests
         Assert.Equal("Bonjour {0}!", Resource1.ResourceManager.GetString("Hello", CultureInfo.GetCultureInfo("fr")));
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    // Ambient UI culture is restored in a finally block, but a leak would be observed by anything running beside this test
+    [Fact(DisableParallelization = true), RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void StringValue()
     {
-        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-        Assert.Equal("value", Resource1.Sample);
+        var previousUICulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+            Assert.Equal("value", Resource1.Sample);
 
-        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr");
-        Assert.Equal("valeur", Resource1.Sample);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr");
+            Assert.Equal("valeur", Resource1.Sample);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUICulture;
+        }
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-
-    <!-- The tests set environment variables, so they cannot run concurrently -->
-    <EnableXunitFullParallelization>false</EnableXunitFullParallelization>
   </PropertyGroup>
 
   <Import Project="../../src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets" />

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -983,7 +983,10 @@ public sealed partial class SnapshotTests
         Assert.Equal("actual", File.ReadAllText(actualPath));
     }
 
-    [Fact]
+    // The lock is released after 250ms and SnapshotEngine.WriteAllBytesWithRetry gives up after ~840ms. The
+    // release runs on the thread pool, so tests running beside this one can delay it past that budget and let
+    // the IOException escape.
+    [Fact(DisableParallelization = true)]
     public async Task Validate_RetriesWhenActualFileIsLocked()
     {
         using var directory = TemporaryDirectory.Create();

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1055,7 +1055,8 @@ public sealed partial class SnapshotTests
         Assert.Equal("the message", exception.Message);
     }
 
-    [Theory]
+    // Sets the process-wide SNAPSHOTTESTING_STRATEGY variable, which every 'new SnapshotSettings()' reads, so it must not run beside any other test
+    [Theory(DisableParallelization = true)]
     [InlineData("DISALLOW", nameof(SnapshotUpdateStrategy.Disallow))]
     [InlineData("overwrite", nameof(SnapshotUpdateStrategy.Overwrite))]
     [InlineData("mErGeToOlSyNc", nameof(SnapshotUpdateStrategy.MergeToolSync))]
@@ -1069,7 +1070,8 @@ public sealed partial class SnapshotTests
         Assert.Same(GetSnapshotUpdateStrategy(expectedStrategyName), settings.SnapshotUpdateStrategy);
     }
 
-    [Fact]
+    // Sets the process-wide SNAPSHOTTESTING_STRATEGY variable, which every 'new SnapshotSettings()' reads, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public void SnapshotUpdateStrategy_Default_InvalidEnvironmentVariableValue_UsesDisallow()
     {
         using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, "invalid");
@@ -1079,7 +1081,8 @@ public sealed partial class SnapshotTests
         Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
     }
 
-    [Fact]
+    // Sets the process-wide SNAPSHOTTESTING_STRATEGY variable, which every 'new SnapshotSettings()' reads, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public void SnapshotUpdateStrategy_ExplicitSetting_HasPriorityOverEnvironmentVariable()
     {
         using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, nameof(SnapshotUpdateStrategy.Overwrite));

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/XunitCollectionBehavior.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/XunitCollectionBehavior.cs
@@ -1,3 +1,0 @@
-#if GITHUB_ACTIONS
-[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.None)]
-#endif


### PR DESCRIPTION
## Why

Test parallelization was controlled by blanket flags rather than by what each test actually needs:

- `Directory.Build.props` set `EnableXunitFullParallelization=false` for every project on CI, downgrading them from `ParallelMode.All` to the xUnit.net defaults.
- `Meziantou.Framework.DiffEngine.Tests`, `Meziantou.Framework.ProcessWrapper.Tests` and `Meziantou.Framework.SnapshotTesting.Tests` opted out entirely with the same property, `Meziantou.Framework.CommandLineTests` used `XunitParallelizationMode=Collections`, and two projects hand-wrote `[assembly: Xunit.v3.Parallelization(Mode = None)]` under `#if GITHUB_ACTIONS`.

That was a blunt instrument in both directions. `DisableParallelization` on `[Fact]`, `[Theory]` and `[TestClass]` is honored **only** in `ParallelMode.All`, so the flags silently voided the fine-grained annotations already in the repository — the eight `[TestClass(DisableParallelization = true)]` of `Meziantou.Framework.TemporaryContainers.Tests` did nothing on CI, for instance. And the projects opting out serialized every test, including the vast majority that never touch process-wide state.

## What changed

Every global, per-project and per-assembly flag is removed. The tests that genuinely cannot run concurrently are annotated instead, each with a comment naming the shared state:

| Test | Annotation | Shared state |
| --- | --- | --- |
| `DiffToolsTests` | `[TestClass(DisableParallelization = true)]` | `DiffEngine_*` and `PATH` environment variables |
| `PromptTests` | `[TestClass(DisableParallelization = true)]` | `Console.SetIn` / `Console.SetOut` |
| 24 of the 100 `ProcessWrapperTests` | `[Fact(DisableParallelization = true)]` | static `DefaultProcessFactory`, global interceptor registrations, `DefaultLogVerbosity`, `ActivityListener` on the shared `ActivitySource` |
| 3 `SnapshotTests` | `[Fact/Theory(DisableParallelization = true)]` | `SNAPSHOTTESTING_STRATEGY` environment variable |

The other 76 `ProcessWrapperTests` now run in parallel. `[Collection("PromptTests")]` is dropped: it named a collection holding a single class, so it serialized nothing.

`InlineSnapshotSettingsTests` already carried the right annotation, so deleting its project's `XunitCollectionBehavior.cs` was enough.

## Notes for the reviewer

**A latent CI-only build break is fixed here.** `Meziantou.Framework.InlineSnapshotTesting.Tests` hand-wrote an `[assembly: Xunit.v3.Parallelization]` that only compiled because the repository-wide flag suppressed the SDK-generated one. Removing the flag alone reproduces `CS0579: Duplicate 'Xunit.v3.Parallelization' attribute` (verified locally with `GITHUB_ACTIONS=true`).

**Turning on full parallelization exposed three genuine races** in `ProcessWrapperTests` — activity listeners and global interceptors observing the processes started by other tests. The blanket flag had been hiding them rather than fixing them; they are annotated now.

**Existing annotations start taking effect.** Now that CI runs in `ParallelMode.All`, the `[TestClass(DisableParallelization = true)]` and `[Fact(DisableParallelization = true)]` already spread across the repository do what they say for the first time on CI.

## Verification

`dotnet build /p:TreatsWarningsAsErrors=true` is clean on all five projects, and `dotnet run ./eng/update-all.cs` exits 0 with no generated changes.

| Project | Result |
| --- | --- |
| `Meziantou.Framework.DiffEngine.Tests` | 80/80 (3 runs) |
| `Meziantou.Framework.ProcessWrapper.Tests` | 193/193 (6 runs) |
| `Meziantou.Framework.CommandLineTests` | 62 passed, 28 skipped (3 runs) |
| `Meziantou.Framework.SnapshotTesting.Tests` | 382/382 (2 runs) |
| `Meziantou.Framework.InlineSnapshotTesting.Tests` | 286/286 |

Repeated runs were used because the outcome is now non-deterministic by design.

**Not verified locally: CI resource behavior.** Nothing changes outside these five projects on a developer machine — the global flag was `GITHUB_ACTIONS`-only, so everything else already ran in `ParallelMode.All` — but on CI every project moves from the xUnit.net defaults to full parallelization. Concurrency stays bounded by `maxParallelThreads` (the processor count) with the conservative algorithm, so this should be fine, but only a CI run will confirm it.

## Loose ends left alone

- `tests/xunit.runner.json` is inert: it sits in `tests/`, not in a project directory, so it is never copied to any output (`find artifacts/bin -name xunit.runner.json` returns nothing). It advertises `parallelAlgorithm: aggressive`, which nothing reads.
- Six vestigial `[Collection("SomeUniqueName")]` attributes (Win32 Lsa/Amsi/Jobs/CredentialManager, `ProcessExtensionsTests`, DnsProxy) each name a collection with a single class, so they serialize nothing in any mode.
- The `GITHUB_ACTIONS` compilation constant in `tests/Directory.Build.props` no longer has any `#if` consumer.
