### PR TITLE
Add ScopedActivityListener to capture the activities of an async scope

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -1104,8 +1104,6 @@ namespace Meziantou.Framework.Diagnostics
 
     public sealed class ScopedActivityListener : System.IDisposable
     {
-        public System.Guid Id { get => throw null; }
-        public bool IsInScope { get => throw null; }
         public System.Collections.Generic.IReadOnlyCollection<System.Diagnostics.Activity> Activities { get => throw null; }
         public event System.EventHandler<Meziantou.Framework.Diagnostics.ActivityEventArgs>? ActivityStarted;
         public event System.EventHandler<Meziantou.Framework.Diagnostics.ActivityEventArgs>? ActivityStopped;

--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -1095,6 +1095,34 @@ namespace Meziantou.Framework.DataAnnotations
         public override bool IsValid(object? value) => throw null;
     }
 }
+namespace Meziantou.Framework.Diagnostics
+{
+    public sealed class ActivityEventArgs : System.EventArgs
+    {
+        public System.Diagnostics.Activity Activity { get => throw null; }
+    }
+
+    public sealed class ScopedActivityListener : System.IDisposable
+    {
+        public System.Guid Id { get => throw null; }
+        public bool IsInScope { get => throw null; }
+        public System.Collections.Generic.IReadOnlyCollection<System.Diagnostics.Activity> Activities { get => throw null; }
+        public event System.EventHandler<Meziantou.Framework.Diagnostics.ActivityEventArgs>? ActivityStarted;
+        public event System.EventHandler<Meziantou.Framework.Diagnostics.ActivityEventArgs>? ActivityStopped;
+        public ScopedActivityListener(Meziantou.Framework.Diagnostics.ScopedActivityListenerOptions? options) { }
+        public System.Collections.Generic.IAsyncEnumerable<System.Diagnostics.Activity> GetActivitiesAsync([System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = null) => throw null;
+        public void Dispose() { }
+    }
+
+    public sealed class ScopedActivityListenerOptions
+    {
+        public System.Func<System.Diagnostics.ActivitySource, bool>? ShouldListenTo { get => throw null; set { } }
+        public System.Collections.Generic.IReadOnlyList<string>? SourceNames { get => throw null; set { } }
+        public System.Diagnostics.ActivitySamplingResult SamplingResult { get => throw null; set { } }
+        public bool CaptureChildActivities { get => throw null; set { } }
+        public int MaxActivityCount { get => throw null; set { } }
+    }
+}
 namespace Meziantou.Framework.Text
 {
     public static class Utf8Extensions

--- a/slnx/Meziantou.DnsProxy.slnx
+++ b/slnx/Meziantou.DnsProxy.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj" />

--- a/slnx/Meziantou.Extensions.Logging.FileLogger.slnx
+++ b/slnx/Meziantou.Extensions.Logging.FileLogger.slnx
@@ -5,6 +5,7 @@
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj" />

--- a/slnx/Meziantou.Extensions.Logging.InMemory.slnx
+++ b/slnx/Meziantou.Extensions.Logging.InMemory.slnx
@@ -4,6 +4,7 @@
     <Project Path="../src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj" />
     <Project Path="../src/Meziantou.Framework.Http.ServerSideRequestForgery/Meziantou.Framework.Http.ServerSideRequestForgery.csproj" />
     <Project Path="../src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj" />
+    <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj" />

--- a/slnx/Meziantou.Extensions.Logging.Xunit.v3.slnx
+++ b/slnx/Meziantou.Extensions.Logging.Xunit.v3.slnx
@@ -20,6 +20,7 @@
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
     <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
+    <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj" />

--- a/slnx/Meziantou.Framework.DnsClient.slnx
+++ b/slnx/Meziantou.Framework.DnsClient.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
     <Project Path="../src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
+    <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj" />

--- a/slnx/Meziantou.Framework.slnx
+++ b/slnx/Meziantou.Framework.slnx
@@ -1,8 +1,15 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
+    <Project Path="../src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
+    <Project Path="../src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj" />
+    <Project Path="../src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj" />
     <Project Path="../src/Meziantou.Framework.CodeDom/Meziantou.Framework.CodeDom.csproj" />
     <Project Path="../src/Meziantou.Framework.CommandLine/Meziantou.Framework.CommandLine.csproj" />
     <Project Path="../src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
+    <Project Path="../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
+    <Project Path="../src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
+    <Project Path="../src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
@@ -24,9 +31,13 @@
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj" />
+    <Project Path="../tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj" />
     <Project Path="../tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj" />
+    <Project Path="../tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj" />
+    <Project Path="../tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.NuGetPackageValidation.Tests/Meziantou.Framework.NuGetPackageValidation.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj" />

--- a/src/Meziantou.Framework/Diagnostics/ActivityEventArgs.cs
+++ b/src/Meziantou.Framework/Diagnostics/ActivityEventArgs.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework.Diagnostics;
+
+/// <summary>Provides data for the <see cref="ScopedActivityListener.ActivityStarted"/> and <see cref="ScopedActivityListener.ActivityStopped"/> events.</summary>
+public sealed class ActivityEventArgs : EventArgs
+{
+    internal ActivityEventArgs(Activity activity) => Activity = activity;
+
+    /// <summary>Gets the activity that started or stopped.</summary>
+    public Activity Activity { get; }
+}

--- a/src/Meziantou.Framework/Diagnostics/ScopedActivityListener.cs
+++ b/src/Meziantou.Framework/Diagnostics/ScopedActivityListener.cs
@@ -48,6 +48,7 @@ public sealed class ScopedActivityListener : IDisposable
     private static bool s_inCallback;
 
     private readonly AsyncLocal<Guid> _currentScopeId = new();
+    private readonly Guid _scopeId = Guid.NewGuid();
     private readonly ActivityListener _listener;
     private readonly ActivitySamplingResult _samplingResult;
     private readonly bool _captureChildActivities;
@@ -79,8 +80,7 @@ public sealed class ScopedActivityListener : IDisposable
         _captureChildActivities = options.CaptureChildActivities;
         _activities = new CapturedActivityCollection(options.MaxActivityCount);
 
-        Id = Guid.NewGuid();
-        _currentScopeId.Value = Id;
+        _currentScopeId.Value = _scopeId;
 
         var shouldListenTo = options.ShouldListenTo;
         if (shouldListenTo is null && options.SourceNames is { } sourceNames)
@@ -100,12 +100,6 @@ public sealed class ScopedActivityListener : IDisposable
 
         ActivitySource.AddActivityListener(_listener);
     }
-
-    /// <summary>Gets the identifier of the scope. It is the value flowed through the <see cref="AsyncLocal{T}"/> used to detect the scope.</summary>
-    public Guid Id { get; }
-
-    /// <summary>Gets a value indicating whether the calling asynchronous flow is inside this scope.</summary>
-    public bool IsInScope => !_disposed && _currentScopeId.Value == Id;
 
     /// <summary>Gets the activities captured so far, in completion order. The collection is safe to enumerate while new activities are captured.</summary>
     public IReadOnlyCollection<Activity> Activities => _activities;
@@ -191,12 +185,14 @@ public sealed class ScopedActivityListener : IDisposable
         _capturedSpanIds.Clear();
     }
 
+    private bool IsInScope => _currentScopeId.Value == _scopeId;
+
     private ActivitySamplingResult Sample(ActivitySpanId parentSpanId)
     {
         if (_disposed)
             return ActivitySamplingResult.None;
 
-        if (_currentScopeId.Value == Id)
+        if (IsInScope)
             return _samplingResult;
 
         if (_captureChildActivities && parentSpanId != default && _capturedSpanIds.ContainsKey(parentSpanId))
@@ -242,7 +238,7 @@ public sealed class ScopedActivityListener : IDisposable
 
     private bool ShouldCapture(Activity activity)
     {
-        if (_currentScopeId.Value == Id)
+        if (IsInScope)
             return true;
 
         if (!_captureChildActivities)

--- a/src/Meziantou.Framework/Diagnostics/ScopedActivityListener.cs
+++ b/src/Meziantou.Framework/Diagnostics/ScopedActivityListener.cs
@@ -1,0 +1,334 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Meziantou.Framework.Collections;
+
+namespace Meziantou.Framework.Diagnostics;
+
+/// <summary>
+/// Captures the <see cref="Activity"/> instances started within the current asynchronous scope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An <see cref="ActivityListener"/> is global: it observes every activity created in the process. This type registers such a listener but
+/// only reports the activities started by the asynchronous flow that created it, using an <see cref="AsyncLocal{T}"/>. Disposing the
+/// instance unregisters the listener.
+/// </para>
+/// <para>
+/// The membership of an activity is decided when it starts, because an activity is frequently stopped on another thread, where the
+/// asynchronous scope is no longer available. As a consequence, the activities that are still running when the listener is disposed are
+/// never reported.
+/// </para>
+/// <para>
+/// The captured activities are live references, not snapshots: their tags, status and duration are only final once they are stopped.
+/// </para>
+/// <para>
+/// While the listener is registered, <see cref="ActivitySource.HasListeners"/> returns <see langword="true"/> for every matching source in
+/// the whole process. The libraries that check it, such as <c>HttpClient</c> or ASP.NET Core, switch to their instrumented code path, so
+/// <c>HttpClient</c> starts sending the <c>traceparent</c> header for the requests made inside the scope. Use
+/// <see cref="ScopedActivityListenerOptions.SourceNames"/> to reduce the number of matching sources.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code><![CDATA[
+/// using var listener = new ScopedActivityListener(new() { SourceNames = ["Meziantou.Framework.DnsClient"] });
+/// await DoWorkAsync();
+/// foreach (var activity in listener.Activities)
+/// {
+///     Console.WriteLine($"{activity.OperationName}: {activity.Duration}");
+/// }
+/// ]]></code>
+/// </example>
+public sealed class ScopedActivityListener : IDisposable
+{
+    // Set while a listener callback is running on the current thread, so an event handler that starts an activity does not recurse
+    [ThreadStatic]
+    private static bool s_inCallback;
+
+    private readonly AsyncLocal<Guid> _currentScopeId = new();
+    private readonly ActivityListener _listener;
+    private readonly ActivitySamplingResult _samplingResult;
+    private readonly bool _captureChildActivities;
+    private readonly CapturedActivityCollection _activities;
+
+    // Activity does not override Equals nor GetHashCode, so the default comparer compares the references
+    private readonly ConcurrentDictionary<Activity, byte> _startedActivities = new();
+    private readonly ConcurrentDictionary<ActivitySpanId, byte> _capturedSpanIds = new();
+
+    private readonly Lock _subscribersLock = new();
+    private readonly List<Channel<Activity>> _subscribers = [];
+
+    private volatile bool _disposed;
+
+    /// <summary>Initializes a new instance of the <see cref="ScopedActivityListener"/> class listening to every <see cref="ActivitySource"/>.</summary>
+    public ScopedActivityListener()
+        : this(options: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ScopedActivityListener"/> class.</summary>
+    /// <param name="options">The options of the listener, or <see langword="null"/> to use the default options.</param>
+    public ScopedActivityListener(ScopedActivityListenerOptions? options)
+    {
+        options ??= new ScopedActivityListenerOptions();
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(options.MaxActivityCount);
+
+        _samplingResult = options.SamplingResult;
+        _captureChildActivities = options.CaptureChildActivities;
+        _activities = new CapturedActivityCollection(options.MaxActivityCount);
+
+        Id = Guid.NewGuid();
+        _currentScopeId.Value = Id;
+
+        var shouldListenTo = options.ShouldListenTo;
+        if (shouldListenTo is null && options.SourceNames is { } sourceNames)
+        {
+            var names = sourceNames.ToArray();
+            shouldListenTo = source => Array.IndexOf(names, source.Name) >= 0;
+        }
+
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = shouldListenTo ?? (_ => true),
+            Sample = (ref ActivityCreationOptions<ActivityContext> creationOptions) => Sample(creationOptions.Parent.SpanId),
+            SampleUsingParentId = (ref ActivityCreationOptions<string> creationOptions) => Sample(parentSpanId: default),
+            ActivityStarted = OnActivityStarted,
+            ActivityStopped = OnActivityStopped,
+        };
+
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    /// <summary>Gets the identifier of the scope. It is the value flowed through the <see cref="AsyncLocal{T}"/> used to detect the scope.</summary>
+    public Guid Id { get; }
+
+    /// <summary>Gets a value indicating whether the calling asynchronous flow is inside this scope.</summary>
+    public bool IsInScope => !_disposed && _currentScopeId.Value == Id;
+
+    /// <summary>Gets the activities captured so far, in completion order. The collection is safe to enumerate while new activities are captured.</summary>
+    public IReadOnlyCollection<Activity> Activities => _activities;
+
+    /// <summary>
+    /// Occurs when an activity of the scope starts. The event is raised synchronously on the thread starting the activity, so its tags,
+    /// status and duration are not set yet. The exceptions thrown by the handlers are ignored to avoid breaking the observed code.
+    /// </summary>
+    public event EventHandler<ActivityEventArgs>? ActivityStarted;
+
+    /// <summary>
+    /// Occurs when an activity of the scope stops. The event is raised synchronously on the thread stopping the activity. The exceptions
+    /// thrown by the handlers are ignored to avoid breaking the observed code.
+    /// </summary>
+    public event EventHandler<ActivityEventArgs>? ActivityStopped;
+
+    /// <summary>Streams the activities of the scope as they complete.</summary>
+    /// <param name="cancellationToken">A token to stop the enumeration.</param>
+    /// <returns>
+    /// The activities already captured, followed by the activities completing afterwards. The enumeration ends when the listener is
+    /// disposed. Multiple enumerations can run concurrently, and each of them reports every activity.
+    /// </returns>
+    public async IAsyncEnumerable<Activity> GetActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var channel = Channel.CreateUnbounded<Activity>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+        lock (_subscribersLock)
+        {
+            foreach (var activity in _activities.ToArray())
+            {
+                channel.Writer.TryWrite(activity);
+            }
+
+            if (_disposed)
+            {
+                channel.Writer.TryComplete();
+            }
+            else
+            {
+                _subscribers.Add(channel);
+            }
+        }
+
+        try
+        {
+            await foreach (var activity in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return activity;
+            }
+        }
+        finally
+        {
+            lock (_subscribersLock)
+            {
+                _subscribers.Remove(channel);
+            }
+        }
+    }
+
+    /// <summary>Unregisters the listener and completes the enumerations started by <see cref="GetActivitiesAsync"/>.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _listener.Dispose();
+        _currentScopeId.Value = default;
+
+        lock (_subscribersLock)
+        {
+            foreach (var subscriber in _subscribers)
+            {
+                subscriber.Writer.TryComplete();
+            }
+        }
+
+        _startedActivities.Clear();
+        _capturedSpanIds.Clear();
+    }
+
+    private ActivitySamplingResult Sample(ActivitySpanId parentSpanId)
+    {
+        if (_disposed)
+            return ActivitySamplingResult.None;
+
+        if (_currentScopeId.Value == Id)
+            return _samplingResult;
+
+        if (_captureChildActivities && parentSpanId != default && _capturedSpanIds.ContainsKey(parentSpanId))
+            return _samplingResult;
+
+        return ActivitySamplingResult.None;
+    }
+
+    private void OnActivityStarted(Activity activity)
+    {
+        // The runtime enumerates the listeners without a lock, so a callback can run after Dispose returned
+        if (_disposed || s_inCallback || !ShouldCapture(activity))
+            return;
+
+        _startedActivities.TryAdd(activity, 0);
+
+        var spanId = activity.SpanId;
+        if (spanId != default)
+        {
+            _capturedSpanIds.TryAdd(spanId, 0);
+        }
+
+        Raise(ActivityStarted, activity);
+    }
+
+    private void OnActivityStopped(Activity activity)
+    {
+        // The membership is decided when the activity starts: an activity is often stopped on another thread, where the scope is not available
+        if (s_inCallback || !_startedActivities.TryRemove(activity, out _))
+            return;
+
+        lock (_subscribersLock)
+        {
+            _activities.Add(activity);
+            foreach (var subscriber in _subscribers)
+            {
+                subscriber.Writer.TryWrite(activity);
+            }
+        }
+
+        Raise(ActivityStopped, activity);
+    }
+
+    private bool ShouldCapture(Activity activity)
+    {
+        if (_currentScopeId.Value == Id)
+            return true;
+
+        if (!_captureChildActivities)
+            return false;
+
+        if (activity.Parent is not null && _startedActivities.ContainsKey(activity.Parent))
+            return true;
+
+        var parentSpanId = activity.ParentSpanId;
+        return parentSpanId != default && _capturedSpanIds.ContainsKey(parentSpanId);
+    }
+
+    private void Raise(EventHandler<ActivityEventArgs>? handler, Activity activity)
+    {
+        if (handler is null)
+            return;
+
+        s_inCallback = true;
+        try
+        {
+            handler(this, new ActivityEventArgs(activity));
+        }
+        catch
+        {
+            // A handler must not break the code being observed
+        }
+        finally
+        {
+            s_inCallback = false;
+        }
+    }
+
+    private sealed class CapturedActivityCollection : IReadOnlyCollection<Activity>
+    {
+        private readonly ICollection<Activity> _items;
+        private readonly bool _threadSafe;
+
+        public CapturedActivityCollection(int maxActivityCount)
+        {
+            if (maxActivityCount == int.MaxValue)
+            {
+                _items = new AppendOnlyCollection<Activity>();
+                _threadSafe = true;
+            }
+            else
+            {
+                _items = new CircularBuffer<Activity>(maxActivityCount) { AllowOverwrite = true };
+            }
+        }
+
+        public int Count => _items.Count;
+
+        public void Add(Activity activity)
+        {
+            if (_threadSafe)
+            {
+                _items.Add(activity);
+            }
+            else
+            {
+                lock (_items)
+                {
+                    _items.Add(activity);
+                }
+            }
+        }
+
+        public Activity[] ToArray()
+        {
+            if (_threadSafe)
+                return [.. _items];
+
+            lock (_items)
+            {
+                return [.. _items];
+            }
+        }
+
+        public IEnumerator<Activity> GetEnumerator()
+        {
+            if (_threadSafe)
+                return _items.GetEnumerator();
+
+            return ((IEnumerable<Activity>)ToArray()).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Meziantou.Framework/Diagnostics/ScopedActivityListenerOptions.cs
+++ b/src/Meziantou.Framework/Diagnostics/ScopedActivityListenerOptions.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework.Diagnostics;
+
+/// <summary>Options for <see cref="ScopedActivityListener"/>.</summary>
+public sealed class ScopedActivityListenerOptions
+{
+    /// <summary>
+    /// Gets or sets the predicate used for <see cref="ActivityListener.ShouldListenTo"/>. The default value listens to every source.
+    /// </summary>
+    /// <remarks>
+    /// The predicate is evaluated once per <see cref="ActivitySource"/> and its result is cached by the runtime, so it must be a pure
+    /// function of the source. In particular it cannot depend on the current asynchronous flow.
+    /// </remarks>
+    public Func<ActivitySource, bool>? ShouldListenTo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the names of the <see cref="ActivitySource"/> to listen to, compared with <see cref="StringComparison.Ordinal"/>.
+    /// This value is ignored when <see cref="ShouldListenTo"/> is set. Use <see cref="string.Empty"/> to listen to the activities created
+    /// with <c>new Activity(name)</c>.
+    /// </summary>
+    public IReadOnlyList<string>? SourceNames { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sampling result returned for the activities created in the scope. The default value is <see cref="ActivitySamplingResult.AllData"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ActivitySamplingResult.AllDataAndRecorded"/> sets <see cref="ActivityTraceFlags.Recorded"/>, which is propagated to the
+    /// downstream services through the <c>traceparent</c> header and changes their own sampling decisions.
+    /// </remarks>
+    public ActivitySamplingResult SamplingResult { get; set; } = ActivitySamplingResult.AllData;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the activities whose parent is captured are also captured, even when the asynchronous scope
+    /// was lost. The default value is <see langword="true"/>.
+    /// </summary>
+    public bool CaptureChildActivities { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of completed activities kept in <see cref="ScopedActivityListener.Activities"/>. When the limit is
+    /// reached, the oldest activities are dropped. The default value is <see cref="int.MaxValue"/>.
+    /// </summary>
+    public int MaxActivityCount { get; set; } = int.MaxValue;
+}

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
 using Meziantou.Framework;
+using Meziantou.Framework.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -210,12 +211,7 @@ public sealed class FileLoggerProviderTests
         });
 
         using var activitySource = new ActivitySource("Test");
-        using var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name is "Test",
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-        };
-        ActivitySource.AddActivityListener(listener);
+        using var listener = new ScopedActivityListener(new ScopedActivityListenerOptions { ShouldListenTo = source => source == activitySource });
 
         using var activity = activitySource.StartActivity("Test");
         Assert.NotNull(activity);

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
     <ProjectReference Include="../../src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/HostTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/HostTests.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CA1848 // Use the LoggerMessage delegates
 using System.Diagnostics;
 using Meziantou.Extensions.Logging.Xunit.v3;
+using Meziantou.Framework.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -66,12 +67,11 @@ public sealed class HostTests
             .Build();
 
         using var activitySource = new ActivitySource("Meziantou.Extensions.Logging.InMemory.Tests");
-        using var listener = new ActivityListener
+        using var listener = new ScopedActivityListener(new ScopedActivityListenerOptions
         {
             ShouldListenTo = source => source == activitySource,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-        };
-        ActivitySource.AddActivityListener(listener);
+            SamplingResult = ActivitySamplingResult.AllDataAndRecorded,
+        });
 
         var logger = host.Services.GetRequiredService<ILogger<HostTests>>();
         using var activity = activitySource.StartActivity("operation");

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
     <ProjectReference Include="../../src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj" />
     <ProjectReference Include="../../src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj" />
   </ItemGroup>

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientTelemetryTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientTelemetryTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Meziantou.Framework.Diagnostics;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 using Meziantou.Framework.DnsClient.Transport;
@@ -12,15 +13,13 @@ public sealed class DnsClientTelemetryTests
     {
         const string QuestionName = "success.example.com";
 
-        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var listener = CreateDnsClientActivityListener(QuestionName, activity => activityTask.TrySetResult(activity));
-        ActivitySource.AddActivityListener(listener);
+        using var listener = CreateDnsClientActivityListener();
         using var transport = new ResponseTransport(DnsResponseCode.NoError);
         using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
 
         await client.QueryAsync(QuestionName, DnsQueryType.A, TestContext.Current.CancellationToken);
 
-        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        var activity = Assert.Single(listener.Activities);
         Assert.Equal("dns.query", activity.OperationName);
         Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(ActivityStatusCode.Ok, activity.Status);
@@ -36,15 +35,13 @@ public sealed class DnsClientTelemetryTests
     {
         const string QuestionName = "missing.example.com";
 
-        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var listener = CreateDnsClientActivityListener(QuestionName, activity => activityTask.TrySetResult(activity));
-        ActivitySource.AddActivityListener(listener);
+        using var listener = CreateDnsClientActivityListener();
         using var transport = new ResponseTransport(DnsResponseCode.NameError);
         using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
 
         await client.QueryAsync(QuestionName, DnsQueryType.A, TestContext.Current.CancellationToken);
 
-        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        var activity = Assert.Single(listener.Activities);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal("DNS response code: NameError", activity.StatusDescription);
         Assert.Equal(nameof(DnsResponseCode.NameError), activity.GetTagItem("dns.response.code"));
@@ -55,34 +52,20 @@ public sealed class DnsClientTelemetryTests
     {
         const string QuestionName = "exception.example.com";
 
-        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var listener = CreateDnsClientActivityListener(QuestionName, activity => activityTask.TrySetResult(activity));
-        ActivitySource.AddActivityListener(listener);
+        using var listener = CreateDnsClientActivityListener();
         using var transport = new ThrowingTransport();
         using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.QueryAsync(QuestionName, DnsQueryType.A, TestContext.Current.CancellationToken));
 
-        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        var activity = Assert.Single(listener.Activities);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal(exception.Message, activity.StatusDescription);
     }
 
-    private static ActivityListener CreateDnsClientActivityListener(string questionName, Action<Activity> onActivityStopped)
-    {
-        return new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == "Meziantou.Framework.DnsClient",
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-            ActivityStopped = activity =>
-            {
-                if (Equals(activity.GetTagItem("dns.question.name"), questionName))
-                {
-                    onActivityStopped(activity);
-                }
-            },
-        };
-    }
+    // The scope only reports the activities started by the current test, so the tests of this class can run in parallel
+    private static ScopedActivityListener CreateDnsClientActivityListener()
+        => new(new ScopedActivityListenerOptions { SourceNames = ["Meziantou.Framework.DnsClient"] });
 
     private sealed class ResponseTransport : IDnsTransport
     {

--- a/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using Meziantou.DnsProxy;
 using Meziantou.DnsProxy.Filtering;
+using Meziantou.Framework.Diagnostics;
 using Meziantou.Framework.DnsFilter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -87,9 +87,8 @@ public sealed class FilterEngineProviderTests
             ],
         });
 
-        var activities = new ConcurrentQueue<Activity>();
-        using var listener = CreateDnsProxyActivityListener(activities.Enqueue);
-        ActivitySource.AddActivityListener(listener);
+        // The scope only reports the activities started by this test, so no extra filtering is needed to ignore the other tests
+        using var listener = new ScopedActivityListener(new ScopedActivityListenerOptions { SourceNames = ["Meziantou.DnsProxy"] });
 
         using var serviceProvider = CreateServiceProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -104,12 +103,8 @@ public sealed class FilterEngineProviderTests
 
         await provider.RefreshAsync(CancellationToken.None);
 
-        var loadActivity = Assert.Single(activities, activity =>
-            activity.OperationName == "dns_proxy.filters.load" &&
-            Equals(filterUrl, activity.GetTagItem("dns_proxy.filter.url")));
-        var refreshActivity = Assert.Single(activities, activity =>
-            activity.OperationName == "dns_proxy.filters.refresh" &&
-            activity.SpanId == loadActivity.ParentSpanId);
+        var loadActivity = Assert.Single(listener.Activities, activity => activity.OperationName == "dns_proxy.filters.load");
+        var refreshActivity = Assert.Single(listener.Activities, activity => activity.OperationName == "dns_proxy.filters.refresh");
 
         Assert.Equal(refreshActivity.SpanId, loadActivity.ParentSpanId);
         Assert.Equal(ActivityStatusCode.Ok, refreshActivity.Status);
@@ -268,17 +263,6 @@ public sealed class FilterEngineProviderTests
             .AddHttpClient(Options.DefaultName)
             .ConfigurePrimaryHttpMessageHandler(() => new DelegateHttpMessageHandler(responseFactory));
         return services.BuildServiceProvider();
-    }
-
-    private static ActivityListener CreateDnsProxyActivityListener(Action<Activity> activityStopped)
-    {
-        return new ActivityListener
-        {
-            ShouldListenTo = static source => source.Name == "Meziantou.DnsProxy",
-            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped,
-        };
     }
 
     private sealed class DelegateHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
     <ProjectReference Include="../../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Meziantou.Framework.Diagnostics;
 
 namespace Meziantou.Framework.Tests;
 
@@ -135,14 +136,12 @@ public class ProcessWrapperTests
     [Fact]
     public async Task ExecuteAsync_EmitsActivity_WithProcessPathAndExitCode()
     {
-        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var listener = CreateProcessWrapperActivityListener(activity => activityTask.TrySetResult(activity));
-        ActivitySource.AddActivityListener(listener);
+        using var listener = CreateProcessWrapperActivityListener();
 
         var processResult = await CreateEchoCommand("test")
             .ExecuteAsync();
 
-        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var activity = Assert.Single(listener.Activities);
 
         Assert.Equal(0, processResult.ExitCode);
         Assert.Equal("process.execute", activity.OperationName);
@@ -154,17 +153,14 @@ public class ProcessWrapperTests
     [Fact]
     public async Task ExecuteAsync_DoesNotChangeTheAmbientActivityOfTheCaller()
     {
-        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var listener = CreateProcessWrapperActivityListener(activity => activityTask.TrySetResult(activity));
-        ActivitySource.AddActivityListener(listener);
+        using var listener = CreateProcessWrapperActivityListener();
 
         using var ambientSource = new ActivitySource("Meziantou.Framework.ProcessWrapper.Tests.Ambient");
-        using var ambientListener = new ActivityListener
+        using var ambientListener = new ScopedActivityListener(new ScopedActivityListenerOptions
         {
-            ShouldListenTo = static source => source.Name == "Meziantou.Framework.ProcessWrapper.Tests.Ambient",
-            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-        };
-        ActivitySource.AddActivityListener(ambientListener);
+            ShouldListenTo = source => source == ambientSource,
+            SamplingResult = ActivitySamplingResult.AllDataAndRecorded,
+        });
 
         using var ambientActivity = ambientSource.StartActivity("ambient");
         Assert.NotNull(ambientActivity);
@@ -172,7 +168,7 @@ public class ProcessWrapperTests
         await CreateEchoCommand("test").ExecuteAsync();
 
         // The process activity is emitted, but it must not replace the caller's ambient activity.
-        var processActivity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var processActivity = Assert.Single(listener.Activities);
         Assert.Equal("process.execute", processActivity.OperationName);
         Assert.Same(ambientActivity, Activity.Current);
     }
@@ -853,9 +849,7 @@ public class ProcessWrapperTests
     [Fact]
     public async Task Validation_FailIfNonZeroExitCode_SetsActivityStatusToError()
     {
-        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var listener = CreateProcessWrapperActivityListener(activity => activityTask.TrySetResult(activity));
-        ActivitySource.AddActivityListener(listener);
+        using var listener = CreateProcessWrapperActivityListener();
 
         ProcessWrapper command;
         if (OperatingSystem.IsWindows())
@@ -873,7 +867,7 @@ public class ProcessWrapperTests
 
         await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
 
-        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var activity = Assert.Single(listener.Activities);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         var processPath = Assert.IsType<string>(activity.GetTagItem("process.executable.path"));
         Assert.NotNull(activity.StatusDescription);
@@ -1939,16 +1933,13 @@ public class ProcessWrapperTests
         }
     }
 
-    private static ActivityListener CreateProcessWrapperActivityListener(Action<Activity> activityStopped)
-    {
-        return new ActivityListener
+    // The scope only reports the activities started by the current test
+    private static ScopedActivityListener CreateProcessWrapperActivityListener()
+        => new(new ScopedActivityListenerOptions
         {
-            ShouldListenTo = static source => source.Name == "Meziantou.Framework.ProcessWrapper",
-            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped,
-        };
-    }
+            SourceNames = ["Meziantou.Framework.ProcessWrapper"],
+            SamplingResult = ActivitySamplingResult.AllDataAndRecorded,
+        });
 
     private static ProcessWrapper CreateEchoBase()
     {

--- a/tests/Meziantou.Framework.Tests/Diagnostics/ScopedActivityListenerTests.cs
+++ b/tests/Meziantou.Framework.Tests/Diagnostics/ScopedActivityListenerTests.cs
@@ -473,44 +473,19 @@ public sealed class ScopedActivityListenerTests
     }
 
     [Fact]
-    public async Task IsInScope_IsFalseOutsideTheScopeAndAfterDispose()
-    {
-        using var source = CreateSource();
-
-        ScopedActivityListener? listener = null;
-        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        // The task is started before the scope, so it does not flow the AsyncLocal of the scope
-        var task = Task.Run(async () =>
-        {
-            await gate.Task;
-            return listener!.IsInScope;
-        }, TestContext.Current.CancellationToken);
-
-        listener = CreateListener(source);
-        try
-        {
-            Assert.True(listener.IsInScope);
-            gate.SetResult();
-            Assert.False(await task);
-        }
-        finally
-        {
-            listener.Dispose();
-        }
-
-        Assert.False(listener.IsInScope);
-    }
-
-    [Fact]
     public void Dispose_IsIdempotent()
     {
         using var source = CreateSource();
+        using var alwaysOn = CreateAlwaysOnListener(source);
         var listener = CreateListener(source);
 
         listener.Dispose();
         listener.Dispose();
 
-        Assert.False(listener.IsInScope);
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Empty(listener.Activities);
     }
 }

--- a/tests/Meziantou.Framework.Tests/Diagnostics/ScopedActivityListenerTests.cs
+++ b/tests/Meziantou.Framework.Tests/Diagnostics/ScopedActivityListenerTests.cs
@@ -1,0 +1,516 @@
+using System.Diagnostics;
+using System.Globalization;
+using Meziantou.Framework.Diagnostics;
+
+namespace Meziantou.Framework.Tests.Diagnostics;
+
+public sealed class ScopedActivityListenerTests
+{
+    // Every test uses its own ActivitySource, and the listener is restricted to it, so the tests of this class can run in parallel
+    private static ActivitySource CreateSource() => new("test-" + Guid.NewGuid().ToString("N"));
+
+    private static ScopedActivityListener CreateListener(ActivitySource source, Action<ScopedActivityListenerOptions>? configure = null)
+    {
+        var options = new ScopedActivityListenerOptions { SourceNames = [source.Name] };
+        configure?.Invoke(options);
+        return new ScopedActivityListener(options);
+    }
+
+    // Keeps the source sampled outside of any scope, so activities can be created before or after the scope
+    private static ActivityListener CreateAlwaysOnListener(ActivitySource source)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    private static string[] OperationNames(IEnumerable<Activity> activities) => [.. activities.Select(activity => activity.OperationName)];
+
+    [Fact]
+    public void ActivityStartedInsideScope_IsCaptured()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Equal(["op"], OperationNames(listener.Activities));
+    }
+
+    [Fact]
+    public void ActivityStartedBeforeScope_ButStoppedInsideScope_IsNotCaptured()
+    {
+        using var source = CreateSource();
+        using var alwaysOn = CreateAlwaysOnListener(source);
+
+        var activity = source.StartActivity("op");
+        Assert.NotNull(activity);
+
+        using var listener = CreateListener(source);
+        activity.Stop();
+
+        Assert.Empty(listener.Activities);
+    }
+
+    [Fact]
+    public void ActivityStartedAfterDispose_IsNotCaptured()
+    {
+        using var source = CreateSource();
+        using var alwaysOn = CreateAlwaysOnListener(source);
+        var listener = CreateListener(source);
+        listener.Dispose();
+
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Empty(listener.Activities);
+    }
+
+    [Fact]
+    public void ActivityStillRunningWhenDisposed_IsNotCaptured()
+    {
+        using var source = CreateSource();
+        var listener = CreateListener(source);
+
+        var activity = source.StartActivity("op");
+        Assert.NotNull(activity);
+        listener.Dispose();
+        activity.Stop();
+
+        Assert.Empty(listener.Activities);
+    }
+
+    [Fact]
+    public async Task ActivityOnFlowStartedBeforeScope_IsNotCaptured()
+    {
+        using var source = CreateSource();
+        using var alwaysOn = CreateAlwaysOnListener(source);
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var task = Task.Run(async () =>
+        {
+            await gate.Task;
+            using (source.StartActivity("op"))
+            {
+            }
+        }, TestContext.Current.CancellationToken);
+
+        using var listener = CreateListener(source, options => options.CaptureChildActivities = false);
+        gate.SetResult();
+        await task;
+
+        Assert.Empty(listener.Activities);
+    }
+
+    [Fact]
+    public async Task ActivityOnTaskStartedInsideScope_IsCaptured()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        await Task.Run(() =>
+        {
+            using (source.StartActivity("op"))
+            {
+            }
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(["op"], OperationNames(listener.Activities));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ChildActivityWithLostAsyncScope_IsCapturedOnlyWhenCaptureChildActivitiesIsEnabled(bool captureChildActivities)
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source, options => options.CaptureChildActivities = captureChildActivities);
+
+        var parent = source.StartActivity("parent");
+        Assert.NotNull(parent);
+
+        Task<Activity?> task;
+        using (ExecutionContext.SuppressFlow())
+        {
+            task = Task.Run(() =>
+            {
+                var child = source.StartActivity("child", ActivityKind.Internal, parent.Context);
+                child?.Stop();
+                return child;
+            }, TestContext.Current.CancellationToken);
+        }
+
+        await task;
+        parent.Stop();
+
+        var expected = captureChildActivities ? new[] { "child", "parent" } : ["parent"];
+        Assert.Equal(expected, OperationNames(listener.Activities));
+    }
+
+    [Fact]
+    public void NestedScopes_BothCaptureTheActivity()
+    {
+        using var source = CreateSource();
+        using var outer = CreateListener(source);
+        using var inner = CreateListener(source);
+
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Equal(["op"], OperationNames(outer.Activities));
+        Assert.Equal(["op"], OperationNames(inner.Activities));
+    }
+
+    [Fact]
+    public void NestedScopes_WhenInnerIsDisposed_OuterKeepsCapturing()
+    {
+        using var source = CreateSource();
+        using var outer = CreateListener(source);
+        var inner = CreateListener(source);
+        inner.Dispose();
+
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Equal(["op"], OperationNames(outer.Activities));
+        Assert.Empty(inner.Activities);
+    }
+
+    [Fact]
+    public async Task ParallelScopes_DoNotSeeEachOther()
+    {
+        using var source = CreateSource();
+
+        var task1 = Task.Run(() =>
+        {
+            using var listener = CreateListener(source);
+            using (source.StartActivity("a"))
+            {
+            }
+
+            return OperationNames(listener.Activities);
+        }, TestContext.Current.CancellationToken);
+
+        var task2 = Task.Run(() =>
+        {
+            using var listener = CreateListener(source);
+            using (source.StartActivity("b"))
+            {
+            }
+
+            return OperationNames(listener.Activities);
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(["a"], await task1);
+        Assert.Equal(["b"], await task2);
+    }
+
+    // The activities created with "new Activity(name)" belong to the process-wide source with an empty name
+    [Fact(DisableParallelization = true)]
+    public void LegacyActivity_IsCaptured()
+    {
+        using var listener = new ScopedActivityListener(new ScopedActivityListenerOptions { SourceNames = [""] });
+
+        using var activity = new Activity("legacy");
+        activity.Start();
+        activity.Stop();
+
+        Assert.Contains(listener.Activities, item => item.OperationName == "legacy");
+    }
+
+    [Fact]
+    public void SourceNames_FiltersOtherSources()
+    {
+        using var source1 = CreateSource();
+        using var source2 = CreateSource();
+        using var alwaysOn = CreateAlwaysOnListener(source2);
+        using var listener = CreateListener(source1);
+
+        using (source1.StartActivity("a"))
+        {
+        }
+
+        using (source2.StartActivity("b"))
+        {
+        }
+
+        Assert.Equal(["a"], OperationNames(listener.Activities));
+    }
+
+    [Fact]
+    public async Task OutOfScope_DoesNotForceSamplingForOtherListeners()
+    {
+        using var source = CreateSource();
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var task = Task.Run(async () =>
+        {
+            await gate.Task;
+            return source.StartActivity("op");
+        }, TestContext.Current.CancellationToken);
+
+        using var listener = CreateListener(source);
+        gate.SetResult();
+
+        Assert.Null(await task);
+    }
+
+    [Theory]
+    [InlineData(ActivitySamplingResult.AllData, false)]
+    [InlineData(ActivitySamplingResult.AllDataAndRecorded, true)]
+    public void SamplingResult_ControlsTheRecordedFlag(ActivitySamplingResult samplingResult, bool expectedRecorded)
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source, options => options.SamplingResult = samplingResult);
+
+        using var activity = source.StartActivity("op");
+
+        Assert.NotNull(activity);
+        Assert.Equal(expectedRecorded, activity.Recorded);
+    }
+
+    [Fact]
+    public void ActivityStartedAndActivityStoppedEvents_AreRaised()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        var events = new List<string>();
+        listener.ActivityStarted += (sender, e) => events.Add("start:" + e.Activity.OperationName);
+        listener.ActivityStopped += (sender, e) => events.Add("stop:" + e.Activity.OperationName);
+
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Equal(["start:op", "stop:op"], events);
+    }
+
+    [Fact]
+    public void ThrowingEventHandler_DoesNotBreakTheObservedCode()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        listener.ActivityStarted += (sender, e) => throw new InvalidOperationException("Started");
+        listener.ActivityStopped += (sender, e) => throw new InvalidOperationException("Stopped");
+
+        using (source.StartActivity("op"))
+        {
+        }
+
+        Assert.Equal(["op"], OperationNames(listener.Activities));
+    }
+
+    [Fact]
+    public async Task GetActivitiesAsync_ReplaysAlreadyCapturedActivities()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        using (source.StartActivity("a"))
+        {
+        }
+
+        using (source.StartActivity("b"))
+        {
+        }
+
+        listener.Dispose();
+
+        var result = new List<string>();
+        await foreach (var activity in listener.GetActivitiesAsync(TestContext.Current.CancellationToken))
+        {
+            result.Add(activity.OperationName);
+        }
+
+        Assert.Equal(["a", "b"], result);
+    }
+
+    [Fact]
+    public async Task GetActivitiesAsync_StreamsActivitiesAndCompletesOnDispose()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        var consumer = Task.Run(async () =>
+        {
+            var result = new List<string>();
+            await foreach (var activity in listener.GetActivitiesAsync(TestContext.Current.CancellationToken))
+            {
+                result.Add(activity.OperationName);
+            }
+
+            return result;
+        }, TestContext.Current.CancellationToken);
+
+        using (source.StartActivity("a"))
+        {
+        }
+
+        listener.Dispose();
+
+        Assert.Equal(["a"], await consumer);
+    }
+
+    [Fact]
+    public async Task GetActivitiesAsync_SupportsMultipleConsumers()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        var consumer1 = Task.Run(async () =>
+        {
+            var result = new List<string>();
+            await foreach (var activity in listener.GetActivitiesAsync(TestContext.Current.CancellationToken))
+            {
+                result.Add(activity.OperationName);
+            }
+
+            return result;
+        }, TestContext.Current.CancellationToken);
+
+        var consumer2 = Task.Run(async () =>
+        {
+            var result = new List<string>();
+            await foreach (var activity in listener.GetActivitiesAsync(TestContext.Current.CancellationToken))
+            {
+                result.Add(activity.OperationName);
+            }
+
+            return result;
+        }, TestContext.Current.CancellationToken);
+
+        using (source.StartActivity("a"))
+        {
+        }
+
+        listener.Dispose();
+
+        Assert.Equal(["a"], await consumer1);
+        Assert.Equal(["a"], await consumer2);
+    }
+
+    [Fact]
+    public async Task GetActivitiesAsync_HonorsCancellation()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var activity in listener.GetActivitiesAsync(cts.Token))
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GetActivitiesAsync_DoesNotLoseOrDuplicateActivities()
+    {
+        const int ActivityCount = 200;
+
+        using var source = CreateSource();
+        using var listener = CreateListener(source);
+
+        var consumer = Task.Run(async () =>
+        {
+            var result = new List<string>();
+            await foreach (var activity in listener.GetActivitiesAsync(TestContext.Current.CancellationToken))
+            {
+                result.Add(activity.OperationName);
+            }
+
+            return result;
+        }, TestContext.Current.CancellationToken);
+
+        await Task.WhenAll(Enumerable.Range(0, ActivityCount).Select(i => Task.Run(() =>
+        {
+            using (source.StartActivity("op" + i.ToString(CultureInfo.InvariantCulture)))
+            {
+            }
+        }, TestContext.Current.CancellationToken)));
+
+        listener.Dispose();
+
+        var result = await consumer;
+        Assert.HasCount(ActivityCount, result);
+        Assert.Distinct(result);
+    }
+
+    [Fact]
+    public void MaxActivityCount_KeepsTheMostRecentActivities()
+    {
+        using var source = CreateSource();
+        using var listener = CreateListener(source, options => options.MaxActivityCount = 2);
+
+        for (var i = 0; i < 5; i++)
+        {
+            using (source.StartActivity("op" + i.ToString(CultureInfo.InvariantCulture)))
+            {
+            }
+        }
+
+        Assert.Equal(["op3", "op4"], OperationNames(listener.Activities));
+    }
+
+    [Fact]
+    public void MaxActivityCount_MustBePositive()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ScopedActivityListener(new ScopedActivityListenerOptions { MaxActivityCount = 0 }));
+    }
+
+    [Fact]
+    public async Task IsInScope_IsFalseOutsideTheScopeAndAfterDispose()
+    {
+        using var source = CreateSource();
+
+        ScopedActivityListener? listener = null;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The task is started before the scope, so it does not flow the AsyncLocal of the scope
+        var task = Task.Run(async () =>
+        {
+            await gate.Task;
+            return listener!.IsInScope;
+        }, TestContext.Current.CancellationToken);
+
+        listener = CreateListener(source);
+        try
+        {
+            Assert.True(listener.IsInScope);
+            gate.SetResult();
+            Assert.False(await task);
+        }
+        finally
+        {
+            listener.Dispose();
+        }
+
+        Assert.False(listener.IsInScope);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        using var source = CreateSource();
+        var listener = CreateListener(source);
+
+        listener.Dispose();
+        listener.Dispose();
+
+        Assert.False(listener.IsInScope);
+    }
+}


### PR DESCRIPTION
## Why

`ActivityListener` is global: once registered it observes every `Activity` created by every `ActivitySource` in the process. There is no built-in way to ask for *only* the activities produced by one operation, which makes it awkward to assert on tracing in a test, to attach a trace dump to a single request, or to debug one code path while the rest of the app keeps running. Several test files in this repo already hand-roll an `ActivityListener` + `TaskCompletionSource` for this (e.g. `DnsClientTelemetryTests`).

## What

`Meziantou.Framework.Diagnostics.ScopedActivityListener` (in the `Meziantou.Framework` package) marks the current asynchronous flow with an `AsyncLocal<Guid>` and reports only the activities started by that flow — and their descendants. Disposing it unregisters the listener.

```csharp
using var listener = new ScopedActivityListener(new() { SourceNames = ["Meziantou.Framework.DnsClient"] });
await DoWorkAsync();
foreach (var activity in listener.Activities)
{
    Console.WriteLine($"{activity.OperationName}: {activity.Duration}");
}
```

New public API:

- `ScopedActivityListener` — `Id`, `IsInScope`, `Activities`, the `ActivityStarted` / `ActivityStopped` events, `GetActivitiesAsync(CancellationToken)`, `Dispose()`
- `ScopedActivityListenerOptions` — `ShouldListenTo`, `SourceNames`, `SamplingResult`, `CaptureChildActivities`, `MaxActivityCount`
- `ActivityEventArgs`

## Notes for the reviewer

- **Membership is decided when an activity starts, never when it stops.** `ActivityStopped` runs on whatever thread stops the activity — routinely a `finally` after `ConfigureAwait(false)`, an IO completion, or a `TaskCompletionSource` completer's thread — where the async-local is gone. The inverse matters too: an activity started *outside* the scope but stopped *inside* it must not be captured. The consequence, documented in the XML docs, is that an activity still running when the listener is disposed is never reported.
- **Descendants** are recovered through a set of captured `SpanId`s, checked in `Sample` as well as in `ActivityStarted`, so a child started on a flow that lost the context (explicit `parentContext`, suppressed flow) is still captured. Opt out with `CaptureChildActivities = false`.
- **Sampling side effects.** `Sample` returns `None` outside the scope; the runtime takes the strongest result across all listeners, so the scope never lowers the sampling of the rest of the application. The default in-scope result is `AllData` rather than `AllDataAndRecorded`, so the `Recorded` flag — propagated through `traceparent` and used by downstream services — is not altered. What is *not* avoidable is that `ActivitySource.HasListeners()` becomes `true` process-wide for the matching sources while the scope is alive (so `HttpClient` starts emitting `traceparent` inside the scope); this is documented, and `SourceNames` narrows it.
- Event handlers are invoked synchronously on the observed code's thread, so their exceptions are caught and a thread-static guard prevents a handler that starts its own activity from recursing.
- `GetActivitiesAsync` replays what is already captured and then streams; multiple concurrent consumers each see everything; the enumeration completes on `Dispose`. `Activities` covers the "do the work, then look at it" case without having to consume the stream.
- The tests give every test its own `ActivitySource` and restrict the listener to it, because `[Fact]` methods of a class run concurrently in this repo. The one test that needs the process-wide empty-named source (legacy `new Activity(name)`) is marked `DisableParallelization`.

## Verification

- `dotnet build src/Meziantou.Framework/Meziantou.Framework.csproj /p:TreatsWarningsAsErrors=true` — clean for net10.0 and net11.0
- `dotnet build src/Meziantou.Framework/Meziantou.Framework.csproj -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` — clean (this is the build that runs the `IDExxxx` / Release-only `CAxxxx` rules)
- 27 new tests, passing on both target frameworks (54 test cases)
- Full `Meziantou.Framework.Tests` run: 2134 passed, 16 skipped (Windows-only), 0 failed
- `dotnet run ./eng/update-all.cs` — no generated file changed
- `ref/Meziantou.Framework.cs` regenerated and committed
