### PR TITLE
Use an acquire read for the AsyncLock.TryLock fast path

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/AsyncLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncLock.cs
@@ -92,7 +92,9 @@ public sealed class AsyncLock
     /// <returns><see langword="true"/> if the lock was acquired; otherwise, <see langword="false"/>.</returns>
     public bool TryLock(out AsyncLockLease lockObject)
     {
-        if (_signaled)
+        // Acquire read: _signaled is written under _lock, so an unsynchronized read could otherwise
+        // observe a stale value indefinitely and make a caller spinning on TryLock never see a release.
+        if (Volatile.Read(ref _signaled))
         {
             lock (_lock)
             {


### PR DESCRIPTION
## What changed

`AsyncLock.TryLock` read `_signaled` in its outer fast-path check without any synchronization. That read now uses `Volatile.Read`.

## Why

`_signaled` is only ever written under `_lock`. An unsynchronized read of it is not ordered against that write, so a caller spinning on `TryLock` had no guarantee of ever observing a release — it could keep seeing a stale `false` and return failure indefinitely.

Using an acquire read pairs the optimistic check with the release store performed when `Release()` exits the lock, which supplies the missing happens-before edge.

## Notes for reviewers

- **Mutual exclusion was never at risk.** The locked recheck already prevented two holders; this is purely a visibility and progress fix. No stale-read failure was actually observed — the finding was source-level review of the memory model, not a reproduction.
- I used an acquire read rather than moving the whole check under `_lock`, so the uncontended path still avoids a lock acquisition. The locked recheck is retained.
- The read inside the monitor stays a plain read — the lock already orders it.
- No test was added: a memory-model stale read has no deterministic repro to assert against, and there is no behavioral change to observe. The existing `TryLock_OnFreeLock_Succeeds` still covers the functional path.
- Public surface is unchanged, so `ref/Meziantou.Framework.Threading.cs` needed no update (confirmed by the build's API verification).

## Verification

- `dotnet build src/Meziantou.Framework.Threading` with `/p:TreatWarningsAsErrors=true` — succeeded, 0 warnings, 0 errors.
- `dotnet test` on `Meziantou.Framework.Threading.Tests` — 354 passed, 0 failed, 0 skipped (177 per TFM across net10.0 and net11.0). Checked the TRX to confirm the `AsyncLock` tests actually ran, including `TryLock_OnFreeLock_Succeeds`, `LockAsync_ProvidesMutualExclusion` and `LockAsync_WaitersAreServedInOrder`.
- `dotnet run ./eng/update-all.cs` — exit 0, no errors, no generated-file changes.
