### PR TITLE
Stop DNS filter regex rules from spuriously reporting a non-match

### DIFF
--- a/src/Meziantou.Framework.DnsFilter/DnsFilterListReader.cs
+++ b/src/Meziantou.Framework.DnsFilter/DnsFilterListReader.cs
@@ -16,7 +16,10 @@ namespace Meziantou.Framework.DnsFilter;
 /// </remarks>
 public static class DnsFilterListReader
 {
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
+    // Only the backtracking fallback needs a deadline; NonBacktracking is bounded by construction.
+    // This is a wall-clock budget, so it must stay well above any plausible thread stall: a match
+    // that costs microseconds of CPU still fails if the thread is descheduled past the deadline.
+    private static readonly TimeSpan BacktrackingRegexTimeout = TimeSpan.FromSeconds(2);
 
     private static readonly string[] LocalhostNames =
     [
@@ -645,11 +648,15 @@ public static class DnsFilterListReader
     private static Regex? TryCreateRegex(string pattern)
     {
         // NonBacktracking guarantees linear-time matching, which is what makes a hostile pattern in
-        // a third-party list harmless. Not every construct is supported, so fall back to the
-        // backtracking engine (still bounded by the match timeout) when it is not.
+        // a third-party list harmless. The timeout is explicitly infinite there: the engine is
+        // already bounded by the input length, and a wall-clock deadline only adds a way for a match
+        // to spuriously report a non-match when the thread is descheduled mid-match. Passing it
+        // explicitly also pins the behaviour against a host that sets REGEX_DEFAULT_MATCH_TIMEOUT.
+        // Not every construct is supported, so fall back to the backtracking engine, where a
+        // timeout is the only bound.
         try
         {
-            return new Regex(pattern, RegexOptions.NonBacktracking | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+            return new Regex(pattern, RegexOptions.NonBacktracking | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, Regex.InfiniteMatchTimeout);
         }
         catch (NotSupportedException)
         {
@@ -661,7 +668,7 @@ public static class DnsFilterListReader
 
         try
         {
-            return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+            return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, BacktrackingRegexTimeout);
         }
         catch (ArgumentException)
         {


### PR DESCRIPTION
Fixes the flaky `build_and_test (windows-2025-vs2026, Debug, Dns)` job seen in [run 34257044734](https://github.com/meziantou/Meziantou.Framework/actions/runs/34257044734/job/102180044804).

## The failure

One test out of 874 failed, on net11.0 only (net10.0 passed in the same run):

```
failed Meziantou.Framework.DnsFilter.Tests.DnsFilterEngineTests.Evaluate_RegexPattern_Matches
  Assert.True() assertion failed.
  Expression: matchResult.IsMatched
  Expected: true
  Actual:   false
```

That test is fully deterministic — it builds a rule set from `/ads[0-9]+\.example\.com/` and evaluates `ads123.example.com`. No I/O, no timing, no shared state.

## Root cause

`DnsFilterEngine.MatchesPattern` deliberately swallows `RegexMatchTimeoutException` and reports a non-match, so a pathological pattern in a third-party list cannot take the resolver down. Every compiled rule carried a 100 ms match timeout. That is the only non-deterministic route to `IsMatched == false`.

The timeout is a **wall-clock** budget, not a CPU budget. I confirmed the deadline is checked even for this tiny input — with a 1-tick timeout, both engines throw for this exact pattern and input:

```
IgnoreCase, CultureInvariant, NonBacktracking: TIMEOUT
IgnoreCase, CultureInvariant: TIMEOUT
```

So a match costing microseconds of CPU still fails if the thread is descheduled past the deadline. That leg runs 8 test assemblies in parallel, including DNS server integration tests spinning up hosts and sockets, where a >100 ms stall from a GC pause, thread starvation or VM steal is entirely ordinary. The net11.0-vs-net10.0 split is just which process got unlucky.

## Fix

**NonBacktracking → `Regex.InfiniteMatchTimeout`.** This engine is bounded by the input length by construction, which is what actually makes a hostile pattern harmless, so a wall-clock deadline was pure downside.

Passing infinite *explicitly* rather than omitting the argument is the part worth reviewing: the constructor overload without a timeout falls back to the ambient `REGEX_DEFAULT_MATCH_TIMEOUT` `AppDomain` value, so a host application that sets one would silently reintroduce the same failure. (This repo already treats that setting as relevant enough to snapshot, in `ContextSnapshotBuilder`.)

**Backtracking fallback: 100 ms → 2 s.** A timeout stays here, since it is the only bound. But 100 ms of wall clock was far too tight to work as a catastrophic-pattern detector — as the failure shows, it fires on matches that cost microseconds. 2 s gives roughly 20x the headroom against scheduling noise while staying the same order as a DNS client's own timeout, so a genuinely pathological rule surfaces as a slow query rather than a silently wrong answer. Easy to dial if you'd prefer 1 s or 5 s.

The field is renamed to `BacktrackingRegexTimeout` now that it governs only that one path, with a comment noting it is a wall-clock budget — that is the property that made the old value wrong, and the thing to remember if anyone tightens it later.

This also fixes a real production bug, not just a test flake: under load a rule could silently fail to match a domain it should have blocked.

## Verification

- `dotnet test` DnsFilter — 324 passed (162 × net10.0/net11.0), 0 failed
- `dotnet test` DnsProxy — 122 passed, 0 failed
- Builds of the test project and the `Meziantou.DnsProxy` consumer with `/p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors (confirmed the assembly actually rebuilt rather than passing on an incremental no-op)
- `dotnet run ./eng/update-all.cs` — exit 0, no generated file changes

One caveat on what the green run proves: the flake was a timing artifact of a loaded runner, so local tests cannot demonstrate the fix directly. The argument is structural — `Evaluate` has exactly one non-deterministic route to `IsMatched == false`, and it is now unreachable for every regex the suite compiles, since none use lookarounds, backreferences or atomic groups and all therefore take the NonBacktracking path.
