### PR TITLE
Guard the AMSI EICAR tests with RunIf(Windows)

### DIFF
--- a/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
@@ -5,7 +5,7 @@ namespace Meziantou.Framework.Win32.AmsiTests;
 [Collection("AmsiContextTests")]
 public class AmsiContextTests
 {
-    [Fact, SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
+    [Fact, RunIf(TestOperatingSystems.Windows), SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
     public void AmsiShouldDetectMalware_Buffer()
     {
         using var application = AmsiContext.Create("MyApplication");
@@ -13,7 +13,7 @@ public class AmsiContextTests
         Assert.False(application.IsMalware(new byte[] { 0, 0, 0, 0 }, "EICAR"));
     }
 
-    [Fact, SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
+    [Fact, RunIf(TestOperatingSystems.Windows), SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
     public void AmsiShouldDetectMalware_String()
     {
         using var application = AmsiContext.Create("MyApplication");
@@ -21,7 +21,7 @@ public class AmsiContextTests
         Assert.False(application.IsMalware("0000", "EICAR"));
     }
 
-    [Fact, SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
+    [Fact, RunIf(TestOperatingSystems.Windows), SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
     public void AmsiSessionShouldDetectMalware_Buffer()
     {
         using var application = AmsiContext.Create("MyApplication");
@@ -30,7 +30,7 @@ public class AmsiContextTests
         Assert.False(session.IsMalware([0, 0, 0, 0], "EICAR"));
     }
 
-    [Fact, SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
+    [Fact, RunIf(TestOperatingSystems.Windows), SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
     public void AmsiSessionShouldDetectMalware_String()
     {
         using var application = AmsiContext.Create("MyApplication");


### PR DESCRIPTION
## What changed

Adds `[RunIf(TestOperatingSystems.Windows)]` to four tests in `tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs`:

- `AmsiShouldDetectMalware_Buffer`
- `AmsiShouldDetectMalware_String`
- `AmsiSessionShouldDetectMalware_Buffer`
- `AmsiSessionShouldDetectMalware_String`

## Why

These four were attributed only with `SkipIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)`, unlike every other AMSI test in the class. On a non-Windows machine they reach `AmsiContext.Create(...)`, which P/Invokes into `Amsi.dll`, and fail with:

```
System.DllNotFoundException: Unable to load shared library 'Amsi.dll'
```

On an arm64 macOS dev machine that is 8 failures in a full-solution run (4 tests × net11.0/net10.0). CI never caught it, because these same tests skip on GitHub Actions.

## Notes for reviewers

- **The existing `SkipIf` is intentionally kept.** Hosted agents can initialize AMSI but have no provider ready to scan — see the comment on `DisposingTheContextBeforeTheSessionIsSafe`. The two attributes guard different things, so both are needed.
- **Attribute ordering matches the existing precedent** in the same file: `ScanReportsTheRawProviderResult` already combines `[Fact, RunIf(...), SkipIf(...)]` for exactly this reason.
- **This does not change CI coverage.** These four tests still never execute in CI. The change removes local-macOS noise; the EICAR assertions remain covered only on a Windows machine with a live AMSI provider. Worth knowing if you were counting on CI to catch a regression here.

## Verification

macOS (arm64), Release, `/p:TreatsWarningsAsErrors=true`:

```
dotnet test tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj -c Release /p:TreatsWarningsAsErrors=true
```

```
total: 64 | failed: 0 | succeeded: 40 | skipped: 24
```

Zero failures across both TFMs, down from 8 `DllNotFoundException` failures. Skips went 8 → 12 per TFM, the expected +4.

Confirmed the tests are reported rather than silently dropped: all eight entries (4 tests × 2 TFMs) appear in the `.trx` files with `outcome="NotExecuted"`, each with the reason `Run only on Windows`.

`dotnet run ./eng/update-all.cs` ran to completion and regenerated nothing.
