### PR TITLE
Update Meziantou.Polyfill to 1.0.165

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
 
   <!-- Analyzers -->
   <ItemGroup>
-    <PackageReference Include="Meziantou.Polyfill" Version="1.0.164">
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.165">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Meziantou.Framework.Tests/ThrottleExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/ThrottleExtensionsTests.cs
@@ -32,9 +32,13 @@ public class ThrottleExtensionsTests
     public void Throttle_UsesAConsistentSetOfArguments()
     {
         var timeProvider = new FakeTimeProvider();
+        using var invoked = new ManualResetEventSlim(initialState: false);
         var observed = new List<(int First, int Second)>();
-        var throttled = ((Action<int, int>)((first, second) => observed.Add((first, second))))
-            .Throttle(TimeSpan.FromSeconds(1), timeProvider);
+        var throttled = ((Action<int, int>)((first, second) =>
+        {
+            observed.Add((first, second));
+            invoked.Set();
+        })).Throttle(TimeSpan.FromSeconds(1), timeProvider);
 
         // Every call passes a matching pair, so the invocation must observe a matching pair
         for (var i = 0; i < 100; i++)
@@ -43,7 +47,11 @@ public class ThrottleExtensionsTests
         }
 
         timeProvider.Advance(TimeSpan.FromSeconds(2));
-        SpinWait.SpinUntil(() => observed.Count > 0, TimeSpan.FromSeconds(5));
+
+        // The invocation is queued to the thread pool, so it can be delayed well beyond the interval
+        // when the pool is saturated by the tests running beside this one. Block on the signal the
+        // action itself sets instead of spinning, and give it a budget large enough to survive that.
+        Assert.True(invoked.Wait(TimeSpan.FromSeconds(30)), "The throttled action was not invoked");
 
         Assert.Single(observed);
         Assert.Equal(observed[0].First, observed[0].Second);


### PR DESCRIPTION
Bumps the `Meziantou.Polyfill` `PackageReference` in `Directory.Build.props` from 1.0.164 to 1.0.165 (latest on NuGet).

## What changed in the package

I diffed the generated output of both versions against a `netstandard2.0` probe project. Only 3 of the 416 emitted files differ:

- `M_System.Console.OpenStandardErrorHandle.g.cs`
- `M_System.Console.OpenStandardInputHandle.g.cs`
- `M_System.Console.OpenStandardOutputHandle.g.cs`

Each gains an `#if MEZIANTOU_POLYFILL_SUPPORT_UPDATED_MEMORY_SAFETY_RULES` branch that declares `GetStdHandle` with the new `safe extern` syntax, falling back to the existing `[DllImport("kernel32.dll")]` declaration otherwise. That symbol is not defined anywhere in this repo, nor by Meziantou.NET.Sdk 1.0.166, so the `#else` branch is what compiles and the emitted code is byte-identical to 1.0.164. The bump is effectively inert here today, and picks up the new syntax path for whenever the symbol becomes defined.

## Verification

- `dotnet run ./eng/update-all.cs` — ran clean, produced no file changes.
- `dotnet build eng/build.proj -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` — build succeeded, 0 warnings, 0 errors. No `ref/` regeneration, so no public API impact.
- Tests for every project that consumes the polyfill (the `netstandard2.0` targets) — 7,244 passed, 0 failed:
  - Assertions (864) and Assertions.Analyzer (212)
  - FullPath (216) and FullPath.Analyzer (122)
  - Scheduling (836)
  - Yaml (1996)
  - StronglyTypedId (1476) and StronglyTypedId.GeneratorTests (196)
  - ResxSourceGenerator (88)
  - FastEnumGenerator (108)
  - FixedStringBuilder (96)
  - Roslyn 4.8 / 5.0 / 5.3 / 5.6 (354 / 354 / 354 / 356) and Roslyn.PackageTests (14)