### PR TITLE
Release the cancellation source even when a callback throws

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/ResettableCancellationTokenSource.cs
+++ b/src/Meziantou.Framework.Threading/Threading/ResettableCancellationTokenSource.cs
@@ -90,27 +90,52 @@ public sealed class ResettableCancellationTokenSource : IDisposable
     }
 
     /// <summary>Resets the cancellation token source to its initial state.</summary>
+    /// <remarks>
+    /// The instance is reset even when a cancellation callback throws: the exception raised by
+    /// <see cref="CancellationTokenSource.Cancel()"/> propagates to the caller only after a fresh
+    /// <see cref="Token"/> is available. A callback that disposes this instance wins, and the reset is abandoned.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The instance is disposed.</exception>
+    /// <exception cref="AggregateException">A callback registered on the current <see cref="Token"/> threw.</exception>
     public void Reset()
     {
         lock (_lock)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnReset))
+            try
             {
-                _cts.Cancel();
+                if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnReset))
+                {
+                    _cts.Cancel();
+                }
             }
-
-            // Replacing the source is only safe while the lock is held: every other member reads _cts under the same
-            // lock, so no caller can be using the instance that is about to be disposed.
-            if (!_cts.TryReset())
+            finally
             {
-                _cts.Dispose();
-                _cts = new CancellationTokenSource();
+                // A callback may have disposed this instance reentrantly, in which case the source is already gone.
+                if (!_disposed)
+                {
+                    // Replacing the source is only safe while the lock is held: every other member reads _cts under the
+                    // same lock, so no caller can be using the instance that is about to be disposed. _cts is read here
+                    // rather than before the cancellation because a callback may have replaced it reentrantly.
+                    var cts = _cts;
+                    if (!cts.TryReset())
+                    {
+                        cts.Dispose();
+                        _cts = new CancellationTokenSource();
+                    }
+                }
             }
         }
     }
 
+    /// <summary>Releases the resources used by this <see cref="ResettableCancellationTokenSource"/>.</summary>
+    /// <remarks>
+    /// The underlying <see cref="CancellationTokenSource"/> is disposed even when a cancellation callback throws: the
+    /// exception raised by <see cref="CancellationTokenSource.Cancel()"/> propagates to the caller only after the
+    /// resources are released. Subsequent calls do nothing.
+    /// </remarks>
+    /// <exception cref="AggregateException">A callback registered on the current <see cref="Token"/> threw.</exception>
     public void Dispose()
     {
         lock (_lock)
@@ -120,12 +145,17 @@ public sealed class ResettableCancellationTokenSource : IDisposable
 
             _disposed = true;
 
-            if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnDispose))
+            try
             {
-                _cts.Cancel();
+                if (_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnDispose))
+                {
+                    _cts.Cancel();
+                }
             }
-
-            _cts.Dispose();
+            finally
+            {
+                _cts.Dispose();
+            }
         }
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/ResettableCancellationTokenSourceTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ResettableCancellationTokenSourceTests.cs
@@ -63,6 +63,57 @@ public sealed class ResettableCancellationTokenSourceTests
     }
 
     [Fact]
+    public void Dispose_DisposesTheUnderlyingSource_WhenACancellationCallbackThrows()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        cts.Token.Register(() => throw new InvalidOperationException("callback"));
+
+        Assert.Throws<AggregateException>(cts.Dispose);
+
+        // The underlying source must be disposed even though the callback threw, otherwise the resources it holds
+        // (such as an allocated wait handle) stay alive until the finalizer runs.
+        Assert.Throws<ObjectDisposedException>(() => cts.Token);
+        Assert.Throws<ObjectDisposedException>(cts.Reset);
+        cts.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent_AfterACancellationCallbackThrows()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        cts.Token.Register(() => throw new InvalidOperationException("callback"));
+
+        Assert.Throws<AggregateException>(cts.Dispose);
+        cts.Dispose();
+    }
+
+    [Fact]
+    public void Reset_ProducesAFreshToken_WhenACancellationCallbackThrows()
+    {
+        using var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnReset);
+        var token = cts.Token;
+        token.Register(() => throw new InvalidOperationException("callback"));
+
+        Assert.Throws<AggregateException>(cts.Reset);
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.False(cts.IsCancellationRequested);
+        Assert.False(cts.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Reset_IsAbandoned_WhenACancellationCallbackDisposesTheInstance()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnReset);
+        cts.Token.Register(cts.Dispose);
+
+        cts.Reset();
+
+        Assert.Throws<ObjectDisposedException>(() => cts.Token);
+        cts.Dispose();
+    }
+
+    [Fact]
     public void Reset_AfterDispose_Throws()
     {
         var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);


### PR DESCRIPTION
## What

`ResettableCancellationTokenSource.Dispose` set `_disposed`, called `_cts.Cancel()`, then `_cts.Dispose()`. A callback registered on the token that throws makes `Cancel()` raise an `AggregateException`, so `_cts.Dispose()` never ran — and because `_disposed` was already set, every subsequent `Dispose()` returned immediately. The underlying source stayed alive with its resources (an allocated wait handle, for example) held until finalization, and `Token` was still readable afterwards.

`Cancel()` now runs inside a `try` with the disposal in the `finally`. The source is always released, and the callback's `AggregateException` still reaches the caller unchanged.

`Reset` had the same hole plus two reentrancy cases that were previously undefined. Both now have an explicit policy, documented in `<remarks>`/`<exception>`:

- **A callback throws** — the reset still completes, so a fresh `Token` is available before the `AggregateException` propagates. Previously `Reset` exited without resetting anything.
- **A callback disposes the instance reentrantly** — disposal wins and the reset is abandoned, instead of calling `TryReset()` on a just-disposed source and throwing `ObjectDisposedException` out of `Reset`.
- `_cts` is read *inside* the `finally` rather than captured before `Cancel()`, so a reentrant `Reset` from a callback doesn't cause the outer call to dispose a source that was already replaced.

## Notes for reviewers

- No public signature changed; `ref/Meziantou.Framework.Threading.cs` is untouched (confirmed by a Release + `IsOfficialBuild=true` build).
- Disposing a `CancellationTokenSource` from inside its own callback is safe — `Dispose` skips the wait when the executing thread is the current one — so the reentrant-dispose path doesn't deadlock under the instance lock.
- Four tests were added to `ResettableCancellationTokenSourceTests`. Three of them fail against the pre-fix code (verified by reverting the source: 3 failed / 10 succeeded); the fourth pins idempotency after a throwing callback, which the old code satisfied only by leaving the source permanently undisposed.

## Verification

- Build with `-p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- `Meziantou.Framework.Threading.Tests`, both TFMs: 362/362 passed, 0 skipped; the trx confirms all four new tests ran.
- Release + `IsOfficialBuild=true` build of the library (IDE analyzers and `ref/` generation): clean, no `ref/` changes.
- `dotnet run ./eng/update-all.cs`: exit 0, no files changed.
