### PR TITLE
Release readers blocked behind a canceled writer in AsyncReaderWriterLock

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
@@ -168,26 +168,33 @@ public sealed class AsyncReaderWriterLock
     /// returned waiters are completed outside it.</summary>
     private List<Waiter>? GrantOwnership()
     {
-        if (_status != 0)
+        // A writer holds the lock, nothing can be granted until it releases.
+        if (_status < 0)
             return null;
 
         if (_waitingWriters.Count > 0)
         {
+            // Writers still have priority over the queued readers, so nothing is granted until the lock is free.
+            if (_status > 0)
+                return null;
+
             _status = -1;
             return [_waitingWriters.Dequeue()];
         }
 
         if (_waitingReaders.Count > 0)
         {
-            // Every queued reader is admitted at once. This also covers the case where the writers that were
-            // blocking them have all been canceled, which would otherwise leave the readers queued forever.
+            // Every queued reader is admitted at once. Readers only ever queue behind a writer, so once no writer
+            // is left they can join the readers already holding the lock instead of waiting for those to release.
+            // This also covers the case where the writers that were blocking them have all been canceled, which
+            // would otherwise leave the readers queued forever.
             var readers = new List<Waiter>(_waitingReaders.Count);
             while (_waitingReaders.Count > 0)
             {
                 readers.Add(_waitingReaders.Dequeue());
             }
 
-            _status = readers.Count;
+            _status += readers.Count;
             return readers;
         }
 
@@ -217,8 +224,8 @@ public sealed class AsyncReaderWriterLock
         {
             removed = RemoveMidQueue(waiter.IsWriter ? _waitingWriters : _waitingReaders, waiter);
 
-            // Removing a waiter can leave the lock free with others still queued behind it. GrantOwnership is a
-            // no-op unless _status is 0, so this only does something when that actually happened.
+            // Removing a waiter can unblock the ones queued behind it: the lock may now be free, or the canceled
+            // writer may have been the last one holding back readers that are compatible with the current owners.
             toWake = removed ? GrantOwnership() : null;
         }
 

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -191,6 +191,29 @@ public class AsyncReaderWriterLockTests
     }
 
     [Fact]
+    public async Task CancelingTheQueuedWriter_ReleasesTheReadersBlockedBehindIt_WhileAnotherReaderHoldsTheLock()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        using var cts = new CancellationTokenSource();
+
+        var reader1 = await rwLock.ReaderLockAsync();
+        var queuedWriter = rwLock.WriterLockAsync(cts.Token);
+        var reader2 = rwLock.ReaderLockAsync(); // queued behind the writer
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => queuedWriter);
+
+        // No writer is left, so the queued reader can join the reader already holding the lock.
+        var releaser2 = await reader2.WaitAsync(TimeSpan.FromSeconds(30));
+
+        reader1.Dispose();
+        releaser2.Dispose();
+
+        // Both readers must have been accounted for, otherwise the lock never becomes free again.
+        (await rwLock.WriterLockAsync().WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+    }
+
+    [Fact]
     public async Task ReaderContinuationsAreNotInlinedOnTheReleasingThread()
     {
         // The waiting readers used to share a TaskCompletionSource created without


### PR DESCRIPTION
## What

`AsyncReaderWriterLock.GrantOwnership` returned early unless `_status == 0`, so it only ever handed out a *free* lock.

Readers queue for one reason only: a writer is ahead of them. When that writer was canceled while other readers still held the lock (`_status > 0`), the queued reader was compatible with the current owners, but stayed blocked until every active reader released — while a reader arriving at that same moment acquired the lock immediately, since no writer was queued any more.

Repro: acquire reader R1, queue writer W with a token, queue reader R2 behind it, then cancel W. `R2` does not complete until R1 is released. An application where R1 waits for work that needs R2 deadlocks after the canceled writer has disappeared.

## How

In `GrantOwnership`:

- Only a writer holding the lock (`_status < 0`) is an unconditional bail-out.
- Writer preference stays explicit: with a writer queued, nothing is granted until `_status == 0`.
- Queued readers are admitted whenever no writer is waiting, and are **added** to the current count (`_status += readers.Count` instead of `_status =`) so the readers already holding the lock keep their ownership. Without that, the count would be lost and the lock would never return to free.

The comment in `OnCancellationRequest` that documented the old "no-op unless `_status` is 0" behaviour was updated to match.

## Notes for reviewers

- The new test `CancelingTheQueuedWriter_ReleasesTheReadersBlockedBehindIt_WhileAnotherReaderHoldsTheLock` covers the scenario and also asserts a final `WriterLockAsync` succeeds — that second assertion is what catches the ownership-count regression a naive `_status = readers.Count` fix would introduce.
- I verified the test actually reproduces the bug: reverting the source made it hang (30s timeout) on both target frameworks, and it passes with the fix.
- Public API is unchanged, so `ref/` needed no regeneration.

## Verification

- `dotnet test` on `Meziantou.Framework.Threading.Tests`: 334/334 passed (167 per TFM, 14 in `AsyncReaderWriterLockTests`).
- Release build with `/p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet run ./eng/update-all.cs`: no file changes.
