### PR TITLE
Fix infinite loop parsing malformed JSON containers

### DIFF
--- a/src/Meziantou.Framework.Language.Json/JsonSyntaxTree.cs
+++ b/src/Meziantou.Framework.Language.Json/JsonSyntaxTree.cs
@@ -189,6 +189,13 @@ public sealed class JsonSyntaxTree
                 if (Current.Kind is JsonSyntaxKind.CloseBraceToken or JsonSyntaxKind.EndOfFileToken)
                     continue;
 
+                if (member.Value.FullSpan.Length == 0)
+                {
+                    // The current token cannot start a value, so skip it to guarantee the loop makes progress.
+                    childNodes.Add(ParseSkippedTextUntil(JsonSyntaxKind.CommaToken, JsonSyntaxKind.CloseBraceToken, JsonSyntaxKind.EndOfFileToken));
+                    continue;
+                }
+
                 AddDiagnostic(Current.FullSpan, "JSON0009", "Expected a comma or the end of the object.");
             }
 
@@ -252,6 +259,13 @@ public sealed class JsonSyntaxTree
 
                 if (Current.Kind is JsonSyntaxKind.CloseBracketToken or JsonSyntaxKind.EndOfFileToken)
                     continue;
+
+                if (value.FullSpan.Length == 0)
+                {
+                    // The current token cannot start a value, so skip it to guarantee the loop makes progress.
+                    childNodes.Add(ParseSkippedTextUntil(JsonSyntaxKind.CommaToken, JsonSyntaxKind.CloseBracketToken, JsonSyntaxKind.EndOfFileToken));
+                    continue;
+                }
 
                 AddDiagnostic(Current.FullSpan, "JSON0009", "Expected a comma or the end of the array.");
             }

--- a/tests/Meziantou.Framework.Language.Json.Tests/JsonSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Language.Json.Tests/JsonSyntaxTreeTests.cs
@@ -97,6 +97,73 @@ public sealed class JsonSyntaxTreeTests
         Assert.All(tree.Diagnostics, diagnostic => Assert.Equal(JsonDiagnosticSeverity.Error, diagnostic.Severity));
     }
 
+    public static TheoryData<string> UnexpectedTokenInContainerSamples => new()
+    {
+        "[:]",
+        "[:",
+        "[}]",
+        "[1, :, 2]",
+        "[[:]]",
+        """{"a":]}""",
+        """{"a":]""",
+        "{]}",
+        "{:}",
+        """{"a":}, "b":1}""",
+        """{"a":{"b":]}}""",
+    };
+
+    [Theory]
+    [MemberData(nameof(UnexpectedTokenInContainerSamples))]
+    public void ParseText_UnexpectedTokenInContainer_TerminatesAndKeepsSkippedText(string text)
+    {
+        var tree = ParseWithTimeout(text);
+
+        Assert.NotEmpty(tree.Diagnostics);
+        Assert.Equal(text, tree.Root.ToFullString());
+        Assert.All(tree.Diagnostics, diagnostic => Assert.Equal(JsonDiagnosticSeverity.Error, diagnostic.Severity));
+        Assert.True(tree.Diagnostics.Count <= text.Length * 2, $"Expected a bounded number of diagnostics, got {tree.Diagnostics.Count}.");
+    }
+
+    [Fact]
+    public void ParseText_UnexpectedTokenAfterValue_StillRecoversFollowingMembers()
+    {
+        const string Text = """{"a":], "b":2}""";
+
+        var tree = ParseWithTimeout(Text);
+        var obj = Assert.IsType<JsonObjectSyntax>(tree.Root.Value);
+
+        var member = obj.GetMember("b");
+
+        Assert.Equal(Text, tree.Root.ToFullString());
+        Assert.NotNull(member);
+        Assert.Equal("2", Assert.IsType<JsonNumberSyntax>(member.Value).Text);
+    }
+
+    [Fact]
+    public void ParseText_UnexpectedTokenInArray_StillRecoversFollowingElements()
+    {
+        const string Text = "[1, :, 2]";
+
+        var tree = ParseWithTimeout(Text);
+        var array = Assert.IsType<JsonArraySyntax>(tree.Root.Value);
+
+        Assert.Equal(Text, tree.Root.ToFullString());
+        Assert.Contains(array.Elements, element => element.Value is JsonNumberSyntax { Text: "1" });
+        Assert.Contains(array.Elements, element => element.Value is JsonNumberSyntax { Text: "2" });
+    }
+
+    /// <summary>Parses <paramref name="text"/> on a dedicated thread so a parser that fails to make progress fails the test instead of hanging the test run.</summary>
+    private static JsonSyntaxTree ParseWithTimeout(string text)
+    {
+        JsonSyntaxTree? tree = null;
+        var thread = new Thread(() => tree = JsonSyntaxTree.ParseText(text)) { IsBackground = true };
+        thread.Start();
+
+        Assert.True(thread.Join(TimeSpan.FromSeconds(30)), $"Parsing '{text}' did not complete; the parser is likely stuck on a token it never consumes.");
+
+        return tree!;
+    }
+
     [Fact]
     public void ParseText_CommentsAreTriviaWithSourceLocations()
     {


### PR DESCRIPTION
## What changed

`JsonSyntaxTree.ParseText` could loop forever on tiny malformed documents. `ParseValue`'s `default:` case emits `JSON0007` and returns a zero-width `JsonSkippedTextSyntax` **without consuming the token**. Both container loops then fell through to the `JSON0009` "expected a comma or the end of…" diagnostic and retried the identical token forever, allocating a node and a diagnostic on every pass.

Confirmed hanging inputs: `[:]`, `{"a":]}`, `{]}`, `[}]` — the last two are beyond the originally reported cases.

Each container loop now detects that the value it just parsed is zero-width and recovers through the existing `ParseSkippedTextUntil` path instead of falling through to `JSON0009`:

- `ParseObject`, keyed on `member.Value.FullSpan.Length == 0`
- `ParseArray`, keyed on `value.FullSpan.Length == 0`

The comma and the matching closing token are already handled earlier in each loop, so the skip always consumes at least one token and every iteration makes progress.

## Why key on the value width rather than the token position

A raw "did `_position` move?" guard also terminates, but recovery is worse: `{"a":]}` re-enters `ParseMember` on `]` and produces a phantom member with six diagnostics. Keying on the value width lets the parser recognize that `ParseValue` already rejected this token and recover straight to the next separator — `{"a":]}` reports just `JSON0007` + `JSON0005`.

Missing-comma recovery is deliberately untouched: `[1 2]` and `{"a":1 "b":2}` still report a single `JSON0009` and parse the following element.

## Testing

- All four hanging inputs now complete, with full round-trip fidelity (`ToFullString()` returns the original text).
- Exhaustive fuzz over every input up to length 4 from a 13-character alphabet of JSON structural characters: **30,940 inputs, no hang, 0 round-trip failures**.
- 13 tests added to the existing `JsonSyntaxTreeTests` — a bounded malformed-input theory covering both containers plus nesting (`[[:]]`, `{"a":{"b":]}}`) and truncation (`[:`, `{"a":]`), and two tests confirming elements/members after the bad token still parse.
- **The new tests were confirmed to catch the regression**: with only the parser fix stashed they fail with "the parser is likely stuck on a token it never consumes"; they pass with it.
- 36/36 tests pass on net10.0 and net11.0. 848/848 `Meziantou.Framework.JsonPath` tests (the main consumer of this tree) pass.
- Release + `IsOfficialBuild=true` build with `TreatWarningsAsErrors`: 0 warnings, 0 errors. No `ref/` changes — the fix is inside the private nested parser, so there is no public API surface change.
- `dotnet run ./eng/update-all.cs` ran clean with no generated-file changes.

## Note for reviewers

Test parsing runs on a dedicated background thread with a `Join` timeout (`ParseWithTimeout`). Without it, a future regression would hang the whole test run instead of failing one test with a useful message.
