### PR TITLE
Update to .NET 11 RC1

### DIFF
--- a/common/TargetFrameworkHelper.cs
+++ b/common/TargetFrameworkHelper.cs
@@ -15,7 +15,7 @@ internal static class TargetFrameworkHelper
 #if NET10_0
         $"10.0.0";
 #elif NET11_0
-        $"11.0.0-preview.7.26381.103";
+        $"11.0.0-rc.1.26425.128";
 #else
 #error Version not supported
 #endif

--- a/eng/update-all.cs
+++ b/eng/update-all.cs
@@ -1491,9 +1491,22 @@ static string GetToolHelpText(string csproj, string latestTfm, string? toolName,
         throw new InvalidOperationException($"Process 'dotnet {string.Join(' ', runArgs)}' produced empty help output.");
     }
 
-    if (!string.IsNullOrEmpty(toolName))
+    var projectName = Path.GetFileNameWithoutExtension(csproj);
+    return RewriteUsageCommandName(helpText, projectName, string.IsNullOrEmpty(toolName) ? projectName : toolName);
+}
+
+// System.CommandLine names the root command after the running executable. 'dotnet run' starts the apphost,
+// whose file name has no extension on Unix, so the last segment of the project name (".Tool") gets trimmed off.
+// Only the usage line is rewritten: a description may legitimately mention the library the tool is built on.
+static string RewriteUsageCommandName(string helpText, string projectName, string commandName)
+{
+    string[] candidates = [projectName, Path.GetFileNameWithoutExtension(projectName)];
+    foreach (var candidate in candidates)
     {
-        helpText = helpText.Replace(Path.GetFileNameWithoutExtension(csproj), toolName, StringComparison.Ordinal);
+        var pattern = $@"(?<=^Usage:\r?\n  ){Regex.Escape(candidate)}(?=[ \r\n]|$)";
+        var rewritten = Regex.Replace(helpText, pattern, _ => commandName, RegexOptions.Multiline | RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan);
+        if (rewritten != helpText)
+            return rewritten;
     }
 
     return helpText;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.7.26381.103",
+    "version": "11.0.100-rc.1.26425.128",
     "rollForward": "latestFeature"
   },
   "test": {

--- a/samples/BlazorAppSample/BlazorAppSample.csproj
+++ b/samples/BlazorAppSample/BlazorAppSample.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26381.103" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="11.0.0-preview.7.26381.103" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-rc.1.26425.128" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="11.0.0-rc.1.26425.128" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26381.103" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="11.0.0-rc.1.26425.128" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">

--- a/src/Meziantou.AspNetCore.Components.WebAssembly/Meziantou.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Meziantou.AspNetCore.Components.WebAssembly/Meziantou.AspNetCore.Components.WebAssembly.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26381.103" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.1.26425.128" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">

--- a/src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj
+++ b/src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26381.103" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="11.0.0-rc.1.26425.128" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">

--- a/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-rc.1.26425.128" />
     <!-- Force Microsoft.OpenApi to a non-vulnerable (transitive: Microsoft.AspNetCore.OpenApi) -->
     <PackageReference Include="Microsoft.OpenApi" Version="3.10.2" />
   </ItemGroup>

--- a/src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj
+++ b/src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AssertionsAnalyzerTestBase.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AssertionsAnalyzerTestBase.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.Tests;
 
 public abstract class AssertionsAnalyzerTestBase
 {
-    private static readonly ReferenceAssemblies Net11 = new ReferenceAssemblies("net11.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "11.0.0-preview.7.26381.103"), Path.Combine("ref", "net11.0"));
+    private static readonly ReferenceAssemblies Net11 = new ReferenceAssemblies("net11.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "11.0.0-rc.1.26425.128"), Path.Combine("ref", "net11.0"));
 
     protected static CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> CreateAnalyzerTest<TAnalyzer>(string source, bool addAssertionsReference = true)
         where TAnalyzer : DiagnosticAnalyzer, new()

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -1009,7 +1009,9 @@ public sealed class DnsServerIntegrationTests
     {
         // A hosted service registered after the DNS server fails once the UDP listener is already
         // running, so the host unwinds and disposes it while ExecuteAsync is still starting up.
-        for (var attempt = 0; attempt < 20; attempt++)
+        var completedAttempts = 0;
+        var portCollisions = 0;
+        while (completedAttempts < 20)
         {
             var builder = WebApplication.CreateBuilder();
             builder.WebHost.UseUrls("http://127.0.0.1:0");
@@ -1029,9 +1031,21 @@ public sealed class DnsServerIntegrationTests
 
             var exception = await Assert.ThrowsAnyAsync<Exception>(() => app.StartAsync(XunitCancellationToken));
 
+            // The ports are probed by binding and releasing them, so anything else on the machine can take
+            // one back before the listener binds it - the other target framework running this same test, for
+            // one. That collision says nothing about the race under test, so re-roll the attempt rather than
+            // read the SocketException as the startup failure. A run that only ever collides still fails.
+            if (exception is SocketException { SocketErrorCode: SocketError.AddressAlreadyInUse })
+            {
+                portCollisions++;
+                Assert.True(portCollisions <= 20, "Could not reserve the listener ports often enough to exercise the race.");
+                continue;
+            }
+
             // The startup failure has to be the one the service reported, not a collection-modified
             // race inside the listener.
             Assert.IsType<InvalidTimeZoneException>(exception);
+            completedAttempts++;
         }
     }
 

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FullPathAnalyzerTestBase.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FullPathAnalyzerTestBase.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.Tests;
 
 public abstract class FullPathAnalyzerTestBase
 {
-    private static readonly ReferenceAssemblies Net11 = new ReferenceAssemblies("net11.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "11.0.0-preview.7.26381.103"), Path.Combine("ref", "net11.0"));
+    private static readonly ReferenceAssemblies Net11 = new ReferenceAssemblies("net11.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "11.0.0-rc.1.26425.128"), Path.Combine("ref", "net11.0"));
 
     protected static CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> CreateAnalyzerTest<TAnalyzer>(string source)
         where TAnalyzer : DiagnosticAnalyzer, new()

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
+++ b/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
@@ -502,6 +502,13 @@ public sealed class NtpServerTests : IAsyncLifetime
         var port = server.Port;
         server.Dispose();
 
+        // Every test here binds an ephemeral port, so the port the server just released can be handed to
+        // another server started in parallel, which then answers the query and the assertion never fires.
+        // Holding the port with a socket that never replies keeps it out of that pool; the bind also fails
+        // if Dispose stopped releasing the socket, which is the behavior under test.
+        using var placeholder = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp) { ExclusiveAddressUse = true };
+        placeholder.Bind(new IPEndPoint(IPAddress.Loopback, port));
+
         var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = port, Timeout = TimeSpan.FromSeconds(1) });
 
         await Assert.ThrowsAnyAsync<Exception>(() => client.QueryAsync(XunitCancellationToken));

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-rc.1.26425.128" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1465,7 +1465,8 @@ public class ProcessWrapperTests
             startInfo => Assert.True(startInfo.StartDetached));
     }
 
-    [Fact]
+    // Registers process-wide interceptors, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
     public async Task StartAndForget_AppliesConfigurationAndInterceptors()
     {
         using var temporaryDirectory = TemporaryDirectory.Create();
@@ -1501,7 +1502,9 @@ public class ProcessWrapperTests
         Assert.Equal("wrapper start-info argument", output.Trim());
     }
 
-    [Fact]
+    // Registers a process-wide interceptor that turns validation on for every wrapper created while it is
+    // alive, which makes StartAndForget throw in any test running beside it
+    [Fact(DisableParallelization = true)]
     public void StartAndForget_WithUnsupportedConfiguration_Throws()
     {
         Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithOutputStream(OutputTarget.ToTextDelegate(_ => { })).StartAndForget());


### PR DESCRIPTION
Moves the repo from .NET 11 preview 7 to RC1, released today.

## What changed

- `global.json`: SDK `11.0.100-preview.7.26381.103` → `11.0.100-rc.1.26425.128`
- 15 project and source files: every `Microsoft.AspNetCore.*` and `Microsoft.NETCore.App.Ref` reference `11.0.0-preview.7.26381.103` → `11.0.0-rc.1.26425.128`, including the version `TargetFrameworkHelper` hands to the analyzer test harnesses
- `eng/update-all.cs`: fixed tool-readme generation, which the SDK bump broke

## Why the generator needed fixing

RC1 changes how `dotnet run` starts a project: it launches the apphost instead of running the assembly through the muxer. On Unix the apphost file has no extension, so System.CommandLine — which names the root command after the running executable — reports `Meziantou.Framework.Html` instead of `Meziantou.Framework.Html.Tool`.

`update-all.cs` builds the tool readmes from that `--help` output and substituted the project name for the `ToolCommandName`. With the name arriving trimmed, the substitution stopped matching and every tool readme lost its usage line — `meziantou.html append-version` became `Meziantou.Framework.Html append-version`.

`GetToolHelpText` now also recognizes the trimmed name, and rewrites **only** the line under `Usage:`. The old substitution ran over the whole help text, which works as long as it matches nothing else — but the trimmed name is exactly the name of the library each tool is built on, so a blanket replace corrupted four descriptions (`Convert HTML to Markdown using Meziantou.Framework.HtmlToMarkdown` → `... using Meziantou.Framework.HtmlToMarkdown.Tool`). Anchoring on the usage line keeps the output identical on Windows, where the apphost is an `.exe` and the name arrives untrimmed, and on the Linux agent that validates the generated files in CI.

## Verification

- Release build with `/p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true`: 0 errors, 0 warnings. No `ref/` API changes.
- All three `eng/*.cs` scripts build.
- `dotnet run ./eng/update-all.cs` exits 0 with an empty diff.
- Full suite on arm64 macOS: **47,565 tests — 47,016 passed, 536 skipped, 13 failed.** All 13 are pre-existing environment issues, none caused by the upgrade:
  - 8 × AMSI EICAR tests — Windows P/Invoke with no `RunIf(Windows)` guard, only a GitHub Actions skip, so they always fail on non-Windows. Being fixed separately.
  - 2 × `SqlServerContainerTests` — the mssql image has no arm64 variant.
  - 2 × `UpdateDotNetSdk` — the dependency-scanning tool's `--minimum-age` defaults to 7 days and every .NET channel published today, so all candidates were filtered out. Confirmed by running the tool with `--minimum-age 0`, which updates 8.0.404 → 10.0.401. This test fails on every .NET release day.
  - 1 × `GeneratedSourceRootFile_IsEmbeddedInBinlog` — MSB3030 race between the net10.0 and net11.0 legs building into the same `artifacts/bin` folder. Passes when run alone.

## Note for reviewers

Building this branch needs the RC1 SDK installed locally.