### PR TITLE
Publish the DNS filter engine and its rule count together

### DIFF
--- a/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
+++ b/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
@@ -11,8 +11,7 @@ internal sealed class FilterEngineProvider
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<DnsProxyOptions> _options;
     private readonly ILogger<FilterEngineProvider> _logger;
-    private DnsFilterEngine _engine;
-    private int _ruleCount;
+    private FilterSnapshot _snapshot;
 
     public FilterEngineProvider(IHttpClientFactory httpClientFactory, IOptions<DnsProxyOptions> options, ILogger<FilterEngineProvider> logger)
     {
@@ -22,13 +21,12 @@ internal sealed class FilterEngineProvider
 
         var initialRuleSet = new DnsFilterRuleSet();
         AddCachedFilterLists(initialRuleSet, options.Value);
-        _engine = new DnsFilterEngine(initialRuleSet);
-        _ruleCount = initialRuleSet.Count;
+        _snapshot = FilterSnapshot.Create(initialRuleSet);
     }
 
-    public DnsFilterEngine Engine => Volatile.Read(ref _engine);
+    public DnsFilterEngine Engine => Volatile.Read(ref _snapshot).Engine;
 
-    public int RuleCount => Volatile.Read(ref _ruleCount);
+    public int RuleCount => Volatile.Read(ref _snapshot).RuleCount;
 
     public async Task RefreshAsync(CancellationToken cancellationToken)
     {
@@ -72,8 +70,7 @@ internal sealed class FilterEngineProvider
             activity?.SetStatus(ActivityStatusCode.Error, $"{failedFilterCount} filter lists failed to load");
         }
 
-        Volatile.Write(ref _ruleCount, ruleSet.Count);
-        Volatile.Write(ref _engine, new DnsFilterEngine(ruleSet));
+        Volatile.Write(ref _snapshot, FilterSnapshot.Create(ruleSet));
     }
 
     private async Task<bool> TryLoadFilterAsync(HttpClient httpClient, DnsFilterRuleSet ruleSet, DnsProxyOptions options, FilterListOption filter, CancellationToken cancellationToken)
@@ -249,6 +246,15 @@ internal sealed class FilterEngineProvider
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(filter.Url))).ToLowerInvariant();
 
         return Path.Combine(cacheFolderPath, hash + ".txt");
+    }
+
+    /// <summary>
+    /// The engine and the rule count are published together, so a caller that uses <see cref="RuleCount"/> as a
+    /// readiness signal never gets an <see cref="Engine"/> still matching the previous rule set.
+    /// </summary>
+    private sealed record FilterSnapshot(DnsFilterEngine Engine, int RuleCount)
+    {
+        public static FilterSnapshot Create(DnsFilterRuleSet ruleSet) => new(new DnsFilterEngine(ruleSet), ruleSet.Count);
     }
 
     /// <summary>Fails the read as soon as more than <paramref name="maxSize"/> bytes have been consumed.</summary>

--- a/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
@@ -70,6 +70,53 @@ public sealed class FilterEngineProviderTests
     }
 
     [Fact]
+    public async Task RefreshAsync_DoesNotReportRulesBeforeTheEngineMatchesThem()
+    {
+        using var cacheDirectory = TemporaryDirectory.Create();
+        var options = Options.Create(new DnsProxyOptions
+        {
+            BlockListCacheFolderPath = cacheDirectory.FullPath,
+            Filters =
+            [
+                new FilterListOption
+                {
+                    Url = "https://filters.example/list.txt",
+                    Format = nameof(DnsFilterListFormat.AdBlock),
+                },
+            ],
+        });
+
+        // A large list makes building the engine slow enough for a reader to observe a rule count published before the
+        // engine that matches it.
+        var listText = string.Join('\n', Enumerable.Range(0, 20_000).Select(i => $"||blocked{i}.example.com^"));
+        using var serviceProvider = CreateServiceProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(listText),
+        });
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        var provider = new FilterEngineProvider(
+            factory,
+            options,
+            NullLogger<FilterEngineProvider>.Instance);
+
+        // Callers use the rule count as a readiness signal, so the engine must already match the rules it reports.
+        using var readerTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var reader = Task.Factory.StartNew(() =>
+        {
+            while (provider.RuleCount is 0 && !readerTimeout.IsCancellationRequested)
+            {
+            }
+
+            return provider.Engine.Evaluate("blocked0.example.com").IsMatched;
+        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+        await provider.RefreshAsync(CancellationToken.None);
+
+        Assert.True(await reader, "The provider reported loaded rules while the engine was still matching the previous rule set.");
+    }
+
+    [Fact]
     public async Task RefreshAsync_EmitsActivitiesWhenLoadingRemoteFilters()
     {
         using var cacheDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
Fixes the flaky `Meziantou.Framework.DnsProxy.Tests.DnsProxyHandlerTests.AppliesADnsRewriteRuleWithoutContactingAnUpstream`, seen in [this CI run](https://github.com/meziantou/Meziantou.Framework/actions/runs/34315470367/job/102350877632) with `Expected: 0, Actual: 1` for `upstreamCallCount`: the proxy forwarded a query upstream even though a `$dnsrewrite` rule should have answered it without leaving the process.

## Root cause

The test waits for the filter list by polling the diagnostics page until `LoadedFilterRules` is no longer 0, then sends the query. That readiness signal could lie, because `RefreshAsync` published the rule count *before* the engine:

```csharp
Volatile.Write(ref _ruleCount, ruleSet.Count);
Volatile.Write(ref _engine, new DnsFilterEngine(ruleSet));
```

Between those two writes, `RuleCount` advertises the new rules while `Engine` — what `DnsProxyHandler` evaluates on every request — is still the empty engine built at startup. A query landing in that window matches nothing and is forwarded upstream. The refresh thread only has to be descheduled briefly for the test's two in-memory requests to slip through, which is what a loaded CI agent does.

This is not only a test concern: the diagnostics page can report rules that are not in effect yet.

## Change

The engine and its rule count are published as a single immutable `FilterSnapshot`, so the two can never disagree whatever the order of the reads.

## Tests

`RefreshAsync_DoesNotReportRulesBeforeTheEngineMatchesThem` spins on `RuleCount` and evaluates the engine the instant it goes non-zero, against a list large enough to make the build window wide. Verified it fails on the previous code (by reverting the source change) and passes on this one.

Full `Meziantou.Framework.DnsProxy.Tests` project, both target frameworks, with `/p:TreatsWarningsAsErrors=true`: 124/124 passing. `dotnet run ./eng/update-all.cs` ran clean with no generated file changes.