### PR TITLE
Post the pending notifications again after a failed SynchronizationContext.Post

### DIFF
--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentObservableCollection.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentObservableCollection.cs
@@ -10,6 +10,11 @@ namespace Meziantou.Framework.Collections.Concurrent;
 /// <remarks>
 /// The collection itself can be modified from any thread. The collection exposed by <see cref="AsObservable"/> raises
 /// its change notifications on the thread associated with the <see cref="SynchronizationContext"/> provided to the constructor.
+/// <para>
+/// When the synchronization context refuses the callback, for instance because the thread it is bound to is gone, the exception is
+/// propagated to the caller that modified the collection. The modification is kept, and its notification stays queued until a later
+/// modification succeeds in posting to the context.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/Internals/DispatchedObservableCollection.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/Internals/DispatchedObservableCollection.cs
@@ -215,7 +215,18 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
             if (!_isProcessingPending)
             {
                 _isProcessingPending = true;
-                _synchronizationContext.Post(static state => ((DispatchedObservableCollection<T>)state!).ProcessPendingEvents(), this);
+                try
+                {
+                    _synchronizationContext.Post(static state => ((DispatchedObservableCollection<T>)state!).ProcessPendingEvents(), this);
+                }
+                catch
+                {
+                    // The synchronization context refused the callback, so nothing will process the queue. The events stay
+                    // queued and the flag is restored, so the next modification posts again and raises every pending
+                    // notification as soon as the context accepts a callback.
+                    _isProcessingPending = false;
+                    throw;
+                }
             }
 
             return;

--- a/tests/Meziantou.Framework.Threading.Tests/ObservableCollectionTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ObservableCollectionTests.cs
@@ -326,6 +326,35 @@ public sealed partial class ObservableCollectionTests : IDisposable
     }
 
     [Fact]
+    public void ChangesAreNotifiedAfterTheSynchronizationContextRejectedAPost()
+    {
+        var context = new QueuedSynchronizationContext();
+        var previousSynchronizationContext = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(context);
+        try
+        {
+            var collection = new ConcurrentObservableCollection<int>(context);
+            var observable = collection.AsObservable;
+            using var eventAssert = new EventAssert(observable);
+
+            context.RejectPost = true;
+            Assert.IsType<InvalidOperationException>(RunOnAnotherThread(() => collection.Add(1)));
+
+            context.RejectPost = false;
+            Assert.Null(RunOnAnotherThread(() => collection.Add(2)));
+
+            // The notification of the first item was queued and is raised by the post of the second one
+            Assert.Equal(1, context.Run());
+            Assert.Equal([1, 2], observable.ToList());
+            Assert.HasCount(2, eventAssert.CollectionChangedArgs);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousSynchronizationContext);
+        }
+    }
+
+    [Fact]
     public void ObservableCollectionCannotBeAccessedFromAnotherThread()
     {
         var observable = CreateCollection<int>().AsObservable;
@@ -388,11 +417,41 @@ public sealed partial class ObservableCollectionTests : IDisposable
         }
     }
 
+    /// <summary>Runs <paramref name="action"/> on a thread with no synchronization context and returns the exception it threw, if any.</summary>
+    private static Exception? RunOnAnotherThread(Action action)
+    {
+        Exception? exception = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+        });
+
+        thread.Start();
+        thread.Join();
+        return exception;
+    }
+
     private sealed class QueuedSynchronizationContext : SynchronizationContext
     {
         private readonly System.Collections.Concurrent.ConcurrentQueue<(SendOrPostCallback Callback, object? State)> _callbacks = new();
 
-        public override void Post(SendOrPostCallback d, object? state) => _callbacks.Enqueue((d, state));
+        /// <summary>When set to <see langword="true"/>, <see cref="Post"/> throws instead of queuing the callback.</summary>
+        public bool RejectPost { get; set; }
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            if (RejectPost)
+                throw new InvalidOperationException("The synchronization context cannot accept the callback");
+
+            _callbacks.Enqueue((d, state));
+        }
 
         /// <summary>Runs the pending callbacks and returns how many were executed.</summary>
         public int Run()


### PR DESCRIPTION
## Problem

`DispatchedObservableCollection` sets `_isProcessingPending` to `true` before calling `SynchronizationContext.Post`, and only the posted callback clears it. When `Post` throws, the flag stays set forever, so every later change coming from a background thread sees a dispatch as already in flight and never posts again.

The result is a permanently desynchronized collection: the source `ConcurrentObservableCollection<T>` keeps accepting and committing the changes (the mutation happens before the post), while the observable view never receives another notification, even after the synchronization context becomes usable again. Two background adds against a context that fails its first post produced a single post attempt in total, leaving both notifications stuck in the queue.

## Fix

Restore `_isProcessingPending` when `Post` throws, and rethrow.

Behavior after the fix:

- the pending events stay queued, so nothing is lost;
- the exception still reaches the caller that modified the collection, so a notification that could not be delivered is not silent;
- the next modification posts again and drains the whole queue, so the observable collection resynchronizes with everything that happened while the context was unavailable;
- there is no terminal failure state: a context that recovers works again instead of poisoning the collection.

Retrying on the next modification was chosen over a terminal state or a background retry loop because it needs no new API and matches the existing design, which has no timer of its own. The contract is now documented in the public `<remarks>` of `ConcurrentObservableCollection<T>`, since the exception surfaces from public mutating methods while the modification itself is kept.

## Tests

New `ChangesAreNotifiedAfterTheSynchronizationContextRejectedAPost`: a `QueuedSynchronizationContext` that rejects the first `Post`, then two adds from background threads. On the pre-fix code it fails with exactly the reported symptom — `context.Run()` returns 0, no post ever arrived — and passes with the fix, with both notifications raised by the second post.

## Verification

- `Meziantou.Framework.Threading.Tests`: 356 passed / 0 failed / 0 skipped (178 per TFM, net10.0 + net11.0) with `/p:TreatWarningsAsErrors=true`; the trx confirms the new test ran and passed.
- `Meziantou.Framework.Threading` built in Release with `IsOfficialBuild=true`: 0 warnings, `ref/Meziantou.Framework.Threading.cs` unchanged (no public API change; ref files carry no XML docs).
- `Meziantou.Framework.Threading.Windows.Tests` builds clean; those tests cannot run on macOS (no WindowsDesktop runtime for osx-arm64).
- `dotnet run ./eng/update-all.cs`: no changes.