### PR TITLE
Fill every reserved block in PooledMemoryStream

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -45,6 +45,11 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     private int _cursorIndex;
     private long _cursorStart;
 
+    // Index of the segment appends go into. Every segment after it is empty: either blocks reserved ahead of time by
+    // EnsureCapacityAtLeast, or the remainder of a reservation the append point has not reached yet. The index only
+    // ever moves forward, so segments before it are frozen and the logical order of the data is the segment order.
+    private int _appendIndex;
+
     /// <summary>Initializes a new instance using <see cref="PooledMemoryStreamOptions.Default"/>.</summary>
     public PooledMemoryStream()
         : this(PooledMemoryStreamOptions.Default, initialCapacity: 0)
@@ -439,14 +444,14 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         if (count == 0)
             return;
 
-        if (_segments.Count == 0 || count > _segments[^1].Array.Length - _segments[^1].Used)
+        if (_appendIndex >= _segments.Count || count > _segments[_appendIndex].Array.Length - _segments[_appendIndex].Used)
             throw new InvalidOperationException("Cannot advance past the end of the reserved buffer.");
 
         // Subtract rather than add: _length + count can overflow long on a stream near Int64.MaxValue.
         if (_length > long.MaxValue - count)
             throw new IOException("Stream was too long.");
 
-        CollectionsMarshal.AsSpan(_segments)[_segments.Count - 1].Used += count;
+        CollectionsMarshal.AsSpan(_segments)[_appendIndex].Used += count;
         _length += count;
         _position = _length;
     }
@@ -480,6 +485,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
             _length = 0;
             _position = 0;
             _capacity = 0;
+            _appendIndex = 0;
             ResetCursor();
         }
 
@@ -590,35 +596,66 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
 
         var needed = Math.Max(sizeHint, 1);
 
-        if (_segments.Count > 0)
+        if (_appendIndex < _segments.Count)
         {
-            var last = _segments[^1];
-            if (last.Array.Length - last.Used >= needed)
-                return _segments.Count - 1;
+            var current = _segments[_appendIndex];
+            if (current.Array.Length - current.Used >= needed)
+                return _appendIndex;
+
+            // The region has to be contiguous, so the only other candidate is the next reserved block. Move on to it
+            // only when the current one already holds data: skipping an empty block would strand its capacity, and
+            // inserting the new block in front of it keeps it available for later appends instead.
+            if (current.Used > 0 && _appendIndex + 1 < _segments.Count && _segments[_appendIndex + 1].Array.Length >= needed)
+                return ++_appendIndex;
         }
 
         var desired = Math.Max(needed, _options.GetBlockSize(_capacity));
-        return AddSegment(_options.GetContiguousBlockSize(desired));
+        return AddAppendSegment(_options.GetContiguousBlockSize(desired));
     }
 
     private int EnsureAppendCapacity()
     {
-        if (_segments.Count > 0)
+        // Walk forward through the blocks reserved after the append point instead of always targeting the last one:
+        // otherwise every block a reservation rented but the last stays empty and the stream grows past its capacity.
+        while (_appendIndex < _segments.Count)
         {
-            var last = _segments[^1];
-            if (last.Used < last.Array.Length)
-                return _segments.Count - 1;
+            var segment = _segments[_appendIndex];
+            if (segment.Used < segment.Array.Length)
+                return _appendIndex;
+
+            _appendIndex++;
         }
 
-        return AddSegment(_options.GetBlockSize(_capacity));
+        return AddAppendSegment(_options.GetBlockSize(_capacity));
     }
 
-    private int AddSegment(int size)
+    private int AddAppendSegment(int size)
+    {
+        // The new block belongs at the append point, which is not necessarily the end of the chain: blocks reserved
+        // by EnsureCapacityAtLeast sit after it and have to stay usable rather than be stranded behind the new one.
+        var index = _appendIndex < _segments.Count && _segments[_appendIndex].Used > 0 ? _appendIndex + 1 : _appendIndex;
+        var array = PooledBufferPool.Shared.Rent(size);
+        if (index < _segments.Count)
+        {
+            // Inserting shifts every later segment, and the cursor caches an index.
+            _segments.Insert(index, new Segment(array));
+            ResetCursor();
+        }
+        else
+        {
+            _segments.Add(new Segment(array));
+        }
+
+        _capacity += array.Length;
+        _appendIndex = index;
+        return index;
+    }
+
+    private void AddReservedSegment(int size)
     {
         var array = PooledBufferPool.Shared.Rent(size);
         _segments.Add(new Segment(array));
         _capacity += array.Length;
-        return _segments.Count - 1;
     }
 
     private void EnsureCapacityAtLeast(long target)
@@ -627,7 +664,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         // GetContiguousBlockSize(70_000) is 1 MiB, so a 70 KB reservation used to allocate 15x what was asked for.
         while (_capacity < target)
         {
-            AddSegment(_options.GetReservationBlockSize(target - _capacity));
+            AddReservedSegment(_options.GetReservationBlockSize(target - _capacity));
         }
     }
 
@@ -643,6 +680,10 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
             _segments.RemoveAt(_segments.Count - 1);
             PooledBufferPool.Shared.Return(last.Array, _options.MaxRetainedBytesPerBucket, _options.ClearOnReturn);
         }
+
+        // Only empty trailing blocks are dropped, so whatever is left last still holds data and can host appends.
+        if (_appendIndex >= _segments.Count)
+            _appendIndex = Math.Max(_segments.Count - 1, 0);
     }
 
     private void Truncate(long value)
@@ -674,6 +715,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
                 }
 
                 _length = value;
+                _appendIndex = Math.Max(_segments.Count - 1, 0);
                 return;
             }
 
@@ -700,6 +742,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
 
         _segments.Add(new Segment(array) { Used = (int)_length });
         _capacity = array.Length;
+        _appendIndex = 0;
         ResetCursor();
         return ClearTail(array);
     }

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -257,6 +257,82 @@ public sealed class PooledMemoryStreamTests
     }
 
     [Fact]
+    public void Capacity_ReservedBlocksAreFilledBeforeRentingMore()
+    {
+        var options = new PooledMemoryStreamOptions { BufferSizes = [4, 16] };
+        using var stream = new PooledMemoryStream(options, initialCapacity: 20);
+        Assert.Equal(20, stream.Capacity);
+
+        // The reservation is a 16-byte block followed by a 4-byte one. Appends used to target the last block only,
+        // so these 20 bytes filled the 4-byte block and then rented another 16 instead of using the reserved one.
+        var data = CreateData(20, seed: 20);
+        stream.Write(data);
+
+        Assert.Equal(20, stream.Capacity);
+        Assert.Equal(20, stream.Length);
+        Assert.Equal(data, stream.ToArray());
+    }
+
+    [Fact]
+    public void Capacity_ReservedOnAnExistingStream_IsUsedByLaterWrites()
+    {
+        var options = new PooledMemoryStreamOptions { BufferSizes = [16, 64] };
+        using var stream = new PooledMemoryStream(options);
+        var first = CreateData(10, seed: 21);
+        stream.Write(first);
+
+        stream.Capacity = 200;
+        var capacity = stream.Capacity;
+
+        var second = CreateData(capacity - first.Length, seed: 22);
+        stream.Write(second);
+
+        Assert.Equal(capacity, stream.Capacity);
+        Assert.Equal(capacity, stream.Length);
+        Assert.Equal([.. first, .. second], stream.ToArray());
+    }
+
+    [Fact]
+    public void IBufferWriter_FillsReservedBlocksBeforeRentingMore()
+    {
+        var options = new PooledMemoryStreamOptions { BufferSizes = [16, 64] };
+        using var stream = new PooledMemoryStream(options, initialCapacity: 128);
+        var capacity = stream.Capacity;
+        IBufferWriter<byte> writer = stream;
+
+        for (var i = 0; i < capacity / 16; i++)
+        {
+            writer.GetSpan(16)[..16].Fill((byte)i);
+            writer.Advance(16);
+        }
+
+        Assert.Equal(capacity, stream.Capacity);
+        Assert.Equal(capacity, stream.Length);
+
+        var result = stream.ToArray();
+        for (var i = 0; i < result.Length; i++)
+            Assert.Equal((byte)(i / 16), result[i]);
+    }
+
+    [Fact]
+    public void IBufferWriter_LargeRequest_DoesNotStrandReservedBlocks()
+    {
+        var options = new PooledMemoryStreamOptions { BufferSizes = [16, 64] };
+        using var stream = new PooledMemoryStream(options, initialCapacity: 128);
+        IBufferWriter<byte> writer = stream;
+
+        // Larger than any reserved block, so a new one is rented; the reserved blocks must stay usable behind it.
+        writer.GetSpan(200)[..200].Fill(1);
+        writer.Advance(200);
+        var capacity = stream.Capacity;
+
+        stream.Write(CreateData(128, seed: 23));
+
+        Assert.Equal(capacity, stream.Capacity);
+        Assert.Equal(328, stream.Length);
+    }
+
+    [Fact]
     public void Constructor_WithInitialCapacity()
     {
         using var stream = new PooledMemoryStream(1234);
@@ -684,6 +760,71 @@ public sealed class PooledMemoryStreamTests
 
             Assert.Equal(reference.Length, pooled.Length);
             Assert.Equal(reference.Position, pooled.Position);
+        }
+
+        Assert.Equal(reference.ToArray(), pooled.ToArray());
+    }
+
+    [Fact]
+    public void ParityWithMemoryStream_RandomCapacityAndBufferWriterOperations()
+    {
+        var state = 987u;
+        using var pooled = new PooledMemoryStream(SmallTiers());
+        IBufferWriter<byte> writer = pooled;
+        using var reference = new MemoryStream();
+
+        for (var i = 0; i < 2000; i++)
+        {
+            switch (NextRandom(ref state, 7))
+            {
+                case 0: // write
+                    var data = CreateData(NextRandom(ref state, 100), seed: (int)NextRandom(ref state));
+                    pooled.Write(data);
+                    reference.Write(data);
+                    break;
+                case 1: // seek
+                    var pos = NextRandom(ref state, (int)reference.Length + 50);
+                    pooled.Position = pos;
+                    reference.Position = pos;
+                    break;
+                case 2: // set length
+                    var len = NextRandom(ref state, (int)reference.Length + 100);
+                    pooled.SetLength(len);
+                    reference.SetLength(len);
+                    break;
+                case 3: // read
+                    var count = NextRandom(ref state, 50);
+                    var bufA = new byte[count];
+                    var bufB = new byte[count];
+                    Assert.Equal(reference.Read(bufB, 0, count), pooled.Read(bufA, 0, count));
+                    Assert.Equal(bufB, bufA);
+                    break;
+                case 4: // reserve capacity ahead of the writes
+                    pooled.Capacity = (int)pooled.Length + NextRandom(ref state, 500);
+                    break;
+                case 5: // release the unused capacity
+                    pooled.Capacity = (int)pooled.Length;
+                    break;
+                case 6: // append through IBufferWriter
+                    var hint = NextRandom(ref state, 200);
+                    var span = writer.GetSpan(hint);
+                    Assert.HasCountGreaterThanOrEqual(Math.Max(hint, 1), span);
+
+                    var advance = NextRandom(ref state, span.Length) + 1;
+                    reference.Position = reference.Length;
+                    for (var j = 0; j < advance; j++)
+                    {
+                        span[j] = (byte)(j + i);
+                        reference.WriteByte((byte)(j + i));
+                    }
+
+                    writer.Advance(advance);
+                    break;
+            }
+
+            Assert.Equal(reference.Length, pooled.Length);
+            Assert.Equal(reference.Position, pooled.Position);
+            Assert.True(pooled.Capacity >= pooled.Length);
         }
 
         Assert.Equal(reference.ToArray(), pooled.ToArray());


### PR DESCRIPTION
## What

`PooledMemoryStream` did not use all the capacity it reserved. Both append paths — `EnsureAppendCapacity` (`Write` / `WriteByte` / `SetLength`-extend) and `ReserveTail` (`IBufferWriter.GetSpan` / `GetMemory`) — only ever looked at `_segments[^1]`.

A reservation from `EnsureCapacityAtLeast` rents *several* blocks in descending tier order, so appends filled the last (smallest) block and then rented more, leaving every earlier reserved block permanently empty. With `BufferSizes = [4, 16]` and an initial capacity of 20, writing 20 bytes grew the capacity from **20 to 36** while the 16-byte reserved block stayed unused. The same applied to expanding `Capacity` on an existing stream. Output bytes were always correct; the cost was allocation and retention — reserving capacity could *increase* it rather than prevent growth, and a large reservation could leave nearly all of its blocks unused.

## How

The stream now tracks the append point explicitly with `_appendIndex`, under the invariant that every segment after it is empty and the index only moves forward — so segments before it are frozen and the segment order stays the logical byte order.

- `EnsureAppendCapacity` walks forward through the reserved blocks instead of jumping to the last one.
- `ReserveTail` starts at the append point, and may move to the next reserved block for a contiguous region — but only when the current one already holds data, so it never skips (and strands) an empty block.
- When a new block is genuinely needed, `AddAppendSegment` inserts it *at* the append point rather than at the end of the chain, so blocks reserved after it stay usable instead of being stranded behind it. `EnsureCapacityAtLeast` keeps appending its reservations at the end via `AddReservedSegment`.
- `IBufferWriter.Advance`, `Truncate`, `TrimTrailingEmptySegments`, `Consolidate` and `Dispose` maintain the index.

No public API change.

## Notes for reviewers

- The one place that inserts mid-chain (`AddAppendSegment`) resets the segment cursor, since inserting shifts every later index.
- `ReserveTail` deliberately considers only two blocks (the append block and the one after it). A later, larger reserved block could occasionally have hosted the region, which costs one extra rent in that case — but scanning further would either strand the blocks it skipped or cost an O(n) walk on every `GetSpan`.

## Tests

Five new tests in `PooledMemoryStreamTests`; the first four fail on `main` and pass here:

- the exact repro — `BufferSizes = [4, 16]`, capacity 20, write 20 bytes → capacity stays **20**
- a reservation applied to an already-populated stream
- `IBufferWriter` filling reserved blocks before renting more
- a `GetSpan` larger than any reserved block, asserting the reserved blocks are not stranded
- `ParityWithMemoryStream_RandomCapacityAndBufferWriterOperations` — 2000 random ops (write / seek / `SetLength` / read / reserve capacity / release capacity / `GetSpan`+`Advance`) against a `MemoryStream` oracle, asserting content, length, position and `Capacity >= Length` throughout

## Verification

- `dotnet test` on the project: **134 passed, 0 failed** (67 tests × net10.0/net11.0); the trx confirms all five new tests ran.
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet run ./eng/update-all.cs`: no file changes.
