### PR TITLE
Reject the CONNECT tunnel a destination-specific proxy opens

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -112,8 +112,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var requestUri = context.InitialRequestMessage?.RequestUri ?? throw new InvalidOperationException("The request URI cannot be null.");
-        EnsureConnectionIsNotToAProxy(handler, requestUri, context.DnsEndPoint, options);
+        EnsureConnectionIsNotToAProxy(handler, context.InitialRequestMessage, context.DnsEndPoint, options);
         return ConnectAsync(context, options, dnsIpAddressResolver, cancellationToken);
     }
 
@@ -229,9 +228,12 @@ internal static class ServerSideRequestForgeryConnectPipeline
         return !options.UnsafeIpNetworks.Any(network => network.Contains(normalizedAddress));
     }
 
-    internal static void EnsureConnectionIsNotToAProxy(SocketsHttpHandler handler, Uri requestUri, DnsEndPoint dnsEndPoint, ServerSideRequestForgeryOptions options)
+    internal static void EnsureConnectionIsNotToAProxy(SocketsHttpHandler handler, HttpRequestMessage request, DnsEndPoint dnsEndPoint, ServerSideRequestForgeryOptions options)
     {
-        if (!IsConnectionToAProxy(handler, requestUri, dnsEndPoint))
+        ArgumentNullException.ThrowIfNull(request);
+
+        var requestUri = request.RequestUri ?? throw new InvalidOperationException("The request URI cannot be null.");
+        if (!IsConnectionToAProxy(handler, request, requestUri, dnsEndPoint))
             return;
 
         Log.RejectedProxyConnection(options.Logger, FormatRequestOrigin(requestUri), dnsEndPoint.Host);
@@ -239,13 +241,22 @@ internal static class ServerSideRequestForgeryConnectPipeline
         throw new ServerSideRequestForgeryException("The connection targets a proxy. The request's real destination is established by the proxy and is not visible here, so it cannot be validated. Set SocketsHttpHandler.UseProxy to false, or send requests that need SSRF protection through a handler that does not use a proxy.");
     }
 
-    private static bool IsConnectionToAProxy(SocketsHttpHandler handler, Uri requestUri, DnsEndPoint dnsEndPoint)
+    private static bool IsConnectionToAProxy(SocketsHttpHandler handler, HttpRequestMessage request, Uri requestUri, DnsEndPoint dnsEndPoint)
     {
         // Reading the proxy here rather than when the callback is installed keeps the check correct when the
         // proxy is assigned after ConfigureSsrf, or when HttpClient.DefaultProxy changes later.
         var proxy = handler.UseProxy ? handler.Proxy ?? HttpClient.DefaultProxy : null;
         if (proxy is null)
             return false;
+
+        // A tunnelled destination is opened by a CONNECT request the pool builds itself, targeting the proxy and
+        // naming the real destination only in the Host header. The proxy has already been consulted by then, for
+        // a destination this callback never receives, so asking it anything here answers about the wrong URI: a
+        // proxy that applies to some destinations only (a PAC script, a custom IWebProxy) reports DIRECT for
+        // everything reachable from here and would hide the destination it does proxy behind its own address.
+        // The tunnel request is therefore the signal, and it is conclusive on its own.
+        if (request.Method == HttpMethod.Connect)
+            return true;
 
         // Asking about the request URI alone is not enough. For an https target the pool substitutes the proxy's
         // own URI as the initial request, and GetProxy then returns that same URI - which is indistinguishable

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
@@ -88,6 +88,13 @@ handler.ConfigureSsrf(options);
 
 Requests the proxy is configured to bypass are connected to directly and are validated normally.
 
+The rejection does not depend on what the proxy reports for the destinations it can be asked about here. An
+`https` destination is reached over a `CONNECT` tunnel the connection pool opens with a request of its own, which
+targets the *proxy* and carries the real destination only in a `Host` header. A proxy that applies to some
+destinations only - a PAC script, or a custom `IWebProxy` - answers DIRECT for every destination reachable from
+the connection callback, and would otherwise hide the destination it does proxy behind its own address. The tunnel
+request is therefore treated as a proxy connection on its own.
+
 ## HTTP/3
 
 Validation runs from `SocketsHttpHandler.ConnectCallback`, which the runtime uses only for TCP connections. An

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -306,6 +306,66 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     }
 
     [Fact]
+    public async Task ConnectCallback_RejectsATunnelToAProxyThatOnlyAppliesToTheTarget()
+    {
+        var options = CreateProxyTestOptions();
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = true,
+            Proxy = new DestinationSpecificWebProxy(new Uri("http://127.0.0.1:9"), proxiedHost: "example.invalid"),
+        };
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri("https://example.invalid/"), TestContext.Current.CancellationToken));
+
+        // The proxy applies to the target only, so it reports DIRECT for every destination this callback can ask
+        // about - including the proxy URI the pool substitutes for the request. Without the tunnel check the
+        // connection to the proxy is validated as a direct one and the request fails with a socket error.
+        Assert.IsType<ServerSideRequestForgeryException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_RejectsATunnelRequestNoDestinationReportsTheProxyFor()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        var proxy = new DestinationSpecificWebProxy(new Uri("http://proxy.invalid:8080"), proxiedHost: "hidden.invalid");
+        using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = proxy };
+
+        // What the pool builds to open an https tunnel: the proxy's own URI, the real destination only in Host.
+        using var tunnelRequest = new HttpRequestMessage(HttpMethod.Connect, "http://proxy.invalid:8080/");
+        tunnelRequest.Headers.Host = "hidden.invalid:443";
+
+        var exception = Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            tunnelRequest,
+            new DnsEndPoint("proxy.invalid", 8080),
+            options));
+
+        Assert.Contains("targets a proxy", exception.Message);
+    }
+
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_DoesNotThrowOnAConnectRequestWhenNoProxyIsConfigured()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = false,
+            Proxy = new WebProxy("http://proxy.invalid:8080", BypassOnLocal: false),
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Connect, "https://example.com/");
+
+        // No proxy can tunnel this connection, so the request URI is the real destination and gets validated.
+        ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            request,
+            new DnsEndPoint("example.com", 443),
+            options);
+    }
+
+    [Fact]
     public void EnsureConnectionIsNotToAProxy_LogsRejectionReason()
     {
         using var loggerProvider = new InMemoryLoggerProvider();
@@ -319,9 +379,11 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
             Proxy = new WebProxy("http://proxy.invalid:8080", BypassOnLocal: false),
         };
 
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
+
         Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
             handler,
-            new Uri("https://example.com/"),
+            request,
             new DnsEndPoint("proxy.invalid", 8080),
             options));
 
@@ -338,9 +400,11 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
             Proxy = new WebProxy("http://proxy.invalid:8080", BypassOnLocal: false),
         };
 
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
+
         ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
             handler,
-            new Uri("https://example.com/"),
+            request,
             new DnsEndPoint("example.com", 443),
             options);
     }
@@ -352,11 +416,12 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         var proxy = new CountingWebProxy(new Uri("http://proxy.invalid:8080"));
         using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = proxy };
 
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
         for (var i = 0; i < 5; i++)
         {
             ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
                 handler,
-                new Uri("https://example.com/"),
+                request,
                 new DnsEndPoint("example.com", 443),
                 options);
         }
@@ -373,17 +438,19 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         var proxy = new CountingWebProxy(new Uri("http://proxy.invalid:8080"));
         using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = proxy };
 
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
+
         // Populate the cache with a connection that is not to the proxy.
         ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
             handler,
-            new Uri("https://example.com/"),
+            request,
             new DnsEndPoint("example.com", 443),
             options);
 
         // A later connection that does target the proxy must still be rejected off the cached probe result.
         var exception = Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
             handler,
-            new Uri("https://example.com/"),
+            request,
             new DnsEndPoint("proxy.invalid", 8080),
             options));
 
@@ -399,21 +466,33 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         var second = new CountingWebProxy(new Uri("http://proxy-two.invalid:9090"));
 
         using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = first };
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
         ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
             handler,
-            new Uri("https://example.com/"),
+            request,
             new DnsEndPoint("example.com", 443),
             options);
 
         handler.Proxy = second;
         Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
             handler,
-            new Uri("https://example.com/"),
+            request,
             new DnsEndPoint("proxy-two.invalid", 9090),
             options));
 
         Assert.Equal(2, first.ProbeQueryCount);
         Assert.Equal(2, second.ProbeQueryCount);
+    }
+
+    // A proxy that applies to one destination only. Everything else - the probe destinations and the proxy URI the
+    // pool substitutes for a tunnelled request - is reported as bypassed.
+    private sealed class DestinationSpecificWebProxy(Uri proxyUri, string proxiedHost) : IWebProxy
+    {
+        public ICredentials? Credentials { get; set; }
+
+        public Uri? GetProxy(Uri destination) => IsBypassed(destination) ? destination : proxyUri;
+
+        public bool IsBypassed(Uri host) => !string.Equals(host.Host, proxiedHost, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed class CountingWebProxy(Uri proxyUri) : IWebProxy


### PR DESCRIPTION
## The problem

`ServerSideRequestForgeryConnectPipeline` refuses to validate a proxied connection, because the real destination is established by the proxy and is not visible at connect time. That refusal could be evaded.

For an `https` destination, `SocketsHttpHandler` opens the connection with a `CONNECT` request it builds itself. Verified against the runtime:

```text
GetProxy(https://127.0.0.1/) -> https://8.8.8.8/
callback: method=CONNECT uri=https://8.8.8.8/ hostHeader=127.0.0.1:443 endpoint=8.8.8.8:443
```

The request URI is the *proxy's*; the real destination survives only in the `Host` header. The proxy has already been consulted by then, for a destination `ConnectCallback` never receives — so every question the guard could still ask is about the wrong URI: the substituted request URI, and the two reserved `.invalid` probe destinations alike.

A proxy whose routing depends on the destination — a PAC script, a custom `IWebProxy` — therefore answers DIRECT to all of them. The guard concluded the connection was direct, validated the proxy's own (public, allowed) address, and let the forbidden destination through the tunnel.

## The fix

With a proxy configured, a `CONNECT` initial request *is* the tunnel. That is conclusive on its own, and no amount of interrogating the proxy can add to it:

```csharp
if (request.Method == HttpMethod.Connect)
    return true;
```

`EnsureConnectionIsNotToAProxy` now takes the `HttpRequestMessage` rather than just its URI.

The existing `GetProxy` and probe checks stay. They cover plaintext-over-proxy and SOCKS, where the real destination URI *does* reach the callback, and destinations the proxy bypasses keep connecting directly and being validated normally.

## For the reviewer

One deliberate trade rather than a certainty: a user-issued HTTP/2 extended `CONNECT` (a WebSocket upgrade) on a handler that has a proxy configured but bypasses the target is now rejected too, even though its destination could in principle have been validated. That fails closed and matches the library's documented contract of `UseProxy = false`, but it is a behavior change if anyone relied on it.

The alternative considered — gating on the `Host` header naming an authority other than the request URI, which is what actually distinguishes the two — was dropped as too dependent on a runtime implementation detail to be worth the narrower rejection.

Every change is internal; `ref/` is unaffected.

## Verification

Three tests added, driven by a `DestinationSpecificWebProxy` that mirrors the reported reproduction, including an end-to-end one through `HttpClient`. Both rejection tests were confirmed to fail with the new check disabled and pass with it.

- `dotnet test` on the project: **192/192 pass** (96 × net10.0/net11.0), 0 warnings with `TreatWarningsAsErrors=true`.
- `dotnet run ./eng/update-all.cs`: exit 0, no generated-file changes.

The readme's Proxies section now explains why the tunnel is rejected regardless of what the proxy reports.
