### PR TITLE
Apply stale-if-error to origin errors when the cached entry has no validator

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -352,6 +352,22 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
         var freshResponseTime = _timeProvider.GetUtcNow();
 
+        // RFC 5861: an error status from the origin is the situation stale-if-error exists for, exactly as
+        // it is on the conditional path. An entry without a validator must not lose the fallback merely
+        // because the request could not be made conditional.
+        if (cacheResult is not null && IsStaleIfErrorStatus(freshResponse.StatusCode))
+        {
+            var errorAge = cacheResult.CalculateCurrentAge(freshResponseTime);
+            if (CanServeStaleOnError(cacheResult, errorAge, cacheResult.FreshnessLifetime))
+            {
+                freshResponse.Dispose();
+
+                // RFC 7234 Section 5.5: Add Warning headers
+                var warnings = "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"";
+                return CreateCachedResponse(request, cacheResult, errorAge, warnings);
+            }
+        }
+
         await StoreAsync(request, freshResponse, requestTime, freshResponseTime, cancellationToken).ConfigureAwait(false);
 
         // Set RequestMessage if it's not already set by the base handler

--- a/src/Meziantou.Framework.Http.Caching/readme.md
+++ b/src/Meziantou.Framework.Http.Caching/readme.md
@@ -272,7 +272,7 @@ This is particularly useful for versioned resources (e.g., `/assets/script.v123.
 | `Expires` | `<date>` | Expiration date (fallback if `max-age` not present) |
 | `ETag` | `<value>` | Entity tag for conditional requests |
 | `Last-Modified` | `<date>` | Last modification date for conditional requests |
-| | `stale-if-error=<seconds>` | Serve the stale response when revalidation fails or the origin cannot be reached (RFC 5861) |
+| | `stale-if-error=<seconds>` | Serve the stale response when the origin cannot be reached or answers with 500, 502, 503 or 504 (RFC 5861) |
 | `Vary` | `<headers>` | Headers that affect response variant |
 | `No-Vary-Search` | `key-order`, `params`, `except` | Query parameters that do not affect the response |
 | `Age` | `<seconds>` | Age of cached response (added when serving from cache) |

--- a/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
@@ -405,6 +405,94 @@ public class StaleResponseTests
         Assert.Equal("from-origin", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task WhenEntryHasNoValidatorAndOriginReturnsAServerErrorAndStaleIfErrorAllowsItThenStaleResponseServed(HttpStatusCode statusCode)
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60")));
+        innerHandler.AddResponse(() => CreateResponse(statusCode, "error"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        // The entry carries no validator, so the request goes to the origin unconditionally. The error it
+        // answers with is the same situation stale-if-error covers on the conditional path.
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal("cached", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+        Assert.Equal("110 - \"Response is Stale\", 111 - \"Revalidation Failed\"", string.Join(", ", secondResponse.Headers.GetValues("Warning")));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.MovedPermanently)]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Gone)]
+    [InlineData(HttpStatusCode.NotImplemented)]
+    public async Task WhenEntryHasNoValidatorAndOriginReturnsANonErrorStatusThenStaleIfErrorDoesNotApply(HttpStatusCode statusCode)
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60")));
+        innerHandler.AddResponse(() => CreateResponse(statusCode, "from-origin"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(statusCode, secondResponse.StatusCode);
+        Assert.Equal("from-origin", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenEntryHasNoValidatorAndStaleIfErrorWindowHasPassedThenTheServerErrorIsReturned()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=10")));
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.ServiceUnavailable, "error"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(60));
+
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, secondResponse.StatusCode);
+        Assert.Equal("error", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenEntryHasNoValidatorAndMustRevalidateThenStaleIfErrorDoesNotServeStaleResponseOnAServerError()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, must-revalidate, stale-if-error=60")));
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.ServiceUnavailable, "error"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, secondResponse.StatusCode);
+        Assert.Equal("error", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
     private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode, string? content = null, params (string Name, string Value)[] headers)
     {


### PR DESCRIPTION
## What changed

`HttpCachingDelegateHandler` now applies the RFC 5861 `stale-if-error` fallback to server-error responses on the *unconditional* origin path, not just on the conditional revalidation path.

## Why

The conditional path (`HttpCachingDelegateHandler.cs`, the `IsStaleIfErrorStatus(conditionalResponse.StatusCode)` check) already serves a permitted stale entry when the origin answers 500, 502, 503 or 504. The path taken when the stored entry has neither an `ETag` nor a `Last-Modified` only handled transport failures — an ordinary error response went straight to storage and back to the caller.

Reproduction before this change: cache a 200 with `Cache-Control: max-age=2, stale-if-error=60` and no validator, advance the time provider by 3 seconds, have the origin answer 503. The caller received `503 / error` instead of the cached 200. An entry lost the fallback merely because the request could not be made conditional.

## How

After the origin response is received, if there is a stored entry and the status is 500/502/503/504:

- the current age is recalculated at the response time;
- the existing `CanServeStaleOnError` restrictions apply unchanged (`stale-if-error` window, `must-revalidate`, response `no-cache`);
- the error response is disposed and the stale entry is served with the `110 - "Response is Stale", 111 - "Revalidation Failed"` warnings.

Otherwise the behaviour is exactly as before: the response is stored and returned.

## Tests

11 new cases in `StaleResponseTests.cs`, all on entries with no validator:

- the four error statuses serve the stale body with both warning codes;
- 301, 400, 404, 410 and 501 still reach the caller (mirrors the existing conditional-path test — only the four statuses RFC 5861 names are errors);
- an elapsed `stale-if-error` window returns the 503;
- `must-revalidate` returns the 503.

## Notes for the reviewer

- The `readme.md` directive table said `stale-if-error` applied "when revalidation fails or the origin cannot be reached"; it now names the four statuses, which is what both paths implement.
- Build with `/p:TreatWarningsAsErrors=true`: 0 warnings. `Meziantou.Framework.Http.Caching.Tests` on net10.0 and net11.0: 265 total, 262 passed, 3 skipped, 0 failed on both; the TRX confirms every new case ran. `dotnet run ./eng/update-all.cs` exits 0 with no generated-file changes.