### PR TITLE
Cap the DoH cache lifetime of negative answers at the SOA MINIMUM

### DIFF
--- a/src/Meziantou.Framework.DnsServer/Hosting/DnsEndpointRouteBuilderExtensions.cs
+++ b/src/Meziantou.Framework.DnsServer/Hosting/DnsEndpointRouteBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Net;
 using Meziantou.Framework.DnsServer.Handler;
 using Meziantou.Framework.DnsServer.Protocol;
+using Meziantou.Framework.DnsServer.Protocol.Records;
 using Meziantou.Framework.DnsServer.Protocol.Wire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -122,7 +123,8 @@ public static class DnsEndpointRouteBuilderExtensions
             return Results.BadRequest("Invalid DNS message.");
         }
 
-        // RFC 8484 5.1: the response is cacheable for as long as its shortest record TTL.
+        // RFC 8484 5.1: the response is cacheable for as long as its shortest record TTL, and no
+        // longer than the authority SOA MINIMUM when there is no answer.
         httpContext.Response.Headers.CacheControl = GetCacheControl(responseBytes);
 
         return Results.Bytes(responseBytes, DnsMessageContentType);
@@ -136,7 +138,22 @@ public static class DnsEndpointRouteBuilderExtensions
             var response = DnsMessageEncoder.DecodeQuery(responseBytes);
             foreach (var record in response.Answers.Concat(response.Authorities).Concat(response.AdditionalRecords))
             {
-                minimumTtl = minimumTtl is { } current ? Math.Min(current, record.TimeToLive) : record.TimeToLive;
+                minimumTtl = Math.Min(minimumTtl ?? uint.MaxValue, record.TimeToLive);
+            }
+
+            // RFC 8484 5.1: when the answer section is empty, an SOA in the authority section caps the
+            // lifetime at its MINIMUM field, which is what bounds negative caching (RFC 2308 5). Without
+            // this an NXDOMAIN or NODATA answer could be held by HTTP caches for the whole SOA TTL and
+            // hide a record created in the meantime.
+            if (response.Answers.Count is 0)
+            {
+                foreach (var authority in response.Authorities)
+                {
+                    if (authority.Data is DnsSoaRecordData soa)
+                    {
+                        minimumTtl = Math.Min(minimumTtl ?? uint.MaxValue, soa.Minimum);
+                    }
+                }
             }
         }
         catch (DnsProtocolException)

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -872,6 +872,62 @@ public sealed class DnsServerIntegrationTests
         }
     }
 
+    [Theory]
+    // A negative answer must not outlive the SOA MINIMUM, whether it is an NXDOMAIN or a NODATA answer.
+    [InlineData(DnsResponseCode.NameError, 3600u, 60u, "max-age=60")]
+    [InlineData(DnsResponseCode.NoError, 3600u, 60u, "max-age=60")]
+    // A zero MINIMUM forbids caching the negative answer at all.
+    [InlineData(DnsResponseCode.NameError, 600u, 0u, "no-store")]
+    [InlineData(DnsResponseCode.NoError, 600u, 0u, "no-store")]
+    // The SOA TTL still applies when it is the shorter of the two.
+    [InlineData(DnsResponseCode.NameError, 30u, 600u, "max-age=30")]
+    public async Task DoH_ResponseWithoutAnswers_CacheLifetimeIsCappedByTheSoaMinimum(DnsResponseCode responseCode, uint soaTimeToLive, uint soaMinimum, string expectedCacheControl)
+    {
+        await using var app = await StartDohServerAsync((context, ct) =>
+        {
+            var response = context.CreateResponse();
+            response.ResponseCode = responseCode;
+            response.Authorities.Add(new DnsResourceRecord
+            {
+                Name = "example.com",
+                Type = DnsQueryType.SOA,
+                Class = DnsQueryClass.IN,
+                TimeToLive = soaTimeToLive,
+                Data = new DnsSoaRecordData
+                {
+                    PrimaryNameServer = "ns1.example.com",
+                    ResponsibleMailbox = "hostmaster.example.com",
+                    Serial = 1,
+                    Refresh = 7200,
+                    Retry = 3600,
+                    Expire = 1209600,
+                    Minimum = soaMinimum,
+                },
+            });
+
+            return ValueTask.FromResult(response);
+        });
+
+        try
+        {
+            var address = app.Urls.First(u => u.StartsWith("http://", StringComparison.Ordinal));
+            using var httpClient = new HttpClient { BaseAddress = new Uri(address) };
+
+            using var content = new ByteArrayContent(CreateQueryBytes("missing.example.com", DnsQueryType.A));
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/dns-message");
+
+            using var response = await httpClient.PostAsync("/dns-query", content, XunitCancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            // RFC 8484 5.1: with an empty answer section the lifetime is bounded by the authority SOA MINIMUM.
+            Assert.Equal(expectedCacheControl, response.Headers.CacheControl?.ToString());
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
     [Fact]
     public async Task MapDnsHandler_CalledTwice_Throws()
     {
@@ -1042,14 +1098,9 @@ public sealed class DnsServerIntegrationTests
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
-    private static async Task<WebApplication> StartDohServerAsync()
+    private static Task<WebApplication> StartDohServerAsync()
     {
-        var builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseUrls("http://127.0.0.1:0");
-        builder.AddDnsServer(_ => { });
-
-        var app = builder.Build();
-        app.MapDnsHandler((context, ct) =>
+        return StartDohServerAsync((context, ct) =>
         {
             var response = context.CreateResponse();
             response.Answers.Add(new DnsResourceRecord
@@ -1063,6 +1114,16 @@ public sealed class DnsServerIntegrationTests
 
             return ValueTask.FromResult(response);
         });
+    }
+
+    private static async Task<WebApplication> StartDohServerAsync(DnsRequestDelegate handler)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.AddDnsServer(_ => { });
+
+        var app = builder.Build();
+        app.MapDnsHandler(handler);
         app.MapDnsOverHttps("/dns-query");
 
         await app.StartAsync();


### PR DESCRIPTION
## What

`GetCacheControl` in `DnsEndpointRouteBuilderExtensions` took the minimum resource-record `TimeToLive` across the answer, authority and additional sections, but ignored `DnsSoaRecordData.Minimum`. It now also caps the lifetime at the authority SOA's `MINIMUM` when the answer section is empty.

## Why

A negative answer — NXDOMAIN or NODATA — whose authority SOA carried a large TTL and a small MINIMUM was advertised to HTTP caches for the full TTL. Encoding a response with no answers and an authority SOA of `TimeToLive = 3600` / `Minimum = 60` produced `Cache-Control: max-age=3600`, so a record created in the meantime stayed hidden for an hour instead of the intended minute.

[RFC 8484 §5.1](https://www.rfc-editor.org/rfc/rfc8484.html#section-5.1) requires that a response with no records in the answer section have a freshness lifetime no greater than the MINIMUM field of the SOA in the authority section.

## How

The SOA MINIMUM is combined with the existing per-record minimum rather than replacing it, so whichever of the SOA TTL and its MINIMUM is shorter wins — that matches the negative-caching bound of [RFC 2308 §5](https://www.rfc-editor.org/rfc/rfc2308.html#section-5). A MINIMUM of zero falls into the existing `no-store` branch.

Public API is unchanged (the method is private), so `ref/` is untouched.

## Tests

Added `DoH_ResponseWithoutAnswers_CacheLifetimeIsCappedByTheSoaMinimum` to the existing `DnsServerIntegrationTests` — a `[Theory]` with 5 cases covering NXDOMAIN and NODATA, MINIMUM zero for both, and the case where the SOA TTL is the shorter bound. It drives the real DoH endpoint over HTTP and asserts on the `Cache-Control` header.

`StartDohServerAsync` gained an overload taking a `DnsRequestDelegate`; the existing parameterless helper now delegates to it, so no existing test changed behaviour.

## Verification

- Full `Meziantou.Framework.DnsServer.Tests`: 168/168 passed (84 per TFM, net10.0 + net11.0). `DnsProxy.Tests` 122/122, `DnsFilter.Tests` 324/324.
- Builds clean with `/p:TreatsWarningsAsErrors=true`, and under `-c Release /p:IsOfficialBuild=true` (which runs the IDE analyzers and regenerates `ref/` — no diff).
- `dotnet run ./eng/update-all.cs` produced no file changes.
- Checked the new tests actually cover the bug: with the new block disabled, 4 of the 5 cases fail with the old `max-age=3600` / `max-age=600` values. The fifth (SOA TTL shorter than MINIMUM) passes either way and guards against over-correcting.
