### PR TITLE
Give each NTP rate limiter bucket an aggregate budget

### DIFF
--- a/src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj
+++ b/src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj
@@ -8,6 +8,10 @@
     <PackageTags>ntp, sntp, time, server, networking</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.NtpServer.Tests" />
+  </ItemGroup>
+
   <!-- The wire format is defined once, in the client project, and shared as source. These types are
        internal, so compiling them into both assemblies does not create duplicate public API for a
        consumer that references both packages. -->

--- a/src/Meziantou.Framework.NtpServer/NtpRateLimiter.cs
+++ b/src/Meziantou.Framework.NtpServer/NtpRateLimiter.cs
@@ -10,7 +10,9 @@ namespace Meziantou.Framework.Ntp;
 /// Source addresses on a UDP server are attacker-controlled and trivially spoofed, so the limiter
 /// cannot allocate an entry per address without becoming a memory-exhaustion vector itself. Addresses
 /// are mapped onto a fixed number of buckets instead; colliding addresses share a budget, which makes
-/// the limit conservative rather than leaky.
+/// the limit conservative rather than leaky. A bucket therefore counts every request that lands in it
+/// for the whole window, and never restarts its window because the source address changed: rotating
+/// through colliding addresses cannot clear a budget that is already being spent.
 /// </remarks>
 internal sealed class NtpRateLimiter
 {
@@ -39,27 +41,13 @@ internal sealed class NtpRateLimiter
     {
         isFirstRejection = false;
 
-        var hash = address.GetHashCode();
-        var index = (int)((uint)hash % BucketCount);
+        var index = (int)((uint)address.GetHashCode() % BucketCount);
         var now = _timeProvider.GetTimestamp();
 
         lock (_lock)
         {
             ref var bucket = ref _buckets[index];
             var inWindow = bucket.Count > 0 && _timeProvider.GetElapsedTime(bucket.WindowStart, now) < Window;
-
-            if (bucket.Hash != hash)
-            {
-                // Refuse to hand the bucket to a different address while its current occupant is over
-                // the limit: otherwise a flood of spoofed addresses would clear the limiter on every
-                // packet, disabling it exactly when it is needed.
-                if (inWindow && bucket.Count > _maxRequestsPerWindow)
-                    return false;
-
-                bucket = new Bucket { Hash = hash, WindowStart = now, Count = 1 };
-                return true;
-            }
-
             if (!inWindow)
             {
                 bucket.WindowStart = now;
@@ -79,7 +67,6 @@ internal sealed class NtpRateLimiter
     [StructLayout(LayoutKind.Auto)]
     private struct Bucket
     {
-        public int Hash;
         public long WindowStart;
         public int Count;
     }

--- a/tests/Meziantou.Framework.NtpServer.Tests/Meziantou.Framework.NtpServer.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpServer.Tests/Meziantou.Framework.NtpServer.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <ProjectReference Include="../../src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj" />
   </ItemGroup>

--- a/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
+++ b/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.Ntp.Tests;
 
@@ -325,6 +326,119 @@ public sealed class NtpServerTests : IAsyncLifetime
 
         Assert.Equal(RequestCount, replies);
     }
+
+    [Fact]
+    public void RateLimiter_CollidingAddressesShareTheBucketBudget()
+    {
+        var (first, second) = FindAddressesInTheSameBucket();
+        var limiter = new NtpRateLimiter(maxRequestsPerWindow: 1, new FakeTimeProvider());
+
+        Assert.True(limiter.TryAcquire(first, out _));
+
+        // Rotating through addresses that land in the same bucket must not restart the bucket window:
+        // the budget is spent for the window, whichever colliding address spent it.
+        for (var i = 0; i < 100; i++)
+        {
+            Assert.False(limiter.TryAcquire(second, out _));
+            Assert.False(limiter.TryAcquire(first, out _));
+        }
+    }
+
+    [Fact]
+    public void RateLimiter_CollidingAddressesShareTheKissOfDeathBudget()
+    {
+        var (first, second) = FindAddressesInTheSameBucket();
+        var limiter = new NtpRateLimiter(maxRequestsPerWindow: 1, new FakeTimeProvider());
+
+        Assert.True(limiter.TryAcquire(first, out var isFirstRejection));
+        Assert.False(isFirstRejection);
+
+        Assert.False(limiter.TryAcquire(second, out isFirstRejection));
+        Assert.True(isFirstRejection);
+
+        Assert.False(limiter.TryAcquire(first, out isFirstRejection));
+        Assert.False(isFirstRejection);
+    }
+
+    [Fact]
+    public void RateLimiter_AddressesInDistinctBucketsHaveTheirOwnBudget()
+    {
+        var (first, second) = FindAddressesInDistinctBuckets();
+        var limiter = new NtpRateLimiter(maxRequestsPerWindow: 1, new FakeTimeProvider());
+
+        Assert.True(limiter.TryAcquire(first, out _));
+        Assert.False(limiter.TryAcquire(first, out _));
+
+        Assert.True(limiter.TryAcquire(second, out _));
+        Assert.False(limiter.TryAcquire(second, out _));
+    }
+
+    [Fact]
+    public void RateLimiter_RejectedRequestsDoNotExtendTheWindow()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var address = IPAddress.Parse("192.0.2.1");
+        var limiter = new NtpRateLimiter(maxRequestsPerWindow: 1, timeProvider);
+
+        Assert.True(limiter.TryAcquire(address, out _));
+
+        // A source that keeps sending while throttled must not push its own window forever.
+        for (var i = 0; i < 10; i++)
+        {
+            timeProvider.Advance(TimeSpan.FromMilliseconds(90));
+            Assert.False(limiter.TryAcquire(address, out _));
+        }
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+        Assert.True(limiter.TryAcquire(address, out _));
+    }
+
+    /// <summary>Returns two distinct addresses that <see cref="NtpRateLimiter"/> maps onto the same bucket.</summary>
+    private static (IPAddress First, IPAddress Second) FindAddressesInTheSameBucket()
+    {
+        var seen = new Dictionary<int, IPAddress>();
+        foreach (var address in EnumerateAddresses())
+        {
+            if (seen.TryGetValue(GetBucketIndex(address), out var previous))
+                return (previous, address);
+
+            seen[GetBucketIndex(address)] = address;
+        }
+
+        throw new InvalidOperationException("The address space is larger than the bucket count, so a collision must exist");
+    }
+
+    private static (IPAddress First, IPAddress Second) FindAddressesInDistinctBuckets()
+    {
+        IPAddress? first = null;
+        foreach (var address in EnumerateAddresses())
+        {
+            if (first is null)
+            {
+                first = address;
+                continue;
+            }
+
+            if (GetBucketIndex(first) != GetBucketIndex(address))
+                return (first, address);
+        }
+
+        throw new InvalidOperationException("The buckets cannot all hold the whole address space");
+    }
+
+    private static IEnumerable<IPAddress> EnumerateAddresses()
+    {
+        for (var high = 0; high <= byte.MaxValue; high++)
+        {
+            for (var low = 0; low <= byte.MaxValue; low++)
+            {
+                yield return new IPAddress([203, 0, (byte)high, (byte)low]);
+            }
+        }
+    }
+
+    /// <summary>Mirrors the bucket mapping of <see cref="NtpRateLimiter"/>.</summary>
+    private static int GetBucketIndex(IPAddress address) => (int)((uint)address.GetHashCode() % 1024);
 
     [Fact]
     public async Task StartAsync_CalledTwiceThrows()


### PR DESCRIPTION
## The bug

`NtpRateLimiter` maps source addresses onto 1024 buckets and stored the address hash in each bucket. When a request hashed to a bucket held by a *different* address, the bucket was replaced with a fresh `WindowStart` and `Count = 1`, guarded only by "refuse if the current occupant is already over the limit".

That guard never fires when two colliding addresses alternate: each one resets the other's counter before either can cross the threshold. With `MaxRequestsPerSecond = 1`, alternating two addresses that map to the same bucket admits **every** request instead of one.

This contradicts what the class already documents — that colliding addresses share a budget, making the limit conservative rather than leaky. The attempt at per-address fairness inside a shared bucket is precisely what made the bucket resettable. On a UDP server, where source addresses are trivially spoofed, this weakens the limiter as reflection/abuse protection.

## The fix

Drop the per-bucket `Hash` field. A bucket now counts every request that lands in it for the whole window, whichever colliding address sent it, so rotating through identities cannot clear a budget that is already being spent. Rejected requests still do not move `WindowStart`, so a throttled source cannot starve itself out of the next window.

The change removes a field and a branch rather than adding any, and the public documentation on `MaxRequestsPerSecond` and in the readme already described these semantics, so no doc updates were needed.

## Tests

Added to `NtpServerTests.cs`, which required `InternalsVisibleTo` on the server project (the established pattern in this repo, e.g. `Meziantou.DnsProxy`) and the `Microsoft.Extensions.TimeProvider.Testing` package:

- `RateLimiter_CollidingAddressesShareTheBucketBudget` — the reproduction: two addresses that share a bucket, `max = 1`, alternated 100 times.
- `RateLimiter_CollidingAddressesShareTheKissOfDeathBudget` — one Kiss-o'-Death per bucket window, not one per colliding identity.
- `RateLimiter_AddressesInDistinctBucketsHaveTheirOwnBudget` — guards against over-restricting the fix.
- `RateLimiter_RejectedRequestsDoNotExtendTheWindow` — no starvation under continuous load.

The colliding pairs are discovered at runtime by mirroring the bucket mapping rather than hardcoding a hash value, so the tests do not depend on `IPAddress.GetHashCode` staying stable across runtimes.

## Verification

- `dotnet test` with `/p:TreatsWarningsAsErrors=true`: 76 passed (38 × net10.0/net11.0), 0 failed.
- Confirmed the new tests catch the original bug: reverting `NtpRateLimiter.cs` to the previous implementation fails both collision tests (4 failures across the two TFMs); restoring the fix makes them pass.
- Release build with `IsOfficialBuild=true` (enables the IDE analyzers): 0 warnings.
- `dotnet run ./eng/update-all.cs`: exit 0, no generated-file changes (the type is internal, so `ref/` is untouched).
