### PR TITLE
Give the XML syntax tree absolute source positions

### DIFF
--- a/ref/Meziantou.Framework.Language.Xml.cs
+++ b/ref/Meziantou.Framework.Language.Xml.cs
@@ -73,7 +73,7 @@ namespace Meziantou.Framework.Language.Xml
     {
         public string Name { get => throw null; }
         public string Value { get => throw null; }
-        public XmlAttributeSyntax(string name, string value, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlAttributeSyntax(string name, string value, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax WithName(string name) => throw null;
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax WithValue(string value) => throw null;
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax WithLeadingTrivia(System.Collections.Generic.IEnumerable<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia>? leadingTrivia) => throw null;
@@ -85,7 +85,7 @@ namespace Meziantou.Framework.Language.Xml
     public sealed class XmlCDataSectionSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode
     {
         public string Text { get => throw null; }
-        public XmlCDataSectionSyntax(string text, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlCDataSectionSyntax(string text, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlCDataSectionSyntax WithText(string text) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
         public override TResult Accept<TResult>(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor<TResult> visitor) => throw null;
@@ -94,7 +94,7 @@ namespace Meziantou.Framework.Language.Xml
     public sealed class XmlCommentSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode
     {
         public string Text { get => throw null; }
-        public XmlCommentSyntax(string text, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlCommentSyntax(string text, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlCommentSyntax WithText(string text) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
         public override TResult Accept<TResult>(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor<TResult> visitor) => throw null;
@@ -109,7 +109,7 @@ namespace Meziantou.Framework.Language.Xml
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax? VersionAttribute { get => throw null; }
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax? EncodingAttribute { get => throw null; }
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax? StandaloneAttribute { get => throw null; }
-        public XmlDeclarationSyntax(string version, string? encoding, string? standalone, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlDeclarationSyntax(string version, string? encoding, string? standalone, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlDeclarationSyntax WithVersion(string version) => throw null;
         public Meziantou.Framework.Language.Xml.XmlDeclarationSyntax WithEncoding(string? encoding) => throw null;
         public Meziantou.Framework.Language.Xml.XmlDeclarationSyntax WithStandalone(string? standalone) => throw null;
@@ -153,7 +153,7 @@ namespace Meziantou.Framework.Language.Xml
     public sealed class XmlDocumentSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode, System.Xml.XPath.IXPathNavigable
     {
         public override System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxNode> ChildNodes { get => throw null; }
-        public XmlDocumentSyntax(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxNode> childNodes, string? fullText = null) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlDocumentSyntax(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxNode> childNodes, string? fullText = null) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlDocumentSyntax WithChildNodes(System.Collections.Generic.IEnumerable<Meziantou.Framework.Language.Xml.XmlSyntaxNode> childNodes) => throw null;
         public override Meziantou.Framework.Language.Xml.XmlDocumentSyntax ReplaceNode(Meziantou.Framework.Language.Xml.XmlSyntaxNode oldNode, Meziantou.Framework.Language.Xml.XmlSyntaxNode newNode) => throw null;
         public override Meziantou.Framework.Language.Xml.XmlDocumentSyntax ReplaceToken(Meziantou.Framework.Language.Xml.XmlSyntaxToken oldToken, Meziantou.Framework.Language.Xml.XmlSyntaxToken newToken) => throw null;
@@ -178,7 +178,7 @@ namespace Meziantou.Framework.Language.Xml
     {
         public string Name { get => throw null; }
         public string? Value { get => throw null; }
-        public XmlDocumentTypeSyntax(string name, string? value, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlDocumentTypeSyntax(string name, string? value, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlDocumentTypeSyntax WithName(string name) => throw null;
         public Meziantou.Framework.Language.Xml.XmlDocumentTypeSyntax WithValue(string? value) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
@@ -194,7 +194,7 @@ namespace Meziantou.Framework.Language.Xml
         public bool IsSelfClosing { get => throw null; }
         public string StartTagText { get => throw null; }
         public override System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxNode> ChildNodes { get => throw null; }
-        public XmlElementSyntax(string name, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlAttributeSyntax> attributes, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxNode> content, Meziantou.Framework.Language.Xml.XmlEndTagSyntax? endTag, bool isSelfClosing, string fullText, string startTagText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlElementSyntax(string name, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlAttributeSyntax> attributes, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxNode> content, Meziantou.Framework.Language.Xml.XmlEndTagSyntax? endTag, bool isSelfClosing, string fullText, string startTagText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlAttributeSyntax? GetAttribute(string name) => throw null;
         public string GetInnerText() => throw null;
         public Meziantou.Framework.Language.Xml.XmlElementSyntax WithName(string name) => throw null;
@@ -211,7 +211,7 @@ namespace Meziantou.Framework.Language.Xml
     public sealed class XmlEndTagSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode
     {
         public string Name { get => throw null; }
-        public XmlEndTagSyntax(string name, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlEndTagSyntax(string name, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlEndTagSyntax WithName(string name) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
         public override TResult Accept<TResult>(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor<TResult> visitor) => throw null;
@@ -233,7 +233,7 @@ namespace Meziantou.Framework.Language.Xml
     {
         public string Target { get => throw null; }
         public string? Data { get => throw null; }
-        public XmlProcessingInstructionSyntax(string target, string? data, string fullText) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlProcessingInstructionSyntax(string target, string? data, string fullText, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlProcessingInstructionSyntax WithTarget(string target) => throw null;
         public Meziantou.Framework.Language.Xml.XmlProcessingInstructionSyntax WithData(string? data) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
@@ -243,7 +243,7 @@ namespace Meziantou.Framework.Language.Xml
     public sealed class XmlSkippedTextSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode
     {
         public string Text { get => throw null; }
-        public XmlSkippedTextSyntax(string text) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlSkippedTextSyntax(string text, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlSkippedTextSyntax WithText(string text) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
         public override TResult Accept<TResult>(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor<TResult> visitor) => throw null;
@@ -297,7 +297,7 @@ namespace Meziantou.Framework.Language.Xml
         public Meziantou.Framework.Language.Xml.TextSpan FullSpan { get => throw null; }
         public bool ContainsDiagnostics { get => throw null; }
         public bool ContainsSkippedText { get => throw null; }
-        protected XmlSyntaxNode(Meziantou.Framework.Language.Xml.XmlSyntaxKind kind, string fullText, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>? tokens = null) { }
+        protected XmlSyntaxNode(Meziantou.Framework.Language.Xml.XmlSyntaxKind kind, string fullText, int fullStart = 0, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>? tokens = null) { }
         public virtual string ToFullString() => throw null;
         public System.Collections.Generic.IEnumerable<Meziantou.Framework.Language.Xml.XmlSyntaxNodeOrToken> ChildNodesAndTokens() => throw null;
         public System.Collections.Generic.IEnumerable<Meziantou.Framework.Language.Xml.XmlSyntaxNode> DescendantNodes() => throw null;
@@ -358,9 +358,10 @@ namespace Meziantou.Framework.Language.Xml
         public string ValueText { get => throw null; }
         public bool IsMissing { get => throw null; }
         public Meziantou.Framework.Language.Xml.TextSpan Span { get => throw null; }
+        public Meziantou.Framework.Language.Xml.TextSpan FullSpan { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia> LeadingTrivia { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia> TrailingTrivia { get => throw null; }
-        public XmlSyntaxToken(Meziantou.Framework.Language.Xml.XmlSyntaxKind kind, string text, string? valueText = null, bool isMissing = false, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia>? leadingTrivia = null, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia>? trailingTrivia = null) { }
+        public XmlSyntaxToken(Meziantou.Framework.Language.Xml.XmlSyntaxKind kind, string text, string? valueText = null, bool isMissing = false, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia>? leadingTrivia = null, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia>? trailingTrivia = null, int fullStart = 0) { }
         public string ToFullString() => throw null;
         public Meziantou.Framework.Language.Xml.XmlSyntaxToken WithText(string text) => throw null;
         public Meziantou.Framework.Language.Xml.XmlSyntaxToken WithLeadingTrivia(System.Collections.Generic.IEnumerable<Meziantou.Framework.Language.Xml.XmlSyntaxTrivia>? leadingTrivia) => throw null;
@@ -387,7 +388,9 @@ namespace Meziantou.Framework.Language.Xml
     {
         public Meziantou.Framework.Language.Xml.XmlSyntaxKind Kind { get => throw null; }
         public string Text { get => throw null; }
-        public XmlSyntaxTrivia(Meziantou.Framework.Language.Xml.XmlSyntaxKind kind, string text) { }
+        public Meziantou.Framework.Language.Xml.TextSpan Span { get => throw null; }
+        public Meziantou.Framework.Language.Xml.TextSpan FullSpan { get => throw null; }
+        public XmlSyntaxTrivia(Meziantou.Framework.Language.Xml.XmlSyntaxKind kind, string text, int start = 0) { }
         public Meziantou.Framework.Language.Xml.XmlSyntaxTrivia WithText(string text) => throw null;
     }
 
@@ -435,7 +438,7 @@ namespace Meziantou.Framework.Language.Xml
     public sealed class XmlTextSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode
     {
         public string Text { get => throw null; }
-        public XmlTextSyntax(string text) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
+        public XmlTextSyntax(string text, int fullStart = 0) : base(default(Meziantou.Framework.Language.Xml.XmlSyntaxKind), default(string), default(int), default(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Language.Xml.XmlSyntaxToken>)) { }
         public Meziantou.Framework.Language.Xml.XmlTextSyntax WithText(string text) => throw null;
         public override void Accept(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor visitor) { }
         public override TResult Accept<TResult>(Meziantou.Framework.Language.Xml.XmlSyntaxVisitor<TResult> visitor) => throw null;

--- a/src/Meziantou.Framework.Language.Xml/Meziantou.Framework.Language.Xml.csproj
+++ b/src/Meziantou.Framework.Language.Xml/Meziantou.Framework.Language.Xml.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Meziantou.Framework.Language.Xml</RootNamespace>
     <Description>Immutable XML syntax tree with diagnostics, editing helpers, and XPath navigation.</Description>
     <PackageTags>xml, syntax-tree, cst, parser, xpath</PackageTags>
-    <Version>2.0.2</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Language.Xml/XmlAttributeSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlAttributeSyntax.cs
@@ -9,11 +9,24 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlAttributeSyntax : XmlSyntaxNode
 {
-    public XmlAttributeSyntax(string name, string value, string fullText)
-        : base(XmlSyntaxKind.XmlAttribute, fullText, [new XmlSyntaxToken(XmlSyntaxKind.IdentifierToken, name), new XmlSyntaxToken(XmlSyntaxKind.AttributeValueToken, value)])
+    public XmlAttributeSyntax(string name, string value, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlAttribute, fullText, fullStart, BuildTokens(name, value, fullText, fullStart))
     {
         Name = name;
         Value = value;
+    }
+
+    private static XmlSyntaxToken[] BuildTokens(string name, string value, string fullText, int fullStart)
+    {
+        // The declaration parser hands over an attribute whose text keeps the whitespace that separates it from the
+        // previous one, so the name is not always at offset 0.
+        var nameStart = GetAttributeNameStart(fullText);
+        var valueStart = TryGetAttributeValueSpan(fullText, out var valueSpan, out _) ? valueSpan.Start : 0;
+        return
+        [
+            new XmlSyntaxToken(XmlSyntaxKind.IdentifierToken, name, fullStart: fullStart + (nameStart < 0 ? 0 : nameStart)),
+            new XmlSyntaxToken(XmlSyntaxKind.AttributeValueToken, value, fullStart: fullStart + valueStart),
+        ];
     }
 
     public string Name { get; }
@@ -42,7 +55,7 @@ public sealed class XmlAttributeSyntax : XmlSyntaxNode
             builder.Append(fullText.AsSpan(0, valueSpan.Start));
             builder.Append(escapedValue);
             builder.Append(fullText.AsSpan(valueSpan.End));
-            return new XmlAttributeSyntax(Name, value, builder.ToString());
+            return new XmlAttributeSyntax(Name, value, builder.ToString(), FullSpan.Start);
         }
 
         return SyntaxFactory.Attribute(Name, value);
@@ -60,7 +73,7 @@ public sealed class XmlAttributeSyntax : XmlSyntaxNode
         if (string.Equals(updated, fullText, StringComparison.Ordinal))
             return this;
 
-        return new XmlAttributeSyntax(Name, Value, updated);
+        return new XmlAttributeSyntax(Name, Value, updated, FullSpan.Start);
     }
 
     public XmlAttributeSyntax WithTrailingTrivia(IEnumerable<XmlSyntaxTrivia>? trailingTrivia)
@@ -86,7 +99,7 @@ public sealed class XmlAttributeSyntax : XmlSyntaxNode
         if (string.Equals(updated, fullText, StringComparison.Ordinal))
             return this;
 
-        return new XmlAttributeSyntax(Name, Value, updated);
+        return new XmlAttributeSyntax(Name, Value, updated, FullSpan.Start);
     }
 
     private static bool TryGetAttributeValueSpan(string attributeText, out TextSpan span, out char quoteCharacter)

--- a/src/Meziantou.Framework.Language.Xml/XmlCDataSectionSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlCDataSectionSyntax.cs
@@ -9,11 +9,17 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlCDataSectionSyntax : XmlSyntaxNode
 {
-    public XmlCDataSectionSyntax(string text, string fullText)
-        : base(XmlSyntaxKind.XmlCDataSection, fullText, [new XmlSyntaxToken(XmlSyntaxKind.CDataToken, text)])
+    private const string OpeningDelimiter = "<![CDATA[";
+
+    public XmlCDataSectionSyntax(string text, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlCDataSection, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.CDataToken, text, fullStart: fullStart + GetTextOffset(fullText))])
     {
         Text = text;
     }
+
+    /// <summary>The offset of the section text inside <paramref name="fullText"/>, which the parser always opens with <c>&lt;![CDATA[</c>.</summary>
+    private static int GetTextOffset(string fullText)
+        => fullText.StartsWith(OpeningDelimiter, StringComparison.Ordinal) ? OpeningDelimiter.Length : 0;
 
     public string Text { get; }
 

--- a/src/Meziantou.Framework.Language.Xml/XmlCommentSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlCommentSyntax.cs
@@ -9,11 +9,17 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlCommentSyntax : XmlSyntaxNode
 {
-    public XmlCommentSyntax(string text, string fullText)
-        : base(XmlSyntaxKind.XmlComment, fullText, [new XmlSyntaxToken(XmlSyntaxKind.CommentToken, text)])
+    private const string OpeningDelimiter = "<!--";
+
+    public XmlCommentSyntax(string text, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlComment, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.CommentToken, text, fullStart: fullStart + GetTextOffset(fullText))])
     {
         Text = text;
     }
+
+    /// <summary>The offset of the comment text inside <paramref name="fullText"/>, which the parser always opens with <c>&lt;!--</c>.</summary>
+    private static int GetTextOffset(string fullText)
+        => fullText.StartsWith(OpeningDelimiter, StringComparison.Ordinal) ? OpeningDelimiter.Length : 0;
 
     public string Text { get; }
 

--- a/src/Meziantou.Framework.Language.Xml/XmlDeclarationSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlDeclarationSyntax.cs
@@ -14,13 +14,13 @@ public sealed class XmlDeclarationSyntax : XmlSyntaxNode
     private readonly IReadOnlyList<XmlSyntaxNode> _childNodes;
     private readonly List<DeclarationAttributeSegment> _attributeSegments;
 
-    public XmlDeclarationSyntax(string version, string? encoding, string? standalone, string fullText)
-        : base(XmlSyntaxKind.XmlDeclaration, fullText, [new XmlSyntaxToken(XmlSyntaxKind.DeclarationToken, fullText)])
+    public XmlDeclarationSyntax(string version, string? encoding, string? standalone, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlDeclaration, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.DeclarationToken, fullText, fullStart: fullStart)])
     {
         Version = version;
         Encoding = encoding;
         Standalone = standalone;
-        _attributeSegments = ParseAttributeSegments(fullText);
+        _attributeSegments = ParseAttributeSegments(fullText, fullStart);
         _childNodes = _attributeSegments.Select(item => (XmlSyntaxNode)item.Attribute).ToArray();
         VersionAttribute = _attributeSegments.FirstOrDefault(item => string.Equals(item.Attribute.Name, "version", StringComparison.Ordinal)).Attribute;
         EncodingAttribute = _attributeSegments.FirstOrDefault(item => string.Equals(item.Attribute.Name, "encoding", StringComparison.Ordinal)).Attribute;
@@ -129,7 +129,7 @@ public sealed class XmlDeclarationSyntax : XmlSyntaxNode
         return false;
     }
 
-    private static List<DeclarationAttributeSegment> ParseAttributeSegments(string declarationText)
+    private static List<DeclarationAttributeSegment> ParseAttributeSegments(string declarationText, int fullStart)
     {
         if (declarationText.Length == 0)
             return [];
@@ -210,7 +210,7 @@ public sealed class XmlDeclarationSyntax : XmlSyntaxNode
                 continue;
 
             var attributeText = declarationText[attributeStart..attributeEnd];
-            var attribute = new XmlAttributeSyntax(name, value, attributeText);
+            var attribute = new XmlAttributeSyntax(name, value, attributeText, fullStart + attributeStart);
             result.Add(new DeclarationAttributeSegment(attribute, TextSpan.FromBounds(attributeStart, attributeEnd)));
         }
 

--- a/src/Meziantou.Framework.Language.Xml/XmlDocumentTypeSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlDocumentTypeSyntax.cs
@@ -11,8 +11,8 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlDocumentTypeSyntax : XmlSyntaxNode
 {
-    public XmlDocumentTypeSyntax(string name, string? value, string fullText)
-        : base(XmlSyntaxKind.XmlDocumentType, fullText, [new XmlSyntaxToken(XmlSyntaxKind.DocumentTypeToken, fullText)])
+    public XmlDocumentTypeSyntax(string name, string? value, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlDocumentType, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.DocumentTypeToken, fullText, fullStart: fullStart)])
     {
         Name = name;
         Value = value;

--- a/src/Meziantou.Framework.Language.Xml/XmlElementSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlElementSyntax.cs
@@ -18,8 +18,9 @@ public sealed class XmlElementSyntax : XmlSyntaxNode
         XmlEndTagSyntax? endTag,
         bool isSelfClosing,
         string fullText,
-        string startTagText)
-        : base(isSelfClosing ? XmlSyntaxKind.XmlEmptyElement : XmlSyntaxKind.XmlElement, fullText, [new XmlSyntaxToken(XmlSyntaxKind.IdentifierToken, name, name)])
+        string startTagText,
+        int fullStart = 0)
+        : base(isSelfClosing ? XmlSyntaxKind.XmlEmptyElement : XmlSyntaxKind.XmlElement, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.IdentifierToken, name, name, fullStart: fullStart + GetNameOffset(startTagText))])
     {
         Name = name;
         Attributes = attributes ?? [];
@@ -117,7 +118,8 @@ public sealed class XmlElementSyntax : XmlSyntaxNode
             EndTag,
             isSelfClosing: false,
             StartTagText + text + endTagText,
-            StartTagText);
+            StartTagText,
+            FullSpan.Start);
     }
 
     public XmlElementSyntax WithLeadingTrivia(params ReadOnlySpan<XmlSyntaxTrivia> leadingTrivia)
@@ -163,7 +165,14 @@ public sealed class XmlElementSyntax : XmlSyntaxNode
         var endTagText = EndTag?.ToFullString() ?? string.Empty;
         var innerTextLength = ToFullString().Length - StartTagText.Length - endTagText.Length;
         var innerText = innerTextLength > 0 ? ToFullString().Substring(StartTagText.Length, innerTextLength) : string.Empty;
-        return new XmlElementSyntax(Name, Attributes, Content, EndTag, IsSelfClosing, startTagText + innerText + endTagText, startTagText);
+        return new XmlElementSyntax(Name, Attributes, Content, EndTag, IsSelfClosing, startTagText + innerText + endTagText, startTagText, FullSpan.Start);
+    }
+
+    /// <summary>The offset of the name inside the start tag, which opens with <c>&lt;</c> and may then hold whitespace.</summary>
+    private static int GetNameOffset(string startTagText)
+    {
+        var nameStart = GetElementNameStart(startTagText);
+        return nameStart < 0 ? 0 : nameStart;
     }
 
     private static int GetElementNameStart(string startTagText)

--- a/src/Meziantou.Framework.Language.Xml/XmlEndTagSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlEndTagSyntax.cs
@@ -11,10 +11,25 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlEndTagSyntax : XmlSyntaxNode
 {
-    public XmlEndTagSyntax(string name, string fullText)
-        : base(XmlSyntaxKind.XmlEndTag, fullText, [new XmlSyntaxToken(XmlSyntaxKind.IdentifierToken, name)])
+    public XmlEndTagSyntax(string name, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlEndTag, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.IdentifierToken, name, fullStart: fullStart + GetNameOffset(fullText))])
     {
         Name = name;
+    }
+
+    /// <summary>The offset of the name inside <paramref name="fullText"/>, which opens with <c>&lt;/</c> and may then hold whitespace.</summary>
+    private static int GetNameOffset(string fullText)
+    {
+        if (fullText.Length < 2 || fullText[0] != '<' || fullText[1] != '/')
+            return 0;
+
+        var current = 2;
+        while (current < fullText.Length && char.IsWhiteSpace(fullText[current]))
+        {
+            current++;
+        }
+
+        return current;
     }
 
     public string Name { get; }
@@ -25,7 +40,7 @@ public sealed class XmlEndTagSyntax : XmlSyntaxNode
         if (string.Equals(name, Name, StringComparison.Ordinal))
             return this;
 
-        return new XmlEndTagSyntax(name, $"</{name}>");
+        return new XmlEndTagSyntax(name, $"</{name}>", FullSpan.Start);
     }
 
     public override void Accept(XmlSyntaxVisitor visitor) => visitor.VisitEndTag(this);

--- a/src/Meziantou.Framework.Language.Xml/XmlProcessingInstructionSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlProcessingInstructionSyntax.cs
@@ -9,8 +9,8 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlProcessingInstructionSyntax : XmlSyntaxNode
 {
-    public XmlProcessingInstructionSyntax(string target, string? data, string fullText)
-        : base(XmlSyntaxKind.XmlProcessingInstruction, fullText, [new XmlSyntaxToken(XmlSyntaxKind.ProcessingInstructionToken, fullText)])
+    public XmlProcessingInstructionSyntax(string target, string? data, string fullText, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlProcessingInstruction, fullText, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.ProcessingInstructionToken, fullText, fullStart: fullStart)])
     {
         Target = target;
         Data = data;

--- a/src/Meziantou.Framework.Language.Xml/XmlSkippedTextSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSkippedTextSyntax.cs
@@ -9,8 +9,8 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlSkippedTextSyntax : XmlSyntaxNode
 {
-    public XmlSkippedTextSyntax(string text)
-        : base(XmlSyntaxKind.XmlSkippedText, text, [new XmlSyntaxToken(XmlSyntaxKind.SkippedTextToken, text)])
+    public XmlSkippedTextSyntax(string text, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlSkippedText, text, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.SkippedTextToken, text, fullStart: fullStart)])
     {
         Text = text;
     }
@@ -23,7 +23,7 @@ public sealed class XmlSkippedTextSyntax : XmlSyntaxNode
         if (string.Equals(text, Text, StringComparison.Ordinal))
             return this;
 
-        return new XmlSkippedTextSyntax(text);
+        return new XmlSkippedTextSyntax(text, FullSpan.Start);
     }
 
     public override void Accept(XmlSyntaxVisitor visitor) => visitor.VisitSkippedText(this);

--- a/src/Meziantou.Framework.Language.Xml/XmlSyntaxNode.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSyntaxNode.cs
@@ -14,10 +14,11 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public abstract class XmlSyntaxNode
 {
-    protected XmlSyntaxNode(XmlSyntaxKind kind, string fullText, IReadOnlyList<XmlSyntaxToken>? tokens = null)
+    protected XmlSyntaxNode(XmlSyntaxKind kind, string fullText, int fullStart = 0, IReadOnlyList<XmlSyntaxToken>? tokens = null)
     {
         Kind = kind;
         FullText = fullText ?? string.Empty;
+        FullSpan = new TextSpan(fullStart, FullText.Length);
         Tokens = tokens ?? [];
         foreach (var token in Tokens)
         {
@@ -31,8 +32,16 @@ public abstract class XmlSyntaxNode
     public IReadOnlyList<XmlSyntaxToken> Tokens { get; }
     public XmlSyntaxTree? SyntaxTree { get; internal set; }
     public XmlSyntaxNode? Parent => ParentNode;
-    public TextSpan Span => new(0, ToFullString().Length);
-    public TextSpan FullSpan => Span;
+
+    /// <summary>The absolute span of this node in the source text.</summary>
+    /// <remarks>
+    /// Equal to <see cref="FullSpan"/>. The two differ elsewhere only to exclude a node's leading and trailing
+    /// trivia, and the XML parser attaches no trivia to nodes: whitespace stays inside the node's own text.
+    /// </remarks>
+    public TextSpan Span => FullSpan;
+
+    /// <summary>The absolute span of this node in the source text, including everything it round-trips.</summary>
+    public TextSpan FullSpan { get; }
     public bool ContainsDiagnostics => SyntaxTree is not null && SyntaxTree.Diagnostics.Count > 0;
     public bool ContainsSkippedText => Kind == XmlSyntaxKind.XmlSkippedText || DescendantNodes().Any(node => node.Kind == XmlSyntaxKind.XmlSkippedText);
     internal XmlSyntaxNode? ParentNode { get; set; }
@@ -66,14 +75,14 @@ public abstract class XmlSyntaxNode
 
     public IEnumerable<XmlSyntaxNodeOrToken> DescendantNodesAndTokens()
     {
+        foreach (var token in Tokens)
+        {
+            yield return new XmlSyntaxNodeOrToken(token);
+        }
+
         foreach (var child in ChildNodes)
         {
             yield return new XmlSyntaxNodeOrToken(child);
-            foreach (var token in child.Tokens)
-            {
-                yield return new XmlSyntaxNodeOrToken(token);
-            }
-
             foreach (var descendant in child.DescendantNodesAndTokens())
             {
                 yield return descendant;
@@ -103,13 +112,13 @@ public abstract class XmlSyntaxNode
 
     public IEnumerable<XmlSyntaxToken> DescendantTokens()
     {
+        foreach (var token in Tokens)
+        {
+            yield return token;
+        }
+
         foreach (var child in ChildNodes)
         {
-            foreach (var token in child.Tokens)
-            {
-                yield return token;
-            }
-
             foreach (var token in child.DescendantTokens())
             {
                 yield return token;

--- a/src/Meziantou.Framework.Language.Xml/XmlSyntaxToken.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSyntaxToken.cs
@@ -18,7 +18,8 @@ public sealed class XmlSyntaxToken
         string? valueText = null,
         bool isMissing = false,
         IReadOnlyList<XmlSyntaxTrivia>? leadingTrivia = null,
-        IReadOnlyList<XmlSyntaxTrivia>? trailingTrivia = null)
+        IReadOnlyList<XmlSyntaxTrivia>? trailingTrivia = null,
+        int fullStart = 0)
     {
         Kind = kind;
         Text = text ?? string.Empty;
@@ -26,13 +27,18 @@ public sealed class XmlSyntaxToken
         IsMissing = isMissing;
         LeadingTrivia = leadingTrivia ?? [];
         TrailingTrivia = trailingTrivia ?? [];
+
+        var leadingLength = SumTextLength(LeadingTrivia);
+        Span = new TextSpan(fullStart + leadingLength, Text.Length);
+        FullSpan = new TextSpan(fullStart, leadingLength + Text.Length + SumTextLength(TrailingTrivia));
     }
 
     public XmlSyntaxKind Kind { get; }
     public string Text { get; }
     public string ValueText { get; }
     public bool IsMissing { get; }
-    public TextSpan Span => new(0, Text.Length);
+    public TextSpan Span { get; }
+    public TextSpan FullSpan { get; }
     public IReadOnlyList<XmlSyntaxTrivia> LeadingTrivia { get; }
     public IReadOnlyList<XmlSyntaxTrivia> TrailingTrivia { get; }
     internal XmlSyntaxNode? Parent { get; set; }
@@ -58,7 +64,7 @@ public sealed class XmlSyntaxToken
         return buffer.ToString();
     }
 
-    public XmlSyntaxToken WithText(string text) => new(Kind, text, valueText: null, IsMissing, LeadingTrivia, TrailingTrivia);
+    public XmlSyntaxToken WithText(string text) => new(Kind, text, valueText: null, IsMissing, LeadingTrivia, TrailingTrivia, FullSpan.Start);
 
     public XmlSyntaxToken WithLeadingTrivia(IEnumerable<XmlSyntaxTrivia>? leadingTrivia)
     {
@@ -66,7 +72,7 @@ public sealed class XmlSyntaxToken
         if (trivia.SequenceEqual(LeadingTrivia))
             return this;
 
-        return new XmlSyntaxToken(Kind, Text, ValueText, IsMissing, trivia, TrailingTrivia);
+        return new XmlSyntaxToken(Kind, Text, ValueText, IsMissing, trivia, TrailingTrivia, FullSpan.Start);
     }
 
     public XmlSyntaxToken WithTrailingTrivia(IEnumerable<XmlSyntaxTrivia>? trailingTrivia)
@@ -75,6 +81,17 @@ public sealed class XmlSyntaxToken
         if (trivia.SequenceEqual(TrailingTrivia))
             return this;
 
-        return new XmlSyntaxToken(Kind, Text, ValueText, IsMissing, LeadingTrivia, trivia);
+        return new XmlSyntaxToken(Kind, Text, ValueText, IsMissing, LeadingTrivia, trivia, FullSpan.Start);
+    }
+
+    private static int SumTextLength(IReadOnlyList<XmlSyntaxTrivia> trivia)
+    {
+        var length = 0;
+        foreach (var item in trivia)
+        {
+            length += item.Text.Length;
+        }
+
+        return length;
     }
 }

--- a/src/Meziantou.Framework.Language.Xml/XmlSyntaxTree.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSyntaxTree.cs
@@ -181,7 +181,8 @@ public sealed class XmlSyntaxTree
                     endTag: null,
                     isSelfClosing: false,
                     fullText,
-                    unclosedElement.StartTagText);
+                    unclosedElement.StartTagText,
+                    unclosedElement.Start);
 
                 AddNode(element);
             }
@@ -204,7 +205,7 @@ public sealed class XmlSyntaxTree
             var text = _text[start.._position];
             if (text.Length > 0)
             {
-                AddNode(new XmlTextSyntax(text));
+                AddNode(new XmlTextSyntax(text, start));
             }
         }
 
@@ -217,14 +218,14 @@ public sealed class XmlSyntaxTree
             {
                 AddDiagnostic(start, _text.Length - start, "XML0008", "Unterminated XML comment.");
                 var raw = _text[start..];
-                AddNode(new XmlCommentSyntax(raw.Length >= 4 ? raw[4..] : string.Empty, raw));
+                AddNode(new XmlCommentSyntax(raw.Length >= 4 ? raw[4..] : string.Empty, raw, start));
                 _position = _text.Length;
                 return;
             }
 
             var rawComment = _text[start..(end + 3)];
             var innerText = rawComment[4..^3];
-            AddNode(new XmlCommentSyntax(innerText, rawComment));
+            AddNode(new XmlCommentSyntax(innerText, rawComment, start));
             _position = end + 3;
         }
 
@@ -237,14 +238,14 @@ public sealed class XmlSyntaxTree
             {
                 AddDiagnostic(start, _text.Length - start, "XML0009", "Unterminated CDATA section.");
                 var raw = _text[start..];
-                AddNode(new XmlCDataSectionSyntax(raw.Length >= 9 ? raw[9..] : string.Empty, raw));
+                AddNode(new XmlCDataSectionSyntax(raw.Length >= 9 ? raw[9..] : string.Empty, raw, start));
                 _position = _text.Length;
                 return;
             }
 
             var rawCData = _text[start..(end + 3)];
             var innerText = rawCData[9..^3];
-            AddNode(new XmlCDataSectionSyntax(innerText, rawCData));
+            AddNode(new XmlCDataSectionSyntax(innerText, rawCData, start));
             _position = end + 3;
         }
 
@@ -257,7 +258,7 @@ public sealed class XmlSyntaxTree
             {
                 AddDiagnostic(start, _text.Length - start, "XML0007", "Unterminated XML declaration.");
                 var raw = _text[start..];
-                AddNode(new XmlSkippedTextSyntax(raw));
+                AddNode(new XmlSkippedTextSyntax(raw, start));
                 _position = _text.Length;
                 return;
             }
@@ -268,7 +269,7 @@ public sealed class XmlSyntaxTree
             attributes.TryGetValue("version", out var version);
             attributes.TryGetValue("encoding", out var encoding);
             attributes.TryGetValue("standalone", out var standalone);
-            AddNode(new XmlDeclarationSyntax(version ?? "1.0", encoding, standalone, rawDeclaration));
+            AddNode(new XmlDeclarationSyntax(version ?? "1.0", encoding, standalone, rawDeclaration, start));
             _position = end + 2;
         }
 
@@ -281,7 +282,7 @@ public sealed class XmlSyntaxTree
             {
                 AddDiagnostic(start, _text.Length - start, "XML0012", "Unterminated processing instruction.");
                 var raw = _text[start..];
-                AddNode(new XmlSkippedTextSyntax(raw));
+                AddNode(new XmlSkippedTextSyntax(raw, start));
                 _position = _text.Length;
                 return;
             }
@@ -302,7 +303,7 @@ public sealed class XmlSyntaxTree
                 data = inner[(firstSpaceIndex + 1)..].Trim();
             }
 
-            AddNode(new XmlProcessingInstructionSyntax(target, data, rawInstruction));
+            AddNode(new XmlProcessingInstructionSyntax(target, data, rawInstruction, start));
             _position = end + 2;
         }
 
@@ -355,7 +356,7 @@ public sealed class XmlSyntaxTree
 
             var value = raw.Length > 9 ? raw[9..^1].Trim() : string.Empty;
             var name = value.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
-            AddNode(new XmlDocumentTypeSyntax(name, value, raw));
+            AddNode(new XmlDocumentTypeSyntax(name, value, raw, start));
         }
 
         private void ParseEndTag()
@@ -382,7 +383,7 @@ public sealed class XmlSyntaxTree
             if (_elementStack.Count == 0)
             {
                 AddDiagnostic(start, rawEndTag.Length, "XML0002", $"Unexpected end tag '{name}'.");
-                AddNode(new XmlSkippedTextSyntax(rawEndTag));
+                AddNode(new XmlSkippedTextSyntax(rawEndTag, start));
                 return;
             }
 
@@ -390,7 +391,7 @@ public sealed class XmlSyntaxTree
             if (string.Equals(top.Name, name, StringComparison.Ordinal))
             {
                 _ = _elementStack.Pop();
-                var endTag = new XmlEndTagSyntax(name, rawEndTag);
+                var endTag = new XmlEndTagSyntax(name, rawEndTag, start);
                 var fullText = _text[top.Start.._position];
                 var element = new XmlElementSyntax(
                     top.Name,
@@ -399,14 +400,15 @@ public sealed class XmlSyntaxTree
                     endTag,
                     isSelfClosing: false,
                     fullText,
-                    top.StartTagText);
+                    top.StartTagText,
+                    top.Start);
 
                 AddNode(element);
                 return;
             }
 
             AddDiagnostic(start, rawEndTag.Length, "XML0002", $"Mismatched end tag '{name}'.");
-            AddNode(new XmlSkippedTextSyntax(rawEndTag));
+            AddNode(new XmlSkippedTextSyntax(rawEndTag, start));
         }
 
         private void ParseElementOrSkippedText()
@@ -491,13 +493,13 @@ public sealed class XmlSyntaxTree
                 }
 
                 var rawAttribute = _text[attributeStart.._position];
-                attributes.Add(new XmlAttributeSyntax(attributeName, attributeValue, rawAttribute));
+                attributes.Add(new XmlAttributeSyntax(attributeName, attributeValue, rawAttribute, attributeStart));
             }
 
             var startTagText = _text[start.._position];
             if (isSelfClosing)
             {
-                AddNode(new XmlElementSyntax(name, attributes, [], endTag: null, isSelfClosing: true, startTagText, startTagText));
+                AddNode(new XmlElementSyntax(name, attributes, [], endTag: null, isSelfClosing: true, startTagText, startTagText, start));
                 return;
             }
 
@@ -516,7 +518,7 @@ public sealed class XmlSyntaxTree
 
             var raw = _text[start.._position];
             AddDiagnostic(start, raw.Length, "XML0010", message);
-            AddNode(new XmlSkippedTextSyntax(raw));
+            AddNode(new XmlSkippedTextSyntax(raw, start));
         }
 
         private void AddNode(XmlSyntaxNode node)

--- a/src/Meziantou.Framework.Language.Xml/XmlSyntaxTrivia.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSyntaxTrivia.cs
@@ -6,14 +6,24 @@ namespace Meziantou.Framework.Language.Xml;
 [DebuggerDisplay("{Kind}: '{Text}'")]
 public sealed class XmlSyntaxTrivia
 {
-    public XmlSyntaxTrivia(XmlSyntaxKind kind, string text)
+    public XmlSyntaxTrivia(XmlSyntaxKind kind, string text, int start = 0)
     {
         Kind = kind;
         Text = text ?? string.Empty;
+        Span = new TextSpan(start, Text.Length);
     }
 
     public XmlSyntaxKind Kind { get; }
     public string Text { get; }
 
-    public XmlSyntaxTrivia WithText(string text) => new(Kind, text);
+    /// <summary>The absolute span of this trivia in the source text.</summary>
+    /// <remarks>
+    /// The XML parser never produces trivia: whitespace stays inside the text of the node that contains it. So this
+    /// span is meaningful only for trivia built explicitly, and reads <c>[0..length)</c> on a parsed tree.
+    /// </remarks>
+    public TextSpan Span { get; }
+
+    public TextSpan FullSpan => Span;
+
+    public XmlSyntaxTrivia WithText(string text) => new(Kind, text, Span.Start);
 }

--- a/src/Meziantou.Framework.Language.Xml/XmlTextSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlTextSyntax.cs
@@ -9,8 +9,8 @@ namespace Meziantou.Framework.Language.Xml;
 /// </example>
 public sealed class XmlTextSyntax : XmlSyntaxNode
 {
-    public XmlTextSyntax(string text)
-        : base(XmlSyntaxKind.XmlText, text, [new XmlSyntaxToken(XmlSyntaxKind.TextToken, text)])
+    public XmlTextSyntax(string text, int fullStart = 0)
+        : base(XmlSyntaxKind.XmlText, text, fullStart, [new XmlSyntaxToken(XmlSyntaxKind.TextToken, text, fullStart: fullStart)])
     {
         Text = text;
     }
@@ -23,7 +23,7 @@ public sealed class XmlTextSyntax : XmlSyntaxNode
         if (string.Equals(text, Text, StringComparison.Ordinal))
             return this;
 
-        return new XmlTextSyntax(text);
+        return new XmlTextSyntax(text, FullSpan.Start);
     }
 
     public override void Accept(XmlSyntaxVisitor visitor) => visitor.VisitText(this);

--- a/src/Meziantou.Framework.Language.Xml/readme.md
+++ b/src/Meziantou.Framework.Language.Xml/readme.md
@@ -8,6 +8,7 @@
 - save back while preserving untouched text and formatting
 - support for XML namespaces in queries and edits
 - support invalid XML documents (for example with unclosed tags) and report diagnostics
+- report the absolute source position of every node and token through `Span` / `FullSpan`
 
 ```csharp
 using System.Xml;

--- a/tests/Meziantou.Framework.Language.Xml.Tests/XmlSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Language.Xml.Tests/XmlSyntaxTreeTests.cs
@@ -511,6 +511,162 @@ public sealed class XmlSyntaxTreeTests
         Assert.Contains(nonNamespacedAttributes, attribute => attribute.Name == "flag" && attribute.Value == "local");
     }
 
+    [Theory]
+    [MemberData(nameof(RoundTripSamples))]
+    public void ParseText_EveryNodeSpanSlicesBackToItsOwnText(string text)
+    {
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        foreach (var node in tree.Root.DescendantNodes())
+        {
+            Assert.Equal(node.ToFullString(), text.Substring(node.Span.Start, node.Span.Length));
+            Assert.Equal(node.Span, node.FullSpan);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RoundTripSamples))]
+    public void ParseText_EveryTokenSpanSlicesBackToItsOwnText(string text)
+    {
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        foreach (var token in tree.Root.DescendantTokens())
+        {
+            Assert.Equal(token.Text, text.Substring(token.Span.Start, token.Span.Length));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RoundTripSamples))]
+    public void ParseText_ChildSpansAreContainedInTheirParentSpan(string text)
+    {
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        foreach (var node in tree.Root.DescendantNodes())
+        {
+            var parent = node.Parent;
+            if (parent is null || parent is XmlDocumentSyntax)
+                continue;
+
+            Assert.True(node.Span.Start >= parent.Span.Start, $"{node.Kind} starts before its {parent.Kind} parent");
+            Assert.True(node.Span.End <= parent.Span.End, $"{node.Kind} ends after its {parent.Kind} parent");
+        }
+    }
+
+    [Fact]
+    public void ParseText_NodesCarryAbsoluteSourcePositions()
+    {
+        const string Text = "<?xml version=\"1.0\"?><root attr=\"value\"><child>sample</child><!--c--><![CDATA[data]]></root>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+
+        Assert.Equal(new TextSpan(0, Text.Length), tree.Root.Span);
+
+        var declaration = Assert.IsType<XmlDeclarationSyntax>(tree.Root.ChildNodes[0]);
+        Assert.Equal(0, declaration.Span.Start);
+        Assert.Equal("<?xml version=\"1.0\"?>".Length, declaration.Span.Length);
+
+        var root = Assert.IsType<XmlElementSyntax>(tree.Root.ChildNodes[1]);
+        Assert.Equal(Text.IndexOf("<root", StringComparison.Ordinal), root.Span.Start);
+
+        var attribute = Assert.Single(root.Attributes);
+        Assert.Equal(Text.IndexOf("attr=", StringComparison.Ordinal), attribute.Span.Start);
+
+        var child = Assert.IsType<XmlElementSyntax>(root.Content[0]);
+        Assert.Equal(Text.IndexOf("<child>", StringComparison.Ordinal), child.Span.Start);
+
+        var comment = Assert.IsType<XmlCommentSyntax>(root.Content[1]);
+        Assert.Equal(Text.IndexOf("<!--c-->", StringComparison.Ordinal), comment.Span.Start);
+
+        var cdata = Assert.IsType<XmlCDataSectionSyntax>(root.Content[2]);
+        Assert.Equal(Text.IndexOf("<![CDATA[", StringComparison.Ordinal), cdata.Span.Start);
+
+        var endTag = Assert.IsType<XmlEndTagSyntax>(root.ChildNodes[^1]);
+        Assert.Equal(Text.IndexOf("</root>", StringComparison.Ordinal), endTag.Span.Start);
+    }
+
+    [Fact]
+    public void ParseText_TokensCarryAbsoluteSourcePositions()
+    {
+        const string Text = "<root attr=\"value\"><!--note--><![CDATA[data]]>text</root>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+        var root = Assert.IsType<XmlElementSyntax>(tree.Root.ChildNodes[0]);
+
+        var nameToken = Assert.Single(root.Tokens);
+        Assert.Equal(Text.IndexOf("root", StringComparison.Ordinal), nameToken.Span.Start);
+        Assert.Equal(nameToken.Span, nameToken.FullSpan);
+
+        var attribute = Assert.Single(root.Attributes);
+        Assert.Equal(Text.IndexOf("attr", StringComparison.Ordinal), attribute.Tokens[0].Span.Start);
+        Assert.Equal(Text.IndexOf("value", StringComparison.Ordinal), attribute.Tokens[1].Span.Start);
+
+        var comment = Assert.IsType<XmlCommentSyntax>(root.Content[0]);
+        Assert.Equal(Text.IndexOf("note", StringComparison.Ordinal), Assert.Single(comment.Tokens).Span.Start);
+
+        var cdata = Assert.IsType<XmlCDataSectionSyntax>(root.Content[1]);
+        Assert.Equal(Text.IndexOf("data", StringComparison.Ordinal), Assert.Single(cdata.Tokens).Span.Start);
+
+        var text = Assert.IsType<XmlTextSyntax>(root.Content[2]);
+        Assert.Equal(Text.IndexOf("text", StringComparison.Ordinal), Assert.Single(text.Tokens).Span.Start);
+    }
+
+    [Fact]
+    public void ParseText_DeclarationPseudoAttributesCarryAbsoluteSourcePositions()
+    {
+        const string Text = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<root />";
+        var tree = XmlSyntaxTree.ParseText(Text);
+        var declaration = Assert.IsType<XmlDeclarationSyntax>(tree.Root.ChildNodes[0]);
+
+        var version = Assert.IsType<XmlAttributeSyntax>(declaration.VersionAttribute);
+        Assert.Equal(version.ToFullString(), Text.Substring(version.Span.Start, version.Span.Length));
+        Assert.Equal(Text.IndexOf("version", StringComparison.Ordinal), version.Tokens[0].Span.Start);
+        Assert.Equal(Text.IndexOf("1.0", StringComparison.Ordinal), version.Tokens[1].Span.Start);
+
+        var encoding = Assert.IsType<XmlAttributeSyntax>(declaration.EncodingAttribute);
+        Assert.Equal(encoding.ToFullString(), Text.Substring(encoding.Span.Start, encoding.Span.Length));
+        Assert.Equal(Text.IndexOf("encoding", StringComparison.Ordinal), encoding.Tokens[0].Span.Start);
+    }
+
+    [Fact]
+    public void ParseText_SkippedTextCarriesAbsoluteSourcePositions()
+    {
+        const string Text = "<root/></unexpected>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+
+        var skipped = Assert.IsType<XmlSkippedTextSyntax>(tree.Root.ChildNodes[1]);
+        Assert.Equal(Text.IndexOf("</unexpected>", StringComparison.Ordinal), skipped.Span.Start);
+        Assert.Equal("</unexpected>", Text.Substring(skipped.Span.Start, skipped.Span.Length));
+    }
+
+    [Fact]
+    public void ParseText_DiagnosticSpanMatchesTheNodeItReportsOn()
+    {
+        const string Text = "<a/><root><child/>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+
+        var diagnostic = Assert.Single(tree.Diagnostics, item => item.Id == "XML0001");
+        var element = tree.Root.DescendantNodes().OfType<XmlElementSyntax>().Single(item => item.Name == "root");
+        Assert.Equal(element.Span, diagnostic.Span);
+        Assert.Equal(Text.IndexOf("<root>", StringComparison.Ordinal), diagnostic.Span.Start);
+    }
+
+    [Fact]
+    public void DescendantTokens_IncludesTheTokensOfTheNodeItself()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root/>");
+        var root = Assert.IsType<XmlElementSyntax>(tree.Root.ChildNodes[0]);
+
+        Assert.Equal(["root"], root.DescendantTokens().Select(token => token.Text));
+    }
+
+    [Fact]
+    public void SyntaxFactory_BuiltNodesAreAnchoredAtZero()
+    {
+        var element = SyntaxFactory.Element("item", [SyntaxFactory.Attribute("id", "1")], [], isSelfClosing: true);
+
+        Assert.Equal(0, element.Span.Start);
+        Assert.Equal(element.ToFullString().Length, element.Span.Length);
+    }
+
     private static XmlNamespaceManager CreateNamespaceManager()
     {
         var namespaceManager = new XmlNamespaceManager(new NameTable());


### PR DESCRIPTION
**Stack 2 of 3** — based on #3017. #3019 builds on this.

Of the four `Language.*` libraries, XML was the only one reporting no source positions:

- `XmlSyntaxNode.Span` was `new(0, ToFullString().Length)` and `FullSpan` returned it, so every node started at 0 — and `Span` re-materialized the whole subtree text on each access.
- `XmlSyntaxToken.Span` was `new(0, Text.Length)`, and there was no `FullSpan` at all.
- `XmlSyntaxTrivia` had only `Kind` and `Text` — no span.

Only `XmlDiagnostic.Span` ever carried real offsets, so a diagnostic could not be related back to the node it reported on, and a caller could not build an `XmlTextChange` from a node.

## What changed

A `fullStart` is threaded through `XmlSyntaxNode`, `XmlSyntaxToken` (which gains `FullSpan`), `XmlSyntaxTrivia` (gains `Span`/`FullSpan`), the eleven concrete node types, and the parser — which already held the offset in a local at every one of its ~19 construction sites, so that part is nearly free.

Because XML nodes build their tokens inline from a substring of their own text — the reverse of the JSON library, where a node derives its start *from* its first token — each node also has to position its tokens: element and end-tag names through the existing name-start helpers, comment and CDATA text after their fixed delimiters, and the declaration's pseudo-attributes through `ParseAttributeSegments`.

## Three points worth a reviewer's attention

- **`XmlSyntaxNode.Span` returns `FullSpan`** rather than copying `JsonSyntaxNode`'s min/max over descendant tokens. An element's first token is its *name*, so that formula would report the element as starting after the `<`. The two spans differ elsewhere only to exclude trivia, and the XML parser attaches none to nodes. It also stops `Span` being O(subtree).
- **`DescendantTokens()` and `DescendantNodesAndTokens()` were fixed** to yield the node's own tokens. Both only ever walked the *children's*, so a leaf's own token was invisible to them and `DescendantTrivia()` inherited the hole. Independent bug, but the new `Span` work sits right on top of it.
- **The editing paths are deliberately untouched.** `ReplaceNode` / `ReplaceToken` / `ReplaceTrivia` keep their `IndexOf` searches, because trivia built by `SyntaxFactory` is anchored at 0 and `ReplaceTrivia` would regress. Collapsing that ~100 lines onto the new spans — which is what `JsonDocumentSyntax` does — is worth its own change.

The declaration's private `DeclarationAttributeSegment.Span` and `XmlAttributeSyntax.TryGetAttributeValueSpan` stay **relative**: they are splice offsets into the node's own text, and conflating them with the new absolute ones is the easiest mistake to make here.

## Still out of scope

The XML parser produces **no trivia at all** — `new XmlSyntaxTrivia` appears nowhere in the library, and whitespace stays inside the text of the node that contains it. `XmlSyntaxTrivia.Span` is added for API parity with the other three libraries but reads 0 on any parsed tree. Teaching the parser to lex whitespace into trivia is a redesign of the text-based node model.

## Verification

Breaking (optional parameters on public constructors change binary compatibility, and `Span` changes meaning), so the package goes **2.0.2 → 3.0.0**, and `ref/` was regenerated with `-c Release /p:IsOfficialBuild=true`.

`dotnet build eng/build.proj /p:TreatWarningsAsErrors=true` succeeded with 0 warnings. On this branch alone: `Language.Xml` **112 tests, 0 failed** and `Language.Regex` **1140, 0 failed**.

Of those 112, **40 are the pre-existing tests, unchanged** — that they still pass is the evidence the editing paths did not regress, since none of them assert on spans. The 72 new ones assert that every node's span slices back to its own text, that a child's span sits inside its parent's, that elements, attributes, comments, CDATA, declarations and skipped text land at the right offsets, that a diagnostic's span now equals the span of the node it reports on, and that `SyntaxFactory`-built nodes stay anchored at 0.
