### PR TITLE
Reduce DNS TTLs by the HTTP Age of a DoH response

### DIFF
--- a/src/Meziantou.Framework.DnsClient/DnsClient.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClient.cs
@@ -203,10 +203,11 @@ public sealed class DnsClient : IDisposable
     private async Task<DnsResponseMessage> ExchangeAsync(DnsQueryMessage message, CancellationToken cancellationToken, IDnsTransport? transport = null)
     {
         var queryBytes = DnsMessageEncoder.EncodeQuery(message, out var queryId);
-        var responseBytes = await (transport ?? _transport).SendAsync(queryBytes, cancellationToken).ConfigureAwait(false);
+        var transportResponse = await (transport ?? _transport).SendAsync(queryBytes, cancellationToken).ConfigureAwait(false);
         var response = DnsMessageEncoder.DecodeResponse(
-            responseBytes,
-            preserveRawRecordData: _options.DnssecValidationMode is DnssecValidationMode.Local);
+            transportResponse.Data,
+            preserveRawRecordData: _options.DnssecValidationMode is DnssecValidationMode.Local,
+            ageInSeconds: transportResponse.AgeInSeconds);
 
         ValidateResponseMatchesQuery(message, queryId, response);
         return response;

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
@@ -62,7 +62,11 @@ internal static class DnsMessageEncoder
         return writer.ToArray();
     }
 
-    public static DnsResponseMessage DecodeResponse(ReadOnlySpan<byte> data, bool preserveRawRecordData = false)
+    /// <param name="ageInSeconds">
+    /// How long the message has already been cached before reaching us. Record TTLs are reduced by this amount so a
+    /// response replayed from an HTTP cache does not look freshly resolved.
+    /// </param>
+    public static DnsResponseMessage DecodeResponse(ReadOnlySpan<byte> data, bool preserveRawRecordData = false, uint ageInSeconds = 0)
     {
         if (data.Length < 12)
             throw new DnsProtocolException("DNS message is too short (minimum 12 bytes for header).");
@@ -106,9 +110,9 @@ internal static class DnsMessageEncoder
         response.Questions = questions;
 
         // Answer, Authority, Additional sections
-        response.Answers = ReadRecords(ref reader, header.AnswerCount, preserveRawRecordData);
-        response.Authorities = ReadRecords(ref reader, header.AuthorityCount, preserveRawRecordData);
-        response.AdditionalRecords = ReadRecords(ref reader, header.AdditionalCount, preserveRawRecordData);
+        response.Answers = ReadRecords(ref reader, header.AnswerCount, preserveRawRecordData, ageInSeconds);
+        response.Authorities = ReadRecords(ref reader, header.AuthorityCount, preserveRawRecordData, ageInSeconds);
+        response.AdditionalRecords = ReadRecords(ref reader, header.AdditionalCount, preserveRawRecordData, ageInSeconds);
 
         // RFC 6891 6.1.3: the full RCODE is the OPT record's extended bits followed by the header's four bits.
         // Without this, BADVERS (16) and every other extended code decodes as the header's low nibble - BADVERS
@@ -122,7 +126,7 @@ internal static class DnsMessageEncoder
         return response;
     }
 
-    private static List<DnsRecord> ReadRecords(ref DnsWireReader reader, ushort count, bool preserveRawRecordData)
+    private static List<DnsRecord> ReadRecords(ref DnsWireReader reader, ushort count, bool preserveRawRecordData, uint ageInSeconds)
     {
         var records = new List<DnsRecord>(count);
         for (var i = 0; i < count; i++)
@@ -143,7 +147,9 @@ internal static class DnsMessageEncoder
             record.Name = name;
             record.RecordType = type;
             record.RecordClass = recordClass;
-            record.TimeToLive = ttl;
+            // RFC 6891 6.1.3: an OPT record's TTL field is not a lifetime but the extended RCODE, the EDNS version and
+            // the EDNS flags, so it must be kept exactly as it came off the wire.
+            record.TimeToLive = type is DnsQueryType.OPT ? ttl : ttl - Math.Min(ttl, ageInSeconds);
             record.DataLength = rdLength;
             if (preserveRawRecordData)
             {

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
@@ -41,7 +41,7 @@ internal sealed class DnsHttpsTransport : IDnsTransport
         return new HttpClient(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(2) }, disposeHandler: true);
     }
 
-    public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+    public async Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
     {
         // RFC 8484: DNS over HTTPS using POST with application/dns-message
         using var content = new ByteArrayContent(query);
@@ -65,7 +65,24 @@ internal sealed class DnsHttpsTransport : IDnsTransport
         if (body.Length > MaxResponseLength)
             throw new DnsProtocolException($"The DNS over HTTPS response is {body.Length} bytes, which exceeds the {MaxResponseLength}-byte maximum for a DNS message.");
 
-        return body;
+        return new DnsTransportResponse(body, GetAgeInSeconds(response));
+    }
+
+    /// <summary>
+    /// RFC 8484 5.1: a response served from an HTTP cache still carries the TTLs the server originally sent, so the
+    /// time it spent in that cache has to be taken out of them. The <c>Age</c> header is how far the message is into
+    /// its lifetime.
+    /// </summary>
+    private static uint GetAgeInSeconds(HttpResponseMessage response)
+    {
+        if (response.Headers.Age is not { } age)
+            return 0;
+
+        var seconds = age.TotalSeconds;
+        if (seconds <= 0)
+            return 0;
+
+        return seconds >= uint.MaxValue ? uint.MaxValue : (uint)seconds;
     }
 
     public void Dispose()

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsQuicTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsQuicTransport.cs
@@ -16,7 +16,7 @@ internal sealed class DnsQuicTransport : IDnsTransport
         _endpoint = endpoint;
     }
 
-    public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+    public async Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
     {
         if (!QuicConnection.IsSupported)
             throw new PlatformNotSupportedException("QUIC is not supported on this platform.");
@@ -53,7 +53,7 @@ internal sealed class DnsQuicTransport : IDnsTransport
         var response = new byte[responseLength];
         await stream.ReadExactlyAsync(response, cancellationToken).ConfigureAwait(false);
 
-        return response;
+        return new DnsTransportResponse(response);
     }
 
     public void Dispose()

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsTcpTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsTcpTransport.cs
@@ -13,7 +13,7 @@ internal sealed class DnsTcpTransport : IDnsTransport
         _endpoint = endpoint;
     }
 
-    public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+    public async Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
     {
         using var client = new TcpClient();
         await client.ConnectAsync(_endpoint.Address, _endpoint.Port, cancellationToken).ConfigureAwait(false);
@@ -35,7 +35,7 @@ internal sealed class DnsTcpTransport : IDnsTransport
         var response = new byte[responseLength];
         await stream.ReadExactlyAsync(response, cancellationToken).ConfigureAwait(false);
 
-        return response;
+        return new DnsTransportResponse(response);
     }
 
     public void Dispose()

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsTlsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsTlsTransport.cs
@@ -16,7 +16,7 @@ internal sealed class DnsTlsTransport : IDnsTransport
         _endpoint = endpoint;
     }
 
-    public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+    public async Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
     {
         using var client = new TcpClient();
         await client.ConnectAsync(_endpoint.Address, _endpoint.Port, cancellationToken).ConfigureAwait(false);
@@ -44,7 +44,7 @@ internal sealed class DnsTlsTransport : IDnsTransport
         var response = new byte[responseLength];
         await sslStream.ReadExactlyAsync(response, cancellationToken).ConfigureAwait(false);
 
-        return response;
+        return new DnsTransportResponse(response);
     }
 
     public void Dispose()

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsTransportResponse.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsTransportResponse.cs
@@ -1,0 +1,16 @@
+namespace Meziantou.Framework.DnsClient.Transport;
+
+/// <summary>
+/// A DNS response as it came off a transport, together with how long that transport reports the message has already
+/// been sitting in a cache. Only DNS over HTTPS can report a non-zero age (RFC 8484 5.1: the DNS TTLs of a response
+/// served from an HTTP cache must be reduced by the HTTP <c>Age</c> header).
+/// </summary>
+/// <param name="Data">The raw DNS message.</param>
+/// <param name="AgeInSeconds">The number of seconds the message has been cached, or 0 when it comes straight from the server.</param>
+internal readonly record struct DnsTransportResponse(byte[] Data, uint AgeInSeconds)
+{
+    public DnsTransportResponse(byte[] data)
+        : this(data, AgeInSeconds: 0)
+    {
+    }
+}

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsUdpTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsUdpTransport.cs
@@ -12,7 +12,7 @@ internal sealed class DnsUdpTransport : IDnsTransport
         _endpoint = endpoint;
     }
 
-    public async Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+    public async Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
     {
         using var client = new UdpClient(_endpoint.AddressFamily);
 
@@ -27,7 +27,7 @@ internal sealed class DnsUdpTransport : IDnsTransport
         {
             var result = await client.ReceiveAsync(cancellationToken).ConfigureAwait(false);
             if (result.RemoteEndPoint.Equals(_endpoint))
-                return result.Buffer;
+                return new DnsTransportResponse(result.Buffer);
 
             // A datagram from an unexpected source: ignore it and keep waiting rather than failing the query, so a
             // single stray packet cannot deny service. The caller's timeout bounds this loop.

--- a/src/Meziantou.Framework.DnsClient/Transport/IDnsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/IDnsTransport.cs
@@ -2,5 +2,5 @@ namespace Meziantou.Framework.DnsClient.Transport;
 
 internal interface IDnsTransport : IDisposable
 {
-    Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken);
+    Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken);
 }

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Meziantou.Framework.DnsClient.Protocol;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
+using Meziantou.Framework.DnsClient.Response.Records;
 using Meziantou.Framework.DnsClient.Transport;
 
 using DnsResponseCode = Meziantou.Framework.DnsClient.Response.DnsResponseCode;
@@ -84,6 +85,69 @@ public sealed class DnsClientDnssecOptionsTests
         Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, handler.RequestVersionPolicy);
     }
 
+    [Fact]
+    public async Task QueryAsync_Https_ResponseWithAnAgeHeader_ReducesTheRecordTimeToLives()
+    {
+        // RFC 8484 5.1: a response replayed by an HTTP cache still carries the TTLs the resolver first sent, so the
+        // time it spent in that cache has to come out of them.
+        using var handler = new TimeToLiveHttpMessageHandler(age: TimeSpan.FromSeconds(250));
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken);
+
+        Assert.Equal(350u, Assert.Single(response.Answers).TimeToLive);
+        Assert.Equal(650u, Assert.Single(response.Authorities).TimeToLive);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Https_ResponseWithoutAnAgeHeader_KeepsTheRecordTimeToLives()
+    {
+        using var handler = new TimeToLiveHttpMessageHandler(age: null);
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken);
+
+        Assert.Equal(600u, Assert.Single(response.Answers).TimeToLive);
+        Assert.Equal(900u, Assert.Single(response.Authorities).TimeToLive);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Https_ResponseWithAnAgeLongerThanTheTimeToLives_ClampsThemToZero()
+    {
+        using var handler = new TimeToLiveHttpMessageHandler(age: TimeSpan.FromSeconds(5000));
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0u, Assert.Single(response.Answers).TimeToLive);
+        Assert.Equal(0u, Assert.Single(response.Authorities).TimeToLive);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Https_ResponseWithAnAgeHeader_LeavesTheOptRecordMetadataIntact()
+    {
+        using var handler = new TimeToLiveHttpMessageHandler(age: TimeSpan.FromSeconds(250), optTimeToLive: 0x01008000);
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken);
+        var opt = Assert.IsType<DnsOptRecord>(Assert.Single(response.AdditionalRecords));
+
+        Assert.Equal(0x01008000u, opt.TimeToLive);
+        Assert.True(opt.DnssecOk);
+    }
+
     private static bool IsCheckingDisabled(byte[] query)
     {
         var flags = (query[2] << 8) | query[3];
@@ -113,14 +177,41 @@ public sealed class DnsClientDnssecOptionsTests
     {
         public byte[] LastQuery { get; private set; } = [];
 
-        public Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+        public Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
         {
             LastQuery = query;
-            return Task.FromResult(CreateEmptyResponse(query));
+            return Task.FromResult(new DnsTransportResponse(CreateEmptyResponse(query)));
         }
 
         public void Dispose()
         {
+        }
+    }
+
+    /// <summary>Answers every query with an A record of TTL 600 and an SOA authority record of TTL 900.</summary>
+    private sealed class TimeToLiveHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly TimeSpan? _age;
+        private readonly uint _optTimeToLive;
+
+        public TimeToLiveHttpMessageHandler(TimeSpan? age, uint optTimeToLive = 0)
+        {
+            _age = age;
+            _optTimeToLive = optTimeToLive;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var query = await request.Content!.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            var body = DnsTestMessages.CreateResponseWithTimeToLives(query, answerTimeToLive: 600, authorityTimeToLive: 900, _optTimeToLive);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(body),
+            };
+
+            response.Headers.Age = _age;
+            return response;
         }
     }
 
@@ -317,10 +408,10 @@ public sealed class DnsClientDnssecOptionsTests
 
         public byte[] LastQuery { get; private set; } = [];
 
-        public Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+        public Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
         {
             LastQuery = query;
-            return Task.FromResult(_respond(query));
+            return Task.FromResult(new DnsTransportResponse(_respond(query)));
         }
 
         public void Dispose()

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientTelemetryTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientTelemetryTests.cs
@@ -76,9 +76,9 @@ public sealed class DnsClientTelemetryTests
             _responseCode = responseCode;
         }
 
-        public Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+        public Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
         {
-            return Task.FromResult(CreateResponse(query, _responseCode));
+            return Task.FromResult(new DnsTransportResponse(CreateResponse(query, _responseCode)));
         }
 
         public void Dispose()
@@ -91,7 +91,7 @@ public sealed class DnsClientTelemetryTests
 
     private sealed class ThrowingTransport : IDnsTransport
     {
-        public Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+        public Task<DnsTransportResponse> SendAsync(byte[] query, CancellationToken cancellationToken)
         {
             throw new InvalidOperationException("Could not send DNS query.");
         }

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsTestMessages.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsTestMessages.cs
@@ -1,3 +1,5 @@
+using Meziantou.Framework.DnsClient.Protocol;
+using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 
 namespace Meziantou.Framework.DnsClient.Tests;
@@ -24,6 +26,54 @@ internal static class DnsTestMessages
         response[11] = 0;
 
         return response;
+    }
+
+    /// <summary>
+    /// Builds a response for <paramref name="query"/> holding one A answer, one SOA authority record and an OPT record,
+    /// echoing the query identifier and question so the client's response-to-query validation accepts it.
+    /// </summary>
+    public static byte[] CreateResponseWithTimeToLives(byte[] query, uint answerTimeToLive, uint authorityTimeToLive, uint optTimeToLive)
+    {
+        var questionEnd = GetQuestionSectionEnd(query);
+        var encodedName = query.AsSpan(12, questionEnd - 12 - 4).ToArray();
+
+        var writer = new DnsWireWriter(512);
+        writer.WriteBytes(query.AsSpan(0, questionEnd));
+        writer.WriteUInt16At(0x8180, 2); // QR + RD + RA
+        writer.WriteUInt16At(1, 6); // ANCOUNT
+        writer.WriteUInt16At(1, 8); // NSCOUNT
+        writer.WriteUInt16At(1, 10); // ARCOUNT
+
+        writer.WriteBytes(encodedName);
+        writer.WriteUInt16((ushort)DnsQueryType.A);
+        writer.WriteUInt16((ushort)DnsQueryClass.IN);
+        writer.WriteUInt32(answerTimeToLive);
+        writer.WriteUInt16(4);
+        writer.WriteBytes([1, 2, 3, 4]);
+
+        writer.WriteBytes(encodedName);
+        writer.WriteUInt16((ushort)DnsQueryType.SOA);
+        writer.WriteUInt16((ushort)DnsQueryClass.IN);
+        writer.WriteUInt32(authorityTimeToLive);
+        var rdLengthPosition = writer.Position;
+        writer.WriteUInt16(0);
+        var rdataStart = writer.Position;
+        writer.WriteDomainName("ns.example.com");
+        writer.WriteDomainName("hostmaster.example.com");
+        writer.WriteUInt32(1); // SERIAL
+        writer.WriteUInt32(2); // REFRESH
+        writer.WriteUInt32(3); // RETRY
+        writer.WriteUInt32(4); // EXPIRE
+        writer.WriteUInt32(5); // MINIMUM
+        writer.WriteUInt16At((ushort)(writer.Position - rdataStart), rdLengthPosition);
+
+        writer.WriteByte(0); // root name
+        writer.WriteUInt16((ushort)DnsQueryType.OPT);
+        writer.WriteUInt16(1232); // UDP payload size
+        writer.WriteUInt32(optTimeToLive);
+        writer.WriteUInt16(0); // RDLENGTH
+
+        return writer.ToArray();
     }
 
     /// <summary>Returns the offset just past the question section of a DNS message.</summary>

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -163,6 +163,63 @@ public sealed class DnsWireFormatTests
     }
 
     [Fact]
+    public void DecodeResponse_WithAnAge_SubtractsItFromEveryRecordTimeToLive()
+    {
+        var message = CreateResponseWithTimeToLives(answerTimeToLive: 600, authorityTimeToLive: 900);
+
+        var response = DnsMessageEncoder.DecodeResponse(message, ageInSeconds: 250);
+
+        Assert.Equal(350u, Assert.Single(response.Answers).TimeToLive);
+        Assert.Equal(650u, Assert.Single(response.Authorities).TimeToLive);
+    }
+
+    [Fact]
+    public void DecodeResponse_WithAnAgeLongerThanTheTimeToLive_ClampsToZero()
+    {
+        var message = CreateResponseWithTimeToLives(answerTimeToLive: 600, authorityTimeToLive: 900);
+
+        var response = DnsMessageEncoder.DecodeResponse(message, ageInSeconds: 5000);
+
+        Assert.Equal(0u, Assert.Single(response.Answers).TimeToLive);
+        Assert.Equal(0u, Assert.Single(response.Authorities).TimeToLive);
+    }
+
+    [Fact]
+    public void DecodeResponse_WithAnAge_LeavesTheOptRecordMetadataIntact()
+    {
+        // The OPT record's TTL field holds the extended RCODE, the EDNS version and the DO flag, not a lifetime.
+        var message = CreateResponseWithTimeToLives(answerTimeToLive: 600, authorityTimeToLive: 900, optTimeToLive: 0x01008000);
+
+        var response = DnsMessageEncoder.DecodeResponse(message, ageInSeconds: 250);
+        var opt = Assert.IsType<Response.Records.DnsOptRecord>(Assert.Single(response.AdditionalRecords));
+
+        Assert.Equal(0x01008000u, opt.TimeToLive);
+        Assert.Equal(1, opt.ExtendedRCode);
+        Assert.Equal(0, opt.EdnsVersion);
+        Assert.True(opt.DnssecOk);
+    }
+
+    [Fact]
+    public void DecodeResponse_WithoutAnAge_KeepsTheTimeToLivesFromTheWire()
+    {
+        var message = CreateResponseWithTimeToLives(answerTimeToLive: 600, authorityTimeToLive: 900);
+
+        var response = DnsMessageEncoder.DecodeResponse(message);
+
+        Assert.Equal(600u, Assert.Single(response.Answers).TimeToLive);
+        Assert.Equal(900u, Assert.Single(response.Authorities).TimeToLive);
+    }
+
+    private static byte[] CreateResponseWithTimeToLives(uint answerTimeToLive, uint authorityTimeToLive, uint optTimeToLive = 0)
+    {
+        var message = new DnsQueryMessage();
+        message.Questions.Add(new DnsQuestion("example.com", DnsQueryType.A, DnsQueryClass.IN));
+
+        var query = DnsMessageEncoder.EncodeQuery(message, out _);
+        return DnsTestMessages.CreateResponseWithTimeToLives(query, answerTimeToLive, authorityTimeToLive, optTimeToLive);
+    }
+
+    [Fact]
     public void DecodeResponse_Default_DoesNotPreserveRawRecordData()
     {
         var response = DnsMessageEncoder.DecodeResponse(CreateResponseWithARecord());


### PR DESCRIPTION
## What

The DNS over HTTPS transport now reads the HTTP `Age` header and the decoder subtracts it from the record TTLs of the response.

## Why

[RFC 8484 §5.1](https://www.rfc-editor.org/rfc/rfc8484.html#section-5.1) requires a DoH client to account for the time a response spent in an HTTP cache. The wire message still carries the TTLs the resolver originally sent, so a reply delivered with `Age: 250` and a record TTL of 600 looked exactly as fresh as one resolved a moment ago — its real remaining lifetime was 350.

`DnsHttpsTransport.SendAsync` disposed the `HttpResponseMessage` and returned only the body, so the header was gone by the time `DnsMessageEncoder.DecodeResponse` ran and could not be reconstructed. Callers whose DoH response came through a caching handler, server or intermediary could therefore retain stale DNS information for the full original TTL *on top of* however long it had already been cached.

## How

- `IDnsTransport.SendAsync` returns a new internal `DnsTransportResponse` (`Data` + `AgeInSeconds`) instead of a bare `byte[]`. The UDP, TCP, TLS and QUIC transports talk to the server directly and always report `0`; only the HTTPS transport reports a real age, read from `response.Headers.Age` before the response is disposed and clamped to `[0, uint.MaxValue]`.
- `DecodeResponse` threads the age into `ReadRecords`, where the TTL becomes `ttl - Math.Min(ttl, ageInSeconds)` — saturating at zero. This applies to the answer *and* authority sections, so a negative response's SOA lifetime shrinks too.

## Notes for reviewers

- **OPT records are deliberately excluded.** Per [RFC 6891 §6.1.3](https://www.rfc-editor.org/rfc/rfc6891.html#section-6.1.3) an OPT record's TTL field is not a lifetime but the extended RCODE, the EDNS version and the EDNS flags. Decrementing it would corrupt the DO bit and the extended response code — with `Age: 250`, a DO-flagged `0x00008000` would become `0x00007F06` and the DO bit would be lost. There is a test for exactly this.
- **DNSSEC validation is unaffected.** `DnssecCanonicalizer` signs the RRSIG's own `OriginalTtl` field from the RDATA, not the record's TTL, so adjusting the latter cannot change a signature verification outcome.
- **No public API change.** Every new or modified type here is internal, so `ref/` is untouched.

## Tests

Eight new tests, added to existing files:

- `DnsWireFormatTests` — decoder level: age subtracted from answer and authority TTLs, clamped to zero when the age exceeds the TTL, OPT metadata left intact, and TTLs unchanged when no age is supplied.
- `DnsClientDnssecOptionsTests` — end to end through a DoH `HttpMessageHandler` that sets `Age`: the 600 / `Age: 250` → 350 case, the authority (negative-caching) TTL, clamping, no-`Age` behaviour, and the OPT record keeping `0x01008000` with its DO flag.

## Verification

- Debug and `Release` + `IsOfficialBuild=true` builds with `/p:TreatsWarningsAsErrors=true` for the library, its tests, and the dependent `Meziantou.DnsProxy` and `Trimmable` projects: 0 warnings, 0 errors.
- Confirmed via the TRX output that all 8 new tests ran by name and passed on both `net10.0` and `net11.0`.
- Full suites, 0 failures: DnsClient 284 passed / 2 skipped, DnsServer 158, DnsProxy 122, DnsFilter 324.
- `dotnet run ./eng/update-all.cs` completed and produced no file changes.