### PR TITLE
Avoid the temporary list on single-waiter AsyncReaderWriterLock handoffs

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncReaderWriterLock.cs
@@ -142,7 +142,7 @@ public sealed class AsyncReaderWriterLock
 
     private void ReaderRelease()
     {
-        List<Waiter>? toWake;
+        GrantedWaiters toWake;
         lock (_lock)
         {
             _status -= 1;
@@ -154,7 +154,7 @@ public sealed class AsyncReaderWriterLock
 
     private void WriterRelease()
     {
-        List<Waiter>? toWake;
+        GrantedWaiters toWake;
         lock (_lock)
         {
             _status = 0;
@@ -166,67 +166,80 @@ public sealed class AsyncReaderWriterLock
 
     /// <summary>Hands the free lock to the next waiters. Must be called while holding <see cref="_lock"/>; the
     /// returned waiters are completed outside it.</summary>
-    private List<Waiter>? GrantOwnership()
+    private GrantedWaiters GrantOwnership()
     {
         // A writer holds the lock, nothing can be granted until it releases.
         if (_status < 0)
-            return null;
+            return default;
 
         if (_waitingWriters.Count > 0)
         {
             // Writers still have priority over the queued readers, so nothing is granted until the lock is free.
             if (_status > 0)
-                return null;
+                return default;
 
             _status = -1;
-            return [_waitingWriters.Dequeue()!];
+            return new GrantedWaiters(_waitingWriters.Dequeue()!);
         }
 
-        if (_waitingReaders.Count > 0)
+        var readerCount = _waitingReaders.Count;
+        if (readerCount > 0)
         {
             // Every queued reader is admitted at once. Readers only ever queue behind a writer, so once no writer
             // is left they can join the readers already holding the lock instead of waiting for those to release.
             // This also covers the case where the writers that were blocking them have all been canceled, which
             // would otherwise leave the readers queued forever.
-            var readers = new List<Waiter>(_waitingReaders.Count);
+            _status += readerCount;
+            if (readerCount == 1)
+                return new GrantedWaiters(_waitingReaders.Dequeue()!);
+
+            var readers = new List<Waiter>(readerCount);
             while (_waitingReaders.Dequeue() is { } reader)
             {
                 readers.Add(reader);
             }
 
-            _status += readers.Count;
-            return readers;
+            return new GrantedWaiters(readers);
         }
 
-        return null;
+        return default;
     }
 
-    private void CompleteWaiters(List<Waiter>? waiters)
+    private void CompleteWaiters(GrantedWaiters granted)
     {
-        if (waiters is null)
-            return;
-
-        foreach (var waiter in waiters)
+        if (granted.Waiter is { } single)
         {
-            // A waiter that was dequeued here can no longer be canceled: OnCancellationRequest only completes a
-            // waiter it removed from the queue itself, so exactly one of the two paths owns it.
-            waiter.Registration.Dispose();
-            waiter.TrySetResult(new Releaser(this, waiter.IsWriter));
+            CompleteWaiter(single);
         }
+        else if (granted.Waiters is { } waiters)
+        {
+            foreach (var waiter in waiters)
+            {
+                CompleteWaiter(waiter);
+            }
+        }
+    }
+
+    private void CompleteWaiter(Waiter waiter)
+    {
+        // A waiter that was dequeued here can no longer be canceled: OnCancellationRequest only completes a
+        // waiter it removed from the queue itself, so exactly one of the two paths owns it.
+        waiter.Registration.Dispose();
+        waiter.TrySetResult(new Releaser(this, waiter.IsWriter));
     }
 
     private void OnCancellationRequest(object? state)
     {
         var waiter = (Waiter)state!;
         bool removed;
-        List<Waiter>? toWake;
+        GrantedWaiters toWake;
         lock (_lock)
         {
             removed = (waiter.IsWriter ? _waitingWriters : _waitingReaders).Remove(waiter);
 
             // Removing a waiter can unblock the ones queued behind it: the lock may now be free, or the canceled
             // writer may have been the last one holding back readers that are compatible with the current owners.
-            toWake = removed ? GrantOwnership() : null;
+            toWake = removed ? GrantOwnership() : default;
         }
 
         // Both of these must run outside the lock: Registration.Dispose blocks until a callback running on
@@ -270,6 +283,30 @@ public sealed class AsyncReaderWriterLock
                 }
             }
         }
+    }
+
+    /// <summary>The waiters a grant handed the lock to. A single waiter is held inline, so the writer handoffs and
+    /// the lone-reader grants that make up the common case cost no list allocation.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly struct GrantedWaiters
+    {
+        public GrantedWaiters(Waiter waiter)
+        {
+            Waiter = waiter;
+            Waiters = null;
+        }
+
+        public GrantedWaiters(List<Waiter> waiters)
+        {
+            Waiter = null;
+            Waiters = waiters;
+        }
+
+        /// <summary>The only granted waiter, or <see langword="null"/> when <see cref="Waiters"/> holds them.</summary>
+        public Waiter? Waiter { get; }
+
+        /// <summary>The granted waiters when there is more than one, otherwise <see langword="null"/>.</summary>
+        public List<Waiter>? Waiters { get; }
     }
 
     private sealed class Waiter : TaskCompletionSource<Releaser>, IWaiterQueueNode<Waiter>


### PR DESCRIPTION
## What

`AsyncReaderWriterLock.GrantOwnership` has to hand the granted waiters back to the caller so they can be completed *outside* `_lock`, and it used a `List<Waiter>` to do so. A writer grant is by definition exactly one waiter, so every contended writer handoff allocated a one-element list plus its backing array for no reason:

```csharp
_status = -1;
return [_waitingWriters.Dequeue()!];
```

This replaces the `List<Waiter>?` return with a small private `readonly struct GrantedWaiters` that holds either a single waiter inline or a list:

- **Writer handoffs** take the inline path — no allocation.
- **A lone queued reader** takes it too.
- **Two or more readers** still get the pre-sized list; that allocation is unavoidable, since the whole point of returning them is to complete them after the lock is released.
- The `null` sentinel becomes `default`.
- `CompleteWaiters` now dispatches to a `CompleteWaiter` helper, so the per-waiter logic and the comment explaining why a dequeued waiter can no longer be canceled live in one place instead of being duplicated.

## Why

Writer contention is the case this lock exists for, and it was the case paying an extra allocation on every handoff.

Measured with 8 writers contending for 20,000 acquisitions each, using both implementations in the same process and `GC.GetTotalAllocatedBytes(precise: true)`:

| | bytes/acquire | time |
|---|---|---|
| before | 213–216 | 68–86 ms |
| after | ~152 | 73–75 ms |

The **64-byte delta** is exactly the `List<Waiter>` object (32 B) plus its `Waiter[1]` backing array (32 B) — roughly **30%** of everything a contended writer acquisition allocated. Throughput is unchanged (the timing spread is noise).

## Notes for reviewers

- **No behavior change.** The `_status` accounting is equivalent: `readerCount` is read from the queue before draining it, and the drain loop yields exactly that many waiters, so `_status += readerCount` up front matches the old `_status += readers.Count` afterwards. Nothing in the loop reads `_status`.
- **The locking invariants are untouched.** Every completion — including the new single-waiter path — still runs after `_lock` is released, which matters because `Registration.Dispose` blocks on an in-flight `OnCancellationRequest` that takes the same lock.
- **No public API change**; `GrantedWaiters` is private, so `ref/` is unaffected.

## Verification

- `dotnet build` on `Meziantou.Framework.Threading` with `/p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors. The public API verify step ran and reported no diff.
- `dotnet test` on `Meziantou.Framework.Threading.Tests` — **354 passed, 0 failed, 0 skipped** (177 × net10.0 and net11.0). The trx confirms 16 `AsyncReaderWriterLockTests` ran per TFM, and both new branches are covered: `NewReaderWaitsWhileWriterIsQueued` and `CancelingSomeQueuedReaders_AdmitsOnlyTheRemainingOnes` exercise the single-waiter path, `CancelingTheQueuedWriters_ReleasesTheReadersBlockedBehindThem` exercises the multi-reader list path.
- `dotnet run ./eng/update-all.cs` — exit 0, no files changed.