### PR TITLE
Enforce the DNS over HTTPS response size limit while reading the body

### DIFF
--- a/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Net.Http.Headers;
 
 namespace Meziantou.Framework.DnsClient.Transport;
@@ -61,11 +62,34 @@ internal sealed class DnsHttpsTransport : IDnsTransport
         if (response.Content.Headers.ContentLength > MaxResponseLength)
             throw new DnsProtocolException($"The DNS over HTTPS response declares {response.Content.Headers.ContentLength} bytes, which exceeds the {MaxResponseLength}-byte maximum for a DNS message.");
 
-        var body = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-        if (body.Length > MaxResponseLength)
-            throw new DnsProtocolException($"The DNS over HTTPS response is {body.Length} bytes, which exceeds the {MaxResponseLength}-byte maximum for a DNS message.");
+        return await ReadBodyAsync(response.Content, cancellationToken).ConfigureAwait(false);
+    }
 
-        return body;
+    /// <summary>
+    /// Reads the body without trusting the declared length. At most one byte beyond the maximum is read, so a server
+    /// sending an unknown-length or endless body cannot make the client buffer more than a DNS message can hold.
+    /// </summary>
+    private static async Task<byte[]> ReadBodyAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            const int MaxReadLength = MaxResponseLength + 1;
+
+            var buffer = ArrayPool<byte>.Shared.Rent(MaxReadLength);
+            try
+            {
+                var length = await stream.ReadAtLeastAsync(buffer.AsMemory(0, MaxReadLength), MaxReadLength, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+                if (length > MaxResponseLength)
+                    throw new DnsProtocolException($"The DNS over HTTPS response exceeds the {MaxResponseLength}-byte maximum for a DNS message.");
+
+                return buffer.AsSpan(0, length).ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
     }
 
     public void Dispose()

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
@@ -84,6 +84,121 @@ public sealed class DnsClientDnssecOptionsTests
         Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, handler.RequestVersionPolicy);
     }
 
+    [Fact]
+    public async Task QueryAsync_Https_UnknownLengthResponseLargerThanADnsMessage_IsRejectedWithoutBufferingItAll()
+    {
+        // The response declares no Content-Length, so the size limit can only be enforced while reading the body.
+        using var handler = new StreamingHttpMessageHandler(totalLength: 1024 * 1024);
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        await Assert.ThrowsAsync<DnsProtocolException>(() => client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken));
+
+        Assert.True(handler.BytesRead <= MaxDnsMessageLength + 1, $"The transport read {handler.BytesRead} bytes of an oversized response instead of stopping at {MaxDnsMessageLength + 1}.");
+    }
+
+    [Fact]
+    public async Task QueryAsync_Https_UnknownLengthResponseWithinTheLimit_IsRead()
+    {
+        using var handler = new StreamingHttpMessageHandler(totalLength: null);
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A, TestContext.Current.CancellationToken);
+
+        Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
+        Assert.Equal("example.com", response.Questions[0].Name);
+    }
+
+    /// <summary>A DNS message can never exceed 65535 bytes; the transport must not buffer more than that.</summary>
+    private const int MaxDnsMessageLength = 65535;
+
+    /// <summary>Answers with a body of unknown length, counting how many bytes the transport actually pulls from it.</summary>
+    private sealed class StreamingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly int? _totalLength;
+
+        /// <param name="totalLength">
+        /// The size of the padding body to answer with, representing a resolver that sends far more data than a DNS
+        /// message can hold, or <see langword="null" /> to answer with a well-formed response.
+        /// </param>
+        public StreamingHttpMessageHandler(int? totalLength)
+        {
+            _totalLength = totalLength;
+        }
+
+        public long BytesRead { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var query = await request.Content!.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            var body = _totalLength is { } length ? new byte[length] : CreateEmptyResponse(query);
+
+            // A non-seekable stream is what makes StreamContent report no Content-Length. The response owns it.
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new CountingStream(this, body)),
+            };
+        }
+
+        private sealed class CountingStream : Stream
+        {
+            private readonly StreamingHttpMessageHandler _owner;
+            private readonly byte[] _content;
+            private int _position;
+
+            public CountingStream(StreamingHttpMessageHandler owner, byte[] content)
+            {
+                _owner = owner;
+                _content = content;
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+            public override int Read(Span<byte> buffer)
+            {
+                // Answer in small chunks, so a reader that ignores the limit has to come back for more.
+                var count = Math.Min(Math.Min(buffer.Length, 4096), _content.Length - _position);
+                _content.AsSpan(_position, count).CopyTo(buffer);
+                _position += count;
+                _owner.BytesRead += count;
+                return count;
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+                => ValueTask.FromResult(Read(buffer.Span));
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override void Flush() => throw new NotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+
     private static bool IsCheckingDisabled(byte[] query)
     {
         var flags = (query[2] << 8) | query[3];


### PR DESCRIPTION
## What changed

`DnsHttpsTransport` sends its request with `HttpCompletionOption.ResponseHeadersRead` and then called `response.Content.ReadAsByteArrayAsync(...)`, which buffers the entire body. `HttpClient.MaxResponseContentBufferSize` does not bound that explicit content read, and the only up-front check looked at a declared `Content-Length`. The actual length check ran *after* the whole body had already been materialized, so it could not prevent the allocation it was meant to prevent.

The body is now read through the content stream with `ReadAtLeastAsync` into a pooled buffer of `MaxResponseLength + 1` bytes. The stream is never asked for more than 65,536 bytes, so an unknown-length (or endless) body cannot force the client to buffer more than a DNS message can hold.

## Why

A DNS message can never exceed 65,535 bytes, and the transport already stated that limit — it just enforced it too late. An untrusted or compromised DoH resolver could answer with a chunked/unknown-length body and drive unbounded allocation in the client. Reproduced before the fix: a 1 MB unknown-length response was consumed in full (**1,048,576 bytes**) before the exception was thrown.

## Notes for reviewers

- Reading exactly **one** byte past the maximum is deliberate: it is what still distinguishes a legal 65,535-byte message from an oversized one, so the limit stays exact rather than becoming off-by-one strict.
- `throwOnEndOfStream: false` keeps the normal short-body case working — nearly every real response is far below the limit.
- `ArrayPool` is used because the previous code allocated only what actually arrived (typically a few hundred bytes); renting avoids turning every query into a fresh 64 KB allocation.
- The declared-`Content-Length` fast path is unchanged.
- The post-read exception message no longer reports an exact byte count, since the transport now deliberately stops before it can know one.

## Tests

Two tests added to `DnsClientDnssecOptionsTests`, driven through a `StreamContent` over a non-seekable counting stream (non-seekable is what makes `StreamContent` report no `Content-Length`):

- an oversized unknown-length body throws `DnsProtocolException`, and the test asserts the transport pulled at most 65,536 bytes — not just that it threw.
- a normal unknown-length body is still read and parsed.

I confirmed the first test is not vacuous: with the fix temporarily reverted it fails, reporting all 1,048,576 bytes consumed.

## Verification

- Debug build and Release build with `IsOfficialBuild=true`, both with `TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet test` on `Meziantou.Framework.DnsClient.Tests`: **272 passed, 0 failed, 2 skipped** across `net10.0` and `net11.0`. The 2 skips are pre-existing network/environment guards, unrelated to this change.
- `dotnet run ./eng/update-all.cs` completed successfully and produced no file changes. No `ref/` changes, as expected for an internal-only change.
