### PR TITLE
Retry the WSL update against a time budget in setup-wslc

### DIFF
--- a/.github/actions/setup-wslc/action.yml
+++ b/.github/actions/setup-wslc/action.yml
@@ -9,15 +9,19 @@ runs:
       run: |
         # wslc ships inside WSL itself, and only the pre-release channel carries it (WSL 2.9.3 or higher)
         # The update service intermittently answers with a transient error (e.g. Forbidden (403),
-        # Wsl/UpdatePackage/0x80190193), so retry a few times before giving up. The service can answer with it
-        # for a minute or so while the other agents of the same run are served normally, so the attempts span
-        # roughly 65 seconds. The delay is capped as it would otherwise keep doubling.
-        $maxAttempts = 5
+        # Wsl/UpdatePackage/0x80190193). It keeps answering with it for several minutes while the other
+        # agents of the same run are served normally, so retry until the time budget below is spent instead
+        # of a fixed number of attempts. The delay is capped as it would otherwise keep doubling.
+        $timeoutSeconds = 300
         $baseDelaySeconds = 5
         $maxDelaySeconds = 30
 
-        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-          Write-Host "Updating WSL (attempt $attempt/$maxAttempts)"
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $attempt = 0
+
+        while ($true) {
+          $attempt++
+          Write-Host "Updating WSL (attempt $attempt, $([int]$stopwatch.Elapsed.TotalSeconds)s of ${timeoutSeconds}s elapsed)"
           wsl --update --pre-release
           $exitCode = $LASTEXITCODE
 
@@ -25,11 +29,11 @@ runs:
             break
           }
 
-          if ($attempt -eq $maxAttempts) {
-            throw "wsl --update --pre-release failed with exit code $exitCode"
+          $delaySeconds = [math]::Min([int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1)), $maxDelaySeconds)
+          if (($stopwatch.Elapsed.TotalSeconds + $delaySeconds) -ge $timeoutSeconds) {
+            throw "wsl --update --pre-release failed with exit code $exitCode after $attempt attempt(s) in $([int]$stopwatch.Elapsed.TotalSeconds) second(s)"
           }
 
-          $delaySeconds = [math]::Min([int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1)), $maxDelaySeconds)
           Write-Host "Retrying WSL update in $delaySeconds second(s)."
           Start-Sleep -Seconds $delaySeconds
         }


### PR DESCRIPTION
## What

`.github/actions/setup-wslc` now retries `wsl --update --pre-release` against a **time budget** (5 minutes) instead of a fixed number of attempts. The backoff is unchanged — exponential, capped at 30 seconds — which works out to roughly 12 attempts. An attempt that would overrun the budget is not started, and the step still throws once the budget is spent.

## Why

The Windows `TemporaryContainers` legs keep failing in the `Setup wslc` step, *before any build or test runs*, because the Microsoft update service refuses the download:

```
Checking for updates.

Forbidden (403).

Error code: Wsl/UpdatePackage/0x80190193
```

Most recently on [run 34187061634](https://github.com/meziantou/Meziantou.Framework/actions/runs/34187061634/job/101937546038): all 5 attempts answered 403 over ~65 seconds, and it was the only non-passing job in the run — every other leg succeeded on the same runner image.

The retry window has now been exhausted twice — 3 attempts / 15s (#2996), then 5 attempts / 65s — so the outage is not the brief blip those windows assumed. A budget expressed in time is a better fit than an attempt count for "wait out a transient service refusal", and it stops the window from needing another manual widening the next time the service is slow to recover.

## Notes for the reviewer

- The failure mode is real infrastructure flakiness, not a broken install, so the step deliberately keeps throwing when the budget runs out — a genuinely broken WSL install must still fail the job rather than silently leave the runtime absent. (The `Locate wslc.exe` step only warns, and the Wslc tests are written to fail rather than skip on CI agents.)
- The 5-minute budget is paid only on the failure path, and the job's `timeout-minutes` is 120, so there is plenty of headroom.
- Verified locally by extracting the PowerShell from the action and running it under `pwsh` against a stub `wsl`: the always-failing case backs off and throws with the attempt count and elapsed time, and the succeed-on-third-attempt case breaks out of the loop and goes on to `wsl --version`.
- `dotnet run ./eng/update-all.cs` ran clean; no generated files changed. No C# changed.