### PR TITLE
Give the observable IList adapter the same wrong-type semantics as the source

### DIFF
--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentObservableCollection.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentObservableCollection.cs
@@ -446,7 +446,7 @@ public class ConcurrentObservableCollection<T> : IList<T>, IReadOnlyList<T>, ILi
         ((ICollection)Items).CopyTo(array, index);
     }
 
-    private static bool IsCompatibleObject(object? value)
+    internal static bool IsCompatibleObject(object? value)
     {
         // Non-null values are fine. Only accept nulls if T is a class or Nullable<U>.
         // Note that default(T) is not equal to null for value types except when T is Nullable<U>.

--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/Internals/DispatchedObservableCollection.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/Internals/DispatchedObservableCollection.cs
@@ -102,7 +102,7 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
         {
             // it will immediately modify both collections as we are on the synchronization context thread
             AssertIsOnSynchronizationContextThread();
-            _collection[index] = (T)value!;
+            ((IList)_collection)[index] = value;
         }
     }
 
@@ -320,9 +320,14 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
 
     bool IList.Contains(object? value)
     {
-        // it will immediately modify both collections as we are on the synchronization context thread
+        // The lookup targets the replica, which can still be behind the source collection
         AssertIsOnSynchronizationContextThread();
-        return ((IList)_collection).Contains(value);
+        if (ConcurrentObservableCollection<T>.IsCompatibleObject(value))
+        {
+            return Contains((T)value!);
+        }
+
+        return false;
     }
 
     void IList.Clear()
@@ -335,7 +340,12 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
     int IList.IndexOf(object? value)
     {
         AssertIsOnSynchronizationContextThread();
-        return Items.IndexOf((T)value!);
+        if (ConcurrentObservableCollection<T>.IsCompatibleObject(value))
+        {
+            return IndexOf((T)value!);
+        }
+
+        return -1;
     }
 
     void IList.Insert(int index, object? value)

--- a/tests/Meziantou.Framework.Threading.Tests/ObservableCollectionTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ObservableCollectionTests.cs
@@ -294,6 +294,68 @@ public sealed partial class ObservableCollectionTests : IDisposable
         Assert.False(((IList)collection).Contains(null));
     }
 
+    [Theory]
+    [MemberData(nameof(GetCollections))]
+    public void Contains_WrongItemType(CollectionKind kind)
+    {
+        var collection = CreateCollection(kind);
+        collection.Add(1);
+
+        Assert.False(((IList)collection).Contains("1"));
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCollections))]
+    public void IndexOf_WrongItemType(CollectionKind kind)
+    {
+        var collection = CreateCollection(kind);
+        collection.Add(1);
+
+        Assert.Equal(-1, ((IList)collection).IndexOf("1"));
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCollections))]
+    public void IndexOf_Struct_Null(CollectionKind kind)
+    {
+        var collection = CreateCollection(kind);
+        collection.Add(1);
+
+        Assert.Equal(-1, ((IList)collection).IndexOf(null));
+    }
+
+    [Fact]
+    public void IndexOf_Null_ReferenceType()
+    {
+        var collection = CreateCollection<string?>();
+        collection.AddRange("a", null);
+
+        Assert.Equal(1, ((IList)collection).IndexOf(null));
+        Assert.Equal(1, ((IList)collection.AsObservable).IndexOf(null));
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCollections))]
+    public void SetItem_WrongItemType(CollectionKind kind)
+    {
+        var collection = CreateCollection(kind);
+        collection.Add(1);
+
+        Assert.Throws<ArgumentException>(() => ((IList)collection)[0] = "1");
+        Assert.Equal([1], collection.ToList());
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCollections))]
+    public void SetItem_Struct_Null(CollectionKind kind)
+    {
+        var collection = CreateCollection(kind);
+        collection.Add(1);
+
+        Assert.Throws<ArgumentNullException>(() => ((IList)collection)[0] = null);
+        Assert.Equal([1], collection.ToList());
+    }
+
     [Fact]
     public void ChangesFromAnotherThreadAreNotifiedOnTheSynchronizationContext()
     {


### PR DESCRIPTION
## What

The non-generic `IList` members of `DispatchedObservableCollection<T>` — the collection returned by `ConcurrentObservableCollection<T>.AsObservable` — cast their `object` argument straight to `T`, so a wrong-type or `null` argument produced the wrong behavior.

| Member | Before | After |
| --- | --- | --- |
| `IList.IndexOf(object)` | `InvalidCastException` for an incompatible object; unboxing failure for `null` on a value-type view | `-1` |
| `IList.this[int]` setter | `InvalidCastException` / unboxing failure | `ArgumentException` / `ArgumentNullException` |
| `IList.Contains(object)` | searched the **source** collection | searches the replica, like `ICollection<T>.Contains` |

## Why

`IList.IndexOf` is documented to return `-1` for a value the list cannot contain, and every BCL implementation (`List<T>`, `Collection<T>`, and therefore `ObservableCollection<T>`) does exactly that. The same goes for the indexer setter, which throws `ArgumentException` for a wrong type and `ArgumentNullException` for `null` on a non-nullable value type. Any consumer binding through `IList` — WPF's `CollectionView` and friends — sees the adapter behave differently from the collection it is a view of.

`ConcurrentObservableCollection<T>` already implements all of this correctly; the adapter just wasn't using it. Notably `((IList)collection).IndexOf(x)` and `((IList)collection.AsObservable).IndexOf(x)` disagreed on the same input.

`IList.Contains` had the mirror-image problem: it delegated to the source collection while `ICollection<T>.Contains` reads the replica, so the two overloads disagreed whenever pending events had not been dispatched yet.

## How

- `ConcurrentObservableCollection<T>.IsCompatibleObject` goes from `private` to `internal` so the adapter gates its lookups on the same predicate instead of duplicating it. No public API change; `ref/` is unchanged.
- The non-generic indexer setter goes through `((IList)_collection)[index] = value`, reusing the source's existing `IfNullAndNullsAreIllegalThenThrow` / `ThrowInvalidTypeException` path. This matches how `IList.Add`, `Insert`, `Remove` and `RemoveAt` on the adapter already delegate.
- Lookups keep reading the replica (`Items`), not the live source — the replica is what the observable view exposes, and it can legitimately be behind.

## Notes for the reviewer

The new tests are `[Theory]`-driven over all three `CollectionKind` values, so the built-in `ObservableCollection<int>` runs the same assertions and pins the expected BCL behavior that the two Meziantou collections are checked against.

I verified the tests actually catch the bug: reverting only the `src/` changes makes exactly the four `Observable`-kind cases fail (`IndexOf_WrongItemType`, `IndexOf_Struct_Null`, `SetItem_WrongItemType`, `SetItem_Struct_Null`), while the `Concurrent` and `BuiltIn` cases stay green.

## Verification

- `Meziantou.Framework.Threading.Tests`: 386/386 pass (193 per TFM, net10.0 + net11.0) with `/p:TreatsWarningsAsErrors=true`.
- `Meziantou.Framework.Threading.Windows.Tests` builds clean with 0 warnings; it cannot be executed on macOS (no WindowsDesktop runtime for osx-arm64), so CI covers it.
- Release + `IsOfficialBuild=true` build of the library passes, and `dotnet run ./eng/update-all.cs` reports no file changes.