### PR TITLE
Keep the KeyedLock entry reserved when releasing the lock fails

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/KeyedLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/KeyedLock.cs
@@ -48,7 +48,8 @@ public sealed class KeyedLock<TKey> where TKey : notnull
     /// <returns>A disposable object. Disposing the object releases the lock.</returns>
     /// <remarks>
     /// The returned object must be disposed on the thread that called this method. Disposing it on another thread
-    /// throws <see cref="SynchronizationLockException"/> and leaves the underlying lock held.
+    /// throws <see cref="SynchronizationLockException"/> and leaves the underlying lock held; the object is not
+    /// consumed by such a failed disposal, so the owning thread can still dispose it to release the lock.
     /// </remarks>
     public IDisposable Lock(TKey key)
     {
@@ -72,21 +73,17 @@ public sealed class KeyedLock<TKey> where TKey : notnull
 
     private void Release(TKey key, Entry entry)
     {
-        try
+        // Exit throws when the lease is disposed on a thread that does not own the lock. The lock is then
+        // still held by the owning thread, so the reservation must stay: releasing it could evict the entry
+        // and let another thread acquire a brand new lock for the same key while the critical section is
+        // still running. The lease stays undisposed so the owning thread can release the lock afterwards.
+        entry.Lock.Exit();
+
+        lock (_locks)
         {
-            entry.Lock.Exit();
-        }
-        finally
-        {
-            // The reference count must be released even when Exit throws, which happens when the lease is
-            // disposed on a thread that does not own the lock. Skipping it would leave the entry in the
-            // dictionary forever and permanently deadlock every later acquisition of the same key.
-            lock (_locks)
+            if (--entry.ReferenceCount == 0)
             {
-                if (--entry.ReferenceCount == 0)
-                {
-                    _locks.Remove(key);
-                }
+                _locks.Remove(key);
             }
         }
     }
@@ -115,8 +112,10 @@ public sealed class KeyedLock<TKey> where TKey : notnull
         {
             if (!_disposed)
             {
-                _disposed = true;
+                // Only mark the lease as disposed once the lock is actually released, so a failed release
+                // (disposal on the wrong thread) can still be retried from the thread that owns the lock.
                 _owner.Release(_key, _entry);
+                _disposed = true;
             }
         }
     }

--- a/tests/Meziantou.Framework.Threading.Tests/KeyedLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/KeyedLockTests.cs
@@ -106,10 +106,11 @@ public sealed class KeyedLockTests
     }
 
     [Fact]
-    public void Lock_DisposedOnAnotherThread_ThrowsButStillEvictsTheEntry()
+    public async Task Lock_DisposedOnAnotherThread_ThrowsAndKeepsTheLockHeld()
     {
-        // System.Threading.Lock is thread-affine, so Exit throws here. The reference count must still be
-        // released, otherwise the entry stays in the dictionary and every later Lock(1) deadlocks.
+        // System.Threading.Lock is thread-affine, so Exit throws here and the lock remains held by the
+        // acquiring thread. The entry must therefore stay in the dictionary: evicting it would let another
+        // thread lock a fresh entry for the same key while this critical section is still running.
         var locks = new KeyedLock<int>();
         var lease = locks.Lock(1);
 
@@ -132,12 +133,25 @@ public sealed class KeyedLockTests
         Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
 
         Assert.IsType<SynchronizationLockException>(captured);
-        Assert.Empty(GetEntries(locks));
+        Assert.Single(GetEntries(locks));
 
-        // A fresh entry is created, so the key is usable again rather than permanently wedged.
-        using (locks.Lock(1))
+        using var acquired = new ManualResetEventSlim(initialState: false);
+        var blocked = Task.Run(() =>
         {
-        }
+            using (locks.Lock(1))
+            {
+                acquired.Set();
+            }
+        });
+
+        Assert.False(acquired.Wait(200)); // still blocked by the lock this thread owns
+
+        // The failed disposal did not consume the lease, so the owning thread can still release the lock.
+        lease.Dispose();
+
+        await blocked.WaitAsync(TimeSpan.FromSeconds(30));
+        Assert.True(acquired.IsSet);
+        Assert.Empty(GetEntries(locks));
     }
 
     [Fact]


### PR DESCRIPTION
## What

`KeyedLock<TKey>.Release` no longer drops its bookkeeping when the underlying `Lock.Exit()` throws.

- `Release` calls `entry.Lock.Exit()` outside a `try`/`finally`, so a failure propagates with the reference reservation intact and the entry still in the dictionary.
- `LockLease.Dispose` sets `_disposed` only *after* a successful release, so a failed disposal does not consume the lease. Idempotency on the success path is unchanged.
- The `<remarks>` on `Lock` documents that recovery path.

## Why

`Release` decremented the reference count in a `finally`. A wrong-thread disposal throws `SynchronizationLockException` and leaves the lock held, but the `finally` still ran, so the count could reach zero and the entry was evicted.

Eviction does not release anything — the physical `Lock` is still owned by the original thread. It only lets the next `Lock(key)` create a *second, independent* entry and enter the same critical section concurrently. That trades a hang the caller can still resolve for a silent loss of mutual exclusion, which is worse. The old comment justified the `finally` as avoiding a permanent deadlock; that reasoning does not hold, because the entry it evicts is one whose lock nobody can take anyway.

With this change the entry stays, which matches reality: the lock really is still held. A later `Lock(key)` on another thread blocks, as it should, and the owning thread can still dispose the lease to release it.

This also brings `KeyedLock` in line with `KeyedAsyncLock`, which already released the lock before the reference and left the reservation alone on failure.

## Reviewer notes

`Lock_DisposedOnAnotherThread_ThrowsButStillEvictsTheEntry` encoded the old policy, so it is replaced by `Lock_DisposedOnAnotherThread_ThrowsAndKeepsTheLockHeld`, which asserts the throw, that the entry survives, that another thread stays blocked on the key, and that the owning thread's later `Dispose()` releases it and unblocks the waiter. Reverting the source makes the new test fail on both TFMs with the entry evicted, so it is a real regression guard.

Wrong-thread disposal is explicitly prohibited by the API, so this changes recovery behavior for a misuse case rather than fixing ordinary supported use. No public API change; `ref/Meziantou.Framework.Threading.cs` is untouched.

## Validation

- Built with `/p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `Meziantou.Framework.Threading.Tests`: 354 passed, 0 failed, 0 skipped (177 per TFM across net10.0 and net11.0).
- `dotnet run ./eng/update-all.cs` completed with exit code 0 and generated no changes.