### PR TITLE
Fix the flaky Throttle_UsesAConsistentSetOfArguments test

### DIFF
--- a/tests/Meziantou.Framework.Tests/ThrottleExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/ThrottleExtensionsTests.cs
@@ -32,9 +32,13 @@ public class ThrottleExtensionsTests
     public void Throttle_UsesAConsistentSetOfArguments()
     {
         var timeProvider = new FakeTimeProvider();
+        using var invoked = new ManualResetEventSlim(initialState: false);
         var observed = new List<(int First, int Second)>();
-        var throttled = ((Action<int, int>)((first, second) => observed.Add((first, second))))
-            .Throttle(TimeSpan.FromSeconds(1), timeProvider);
+        var throttled = ((Action<int, int>)((first, second) =>
+        {
+            observed.Add((first, second));
+            invoked.Set();
+        })).Throttle(TimeSpan.FromSeconds(1), timeProvider);
 
         // Every call passes a matching pair, so the invocation must observe a matching pair
         for (var i = 0; i < 100; i++)
@@ -43,8 +47,15 @@ public class ThrottleExtensionsTests
         }
 
         timeProvider.Advance(TimeSpan.FromSeconds(2));
-        SpinWait.SpinUntil(() => observed.Count > 0, TimeSpan.FromSeconds(5));
 
+        // Advancing the time only queues the invocation to the thread pool. Every test of the process runs
+        // in parallel, and the sibling process running the other target framework competes for the same CPU,
+        // so the work item can sit in the queue for a long time: waiting for it with a short spin turned a
+        // slow agent into a failure. The budget below is not an assertion about the scheduling latency, it
+        // only exists so an invocation that never happens fails the test instead of hanging the run.
+        Assert.True(invoked.Wait(TimeSpan.FromSeconds(60)), "The throttled action was not invoked");
+
+        // Setting the event happens after the list is updated, so waiting for it publishes the writes
         Assert.Single(observed);
         Assert.Equal(observed[0].First, observed[0].Second);
     }


### PR DESCRIPTION
`ThrottleExtensionsTests.Throttle_UsesAConsistentSetOfArguments` failed in CI on `windows-2025-vs2026, Debug, invariant, shard-3` ([run](https://github.com/meziantou/Meziantou.Framework/actions/runs/34310271176/job/102337141651)):

```
failed Meziantou.Framework.Tests.ThrottleExtensionsTests.Throttle_UsesAConsistentSetOfArguments (5s 025ms)
  Assert.Single() assertion failed.
  Expression: observed
  Actual: []
```

## Why it failed

The test is deterministic up to one point. `timeProvider.Advance()` fires the `FakeTimeProvider` timer synchronously, which completes the `Task.Delay` and *queues* the throttle's continuation to `TaskScheduler.Default`; everything after that depends on the thread pool actually running the work item. The test gave it five seconds of `SpinWait.SpinUntil`.

There is no path where the invocation is skipped — the delay task is created inside the first `throttled(...)` call, before the `Advance` — so the only variable is scheduling latency. The failure duration, 5s 025ms, is the whole budget: the work item simply had not run yet.

That latency gets large on a shard. Several test assemblies run at once, each runs its tests in parallel, each in two concurrent target-framework processes, and every test blocked in a wait holds a pool thread, so the pool only grows by hill-climbing. Measured locally with the pool occupied by blocked work items, a continuation queued right after its antecedent completed took **24.5 seconds** to start on a 15-core machine — nothing deadlocked, the work item was just behind everything else.

## The change

Set a `ManualResetEventSlim` from the action and block on it for a minute, with a message, instead of spinning for five seconds:

- The budget is not an assertion about scheduling latency; it only turns an invocation that never happens into a failure instead of a run that never ends — the same reasoning as the two-minute deadlock watchdog in #3039. The 24.5s measurement is why it is 60s rather than the 30s used by the sibling test in this file.
- Blocking instead of spinning also stops the test burning a core that the starved pool needs.
- Waiting on the event gives a happens-before edge, so the assertions no longer read `observed` while another thread may still be writing to it — the old version read `List<T>.Count` and `[0]` with no synchronization at all.

`ThrottleExtensions` itself is unchanged; there is no product bug here.

## Verification

On macOS arm64:

- `dotnet build tests/Meziantou.Framework.Tests /p:TreatsWarningsAsErrors=true` — succeeded, 0 warnings.
- The three `ThrottleExtensionsTests` run 10 times over both TFMs: 6/6 passed every run.
- Full `Meziantou.Framework.Tests`: 2148 total, 2132 passed, 16 skipped (platform and globalization gates), 0 failed.
- `dotnet run ./eng/update-all.cs` — no generated-file changes.
