### PR TITLE
Release the semaphore at most once when a lease is disposed concurrently

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/SemaphoreSlimExtensions.cs
+++ b/src/Meziantou.Framework.Threading/Threading/SemaphoreSlimExtensions.cs
@@ -3,7 +3,7 @@ namespace Meziantou.Framework.Threading;
 /// <summary>Provides extension methods for <see cref="SemaphoreSlim"/> to simplify usage with disposable patterns.</summary>
 public static class SemaphoreSlimExtensions
 {
-    /// <summary>Waits on the semaphore and returns a disposable struct that releases the semaphore when disposed. This method is unsafe because the struct can be copied.</summary>
+    /// <summary>Waits on the semaphore and returns a disposable struct that releases the semaphore when disposed. This method is unsafe because the struct can be copied, so each copy releases the semaphore again.</summary>
     /// <param name="semaphore">The semaphore to wait on.</param>
     /// <param name="cancellationToken">The cancellation token to observe.</param>
     /// <returns>A disposable struct that releases the semaphore when disposed.</returns>
@@ -13,7 +13,7 @@ public static class SemaphoreSlimExtensions
         return new SemaphoreDisposer(semaphore);
     }
 
-    /// <summary>Asynchronously waits on the semaphore and returns a disposable struct that releases the semaphore when disposed. This method is unsafe because the struct can be copied.</summary>
+    /// <summary>Asynchronously waits on the semaphore and returns a disposable struct that releases the semaphore when disposed. This method is unsafe because the struct can be copied, so each copy releases the semaphore again.</summary>
     /// <param name="semaphore">The semaphore to wait on.</param>
     /// <param name="cancellationToken">The cancellation token to observe.</param>
     /// <returns>A task that returns a disposable struct that releases the semaphore when disposed.</returns>
@@ -23,7 +23,7 @@ public static class SemaphoreSlimExtensions
         return new SemaphoreDisposer(semaphore);
     }
 
-    /// <summary>Waits on the semaphore and returns a disposable object that releases the semaphore when disposed.</summary>
+    /// <summary>Waits on the semaphore and returns a disposable object that releases the semaphore when disposed. Disposing the object more than once, from any number of threads, releases the semaphore only once.</summary>
     /// <param name="semaphore">The semaphore to wait on.</param>
     /// <param name="cancellationToken">The cancellation token to observe.</param>
     /// <returns>A disposable object that releases the semaphore when disposed.</returns>
@@ -33,7 +33,7 @@ public static class SemaphoreSlimExtensions
         return new SemaphoreDisposerClass(semaphore);
     }
 
-    /// <summary>Asynchronously waits on the semaphore and returns a disposable object that releases the semaphore when disposed.</summary>
+    /// <summary>Asynchronously waits on the semaphore and returns a disposable object that releases the semaphore when disposed. Disposing the object more than once, from any number of threads, releases the semaphore only once.</summary>
     /// <param name="semaphore">The semaphore to wait on.</param>
     /// <param name="cancellationToken">The cancellation token to observe.</param>
     /// <returns>A task that returns a disposable object that releases the semaphore when disposed.</returns>
@@ -45,8 +45,8 @@ public static class SemaphoreSlimExtensions
 
     private sealed class SemaphoreDisposerClass : IDisposable
     {
-        private readonly SemaphoreSlim _semaphore;
-        private bool _disposed;
+        // Set to null by the thread that claims the release, so concurrent disposals release the semaphore at most once.
+        private SemaphoreSlim? _semaphore;
 
         public SemaphoreDisposerClass(SemaphoreSlim semaphore)
         {
@@ -55,15 +55,11 @@ public static class SemaphoreSlimExtensions
 
         public void Dispose()
         {
-            if (!_disposed)
-            {
-                _semaphore.Release();
-                _disposed = true;
-            }
+            Interlocked.Exchange(ref _semaphore, value: null)?.Release();
         }
     }
 
-    /// <summary>Represents a disposable struct that releases a semaphore when disposed.</summary>
+    /// <summary>Represents a disposable struct that releases a semaphore when disposed. Every copy of the struct releases the semaphore, so dispose exactly one copy exactly once.</summary>
     [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "<Pending>")]
     public readonly struct SemaphoreDisposer : IDisposable
     {

--- a/tests/Meziantou.Framework.Threading.Tests/SemaphoreSlimExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/SemaphoreSlimExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace Meziantou.Framework.Threading.Tests;
 
 public class SemaphoreSlimExtensionsTests
@@ -33,5 +35,82 @@ public class SemaphoreSlimExtensionsTests
         }
 
         Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public void DisposableWait_ReleasesOnDispose()
+    {
+        using var semaphore = new SemaphoreSlim(1, 1);
+
+        using (semaphore.DisposableWait())
+        {
+            Assert.Equal(0, semaphore.CurrentCount);
+        }
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task DisposableWaitAsync_ReleasesOnDispose()
+    {
+        using var semaphore = new SemaphoreSlim(1, 1);
+
+        using (await semaphore.DisposableWaitAsync())
+        {
+            Assert.Equal(0, semaphore.CurrentCount);
+        }
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public void DisposableWait_DisposeIsIdempotent()
+    {
+        using var semaphore = new SemaphoreSlim(1, 1);
+
+        var disposer = semaphore.DisposableWait();
+        disposer.Dispose();
+        disposer.Dispose();
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public void DisposableWait_ConcurrentDisposeReleasesOnlyOnce()
+    {
+        for (var iteration = 0; iteration < 100; iteration++)
+        {
+            using var semaphore = new SemaphoreSlim(1, 1);
+            var disposer = semaphore.DisposableWait();
+
+            var exceptions = new ConcurrentQueue<Exception>();
+            using var barrier = new Barrier(participantCount: 4);
+            var threads = new Thread[barrier.ParticipantCount];
+            for (var i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(() =>
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        disposer.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Enqueue(ex);
+                    }
+                });
+
+                threads[i].Start();
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            Assert.Empty(exceptions);
+            Assert.Equal(1, semaphore.CurrentCount);
+        }
     }
 }


### PR DESCRIPTION
## What

`SemaphoreSlimExtensions.SemaphoreDisposerClass.Dispose` guarded its `Release()` with a plain `bool` field:

```csharp
if (!_disposed)
{
    _semaphore.Release();
    _disposed = true;
}
```

Two threads disposing the same lease can both pass the check before either assigns `_disposed`, so the semaphore is released twice. Depending on the semaphore's maximum and its current waiters, that either throws `SemaphoreFullException` or admits more holders than intended.

The fix claims the release atomically by swapping the semaphore reference for `null`:

```csharp
// Set to null by the thread that claims the release, so concurrent disposals release the semaphore at most once.
private SemaphoreSlim? _semaphore;

public void Dispose()
{
    Interlocked.Exchange(ref _semaphore, value: null)?.Release();
}
```

Exactly one caller observes a non-null value and calls `Release()`, however many threads dispose at once. Using the reference itself rather than a separate `int` flag avoids an extra field and keeps the claim and the released resource in one word.

## Why

This is hardening for an async/threading utility rather than a demonstrated contract violation — the lease was already idempotent for sequential disposal, and the API never explicitly promised thread-safe disposal. But a lease handed to several threads is a natural enough shape for this type that the cheap atomic is worth it.

## Tests

The class-based `DisposableWait` / `DisposableWaitAsync` overloads had **no test coverage at all** — only the struct ones did. Added to `SemaphoreSlimExtensionsTests`:

- `DisposableWait_ReleasesOnDispose` / `DisposableWaitAsync_ReleasesOnDispose` — basic acquire/release
- `DisposableWait_DisposeIsIdempotent` — sequential double-dispose
- `DisposableWait_ConcurrentDisposeReleasesOnlyOnce` — 100 iterations of four barrier-synchronized threads disposing one lease

I verified the race test catches the real bug: with the original implementation restored it fails with precisely the reported symptom —

```
System.Threading.SemaphoreFullException: Adding the specified count to the semaphore would cause it to exceed its maximum count.
   at System.Threading.SemaphoreSlim.Release(Int32 releaseCount)
   at Meziantou.Framework.Threading.SemaphoreSlimExtensions.SemaphoreDisposerClass.Dispose()
```

Worth knowing as a reviewer: on that same run the net10.0 leg happened to pass, which is inherent to a race repro. The test is deterministic in the passing direction but only probabilistic at catching a regression. It uses dedicated `Thread`s rather than pool work items so it cannot be starved by thread-pool latency, and runs in well under a second.

## Docs

The XML docs now state the two contracts distinctly: the class overloads release only once however often they are disposed, while every copy of the deliberately-unsafe struct releases again, so exactly one copy must be disposed exactly once. This is public-facing doc text, so the wording is a judgement call — easy to trim if it is more than you want.

## Verification

- `dotnet build` clean with `/p:TreatsWarningsAsErrors=true`, 0 warnings
- `Meziantou.Framework.Threading.Tests`: **362/362 pass** (181 per TFM, net10.0 + net11.0)
- `dotnet run ./eng/update-all.cs` produced no further file changes
- No public API shape changed (`SemaphoreDisposerClass` is private), so `ref/` needed no regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)