### PR TITLE
Make MonoThreadedTaskScheduler shutdown consistent and race-free

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/MonoThreadedTaskScheduler.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MonoThreadedTaskScheduler.cs
@@ -21,7 +21,12 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
     private readonly AutoResetEvent _dequeue = new(initialState: false);
     // note: Stop must be first in the array (in case both events happen at the same exact time)
     private readonly WaitHandle[] _waitHandles;
-    private int _disposed;
+    // Serializes task acceptance with shutdown, so a task is either enqueued while the worker is guaranteed to
+    // still observe it, or rejected.
+    private readonly Lock _gate = new();
+    private readonly Thread _thread;
+    private volatile bool _shutdownRequested;
+    private int _waitHandleReleaseCount;
 
     /// <summary>Initializes a new instance of the <see cref="MonoThreadedTaskScheduler"/> class.</summary>
     public MonoThreadedTaskScheduler()
@@ -35,24 +40,28 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
     {
         _waitHandles = [_stop, _dequeue];
 
-        Thread = new Thread(SafeThreadExecute)
+        _thread = new Thread(SafeThreadExecute)
         {
             IsBackground = true,
             Name = threadName,
         };
 
-        Thread.Start();
+        _thread.Start();
 
         DisposeThreadJoinTimeout = TimeSpan.FromMilliseconds(1000);
         WaitTimeout = TimeSpan.FromMilliseconds(100);
     }
 
-    private Thread? Thread { get; set; }
-
     /// <summary>Gets or sets a value indicating whether to dequeue remaining tasks when the scheduler is disposed.</summary>
+    /// <remarks>
+    /// When <see langword="true"/>, every task the scheduler accepted is executed before the worker thread exits.
+    /// When <see langword="false"/>, the tasks that have not started running when <see cref="Dispose"/> is called are
+    /// abandoned and never complete. In both cases no task is accepted once <see cref="Dispose"/> has been called.
+    /// </remarks>
     public bool DequeueOnDispose { get; set; }
 
     /// <summary>Gets or sets the timeout to wait for the worker thread to complete when disposing.</summary>
+    /// <remarks>The wait is skipped when <see cref="Dispose"/> is called from the scheduler's own thread.</remarks>
     public TimeSpan DisposeThreadJoinTimeout { get; set; }
 
     /// <summary>Gets or sets the timeout for waiting on the event handle.</summary>
@@ -66,26 +75,40 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
 
     public void Dispose()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        lock (_gate)
+        {
+            if (_shutdownRequested)
+                return;
+
+            // Requesting the shutdown before signaling the event means every task QueueTask accepted was enqueued
+            // before the worker can observe the stop request, and that no task is accepted afterwards. Every
+            // accepted task therefore has a defined outcome: it runs, or it is abandoned per DequeueOnDispose.
+            _shutdownRequested = true;
+            _stop.Set();
+        }
+
+        // Joining the worker thread from the worker thread itself (Dispose called by a task running on this
+        // scheduler) can never complete: it would deadlock on an infinite timeout, and stall for
+        // DisposeThreadJoinTimeout otherwise. The worker finishes its shutdown, final drain included, as soon as
+        // the current task returns.
+        if (_thread != Thread.CurrentThread)
+        {
+            _thread.Join(DisposeThreadJoinTimeout);
+        }
+
+        ReleaseWaitHandles();
+    }
+
+    // Disposing a wait handle while the worker is still blocked on it (in ThreadExecute's WaitAny) is a race
+    // condition that can throw or corrupt the wait. Both the worker (once it has stopped using the handles) and
+    // Dispose (once it has stopped waiting for the worker) call this, and the second one releases them.
+    private void ReleaseWaitHandles()
+    {
+        if (Interlocked.Increment(ref _waitHandleReleaseCount) != 2)
             return;
 
-        // Signal the worker thread to stop. It drains the remaining tasks itself (see ThreadExecute), so
-        // the single-threaded execution guarantee holds even when the join below times out.
-        _stop.Set();
-
-        var thread = Thread;
-        var exited = thread is null || !thread.IsAlive || thread.Join(DisposeThreadJoinTimeout);
-
-        Thread = null;
-
-        // Disposing a wait handle while the worker is still blocked on it (in ThreadExecute's WaitAny) is a
-        // race condition that can throw or corrupt the wait. When the join times out the worker is still
-        // running, so the handles are left to be reclaimed by the GC instead of being pulled out from under it.
-        if (exited)
-        {
-            _stop.Dispose();
-            _dequeue.Dispose();
-        }
+        _stop.Dispose();
+        _dequeue.Dispose();
     }
 
     private bool ExecuteTask(Task task)
@@ -93,16 +116,17 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
         return TryExecuteTask(task);
     }
 
-    private void Dequeue()
+    private void Dequeue(bool untilEmpty)
     {
-        do
+        // Outside of the final drain, stop as soon as a shutdown is requested: DequeueOnDispose must decide whether
+        // the queued tasks run, not whether a drain happened to be in progress when Dispose was called.
+        while (untilEmpty || !_shutdownRequested)
         {
             if (!_tasks.TryDequeue(out var task))
                 break;
 
             ExecuteTask(task);
         }
-        while (true);
     }
 
     private void SafeThreadExecute()
@@ -113,6 +137,10 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
         }
         catch
         {
+        }
+        finally
+        {
+            ReleaseWaitHandles();
         }
     }
 
@@ -125,7 +153,7 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
                 break;
 
             // note: we can dequeue on _dequeue event, or on timeout
-            Dequeue();
+            Dequeue(untilEmpty: false);
         }
         while (true);
 
@@ -133,7 +161,7 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
         // tasks never execute on two threads at once.
         if (DequeueOnDispose)
         {
-            Dequeue();
+            Dequeue(untilEmpty: true);
         }
     }
 
@@ -145,10 +173,14 @@ public sealed class MonoThreadedTaskScheduler : TaskScheduler, IDisposable
     protected override void QueueTask(Task task)
     {
         ArgumentNullException.ThrowIfNull(task);
-        ObjectDisposedException.ThrowIf(_disposed != 0, this);
 
-        _tasks.Enqueue(task);
-        _dequeue.Set();
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_shutdownRequested, this);
+
+            _tasks.Enqueue(task);
+            _dequeue.Set();
+        }
     }
 
     protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)

--- a/tests/Meziantou.Framework.Threading.Tests/MonoThreadedTaskSchedulerTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/MonoThreadedTaskSchedulerTests.cs
@@ -176,6 +176,129 @@ public sealed class MonoThreadedTaskSchedulerTests : IDisposable
     }
 
     [Fact]
+    public void DequeueOnDispose_False_DoesNotRunQueuedTasks()
+    {
+        // The worker is inside Dequeue when the shutdown is requested. Whether a drain happened to be in progress
+        // must not decide the fate of the queued tasks: DequeueOnDispose does.
+        using var started = new ManualResetEventSlim(initialState: false);
+        using var release = new ManualResetEventSlim(initialState: false);
+        using var executed = new ManualResetEventSlim(initialState: false);
+
+        var scheduler = new MonoThreadedTaskScheduler("no-dequeue")
+        {
+            DequeueOnDispose = false,
+            DisposeThreadJoinTimeout = TimeSpan.Zero,
+        };
+
+        _ = Task.Factory.StartNew(
+            () =>
+            {
+                started.Set();
+                release.Wait();
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        started.Wait();
+
+        _ = Task.Factory.StartNew(
+            executed.Set,
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        scheduler.Dispose();
+        release.Set();
+
+        Assert.False(executed.Wait(TimeSpan.FromSeconds(2)));
+        Assert.Equal(1, scheduler.QueueCount);
+    }
+
+    [Fact]
+    public async Task Dispose_FromSchedulerThread_DoesNotJoinItself()
+    {
+        // An infinite join would never complete if the worker waited for itself, and any finite one would stall
+        // for nothing.
+        // The task below disposes the scheduler; the using is only there to cover the paths that do not reach it.
+        using var scheduler = new MonoThreadedTaskScheduler("self-dispose")
+        {
+            DequeueOnDispose = true,
+            DisposeThreadJoinTimeout = Timeout.InfiniteTimeSpan,
+        };
+
+        var executed = 0;
+        Task? queued = null;
+
+        var disposing = Task.Factory.StartNew(
+            () =>
+            {
+                // Accepted before the shutdown is requested, so the final drain must still run it.
+                queued = Task.Factory.StartNew(
+                    () => Interlocked.Increment(ref executed),
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    scheduler);
+
+                scheduler.Dispose();
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        await disposing.WaitAsync(TimeSpan.FromSeconds(30));
+        await queued!.WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Equal(1, executed);
+    }
+
+    [Fact]
+    public async Task QueueTask_RacingWithDispose_NeverOrphansAnAcceptedTask()
+    {
+        // A task the scheduler accepted must always reach completion: it can never slip past the disposed check
+        // and end up queued behind a worker that has already drained for the last time.
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            var scheduler = new MonoThreadedTaskScheduler("race") { DequeueOnDispose = true };
+            using var producing = new ManualResetEventSlim(initialState: false);
+            var accepted = new List<Task>();
+
+            var producer = new Thread(() =>
+            {
+                producing.Set();
+                for (var i = 0; i < 200; i++)
+                {
+                    try
+                    {
+                        accepted.Add(Task.Factory.StartNew(
+                            () => { },
+                            CancellationToken.None,
+                            TaskCreationOptions.None,
+                            scheduler));
+                    }
+                    catch (TaskSchedulerException exception) when (exception.InnerException is ObjectDisposedException)
+                    {
+                        return;
+                    }
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "race-producer",
+            };
+
+            producer.Start();
+            producing.Wait();
+            scheduler.Dispose();
+
+            // The join publishes the list built by the producer thread.
+            producer.Join();
+
+            await Task.WhenAll(accepted).WaitAsync(TimeSpan.FromSeconds(30));
+        }
+    }
+
+    [Fact]
     public void QueueTask_AfterDispose_Throws()
     {
         var scheduler = new MonoThreadedTaskScheduler("disposed");


### PR DESCRIPTION
`MonoThreadedTaskScheduler` had four related shutdown defects. All four are fixed here, each with a regression test.

## What changed

**`Dequeue` ignored shutdown.** It drained the entire queue unconditionally, so the `DequeueOnDispose` flag only governed the *final* drain — not a drain that happened to already be in progress. With `DequeueOnDispose = false`, a blocked first task, a queued second task and a zero join timeout, the second task still executed after disposal. `Dequeue(bool untilEmpty)` now stops as soon as a shutdown is requested, and ignores the flag only for the final drain, so `DequeueOnDispose` alone decides whether queued tasks run.

**`QueueTask` was unsynchronized with shutdown.** It checked `_disposed`, then enqueued and signaled `_dequeue` with no shared synchronization. A submission could pass the check, pause, and resume after the worker had finished its final drain — signaling a disposed event, or leaving an accepted task with no worker to run it. Acceptance and shutdown now share a `Lock`, and the shutdown flag is set *before* `_stop`, so every accepted task is enqueued before the worker can observe the stop request and is therefore visible to the final drain.

**Disposal on the scheduler's own thread joined itself.** Calling `Dispose` from a task running on the scheduler made the worker wait for itself: an outright deadlock with `Timeout.InfiniteTimeSpan`, and an avoidable one-second stall with the default `DisposeThreadJoinTimeout`. `Dispose` now compares `_thread` to `Thread.CurrentThread` and skips the join; the worker completes its shutdown, final drain included, once the current task returns.

**Wait handles were leaked when the join timed out.** Previously they were left to the GC, because disposing them under a still-running worker would corrupt its `WaitAny`. Both the worker (from its cleanup `finally`) and `Dispose` (after its join attempt) now call `ReleaseWaitHandles`, and whichever runs second disposes them — so a timed-out or skipped join still releases the handles deterministically.

**Lifecycle is now documented** on `DequeueOnDispose`: with `true` every accepted task executes; with `false` the tasks that have not started are abandoned; in both cases nothing is accepted once `Dispose` has been called.

## Tests

Three tests added to `MonoThreadedTaskSchedulerTests`. Each was verified to fail against the corresponding pre-fix behavior:

| Test | Behavior before the fix |
| --- | --- |
| `DequeueOnDispose_False_DoesNotRunQueuedTasks` | assertion failure — the queued task ran anyway |
| `Dispose_FromSchedulerThread_DoesNotJoinItself` | 30s timeout — the worker joined itself |
| `QueueTask_RacingWithDispose_NeverOrphansAnAcceptedTask` | 30s timeout — an accepted task never completed |

## Notes for reviewers

- No public API change; `ref/Meziantou.Framework.Threading.cs` is untouched (only XML doc `<remarks>` were added).
- The private `Thread?` property became a `readonly Thread` field, since the self-join check needs a stable reference and it was never meaningfully nulled.
- `_disposed` (an `int` used with `Interlocked.Exchange`) is replaced by a `volatile bool _shutdownRequested` written under the lock, so the worker can read it cheaply in the drain loop.
- Verified: `dotnet test` on `Meziantou.Framework.Threading.Tests` with `-p:TreatWarningsAsErrors=true` — 360 passed / 0 failed / 0 skipped on both net10.0 and net11.0. `dotnet run ./eng/update-all.cs` ran clean and produced no changes.
