### PR TITLE
Reject SuppressThrowing when awaiting a tuple of Task<T>

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.cs
+++ b/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.cs
@@ -786,11 +786,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<T1, T2>(ValueTuple<Task<T1>, Task<T2>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<Task<T1>, Task<T2>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<Task<T1>, Task<T2>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -848,11 +851,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<T1, T2, T3>(ValueTuple<Task<T1>, Task<T2>, Task<T3>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<Task<T1>, Task<T2>, Task<T3>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<Task<T1>, Task<T2>, Task<T3>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -910,11 +916,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<T1, T2, T3, T4>(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -972,11 +981,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<T1, T2, T3, T4, T5>(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -1034,11 +1046,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<T1, T2, T3, T4, T5, T6>(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -1096,11 +1111,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<T1, T2, T3, T4, T5, T6, T7>(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -1140,5 +1158,16 @@ public static partial class TaskExtensions
             public void UnsafeOnCompleted(Action continuation) => _whenAllAwaiter.UnsafeOnCompleted(continuation);
             public void GetResult() => _whenAllAwaiter.GetResult();
         }
+    }
+
+    /// <summary>Validates that <paramref name="options"/> can be used to await tasks that produce results.</summary>
+    private static ConfigureAwaitOptions ValidateOptions(ConfigureAwaitOptions options)
+    {
+        if ((options & ConfigureAwaitOptions.SuppressThrowing) is not 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), options, "ConfigureAwait does not support ConfigureAwaitOptions.SuppressThrowing when the tasks produce results. To suppress throwing, cast the tasks to their base class Task and await the resulting tuple with SuppressThrowing.");
+        }
+
+        return options;
     }
 }

--- a/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.tt
+++ b/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.tt
@@ -110,11 +110,14 @@ public static partial class TaskExtensions
 
     public readonly struct TupleConfiguredTaskAwaitable<<#= GetTemplateString(i) #>>(ValueTuple<<#= Join(", ", i, i => "Task<T" + i + ">") #>> tasks, ConfigureAwaitOptions options)
     {
-        public Awaiter GetAwaiter() => new(tasks, options);
+        private readonly ValueTuple<<#= Join(", ", i, i => "Task<T" + i + ">") #>> _tasks = tasks;
+        private readonly ConfigureAwaitOptions _options = ValidateOptions(options);
+
+        public Awaiter GetAwaiter() => new(_tasks, _options);
 
         public readonly struct Awaiter(ValueTuple<<#= Join(", ", i, i => "Task<T" + i + ">") #>> tasks, ConfigureAwaitOptions options) : ICriticalNotifyCompletion
         {
-            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(<#= Join(", ", i, i => "tasks.Item" + i) #>).ConfigureAwait(options).GetAwaiter();
+            private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter = Task.WhenAll(<#= Join(", ", i, i => "tasks.Item" + i) #>).ConfigureAwait(ValidateOptions(options)).GetAwaiter();
 
             public bool IsCompleted => _whenAllAwaiter.IsCompleted;
             public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
@@ -156,6 +159,17 @@ public static partial class TaskExtensions
         }
     }
 <# } #>
+
+    /// <summary>Validates that <paramref name="options"/> can be used to await tasks that produce results.</summary>
+    private static ConfigureAwaitOptions ValidateOptions(ConfigureAwaitOptions options)
+    {
+        if ((options & ConfigureAwaitOptions.SuppressThrowing) is not 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), options, "ConfigureAwait does not support ConfigureAwaitOptions.SuppressThrowing when the tasks produce results. To suppress throwing, cast the tasks to their base class Task and await the resulting tuple with SuppressThrowing.");
+        }
+
+        return options;
+    }
 }
 <#+
     static string GetTemplateString(int count)

--- a/tests/Meziantou.Framework.Threading.Tests/TaskExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/TaskExtensionsTests.cs
@@ -62,6 +62,41 @@ public sealed class TaskExtensionsTests
     }
 
     [Fact]
+    public void WhenAll_ConfigureAwait_SuppressThrowing_IsRejected()
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => { _ = (Task.FromResult(0), Task.FromResult("test")).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing); });
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void WhenAll_ConfigureAwait_SuppressThrowing_IsRejected_SingleTask()
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => { _ = new ValueTuple<Task<int>>(Task.FromResult(0)).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing); });
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void WhenAll_ConfigureAwait_SuppressThrowing_IsRejected_SevenTasks()
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => { _ = (Task.FromResult(0), Task.FromResult(1), Task.FromResult(2), Task.FromResult(3), Task.FromResult(4), Task.FromResult(5), Task.FromResult(6)).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing); });
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void WhenAll_ConfigureAwait_SuppressThrowing_IsRejectedBeforeAwaitingTheTasks()
+    {
+        var pending = new TaskCompletionSource<int>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => { _ = (pending.Task, Task.FromResult("test")).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing); });
+        Assert.False(pending.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task WhenAll_NonGenericTask_ConfigureAwait_SuppressThrowing()
+    {
+        await (Task.CompletedTask, Task.FromException(new InvalidOperationException("test"))).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2012:Use ValueTasks correctly", Justification = "For testing purpose")]
     public async Task WhenAll_ValueTask()
     {


### PR DESCRIPTION
## What

`ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing)` on a tuple of two to seven `Task<T>` values now throws `ArgumentOutOfRangeException`, matching what the BCL does for `Task<TResult>.ConfigureAwait`. Non-generic tuples (`(Task, Task, …)`) keep supporting the option.

## Why

The generic tuple overloads forwarded the options to a **non-generic** `Task.WhenAll(...)` awaiter, which happily accepts `SuppressThrowing`. `GetResult()` then read every task's `.Result`, which throws on a faulted or canceled task — so the caller got an `AggregateException` despite asking for suppression:

```
tuple(Task<T>) SuppressThrowing => System.AggregateException: One or more errors occurred. (boom)
```

The single-item `ValueTuple<Task<T1>>` overload delegates straight to `Task<T1>.ConfigureAwait` and correctly rejects the option, so the failure semantics changed with the tuple arity. Microsoft excludes suppression for result-bearing tasks ([CA2261](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2261)) precisely because there is no valid result to hand back.

## How

In `TaskExtensions.WhenAll.tt` (the generated `.cs` is regenerated, not hand-edited):

- Added a private `ValidateOptions` helper that throws `ArgumentOutOfRangeException(nameof(options), …)` when `SuppressThrowing` is set, with a message mirroring the BCL's.
- `TupleConfiguredTaskAwaitable<T1…Tn>` now holds explicit `_tasks` / `_options` fields — the same shape the non-generic `TupleConfiguredTaskAwaitableN` already used — and validates in the field initializer. That puts the throw at the `ConfigureAwait(...)` call site, before anything is awaited.
- Its nested `Awaiter` validates too, so directly constructing the awaiter cannot slip past.

After the change:

```
tuple(Task<T>) SuppressThrowing => ArgumentOutOfRangeException: ConfigureAwait does not support ConfigureAwaitOptions.SuppressThrowing when the tasks produce results. …
tuple(Task) SuppressThrowing => suppressed
tuple(Task<T>) ContinueOnCapturedContext => 1, ok
```

## Notes for reviewers

- This is a behavior break for anyone who was passing `SuppressThrowing` to a result-bearing tuple — but that code was already broken, since it threw an `AggregateException` at an unexpected point instead of suppressing.
- Public API is unchanged: only private fields and a private static method were added, and the constructor signatures stayed the same. `ref/Meziantou.Framework.Threading.cs` regenerates with no diff.
- Five tests added to `TaskExtensionsTests`: rejection at arity 2 and 7, the 1-tuple BCL path for parity, a check that the tasks are not awaited before the throw, and a regression test that the non-generic tuple still suppresses.

## Verification

- `dotnet test` on `Meziantou.Framework.Threading.Tests` with `/p:TreatWarningsAsErrors=true`: 364 passed, 0 failed (182 per TFM across net10.0 / net11.0). The `TaskExtensionsTests` class alone runs 15 per TFM (10 pre-existing + 5 new).
- Release build with `IsOfficialBuild=true` and `TreatWarningsAsErrors=true`: 0 warnings, 0 errors; `ref/` regenerated with no diff.
- `dotnet run ./eng/update-all.cs`: exit 0, no files changed.