### PR TITLE
Recognize the UI thread when the SynchronizationContext instance changes

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -269,6 +269,7 @@
     <Project Path="tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.TextDiff.Tests/Meziantou.Framework.TextDiff.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj" />
+    <Project Path="tests/Meziantou.Framework.Threading.Windows.Tests/Meziantou.Framework.Threading.Windows.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.UndoRedo.Tests/Meziantou.Framework.UndoRedo.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj" />

--- a/eng/build.platform-exclusions.proj
+++ b/eng/build.platform-exclusions.proj
@@ -2,6 +2,7 @@
   <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows')) == false">
     <ProjectReference Remove="../tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj" />
     <ProjectReference Remove="../tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj" />
+    <ProjectReference Remove="../tests/Meziantou.Framework.Threading.Windows.Tests/Meziantou.Framework.Threading.Windows.Tests.csproj" />
     <ProjectReference Remove="../Samples/Meziantou.Framework.Scheduling.RecurrenceRuleSample/Meziantou.Framework.Scheduling.RecurrenceRuleSample.csproj" />
     <ProjectReference Remove="../Samples/Meziantou.Framework.Win32.DialogsSamples/Meziantou.Framework.Win32.DialogsSamples.csproj" />
     <ProjectReference Remove="../Samples/Meziantou.Framework.WPF.CollectionSamples/Meziantou.Framework.WPF.CollectionSamples.csproj" />

--- a/slnx/Meziantou.Framework.Threading.slnx
+++ b/slnx/Meziantou.Framework.Threading.slnx
@@ -4,5 +4,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj" />
+    <Project Path="../tests/Meziantou.Framework.Threading.Windows.Tests/Meziantou.Framework.Threading.Windows.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentObservableCollection.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentObservableCollection.cs
@@ -23,6 +23,7 @@ namespace Meziantou.Framework.Collections.Concurrent;
 public class ConcurrentObservableCollection<T> : IList<T>, IReadOnlyList<T>, IList
 {
     private readonly SynchronizationContext _synchronizationContext;
+    private readonly Thread? _synchronizationContextThread;
     private readonly Lock _lock = new();
 
     private ImmutableList<T> _items = ImmutableList<T>.Empty;
@@ -53,6 +54,25 @@ public class ConcurrentObservableCollection<T> : IList<T>, IReadOnlyList<T>, ILi
     public ConcurrentObservableCollection(SynchronizationContext synchronizationContext)
     {
         _synchronizationContext = synchronizationContext ?? throw new ArgumentNullException(nameof(synchronizationContext));
+
+        // WPF and Windows Forms install a new SynchronizationContext instance for the same thread: WPF hands out a new
+        // DispatcherSynchronizationContext bound to the same Dispatcher while running a dispatcher operation, so comparing
+        // the instances reports the UI thread as a foreign thread. Both contexts run their callbacks on a single thread,
+        // so the thread they are installed on identifies them. A SynchronizationContext is not thread-affine in general
+        // (its callbacks can run on any thread), so every other context keeps the instance comparison.
+        if (IsThreadAffine(synchronizationContext) && SynchronizationContext.Current == synchronizationContext)
+        {
+            _synchronizationContextThread = Thread.CurrentThread;
+        }
+    }
+
+    private static bool IsThreadAffine(SynchronizationContext synchronizationContext)
+    {
+        // The assembly doesn't depend on a UI framework, so the types cannot be used directly. Both are sealed,
+        // so comparing the type name is enough. Override IsOnSynchronizationContextThread to support another
+        // thread-affine synchronization context.
+        return synchronizationContext.GetType().FullName is "System.Windows.Threading.DispatcherSynchronizationContext" // WPF
+            or "System.Windows.Forms.WindowsFormsSynchronizationContext"; // Windows Forms
     }
 
     private static SynchronizationContext GetCurrentSynchronizationContext()
@@ -65,9 +85,14 @@ public class ConcurrentObservableCollection<T> : IList<T>, IReadOnlyList<T>, ILi
     /// When it is, change notifications are raised synchronously instead of being posted to <see cref="SynchronizationContext"/>.
     /// </summary>
     /// <returns><see langword="true"/> when the current thread can raise the notifications directly; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// The current thread is considered to be the right one when it runs the <see cref="SynchronizationContext"/> provided to the
+    /// constructor. The WPF and Windows Forms synchronization contexts are also matched by thread, as they run their callbacks on a
+    /// single thread but expose several instances for it. Override this method to support another thread-affine context.
+    /// </remarks>
     protected internal virtual bool IsOnSynchronizationContextThread()
     {
-        return SynchronizationContext.Current == _synchronizationContext;
+        return SynchronizationContext.Current == _synchronizationContext || _synchronizationContextThread == Thread.CurrentThread;
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.Threading.Tests/DispatcherSynchronizationContext.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/DispatcherSynchronizationContext.cs
@@ -1,0 +1,10 @@
+namespace System.Windows.Threading;
+
+/// <summary>
+/// Stand-in for the WPF synchronization context. <c>ConcurrentObservableCollection&lt;T&gt;</c> detects it by type name
+/// because Meziantou.Framework.Threading must not depend on a UI framework, and neither must this test project.
+/// The real type is sealed, so an application cannot provide a different type with this name.
+/// </summary>
+internal sealed class DispatcherSynchronizationContext : global::System.Threading.SynchronizationContext
+{
+}

--- a/tests/Meziantou.Framework.Threading.Tests/ObservableCollectionTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ObservableCollectionTests.cs
@@ -29,6 +29,22 @@ public sealed partial class ObservableCollectionTests : IDisposable
         BuiltIn,
     }
 
+    public enum UISynchronizationContextKind
+    {
+        Wpf,
+        WindowsForms,
+    }
+
+    private static SynchronizationContext CreateUISynchronizationContext(UISynchronizationContextKind kind)
+    {
+        return kind switch
+        {
+            UISynchronizationContextKind.Wpf => new System.Windows.Threading.DispatcherSynchronizationContext(),
+            UISynchronizationContextKind.WindowsForms => new System.Windows.Forms.WindowsFormsSynchronizationContext(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+    }
+
     public static IEnumerable<object[]> GetCollections
     {
         get
@@ -317,6 +333,59 @@ public sealed partial class ObservableCollectionTests : IDisposable
         var thread = new Thread(() => Assert.Throws<InvalidOperationException>(() => observable.Count));
         thread.Start();
         thread.Join();
+    }
+
+    [Theory]
+    [InlineData(UISynchronizationContextKind.Wpf)]
+    [InlineData(UISynchronizationContextKind.WindowsForms)]
+    public void ObservableCollectionCanBeAccessedWhenTheUISynchronizationContextInstanceChanged(UISynchronizationContextKind kind)
+    {
+        // WPF installs a new DispatcherSynchronizationContext instance bound to the same Dispatcher while running a
+        // dispatcher operation, so the UI thread must be recognized even when the instance is not the captured one.
+        var context = CreateUISynchronizationContext(kind);
+        SynchronizationContext.SetSynchronizationContext(context);
+
+        var collection = new ConcurrentObservableCollection<int>(context);
+        var observable = collection.AsObservable;
+        using var eventAssert = new EventAssert(observable);
+
+        SynchronizationContext.SetSynchronizationContext(CreateUISynchronizationContext(kind));
+        collection.Add(1);
+
+        Assert.Equal([1], observable.ToList());
+        eventAssert.AssertPropertyChanged("Count", "Item[]");
+        eventAssert.AssertCollectionChangedAddItem(1);
+    }
+
+    [Fact]
+    public void ObservableCollectionCannotBeAccessedWhenAnUnknownSynchronizationContextInstanceChanged()
+    {
+        // A SynchronizationContext is not thread-affine in general, so a context that is not a known UI one is
+        // still matched by instance: running on the thread it was installed on doesn't mean it runs the callbacks
+        var collection = CreateCollection<int>();
+        var observable = collection.AsObservable;
+
+        SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+
+        Assert.Throws<InvalidOperationException>(() => observable.Count);
+    }
+
+    [Fact]
+    public void CollectionCreatedWithoutSynchronizationContextIsNotBoundToTheCreatingThread()
+    {
+        var previousSynchronizationContext = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(null);
+        try
+        {
+            // The default SynchronizationContext raises the notifications on the thread pool, so no thread owns the collection
+            var observable = new ConcurrentObservableCollection<int>().AsObservable;
+
+            Assert.Throws<InvalidOperationException>(() => observable.Count);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousSynchronizationContext);
+        }
     }
 
     private sealed class QueuedSynchronizationContext : SynchronizationContext

--- a/tests/Meziantou.Framework.Threading.Tests/WindowsFormsSynchronizationContext.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/WindowsFormsSynchronizationContext.cs
@@ -1,0 +1,10 @@
+namespace System.Windows.Forms;
+
+/// <summary>
+/// Stand-in for the Windows Forms synchronization context. <c>ConcurrentObservableCollection&lt;T&gt;</c> detects it by
+/// type name because Meziantou.Framework.Threading must not depend on a UI framework, and neither must this test project.
+/// The real type is sealed, so an application cannot provide a different type with this name.
+/// </summary>
+internal sealed class WindowsFormsSynchronizationContext : global::System.Threading.SynchronizationContext
+{
+}

--- a/tests/Meziantou.Framework.Threading.Windows.Tests/ConcurrentObservableCollectionWindowsFormsTests.cs
+++ b/tests/Meziantou.Framework.Threading.Windows.Tests/ConcurrentObservableCollectionWindowsFormsTests.cs
@@ -1,0 +1,108 @@
+using System.Runtime.ExceptionServices;
+using System.Windows.Forms;
+using Meziantou.Framework.Collections.Concurrent;
+
+namespace Meziantou.Framework.Threading.Windows.Tests;
+
+public sealed class ConcurrentObservableCollectionWindowsFormsTests
+{
+    [Fact(Timeout = 95000)]
+    public void AsObservableCanBeAccessedWhenTheSynchronizationContextInstanceChanged()
+    {
+        RunOnWindowsFormsThread(() =>
+        {
+            var contextAtCreation = Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+            var collection = new ConcurrentObservableCollection<string>();
+            var observable = collection.AsObservable;
+
+            // Windows Forms uses another WindowsFormsSynchronizationContext instance for the same thread when the
+            // context is copied, which is what made the collection consider the UI thread a foreign thread
+            var newContext = contextAtCreation.CreateCopy();
+            Assert.NotSame(contextAtCreation, newContext);
+            SynchronizationContext.SetSynchronizationContext(newContext);
+
+            collection.AddRange("a", "b");
+
+            Assert.Equal(["a", "b"], observable.ToList());
+        }, TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Timeout = 95000)]
+    public void ItemsAddedFromAnotherThreadAreNotifiedOnTheUIThread()
+    {
+        RunOnWindowsFormsThread(() =>
+        {
+            var contextAtCreation = Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+            var collection = new ConcurrentObservableCollection<string>();
+            var observable = collection.AsObservable;
+
+            SynchronizationContext.SetSynchronizationContext(contextAtCreation.CreateCopy());
+
+            var thread = new Thread(() => collection.AddRange("a", "b"));
+            thread.Start();
+            thread.Join();
+
+            // The notifications are posted to the message loop, so the observable collection is still empty
+            Assert.Empty(observable);
+
+            Application.DoEvents();
+
+            Assert.Equal(["a", "b"], observable.ToList());
+        }, TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Timeout = 95000)]
+    public void AsObservableCannotBeAccessedFromAnotherUIThread()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        IReadOnlyObservableCollection<string>? observable = null;
+        RunOnWindowsFormsThread(() => observable = new ConcurrentObservableCollection<string>().AsObservable, cancellationToken);
+
+        // Another UI thread runs its own message loop, so it must not be able to read the collection
+        RunOnWindowsFormsThread(() => Assert.Throws<InvalidOperationException>(() => observable!.Count), cancellationToken);
+    }
+
+    private static void RunOnWindowsFormsThread(Action action, CancellationToken cancellationToken)
+    {
+        Exception? failure = null;
+        using var completed = new ManualResetEventSlim(initialState: false);
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                // A Windows Forms application installs the context on its UI thread when the first control is created
+                using var control = new Control();
+                _ = control.Handle;
+                if (SynchronizationContext.Current is not WindowsFormsSynchronizationContext)
+                {
+                    SynchronizationContext.SetSynchronizationContext(new WindowsFormsSynchronizationContext());
+                }
+
+                action();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                completed.Set();
+            }
+        })
+        {
+            IsBackground = true,
+        };
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        completed.Wait(cancellationToken);
+        thread.Join();
+
+        if (failure is not null)
+        {
+            ExceptionDispatchInfo.Throw(failure);
+        }
+    }
+}

--- a/tests/Meziantou.Framework.Threading.Windows.Tests/ConcurrentObservableCollectionWpfTests.cs
+++ b/tests/Meziantou.Framework.Threading.Windows.Tests/ConcurrentObservableCollectionWpfTests.cs
@@ -1,0 +1,132 @@
+using System.Runtime.ExceptionServices;
+using System.Windows;
+using System.Windows.Threading;
+using Meziantou.Framework.Collections.Concurrent;
+
+// The project enables both WPF and Windows Forms, so the types they both define must be disambiguated
+using ListBox = System.Windows.Controls.ListBox;
+using Size = System.Windows.Size;
+
+namespace Meziantou.Framework.Threading.Windows.Tests;
+
+public sealed class ConcurrentObservableCollectionWpfTests
+{
+    [Fact(Timeout = 95000)]
+    public void AsObservableCanBeBoundToAListBoxWhenTheSynchronizationContextInstanceChanged()
+    {
+        RunOnDispatcherThread(_ =>
+        {
+            // A view model is created while WPF has a DispatcherSynchronizationContext installed on the UI thread
+            var contextAtCreation = Assert.IsType<DispatcherSynchronizationContext>(SynchronizationContext.Current);
+            var collection = new ConcurrentObservableCollection<string>();
+            var listBox = new ListBox { ItemsSource = collection.AsObservable };
+
+            // WPF uses another DispatcherSynchronizationContext instance for the same Dispatcher when it pushes a frame
+            // (Dispatcher.Run, ShowDialog, a nested message loop) or copies the context, which is what made the
+            // collection consider the UI thread a foreign thread
+            var newContext = contextAtCreation.CreateCopy();
+            Assert.NotSame(contextAtCreation, newContext);
+            SynchronizationContext.SetSynchronizationContext(newContext);
+
+            collection.AddRange("a", "b");
+
+            // The layout pass reads the collection through the WPF binding engine
+            listBox.Measure(new Size(1000, 1000));
+            listBox.Arrange(new Rect(0, 0, 1000, 1000));
+
+            Assert.Equal(["a", "b"], listBox.Items.Cast<string>());
+        }, TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Timeout = 95000)]
+    public void ItemsAddedFromAnotherThreadAreNotifiedOnTheDispatcherThread()
+    {
+        RunOnDispatcherThread(dispatcher =>
+        {
+            var contextAtCreation = Assert.IsType<DispatcherSynchronizationContext>(SynchronizationContext.Current);
+            var collection = new ConcurrentObservableCollection<string>();
+            var listBox = new ListBox { ItemsSource = collection.AsObservable };
+
+            SynchronizationContext.SetSynchronizationContext(contextAtCreation.CreateCopy());
+
+            var thread = new Thread(() => collection.AddRange("a", "b"));
+            thread.Start();
+            thread.Join();
+
+            // The notifications are posted to the Dispatcher, so the bound collection is still empty
+            Assert.Empty(listBox.Items);
+
+            DoEvents(dispatcher);
+
+            listBox.Measure(new Size(1000, 1000));
+            listBox.Arrange(new Rect(0, 0, 1000, 1000));
+
+            Assert.Equal(["a", "b"], listBox.Items.Cast<string>());
+        }, TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Timeout = 95000)]
+    public void AsObservableCannotBeAccessedFromAnotherDispatcherThread()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        IReadOnlyObservableCollection<string>? observable = null;
+        RunOnDispatcherThread(_ => observable = new ConcurrentObservableCollection<string>().AsObservable, cancellationToken);
+
+        // Another UI thread has its own Dispatcher, so it must not be able to read the collection
+        RunOnDispatcherThread(_ => Assert.Throws<InvalidOperationException>(() => observable!.Count), cancellationToken);
+    }
+
+    /// <summary>Runs the pending dispatcher operations, like <c>Application.DoEvents</c> does.</summary>
+    private static void DoEvents(Dispatcher dispatcher)
+    {
+        var frame = new DispatcherFrame();
+        _ = dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+
+    private static void RunOnDispatcherThread(Action<Dispatcher> action, CancellationToken cancellationToken)
+    {
+        Dispatcher? dispatcher = null;
+        using var dispatcherCreated = new ManualResetEventSlim(initialState: false);
+
+        var thread = new Thread(() =>
+        {
+            Volatile.Write(ref dispatcher, Dispatcher.CurrentDispatcher);
+            dispatcherCreated.Set();
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true,
+        };
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        dispatcherCreated.Wait(cancellationToken);
+
+        var currentDispatcher = Volatile.Read(ref dispatcher)!;
+
+        // An operation failing on the dispatcher thread would otherwise take the process down instead of failing the test
+        Exception? unhandledException = null;
+        currentDispatcher.UnhandledException += (sender, e) =>
+        {
+            unhandledException = e.Exception;
+            e.Handled = true;
+        };
+
+        try
+        {
+            currentDispatcher.Invoke(() => action(currentDispatcher));
+        }
+        finally
+        {
+            currentDispatcher.InvokeShutdown();
+            thread.Join();
+        }
+
+        if (unhandledException is not null)
+        {
+            ExceptionDispatchInfo.Throw(unhandledException);
+        }
+    }
+}

--- a/tests/Meziantou.Framework.Threading.Windows.Tests/Meziantou.Framework.Threading.Windows.Tests.csproj
+++ b/tests/Meziantou.Framework.Threading.Windows.Tests/Meziantou.Framework.Threading.Windows.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Meziantou.NET.Sdk.Test">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
+    <!-- The collection is bound to a SynchronizationContext, so it is tested against the real WPF and Windows Forms ones -->
+    <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
+    <RootNamespace>Meziantou.Framework.Threading.Windows.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #3045

## Problem

`ConcurrentObservableCollection<T>` decided whether the current thread owns the collection by comparing the `SynchronizationContext` instance captured at construction:

```csharp
return SynchronizationContext.Current == _synchronizationContext;
```

`DispatcherSynchronizationContext` does not override equality, and WPF hands out a *new* instance bound to the *same* `Dispatcher` when it pushes a frame (`Dispatcher.Run`, `ShowDialog`, a nested message loop) or copies the context. The check therefore reported the WPF UI thread as a foreign thread, and `AsObservable` threw during binding and layout:

> The collection must be accessed from the synchronization context thread only.

The 3.x implementation used `Dispatcher.CheckAccess()` — thread identity — which is why this only appeared after the move to `Meziantou.Framework.Threading`. Windows Forms has the same failure mode: `WindowsFormsSynchronizationContext.CreateCopy()` also returns a new instance for the same thread.

## Fix

The constructor now also remembers the thread the context was installed on, and `IsOnSynchronizationContextThread` accepts either the same instance or that thread.

A `SynchronizationContext` is **not** a thread and its callbacks can run anywhere, so the thread is only remembered for contexts known to be thread-affine:

```csharp
if (IsThreadAffine(synchronizationContext) && SynchronizationContext.Current == synchronizationContext)
{
    _synchronizationContextThread = Thread.CurrentThread;
}

private static bool IsThreadAffine(SynchronizationContext synchronizationContext)
{
    return synchronizationContext.GetType().FullName is "System.Windows.Threading.DispatcherSynchronizationContext" // WPF
        or "System.Windows.Forms.WindowsFormsSynchronizationContext"; // Windows Forms
}
```

Any other context — a queueing one, a thread-pool one — keeps the strict instance comparison, so "same thread" is never taken to mean "callbacks run here". The default `SynchronizationContext` fallback of the parameterless constructor still dispatches to the thread pool.

The types cannot be referenced directly because the assembly must not depend on a UI framework; both are `public sealed`, so the name identifies them and no base-type walk is needed. `IsOnSynchronizationContextThread` remains the documented override point for any other thread-affine context (WinUI, MAUI, Avalonia).

No public API change — `ref/Meziantou.Framework.Threading.cs` is untouched.

## Tests

**Cross-platform** (`Meziantou.Framework.Threading.Tests`), using stand-in types declared under the WPF and Windows Forms namespaces so the name matching is exercised without a UI framework dependency:

- `ObservableCollectionCanBeAccessedWhenTheUISynchronizationContextInstanceChanged` (theory over both frameworks) — fails 4/4 without the fix.
- `ObservableCollectionCannotBeAccessedWhenAnUnknownSynchronizationContextInstanceChanged` — fails 2/2 against a version without the `IsThreadAffine` gate, so it pins the narrowness of the relaxation.
- `CollectionCreatedWithoutSynchronizationContextIsNotBoundToTheCreatingThread` — keeps the documented thread-pool fallback.

**Windows-only** (new `Meziantou.Framework.Threading.Windows.Tests`), against the real frameworks — a real STA `Dispatcher` thread with a real `ListBox` bound to `AsObservable`, and a real Windows Forms UI thread with a `Control` and a message loop. The second context instance comes from the framework's own `CreateCopy()`, and every test asserts `NotSame` plus the concrete context type first, so none can pass vacuously. The project is excluded from the traversal on non-Windows, like `Meziantou.Framework.WPF.Tests` already is.

## Reviewer notes

- The two type names are the load-bearing assumption. Both were checked against Microsoft Learn (`public sealed`, exact full names), and the Windows-only tests assert them against the shipping assemblies.
- **The Windows-only tests were never executed.** This machine has no `Microsoft.WindowsDesktop.App` for osx-arm64, so they are compile-verified only (Debug and `Release /p:IsOfficialBuild=true`, 0 warnings) and will run for the first time on the Windows CI leg. Unlike the cross-platform tests, I could not demonstrate that they fail without the fix.
- `Meziantou.Framework.Threading.Tests`: 354 passed / 0 failed (177 per TFM).
- `dotnet run ./eng/update-all.cs` regenerated the two `.slnx` files included here; a second run is a no-op.
