### PR TITLE
Retry the working-directory exec test while the script is still busy

### DIFF
--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -569,12 +569,10 @@ public class ProcessWrapperTests
             File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
         }
 
-        var result = ProcessWrapper.Create(executableName)
+        var processResult = await ExecuteRetryingOnTextFileBusyAsync(async () => await ProcessWrapper.Create(executableName)
             .WithWorkingDirectory(temporaryDirectoryPath)
             .WithSearchWorkingDirectory()
-            .ExecuteBufferedAsync();
-
-        var processResult = await result;
+            .ExecuteBufferedAsync());
 
         Assert.Equal("test-from-working-directory", processResult.Output.StandardOutput.First().Text.Trim());
     }
@@ -2134,6 +2132,29 @@ public class ProcessWrapperTests
         }
 
         return [text];
+    }
+
+    // Executing a file right after writing it races with every process started in parallel: a child forked while the
+    // file is still open for writing inherits that handle until it execs its own image, and execve refuses to run a
+    // file any process holds open for writing (ETXTBSY, "Text file busy"). Waiting for those children to exec is the
+    // only way to close the window, so retry while the file is busy. Any other failure, such as the executable not
+    // being found at all, is reported immediately.
+    private static async Task<T> ExecuteRetryingOnTextFileBusyAsync<T>(Func<Task<T>> execute)
+    {
+        const int TextFileBusy = 26;
+
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
+        {
+            try
+            {
+                return await execute();
+            }
+            catch (System.ComponentModel.Win32Exception ex) when (!OperatingSystem.IsWindows() && ex.NativeErrorCode is TextFileBusy && stopwatch.Elapsed <= TimeSpan.FromSeconds(30))
+            {
+                await Task.Delay(50);
+            }
+        }
     }
 
     private static string NormalizeWorkingDirectoryPath(string path)


### PR DESCRIPTION
## The flake

[`ProcessWrapperTests.WithWorkingDirectory_FindsExecutableInWorkingDirectory`](https://github.com/meziantou/Meziantou.Framework/actions/runs/34363063924/job/102505034756?pr=3049) failed on `ubuntu-26.04, Debug, invariant, shard-2`:

```
System.ComponentModel.Win32Exception : An error occurred trying to start process
'/tmp/MezTD/20260909_143403_.../run.sh' with working directory '...'. Text file busy
```

## Why it happens

Not a `ProcessWrapper` bug, and not the test's own file handle — `File.WriteAllText` closes that before the exec. It is a fork race with the tests running beside it:

1. The test writes `run.sh` and sets the executable bit.
2. Another test thread calls `Process.Start`; .NET forks, and the child inherits every open descriptor, including the write handle on `run.sh`. `O_CLOEXEC` only closes it at `execve`, so it stays open for the whole fork→exec window.
3. Linux refuses to `execve` a file that any process holds open for writing, and returns `ETXTBSY`.

Reproduced in `mcr.microsoft.com/dotnet/sdk:10.0.400` with 16 threads spawning `/bin/echo` as noise: **21 failures out of 200** write-then-exec cycles. With the retry applied, all 17 hits in the second pass recovered on the following attempt.

This is invisible on macOS — XNU does not enforce `ETXTBSY` — so it can only ever show up on the Linux legs.

## The change

A narrow `ExecuteRetryingOnTextFileBusyAsync` helper in the test file, used by the failing test. It retries only on `Win32Exception` with `NativeErrorCode == 26` (`ETXTBSY`) on non-Windows, for up to 30 s at 50 ms intervals. A real breakage — the executable not being found, i.e. `ENOENT` — still fails on the first attempt.

The 30 s ceiling is larger than the 10 s used by the neighbouring `WaitForFileTextAsync` because thread-pool starvation on CI can stretch the `Task.Delay` continuations; a passing test never waits, and a genuinely broken one is not retried at all.

### Left alone deliberately

- `StartAndForget_AppliesConfigurationAndInterceptors` — same create-then-exec shape, but `DisableParallelization = true` means no in-process fork can race it.
- `WithWorkingDirectory_DoesNotFindExecutableInWorkingDirectoryByDefault` — expects the start to fail anyway.
- The stub executables in `DockerRuntimeAdapterTests` carry the same latent race; out of scope here, but worth hardening if it ever surfaces.

## Verification

- `dotnet build /p:TreatsWarningsAsErrors=true` — clean, and clean again under `-c Release /p:IsOfficialBuild=true` so the IDE analyzers ran.
- `dotnet test` on `Meziantou.Framework.ProcessWrapper.Tests`: 193 passed, 0 failed, across net10.0 (93) and net11.0 (100). Confirmed in the `.trx` that the target test itself ran on both TFMs.
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.