### PR TITLE
Answer ConcurrentHashSet.Overlaps and IsSupersetOf without copying the set

### DIFF
--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentHashSet.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentHashSet.cs
@@ -17,6 +17,7 @@ namespace Meziantou.Framework.Collections.Concurrent;
 /// }
 /// ]]></code>
 /// </example>
+/// <remarks>The set comparison methods (<see cref="IsSubsetOf(IEnumerable{T})"/>, <see cref="IsSupersetOf(IEnumerable{T})"/>, <see cref="Overlaps(IEnumerable{T})"/>, <see cref="SetEquals(IEnumerable{T})"/> and their proper variants) do not take an atomic snapshot of the set: elements can be added or removed while they run, so their result is best-effort and only reflects a set that was not modified concurrently.</remarks>
 public sealed class ConcurrentHashSet<T> : ISet<T>, IReadOnlySet<T>
     where T : notnull
 {
@@ -153,11 +154,18 @@ public sealed class ConcurrentHashSet<T> : ISet<T>, IReadOnlySet<T>
     /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> is a superset of a specified collection.</summary>
     /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
     /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> is a superset of <paramref name="other"/>; otherwise, <see langword="false"/>.</returns>
+    /// <remarks><paramref name="other"/> is enumerated only until an element that is not in the set is found, so the elements after it are never looked up.</remarks>
     public bool IsSupersetOf(IEnumerable<T> other)
     {
         ArgumentNullException.ThrowIfNull(other);
 
-        return CreateSet(this).IsSupersetOf(other);
+        foreach (var item in other)
+        {
+            if (!Contains(item))
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> is a proper subset of a specified collection.</summary>
@@ -183,11 +191,21 @@ public sealed class ConcurrentHashSet<T> : ISet<T>, IReadOnlySet<T>
     /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> overlaps with the specified collection.</summary>
     /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
     /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> and <paramref name="other"/> share at least one common element; otherwise, <see langword="false"/>.</returns>
+    /// <remarks><paramref name="other"/> is enumerated only until a common element is found, so the elements after it are never looked up. It is not enumerated at all when the set is empty.</remarks>
     public bool Overlaps(IEnumerable<T> other)
     {
         ArgumentNullException.ThrowIfNull(other);
 
-        return CreateSet(this).Overlaps(other);
+        if (IsEmpty)
+            return false;
+
+        foreach (var item in other)
+        {
+            if (Contains(item))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> and the specified collection contain the same elements.</summary>

--- a/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
@@ -1,4 +1,4 @@
-using Meziantou.Framework.Collections.Concurrent;
+﻿using Meziantou.Framework.Collections.Concurrent;
 
 namespace Meziantou.Framework.Tests.Collections;
 
@@ -154,5 +154,77 @@ public class ConcurrentHashSetTests
         Assert.Equal(0, destination[0]);
         Assert.Equal(0, destination[4]);
         Assert.Equal([1, 2, 3], destination[1..4].Order());
+    }
+
+    [Fact]
+    public void Overlaps_StopsEnumeratingOtherAtTheFirstCommonElement()
+    {
+        var set = new ConcurrentHashSet<int>();
+        set.AddRange(1, 2, 3);
+        List<int> enumerated = [];
+
+        Assert.True(set.Overlaps(Record([7, 2, 3], enumerated)));
+        Assert.Equal([7, 2], enumerated);
+    }
+
+    [Fact]
+    public void Overlaps_EmptySet_DoesNotEnumerateOther()
+    {
+        ConcurrentHashSet<int> set = [];
+        List<int> enumerated = [];
+
+        Assert.False(set.Overlaps(Record([1, 2, 3], enumerated)));
+        Assert.Empty(enumerated);
+    }
+
+    [Fact]
+    public void Overlaps_NoCommonElement_ReturnsFalse()
+    {
+        var set = new ConcurrentHashSet<int>();
+        set.AddRange(1, 2, 3);
+
+        Assert.False(set.Overlaps([4, 5]));
+        Assert.False(set.Overlaps([]));
+    }
+
+    [Fact]
+    public void IsSupersetOf_StopsEnumeratingOtherAtTheFirstMissingElement()
+    {
+        var set = new ConcurrentHashSet<int>();
+        set.AddRange(1, 2, 3);
+        List<int> enumerated = [];
+
+        Assert.False(set.IsSupersetOf(Record([1, 9, 2], enumerated)));
+        Assert.Equal([1, 9], enumerated);
+    }
+
+    [Fact]
+    public void IsSupersetOf_IgnoresDuplicatesInOther()
+    {
+        var set = new ConcurrentHashSet<int>();
+        set.AddRange(1, 2, 3);
+
+        Assert.True(set.IsSupersetOf([1, 1, 2]));
+        Assert.True(set.IsSupersetOf([1, 2, 3]));
+        Assert.True(set.IsSupersetOf([]));
+        Assert.False(set.IsSupersetOf([1, 4]));
+    }
+
+    [Fact]
+    public void IsSupersetOf_EmptySet()
+    {
+        ConcurrentHashSet<int> set = [];
+
+        Assert.True(set.IsSupersetOf([]));
+        Assert.False(set.IsSupersetOf([1]));
+    }
+
+    private static IEnumerable<T> Record<T>(IEnumerable<T> source, List<T> enumerated)
+    {
+        foreach (var item in source)
+        {
+            enumerated.Add(item);
+            yield return item;
+        }
     }
 }


### PR DESCRIPTION
## What changed

`ConcurrentHashSet<T>.Overlaps` and `IsSupersetOf` both delegated to `CreateSet(this).X(other)`, which copied and rehashed **every element of the current set** into a temporary `HashSet<T>` before looking at `other` at all. Checking whether a 100k-element set overlaps a one-element input cost O(Count) time and O(Count) memory, when one dictionary lookup answers it.

Both now answer directly against the underlying `ConcurrentDictionary`:

- **`Overlaps`** scans `other` and returns `true` at the first element `Contains` finds. It also short-circuits on an empty set without enumerating `other` at all — which matches `HashSet<T>.Overlaps`, that likewise returns `false` for an empty set.
- **`IsSupersetOf`** scans `other` and returns `false` at the first element that is missing.

Both are now allocation-free and read only the prefix of `other` they actually need.

## What was deliberately left alone

- `IsSubsetOf`, `IsProperSubsetOf`, `IsProperSupersetOf` and `SetEquals` still build the temporary set. They need the distinct-element counting it provides, so the same trick does not apply.
- `CopyTo` still snapshots into a `List<T>` by design — that is what keeps it failure-atomic when the destination array turns out to be too small.

## Semantics

Behaviour is unchanged for a set that is not being modified concurrently. Duplicates in `other` are still handled correctly by `IsSupersetOf` (a repeated element is simply looked up twice), and an empty `other` still returns `true`.

The best-effort concurrent semantics are now documented in a class-level `<remarks>`. This is not a new caveat introduced here: the old `CreateSet(this)` enumerated a live `ConcurrentDictionary` too, so none of these comparison methods ever gave a global atomic snapshot. The note covers the whole family so the rewritten pair does not read as uniquely non-atomic. Each rewritten method also carries a short note that `other` is only partially enumerated, since that is now observable by callers passing a lazy or side-effecting sequence.

No public API surface changed, so `ref/Meziantou.Framework.Threading.cs` is untouched.

## Tests

Six cases added to `ConcurrentHashSetTests`, including two that wrap `other` in a recording iterator to assert enumeration actually stops where expected, and one asserting an empty set never enumerates `other` at all.

## Verification

- `dotnet build` with `/p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- Filtered run of `ConcurrentHashSetTests`: 18 per TFM (12 existing + 6 new), 36 total, all passed — the count confirms the new tests ran rather than being silently filtered out.
- Full `Meziantou.Framework.Threading.Tests`: **366 passed, 0 failed, 0 skipped**.
- Release + `IsOfficialBuild=true` build of both projects (the configuration that enables the `IDExxxx` analyzers and regenerates `ref/`): 0 warnings, and `ref/` came back unchanged as expected.
- `dotnet run ./eng/update-all.cs`: exits 0, no errors, no generated-file changes.
