### PR TITLE
Retry transient HTTP failures in the dependency updater

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../../common/SharedHttpClient.cs" Link="SharedHttpClient.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NuGet.Configuration" Version="7.9.0" />
     <PackageReference Include="NuGet.Protocol" Version="7.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
@@ -13,7 +13,6 @@ internal sealed class DockerPackageUpdater : PackageUpdater
     // registries that already return everything keep doing so.
     private const int MaxPages = 100;
 
-    private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = DockerVersioningStrategy.Instance;
 
     protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.DockerImage && dependency.Name is not null;
@@ -122,7 +121,7 @@ internal sealed class DockerPackageUpdater : PackageUpdater
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         }
 
-        return await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        return await SharedHttpClient.Instance.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<List<string>> ReadTagsAsync(HttpResponseMessage response, CancellationToken cancellationToken)
@@ -162,7 +161,7 @@ internal sealed class DockerPackageUpdater : PackageUpdater
         }
 
         var tokenUri = BuildTokenUri(realm, service, scope);
-        using var tokenResponse = await HttpClient.GetAsync(tokenUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        using var tokenResponse = await SharedHttpClient.Instance.GetAsync(tokenUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         tokenResponse.EnsureSuccessStatusCode();
 
         await using var tokenStream = await tokenResponse.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DotNetSdkUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DotNetSdkUpdater.cs
@@ -6,13 +6,12 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal sealed class DotNetSdkUpdater : PackageUpdater
 {
-    private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = SemanticVersioningStrategy.Strict;
 
     protected override async IAsyncEnumerable<PackageVersion> GetVersionsAsync(Dependency dependency, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Only get latest SDK
-        var index = await HttpClient.GetFromJsonAsync<DotNetReleaseIndex>("https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases-index.json", cancellationToken).ConfigureAwait(false);
+        var index = await SharedHttpClient.Instance.GetFromJsonAsync<DotNetReleaseIndex>("https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases-index.json", cancellationToken).ConfigureAwait(false);
         if (index?.Releases is null)
         {
             yield break;

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
@@ -14,7 +14,6 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
     // newest release can sit behind the Link header rather than in the first response.
     private const int MaxPages = 10;
 
-    private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = GitHubActionsVersioningStrategy.Instance;
 
     protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.GitHubActions && dependency.Name is not null;
@@ -100,7 +99,7 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
         try
         {
             using var request = CreateTagsRequest(uri);
-            using var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            using var response = await SharedHttpClient.Instance.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.TooManyRequests)
             {
                 // Without this the caller cannot tell "rate limited" from "no newer tag exists"

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
@@ -8,8 +8,6 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal sealed class NpmPackageUpdater : PackageUpdater
 {
-    private static readonly HttpClient HttpClient = new();
-
     public override VersioningStrategy VersioningStrategy { get; set; } = NpmVersioningStrategy.Instance;
 
     protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.Npm && dependency.Name is not null;
@@ -30,7 +28,7 @@ internal sealed class NpmPackageUpdater : PackageUpdater
     private static async IAsyncEnumerable<PackageVersion> GetVersionsFromRegistryWithMetadataAsync(Uri registryUri, string packageName, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var packageUri = new Uri(registryUri, packageName);
-        using var packageResponse = await HttpClient.GetAsync(packageUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        using var packageResponse = await SharedHttpClient.Instance.GetAsync(packageUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (packageResponse.StatusCode is System.Net.HttpStatusCode.NotFound or System.Net.HttpStatusCode.BadRequest)
             yield break;
 


### PR DESCRIPTION
## What

The four HTTP-based updaters in `Meziantou.Framework.DependencyScanning.Tool` (DotNetSdk, GitHubActions, Docker, Npm) each held their own bare `private static readonly HttpClient HttpClient = new()`. They now use the shared `common/SharedHttpClient.cs`, which the tool project compiles in the same way `Meziantou.Framework.NuGetPackageValidation` already does.

## Why

CI went red on [run 34257060043](https://github.com/meziantou/Meziantou.Framework/actions/runs/34257060043/job/102165745583) — `build_and_test (windows-2025-vs2026, Debug, shard-1)`, 1 failure out of 432:

```
failed Meziantou.Framework.DependencyScanning.Tool.Tests.FunctionalTests.UpdateDotNetSdk (net10.0)
  Unable to update DotNetSdk:@8.0.404:...\global.json: The SSL connection could not be established
  0 dependencies updated, 1 failed  ->  exit code 1, Assert.Equal(0, result) failed
```

The same test passed on net11.0 in that same job, so this was a one-off TLS handshake failure against `raw.githubusercontent.com`. With no retry anywhere, a single network blip both fails the CLI for real users (a dependency is reported as impossible to update) and turns CI red.

`SharedHttpClient`'s `HttpRetryMessageHandler` retries up to 5 attempts on `HttpRequestException` — exactly the failure seen here — plus 5xx/408/429, honours `Retry-After`, and sets `PooledConnectionLifetime`/`PooledConnectionIdleTimeout` on a `SocketsHttpHandler`.

## Notes for the reviewer

- **429 is now retried** for GitHub Actions lookups. GitHub returns 403 for the primary rate limit, which is not retried and still produces the updater's existing "set GITHUB_TOKEN" message; the secondary limit sends `Retry-After`, which the shared handler honours. This seemed better than diverging from the repo-wide shared policy.
- **The four updaters now share one connection pool** instead of four. None of them set client-level state — every header is set per request — so nothing collides.
- **No new test coverage.** `HttpRetryMessageHandler` is a private nested class in the shared file, so its retry behavior is not reachable from a test without refactoring, and no existing test covers it either. This change is verified only by the existing tests still passing. If pinning the retry logic down is worth it, the handler would need to be made internal with an injectable delay so a test project including the file could drive it with a stub inner handler — happy to do that separately.

## Verification

- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests` -> 196/196 passed (98 per TFM)
- `dotnet build tests/Meziantou.Framework.DependencyScanning.Tool.Tests -c Release /p:IsOfficialBuild=true /p:TreatWarningsAsErrors=true` -> succeeded, no analyzer diagnostics
- `dotnet run ./eng/update-all.cs` -> exit 0, no generated files changed