### PR TITLE
Remove waiters in O(1) when their acquisition is canceled

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/AsyncAutoResetEvent.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncAutoResetEvent.cs
@@ -18,7 +18,8 @@ namespace Meziantou.Framework.Threading;
 [DebuggerDisplay("Signaled: {_signaled}")]
 public sealed class AsyncAutoResetEvent
 {
-    private readonly Queue<WaiterCompletionSource> _signalAwaiters = new();
+    private readonly WaiterQueue<WaiterCompletionSource> _signalAwaiters = new();
+    private readonly Lock _lock = new();
     private readonly bool _allowInliningAwaiters;
     internal readonly Action<object> _onCancellationRequestHandler;
     private bool _signaled;
@@ -57,7 +58,7 @@ public sealed class AsyncAutoResetEvent
 
         WaiterCompletionSource waiter;
         bool canceled;
-        lock (_signalAwaiters)
+        lock (_lock)
         {
             if (_signaled)
             {
@@ -89,14 +90,11 @@ public sealed class AsyncAutoResetEvent
     /// <summary>Sets the state of the event to signaled, allowing one waiting task to proceed.</summary>
     public void Set()
     {
-        WaiterCompletionSource? toRelease = null;
-        lock (_signalAwaiters)
+        WaiterCompletionSource? toRelease;
+        lock (_lock)
         {
-            if (_signalAwaiters.Count > 0)
-            {
-                toRelease = _signalAwaiters.Dequeue();
-            }
-            else if (!_signaled)
+            toRelease = _signalAwaiters.Dequeue();
+            if (toRelease is null && !_signaled)
             {
                 _signaled = true;
             }
@@ -113,9 +111,9 @@ public sealed class AsyncAutoResetEvent
     {
         var tcs = (WaiterCompletionSource)state;
         bool removed;
-        lock (_signalAwaiters)
+        lock (_lock)
         {
-            removed = RemoveMidQueue(_signalAwaiters, tcs);
+            removed = _signalAwaiters.Remove(tcs);
         }
 
         // We only cancel the task if we removed it from the queue.
@@ -130,30 +128,7 @@ public sealed class AsyncAutoResetEvent
         }
     }
 
-    private static bool RemoveMidQueue<T>(Queue<T> queue, T valueToRemove)
-        where T : class
-    {
-        var originalCount = queue.Count;
-        var dequeueCounter = 0;
-        var found = false;
-        while (dequeueCounter < originalCount)
-        {
-            dequeueCounter++;
-            var dequeued = queue.Dequeue();
-            if (!found && dequeued == valueToRemove)
-            { // only find 1 match
-                found = true;
-            }
-            else
-            {
-                queue.Enqueue(dequeued);
-            }
-        }
-
-        return found;
-    }
-
-    private sealed class WaiterCompletionSource : TaskCompletionSource
+    private sealed class WaiterCompletionSource : TaskCompletionSource, IWaiterQueueNode<WaiterCompletionSource>
     {
         internal WaiterCompletionSource(AsyncAutoResetEvent owner, bool allowInliningContinuations, CancellationToken cancellationToken)
             : base(GetOptions(allowInliningContinuations))
@@ -164,6 +139,10 @@ public sealed class AsyncAutoResetEvent
 
         internal CancellationToken CancellationToken { get; }
         internal CancellationTokenRegistration Registration { get; }
+
+        public WaiterCompletionSource? Previous { get; set; }
+        public WaiterCompletionSource? Next { get; set; }
+        public bool IsQueued { get; set; }
 
         private static TaskCreationOptions GetOptions(bool allowInliningContinuations)
         {

--- a/src/Meziantou.Framework.Threading/Threading/AsyncLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncLock.cs
@@ -21,7 +21,8 @@ namespace Meziantou.Framework.Threading;
 [DebuggerDisplay("Signaled: {_signaled}")]
 public sealed class AsyncLock
 {
-    private readonly Queue<WaiterCompletionSource> _signalAwaiters = new();
+    private readonly WaiterQueue<WaiterCompletionSource> _signalAwaiters = new();
+    private readonly Lock _lock = new();
     private readonly bool _allowInliningAwaiters;
     private readonly Action<object> _onCancellationRequestHandler;
     private bool _signaled = true;
@@ -57,7 +58,7 @@ public sealed class AsyncLock
 
         WaiterCompletionSource waiter;
         bool canceled;
-        lock (_signalAwaiters)
+        lock (_lock)
         {
             if (_signaled)
             {
@@ -93,7 +94,7 @@ public sealed class AsyncLock
     {
         if (_signaled)
         {
-            lock (_signalAwaiters)
+            lock (_lock)
             {
                 if (_signaled)
                 {
@@ -110,14 +111,11 @@ public sealed class AsyncLock
 
     internal void Release()
     {
-        WaiterCompletionSource? toRelease = null;
-        lock (_signalAwaiters)
+        WaiterCompletionSource? toRelease;
+        lock (_lock)
         {
-            if (_signalAwaiters.Count > 0)
-            {
-                toRelease = _signalAwaiters.Dequeue();
-            }
-            else if (!_signaled)
+            toRelease = _signalAwaiters.Dequeue();
+            if (toRelease is null && !_signaled)
             {
                 _signaled = true;
             }
@@ -134,9 +132,9 @@ public sealed class AsyncLock
     {
         var tcs = (WaiterCompletionSource)state;
         bool removed;
-        lock (_signalAwaiters)
+        lock (_lock)
         {
-            removed = RemoveMidQueue(_signalAwaiters, tcs);
+            removed = _signalAwaiters.Remove(tcs);
         }
 
         // We only cancel the task if we removed it from the queue.
@@ -149,29 +147,6 @@ public sealed class AsyncLock
             tcs.TrySetCanceled(tcs.CancellationToken);
             tcs.Registration.Dispose();
         }
-    }
-
-    private static bool RemoveMidQueue<T>(Queue<T> queue, T valueToRemove)
-        where T : class
-    {
-        var originalCount = queue.Count;
-        var dequeueCounter = 0;
-        var found = false;
-        while (dequeueCounter < originalCount)
-        {
-            dequeueCounter++;
-            var dequeued = queue.Dequeue();
-            if (!found && dequeued == valueToRemove)
-            { // only find 1 match
-                found = true;
-            }
-            else
-            {
-                queue.Enqueue(dequeued);
-            }
-        }
-
-        return found;
     }
 
     /// <summary>Represents a disposable lease for an <see cref="AsyncLock"/>. Disposing the lease releases the lock.</summary>
@@ -192,7 +167,7 @@ public sealed class AsyncLock
         }
     }
 
-    private sealed class WaiterCompletionSource : TaskCompletionSource<AsyncLockLease>
+    private sealed class WaiterCompletionSource : TaskCompletionSource<AsyncLockLease>, IWaiterQueueNode<WaiterCompletionSource>
     {
         internal WaiterCompletionSource(AsyncLock owner, bool allowInliningContinuations, CancellationToken cancellationToken)
             : base(GetOptions(allowInliningContinuations))
@@ -203,6 +178,10 @@ public sealed class AsyncLock
 
         internal CancellationToken CancellationToken { get; }
         internal CancellationTokenRegistration Registration { get; }
+
+        public WaiterCompletionSource? Previous { get; set; }
+        public WaiterCompletionSource? Next { get; set; }
+        public bool IsQueued { get; set; }
 
         private static TaskCreationOptions GetOptions(bool allowInliningContinuations)
         {

--- a/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
@@ -38,8 +38,8 @@ public sealed class AsyncReaderWriterLock
     private readonly Action<object?> _onCancellationRequestHandler;
     private readonly Lock _lock = new();
 
-    private readonly Queue<Waiter> _waitingWriters = new();
-    private readonly Queue<Waiter> _waitingReaders = new();
+    private readonly WaiterQueue<Waiter> _waitingWriters = new();
+    private readonly WaiterQueue<Waiter> _waitingReaders = new();
 
     // 0 when the lock is free, the number of readers holding it when positive, -1 when a writer holds it.
     private int _status;
@@ -174,7 +174,7 @@ public sealed class AsyncReaderWriterLock
         if (_waitingWriters.Count > 0)
         {
             _status = -1;
-            return [_waitingWriters.Dequeue()];
+            return [_waitingWriters.Dequeue()!];
         }
 
         if (_waitingReaders.Count > 0)
@@ -182,9 +182,9 @@ public sealed class AsyncReaderWriterLock
             // Every queued reader is admitted at once. This also covers the case where the writers that were
             // blocking them have all been canceled, which would otherwise leave the readers queued forever.
             var readers = new List<Waiter>(_waitingReaders.Count);
-            while (_waitingReaders.Count > 0)
+            while (_waitingReaders.Dequeue() is { } reader)
             {
-                readers.Add(_waitingReaders.Dequeue());
+                readers.Add(reader);
             }
 
             _status = readers.Count;
@@ -215,7 +215,7 @@ public sealed class AsyncReaderWriterLock
         List<Waiter>? toWake;
         lock (_lock)
         {
-            removed = RemoveMidQueue(waiter.IsWriter ? _waitingWriters : _waitingReaders, waiter);
+            removed = (waiter.IsWriter ? _waitingWriters : _waitingReaders).Remove(waiter);
 
             // Removing a waiter can leave the lock free with others still queued behind it. GrantOwnership is a
             // no-op unless _status is 0, so this only does something when that actually happened.
@@ -233,28 +233,6 @@ public sealed class AsyncReaderWriterLock
             waiter.TrySetCanceled(waiter.CancellationToken);
             waiter.Registration.Dispose();
         }
-    }
-
-    private static bool RemoveMidQueue(Queue<Waiter> queue, Waiter valueToRemove)
-    {
-        var originalCount = queue.Count;
-        var dequeueCounter = 0;
-        var found = false;
-        while (dequeueCounter < originalCount)
-        {
-            dequeueCounter++;
-            var dequeued = queue.Dequeue();
-            if (!found && dequeued == valueToRemove)
-            { // only find 1 match
-                found = true;
-            }
-            else
-            {
-                queue.Enqueue(dequeued);
-            }
-        }
-
-        return found;
     }
 
     /// <summary>Represents a disposable releaser for an <see cref="AsyncReaderWriterLock"/>. Disposing the releaser releases either the reader or writer lock.</summary>
@@ -287,7 +265,7 @@ public sealed class AsyncReaderWriterLock
         }
     }
 
-    private sealed class Waiter : TaskCompletionSource<Releaser>
+    private sealed class Waiter : TaskCompletionSource<Releaser>, IWaiterQueueNode<Waiter>
     {
         internal Waiter(AsyncReaderWriterLock owner, bool writer, CancellationToken cancellationToken)
             : base(TaskCreationOptions.RunContinuationsAsynchronously)
@@ -300,5 +278,9 @@ public sealed class AsyncReaderWriterLock
         internal bool IsWriter { get; }
         internal CancellationToken CancellationToken { get; }
         internal CancellationTokenRegistration Registration { get; }
+
+        public Waiter? Previous { get; set; }
+        public Waiter? Next { get; set; }
+        public bool IsQueued { get; set; }
     }
 }

--- a/src/Meziantou.Framework.Threading/Threading/IWaiterQueueNode.cs
+++ b/src/Meziantou.Framework.Threading/Threading/IWaiterQueueNode.cs
@@ -1,0 +1,13 @@
+namespace Meziantou.Framework.Threading;
+
+/// <summary>Implemented by the waiters stored in a <see cref="WaiterQueue{T}"/>. The links live on the waiter
+/// itself, so removing a waiter does not have to search for it.</summary>
+internal interface IWaiterQueueNode<T>
+    where T : class, IWaiterQueueNode<T>
+{
+    T? Previous { get; set; }
+    T? Next { get; set; }
+
+    /// <summary>Whether the waiter currently belongs to a queue. Guarded by the queue owner's lock.</summary>
+    bool IsQueued { get; set; }
+}

--- a/src/Meziantou.Framework.Threading/Threading/WaiterQueue.cs
+++ b/src/Meziantou.Framework.Threading/Threading/WaiterQueue.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework.Threading;
+
+/// <summary>A FIFO queue of waiters that removes a known waiter in constant time.</summary>
+/// <remarks>
+/// A <see cref="Queue{T}"/> can only remove a waiter by dequeuing and re-enqueuing every other one, so canceling
+/// the whole queue costs O(n²) visits. Waiters are canceled one by one during a cancellation storm or a shutdown,
+/// which makes that cost visible. This type is not thread-safe; the owner synchronizes access to it.
+/// </remarks>
+[DebuggerDisplay("Count = {Count}")]
+internal sealed class WaiterQueue<T>
+    where T : class, IWaiterQueueNode<T>
+{
+    private T? _head;
+    private T? _tail;
+
+    public int Count { get; private set; }
+
+    public void Enqueue(T waiter)
+    {
+        Debug.Assert(!waiter.IsQueued, "The waiter is already queued");
+
+        waiter.Previous = _tail;
+        waiter.IsQueued = true;
+
+        if (_tail is null)
+        {
+            _head = waiter;
+        }
+        else
+        {
+            _tail.Next = waiter;
+        }
+
+        _tail = waiter;
+        Count++;
+    }
+
+    /// <summary>Removes and returns the oldest waiter, or <see langword="null"/> when the queue is empty.</summary>
+    public T? Dequeue()
+    {
+        var head = _head;
+        if (head is not null)
+        {
+            Remove(head);
+        }
+
+        return head;
+    }
+
+    /// <summary>Removes <paramref name="waiter"/> from the queue it was enqueued in.</summary>
+    /// <returns><see langword="true"/> if the waiter was queued and got removed; <see langword="false"/> if it had
+    /// already been removed by another caller.</returns>
+    public bool Remove(T waiter)
+    {
+        if (!waiter.IsQueued)
+            return false;
+
+        var previous = waiter.Previous;
+        var next = waiter.Next;
+
+        if (previous is null)
+        {
+            _head = next;
+        }
+        else
+        {
+            previous.Next = next;
+        }
+
+        if (next is null)
+        {
+            _tail = previous;
+        }
+        else
+        {
+            next.Previous = previous;
+        }
+
+        // Clear the links: a waiter usually outlives its removal, and would otherwise keep the rest of the queue alive.
+        waiter.Previous = null;
+        waiter.Next = null;
+        waiter.IsQueued = false;
+        Count--;
+        return true;
+    }
+}

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncAutoResetEventTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncAutoResetEventTests.cs
@@ -64,6 +64,71 @@ public class AsyncAutoResetEventTests
     }
 
     [Fact]
+    public async Task WaitAsync_CancelingWaitersAtEveryPosition_PreservesTheOrderOfTheOthers()
+    {
+        // A canceled waiter is unlinked from the queue. The survivors must keep their FIFO order whether the
+        // canceled waiter was the head, the tail, or in the middle, and consecutive cancellations must not
+        // corrupt the queue.
+        var e = new AsyncAutoResetEvent(initialState: false);
+        var sources = new CancellationTokenSource[10];
+        var waiters = new Task[sources.Length];
+        for (var i = 0; i < sources.Length; i++)
+        {
+            sources[i] = new CancellationTokenSource();
+            waiters[i] = e.WaitAsync(sources[i].Token);
+        }
+
+        int[] canceled = [0, 3, 4, 7, 9];
+        foreach (var index in canceled)
+        {
+            await sources[index].CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiters[index]);
+        }
+
+        int[] survivors = [1, 2, 5, 6, 8];
+        foreach (var index in survivors)
+        {
+            Assert.False(waiters[index].IsCompleted);
+            e.Set();
+            await waiters[index].WaitAsync(Timeout);
+        }
+
+        // The queue is empty again, so a waiter that arrives now must still be reachable.
+        var late = e.WaitAsync();
+        e.Set();
+        await late.WaitAsync(Timeout);
+
+        foreach (var source in sources)
+        {
+            source.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancelingEveryWaiter_LeavesTheQueueEmpty()
+    {
+        var e = new AsyncAutoResetEvent(initialState: false);
+        using var cts = new CancellationTokenSource();
+
+        var waiters = new Task[10];
+        for (var i = 0; i < waiters.Length; i++)
+        {
+            waiters[i] = e.WaitAsync(cts.Token);
+        }
+
+        await cts.CancelAsync();
+        foreach (var waiter in waiters)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+        }
+
+        // The signal must go to a waiter that arrives afterwards, not to one of the canceled ones.
+        var late = e.WaitAsync();
+        e.Set();
+        await late.WaitAsync(Timeout);
+    }
+
+    [Fact]
     public async Task WaitAsync_CancellationRacingWithWait_DoesNotDeadlock()
     {
         // Regression test: WaitAsync used to complete a canceled waiter while still holding the

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncLockTests.cs
@@ -91,6 +91,77 @@ public class AsyncLockTests
     }
 
     [Fact]
+    public async Task LockAsync_CancelingWaitersAtEveryPosition_PreservesTheOrderOfTheOthers()
+    {
+        // A canceled waiter is unlinked from the queue. The survivors must keep their FIFO order whether the
+        // canceled waiter was the head, the tail, or in the middle, and consecutive cancellations must not
+        // corrupt the queue.
+        var asyncLock = new AsyncLock();
+        var held = await asyncLock.LockAsync();
+
+        var sources = new CancellationTokenSource[10];
+        var waiters = new Task<AsyncLock.AsyncLockLease>[sources.Length];
+        for (var i = 0; i < sources.Length; i++)
+        {
+            sources[i] = new CancellationTokenSource();
+            waiters[i] = asyncLock.LockAsync(sources[i].Token).AsTask();
+        }
+
+        int[] canceled = [0, 3, 4, 7, 9];
+        foreach (var index in canceled)
+        {
+            await sources[index].CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiters[index]);
+        }
+
+        var current = held;
+        int[] survivors = [1, 2, 5, 6, 8];
+        foreach (var index in survivors)
+        {
+            Assert.False(waiters[index].IsCompleted);
+            current.Dispose();
+            current = await waiters[index].WaitAsync(Timeout);
+        }
+
+        // The queue is empty again, so a waiter that arrives now must still be reachable.
+        var late = asyncLock.LockAsync().AsTask();
+        current.Dispose();
+        (await late.WaitAsync(Timeout)).Dispose();
+
+        foreach (var source in sources)
+        {
+            source.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task LockAsync_CancelingEveryWaiter_LeavesTheLockFree()
+    {
+        var asyncLock = new AsyncLock();
+        var held = await asyncLock.LockAsync();
+
+        using var cts = new CancellationTokenSource();
+        var waiters = new Task<AsyncLock.AsyncLockLease>[10];
+        for (var i = 0; i < waiters.Length; i++)
+        {
+            waiters[i] = asyncLock.LockAsync(cts.Token).AsTask();
+        }
+
+        await cts.CancelAsync();
+        foreach (var waiter in waiters)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+        }
+
+        // Releasing must not hand the lock to one of the canceled waiters, and a waiter that arrives after the
+        // queue emptied must still be reachable.
+        var late = asyncLock.LockAsync().AsTask();
+        held.Dispose();
+        (await late.WaitAsync(Timeout)).Dispose();
+        Assert.True(asyncLock.TryLock(out _));
+    }
+
+    [Fact]
     public async Task LockAsync_ProvidesMutualExclusion()
     {
         var asyncLock = new AsyncLock();

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -191,6 +191,102 @@ public class AsyncReaderWriterLockTests
     }
 
     [Fact]
+    public async Task CancelingWritersAtEveryPosition_PreservesTheOrderOfTheOthers()
+    {
+        // A canceled waiter is unlinked from the queue. The survivors must keep their FIFO order whether the
+        // canceled waiter was the head, the tail, or in the middle, and consecutive cancellations must not
+        // corrupt the queue.
+        var rwLock = new AsyncReaderWriterLock();
+        var held = await rwLock.WriterLockAsync();
+
+        var sources = new CancellationTokenSource[10];
+        var waiters = new Task<AsyncReaderWriterLock.Releaser>[sources.Length];
+        for (var i = 0; i < sources.Length; i++)
+        {
+            sources[i] = new CancellationTokenSource();
+            waiters[i] = rwLock.WriterLockAsync(sources[i].Token);
+        }
+
+        int[] canceled = [0, 3, 4, 7, 9];
+        foreach (var index in canceled)
+        {
+            await sources[index].CancelAsync();
+            await Assert.ThrowsAsync<TaskCanceledException>(() => waiters[index]);
+        }
+
+        var current = held;
+        int[] survivors = [1, 2, 5, 6, 8];
+        foreach (var index in survivors)
+        {
+            Assert.False(waiters[index].IsCompleted);
+            current.Dispose();
+            current = await waiters[index].WaitAsync(TimeSpan.FromSeconds(30));
+        }
+
+        // The queue is empty again, so a writer that arrives now must still be reachable.
+        var late = rwLock.WriterLockAsync();
+        current.Dispose();
+        (await late.WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+
+        foreach (var source in sources)
+        {
+            source.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CancelingSomeQueuedReaders_AdmitsOnlyTheRemainingOnes()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+        var held = await rwLock.WriterLockAsync();
+
+        var sources = new CancellationTokenSource[6];
+        var waiters = new Task<AsyncReaderWriterLock.Releaser>[sources.Length];
+        for (var i = 0; i < sources.Length; i++)
+        {
+            sources[i] = new CancellationTokenSource();
+            waiters[i] = rwLock.ReaderLockAsync(sources[i].Token);
+        }
+
+        int[] canceled = [0, 2, 5];
+        foreach (var index in canceled)
+        {
+            await sources[index].CancelAsync();
+            await Assert.ThrowsAsync<TaskCanceledException>(() => waiters[index]);
+        }
+
+        held.Dispose();
+
+        // The remaining readers are admitted together, and the reader count must match them exactly: a writer
+        // can only run once every one of them has released.
+        int[] survivors = [1, 3, 4];
+        var releasers = new List<AsyncReaderWriterLock.Releaser>(survivors.Length);
+        foreach (var index in survivors)
+        {
+            releasers.Add(await waiters[index].WaitAsync(TimeSpan.FromSeconds(30)));
+        }
+
+        var writer = rwLock.WriterLockAsync();
+        foreach (var releaser in releasers)
+        {
+            Assert.False(writer.IsCompleted);
+            releaser.Dispose();
+        }
+
+        var writerReleaser = await writer.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // The reader queue is empty again, so a reader that arrives now must still be reachable.
+        var late = rwLock.ReaderLockAsync();
+        writerReleaser.Dispose();
+        (await late.WaitAsync(TimeSpan.FromSeconds(30))).Dispose();
+
+        foreach (var source in sources)
+        {
+            source.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task ReaderContinuationsAreNotInlinedOnTheReleasingThread()
     {
         // The waiting readers used to share a TaskCompletionSource created without


### PR DESCRIPTION
## What

`AsyncAutoResetEvent`, `AsyncLock` and `AsyncReaderWriterLock` stored their waiters in a `Queue<T>`, which can only remove a waiter by dequeuing and re-enqueuing every other one:

```csharp
private static bool RemoveMidQueue<T>(Queue<T> queue, T valueToRemove) { /* O(n) */ }
```

Each cancellation walked the whole queue under the internal lock, so canceling N queued waiters performed N + (N−1) + … + 1 visits — 50,005,000 for 10,000 waiters. A cancellation storm or a shutdown with a long waiter queue turns that into high CPU use and long lock hold times.

The waiters now live in an intrusive doubly-linked queue, so a cancellation unlinks its waiter directly.

## How

Two new internal types:

- `IWaiterQueueNode<T>` — `Previous` / `Next` / `IsQueued`, implemented by each waiter. The links live on the waiter itself, so the queue never has to search for it.
- `WaiterQueue<T>` — `Enqueue` / `Dequeue` / `Remove`, all O(1).

`Remove` returns `false` when the waiter is no longer queued. That preserves the invariant the cancellation paths depend on: exactly one of the cancel path and the grant path removes a given waiter, and only that one completes it. The links are cleared on removal so a canceled waiter does not keep the rest of the queue alive.

FIFO order, signal accounting, and completing waiters / disposing their registrations *outside* the lock are all unchanged.

## Notes for the reviewer

- **`AsyncLock` was fixed too**, though the original issue only named the other two. It carried a byte-identical `RemoveMidQueue`, and leaving one copy behind while introducing the shared type seemed worse than the small extra diff.
- **The public API is unchanged.** Both new types are internal; `ref/Meziantou.Framework.Threading.cs` regenerates with no diff.
- `AsyncAutoResetEvent` and `AsyncLock` used their queue object as their monitor. They now lock a dedicated `Lock`, matching `AsyncReaderWriterLock`.
- **No benchmark.** This is a complexity fix backed by correctness tests; no throughput or elapsed-time improvement is claimed.

## Tests

Six new tests across the three existing test files. Each cancels waiters at the head, the tail and the middle of the queue, then checks that the survivors are served in FIFO order and that a waiter arriving after the queue empties is still reachable.

They were mutation-checked. Two independent breakages of `WaiterQueue.Remove` — dropping the `_tail` fix-up, and dropping the predecessor unlink — each survived the first draft of the tests, so the tests were strengthened until both mutations fail all six.

## Verification

- `dotnet build /p:TreatsWarningsAsErrors=true` — clean, net10.0 and net11.0.
- Release + `IsOfficialBuild=true` — clean; `ref/` regenerated with no diff.
- `dotnet test` — 344 passed (172 × net10.0/net11.0), 0 failed. Confirmed via the `.trx` that all six new tests actually ran.
- `dotnet run ./eng/update-all.cs` — no generated file changes.
- `tests/Trimmable`, the only other project referencing this library, builds clean.
