### PR TITLE
Give each DNS proxy test host its own block-list cache folder

### DIFF
--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyHandlerTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyHandlerTests.cs
@@ -497,18 +497,27 @@ public sealed class DnsProxyHandlerTests
         private const string UnreachableFilterUrl = "http://127.0.0.1:1/filters.txt";
 
         private readonly Dictionary<string, string> _settings;
+        private readonly TemporaryDirectory _blockListCacheDirectory;
 
-        private DnsProxyApplicationFactory(Dictionary<string, string> settings) => _settings = settings;
+        private DnsProxyApplicationFactory(Dictionary<string, string> settings, TemporaryDirectory blockListCacheDirectory)
+        {
+            _settings = settings;
+            _blockListCacheDirectory = blockListCacheDirectory;
+        }
 
         public static DnsProxyApplicationFactory ForUpstreams(params string[] upstreamUrls) => ForUpstreams(upstreamUrls, filterListUrl: null);
 
         public static DnsProxyApplicationFactory ForUpstreams(string[] upstreamUrls, string? filterListUrl)
         {
+            // The block-list cache defaults to the user profile, which the two target framework test processes would
+            // share, and where the cached lists would be read back by the next run through FilterEngineProvider.
+            var blockListCacheDirectory = TemporaryDirectory.Create();
             var settings = new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["DnsProxy:DnsPort"] = "0",
                 ["DnsProxy:HttpPort"] = "0",
                 ["DnsProxy:FilterRefreshInterval"] = "01:00:00",
+                ["DnsProxy:BlockListCacheFolderPath"] = blockListCacheDirectory.FullPath,
                 ["DnsProxy:Filters:0:Url"] = filterListUrl ?? UnreachableFilterUrl,
                 ["DnsProxy:Filters:0:Format"] = "AdBlock",
                 ["DnsProxy:Filters:1:Url"] = UnreachableFilterUrl,
@@ -524,7 +533,7 @@ public sealed class DnsProxyHandlerTests
                 settings[$"DnsProxy:Upstreams:{i}:Priority"] = i.ToString(CultureInfo.InvariantCulture);
             }
 
-            return new DnsProxyApplicationFactory(settings);
+            return new DnsProxyApplicationFactory(settings, blockListCacheDirectory);
         }
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -532,6 +541,20 @@ public sealed class DnsProxyHandlerTests
             foreach (var (name, value) in _settings)
             {
                 builder.UseSetting(name, value);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="WebApplicationFactory{TEntryPoint}.DisposeAsync"/> ends by calling this method once the host is
+        /// stopped, so the cache folder is deleted on the async disposal path the tests use as well as the sync one.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                _blockListCacheDirectory.Dispose();
             }
         }
     }

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
@@ -20,12 +20,17 @@ public sealed partial class DnsProxyIntegrationTests
         const int HttpPort = 5080;
         const string FilterRefreshInterval = "00:10:00";
 
+        // The block-list cache defaults to the user profile, which the two target framework test processes would
+        // share, and where the cached lists would be read back by the next run through FilterEngineProvider.
+        using var blockListCacheDirectory = TemporaryDirectory.Create();
+
         using var baseFactory = new WebApplicationFactory<DnsProxyProgram>();
         using var factory = baseFactory.WithWebHostBuilder(builder =>
         {
             builder.UseSetting("DnsProxy:DnsPort", DnsPort.ToString(CultureInfo.InvariantCulture));
             builder.UseSetting("DnsProxy:HttpPort", HttpPort.ToString(CultureInfo.InvariantCulture));
             builder.UseSetting("DnsProxy:FilterRefreshInterval", FilterRefreshInterval);
+            builder.UseSetting("DnsProxy:BlockListCacheFolderPath", blockListCacheDirectory.FullPath);
             builder.UseSetting("DnsProxy:Upstreams:0:Url", "https://1.1.1.1/dns-query");
             builder.UseSetting("DnsProxy:Upstreams:1:Url", "https://9.9.9.9/dns-query");
             builder.UseSetting("DnsProxy:Upstreams:2:Url", "https://dns.nextdns.io/dns-query");
@@ -127,11 +132,16 @@ public sealed partial class DnsProxyIntegrationTests
         const string CustomRecordDomain = "blocked-custom-record.example";
         const string CustomRecordAddress = "203.0.113.124";
 
+        // The block-list cache defaults to the user profile, which the two target framework test processes would
+        // share, and where the cached lists would be read back by the next run through FilterEngineProvider.
+        using var blockListCacheDirectory = TemporaryDirectory.Create();
+
         using var baseFactory = new WebApplicationFactory<DnsProxyProgram>();
         using var factory = baseFactory.WithWebHostBuilder(builder =>
         {
             builder.UseSetting("DnsProxy:DnsPort", DnsPort.ToString(CultureInfo.InvariantCulture));
             builder.UseSetting("DnsProxy:HttpPort", HttpPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:BlockListCacheFolderPath", blockListCacheDirectory.FullPath);
             builder.UseSetting("DnsProxy:Filters:0:Url", "https://filters.example/list.txt");
             builder.UseSetting("DnsProxy:Filters:0:Format", "AdBlock");
             builder.UseSetting("DnsProxy:Filters:1:Url", "");


### PR DESCRIPTION
`DnsProxyApplicationFactory` in `DnsProxyHandlerTests.cs` builds host settings (`DnsProxy:DnsPort`, `DnsProxy:HttpPort`, `DnsProxy:Filters:0:Url`, ...) but never sets `DnsProxy:BlockListCacheFolderPath`. `FilterEngineProvider.GetCacheFilePath` therefore falls back to `DnsProxyOptions.GetDefaultBlockListCacheFolderPath()` — `<LocalApplicationData>/meziantou/dnsproxy/block-lists`, the developer's real profile folder.

`FakeFilterList` binds a random port, so each run of `AppliesADnsRewriteRuleWithoutContactingAnUpstream` hashes a brand new URL and leaves another cache file behind; 47 had accumulated on the machine this was found on. The two target framework test processes also run concurrently and shared that one folder.

Beyond the pollution, this is ambient state the tests can read back: the `FilterEngineProvider` constructor loads the cached lists and reports their rules through `RuleCount`, which `WaitForFilterRulesAsync` uses as its readiness signal.

## What changed

- `DnsProxyApplicationFactory` creates a `TemporaryDirectory`, points `DnsProxy:BlockListCacheFolderPath` at it, and disposes it from an overridden `Dispose(bool disposing)`.
- Two tests in `DnsProxyIntegrationTests.cs` had the same gap and now use a temporary directory too:
  - `Proxy_StartsWithCustomConfiguration_AndProcessesRequests` sets no `Filters`, so it inherits the two real URLs from `appsettings.json` and was caching genuinely downloaded lists into the profile folder.
  - `CustomRecords_AreUsedBeforeBlockLists` serves a list through a mocked handler and cached it.

## Notes for reviewers

**Why `Dispose(bool)` and not `DisposeAsync`.** The tests use `await using var factory`, so the cleanup has to run on the async path. I decompiled `WebApplicationFactory<T>` from both packages this project actually references — `Microsoft.AspNetCore.Mvc.Testing` 10.0.12 (net10.0) and 11.0.0-rc.1.26425.128 (net11.0) — and both have the same shape: `DisposeAsync()` stops and disposes the host, sets `_disposedAsync = true`, then calls `Dispose(disposing: true)`. So the override runs on both paths, and only after the host has stopped writing to the folder. `Dispose(bool)` guards on `_disposedAsync` so there is no recursion, and `TemporaryDirectory.Dispose` is idempotent regardless.

**Why the other two integration tests are untouched.** `DisableFilteringEndpoint_DoesNotDisableCustomRecords` and `DisableFilteringEndpoint_WithoutAntiforgeryToken_IsRejected` set every `Filters:N:Url` to `""`, and `FilterEngineProvider` skips blank URLs on both the read and the write path, so they never touch the cache folder.

## Verification

- Build on both TFMs with `/p:TreatsWarningsAsErrors=true`: succeeded, 0 warnings.
- `dotnet test` on both TFMs: 124 passed / 0 failed (62 per TFM, so both processes really ran).
- Snapshotted the default cache folder before and after: byte-identical at 47 entries, and `find -newermt` reports 0 files created or modified during the run.
- Positive confirmation the writes still happen and just land elsewhere: polling `$TMPDIR/MezTD` during the run caught cache files being written into the per-factory temporary folders, and `MezTD` is empty afterwards, so the cleanup runs.
- `dotnet run ./eng/update-all.cs` completed with no file changes.

## Out of scope

`Proxy_StartsWithCustomConfiguration_AndProcessesRequests` still downloads the two real filter lists from the public internet on every run, because it does not override `DnsProxy:Filters`. The cache pollution is fixed; the network dependency is pre-existing and left as is.
