### PR TITLE
Keep delayed cancellation failures off the thread pool

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/DelayedCancellationTokenSource.cs
+++ b/src/Meziantou.Framework.Threading/Threading/DelayedCancellationTokenSource.cs
@@ -5,7 +5,7 @@ namespace Meziantou.Framework.Threading;
 /// <code><![CDATA[
 /// var cts = new CancellationTokenSource();
 /// var delayedCts = new DelayedCancellationTokenSource(cts.Token, TimeSpan.FromSeconds(5));
-/// 
+///
 /// // When cts is cancelled, delayedCts will be cancelled 5 seconds later
 /// cts.Cancel();
 /// await Task.Delay(TimeSpan.FromSeconds(6));
@@ -14,43 +14,68 @@ namespace Meziantou.Framework.Threading;
 /// </example>
 public sealed class DelayedCancellationTokenSource : IDisposable, IAsyncDisposable
 {
+    /// <summary>The longest delay accepted by <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.</summary>
+    private static readonly TimeSpan MaxDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
     private readonly CancellationTokenSource _cts;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly CancellationTokenRegistration _cancelRegistration;
+    private Task _delayedCancellation = Task.CompletedTask;
     private int _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="DelayedCancellationTokenSource"/> class that will be cancelled after the specified delay when the source token is cancelled.</summary>
     /// <param name="cancellationToken">The source cancellation token to monitor.</param>
-    /// <param name="delay">The time span to wait before cancelling this token after the source token is cancelled.</param>
+    /// <param name="delay">The time span to wait before cancelling this token after the source token is cancelled. Use <see cref="Timeout.InfiniteTimeSpan"/> to never cancel.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="delay"/> is less than -1 millisecond (<see cref="Timeout.InfiniteTimeSpan"/>) or greater than 4294967294 milliseconds.</exception>
     [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "")]
     public DelayedCancellationTokenSource(CancellationToken cancellationToken, TimeSpan delay)
     {
+        // Validate eagerly: the delay is only consumed once the source token is cancelled, at which point
+        // there is no caller left to report the error to.
+        ArgumentOutOfRangeException.ThrowIfLessThan(delay, Timeout.InfiniteTimeSpan);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(delay, MaxDelay);
+
         _cts = new CancellationTokenSource();
 
-#pragma warning disable MA0147 // Avoid async void method for delegate
-        _cancelRegistration = cancellationToken.Register(async () =>
-        {
-            try
-            {
-                // Flow a token tied to disposal so the underlying timer is released promptly when
-                // this instance is disposed before the delay elapses, instead of staying alive for
-                // the full delay.
-                await Task.Delay(delay, _disposeCts.Token).ConfigureAwait(false);
-
-                _cts.Cancel();
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-        });
-#pragma warning restore MA0147
+        // The callback is synchronous on purpose. An "async void" callback would rethrow its failures on
+        // the thread pool and terminate the process, so it only starts the asynchronous work and publishes
+        // it to _delayedCancellation, where DisposeAsync can observe the outcome.
+        _cancelRegistration = cancellationToken.Register(() => Volatile.Write(ref _delayedCancellation, CancelAfterDelayAsync(delay)));
     }
 
     /// <summary>Gets the cancellation token associated with this <see cref="DelayedCancellationTokenSource"/>.</summary>
     public CancellationToken Token => _cts.Token;
+
+    private async Task CancelAfterDelayAsync(TimeSpan delay)
+    {
+        try
+        {
+            // Flow a token tied to disposal so the underlying timer is released promptly when
+            // this instance is disposed before the delay elapses, instead of staying alive for
+            // the full delay.
+            await Task.Delay(delay, _disposeCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
+        try
+        {
+            // Any exception thrown by a callback registered on Token faults this task instead of escaping
+            // to the thread pool. DisposeAsync rethrows it; Dispose cannot, so it is then reported through
+            // TaskScheduler.UnobservedTaskException.
+            _cts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The instance was disposed while the delay was elapsing.
+        }
+    }
 
     public void Dispose()
     {
@@ -63,14 +88,27 @@ public sealed class DelayedCancellationTokenSource : IDisposable, IAsyncDisposab
         _cts.Dispose();
     }
 
+    /// <summary>Releases the resources used by this instance and waits for a pending delayed cancellation to complete.</summary>
+    /// <exception cref="AggregateException">A callback registered on <see cref="Token"/> threw an exception while the delayed cancellation was being signalled.</exception>
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        // Disposing the registration waits for a running callback to complete, so the delayed cancellation
+        // task, if any, is published by the time this returns.
         await _cancelRegistration.DisposeAsync().ConfigureAwait(false);
         await _disposeCts.CancelAsync().ConfigureAwait(false);
-        _disposeCts.Dispose();
-        _cts.Dispose();
+
+        var delayedCancellation = Volatile.Read(ref _delayedCancellation);
+        try
+        {
+            await delayedCancellation.ConfigureAwait(false);
+        }
+        finally
+        {
+            _disposeCts.Dispose();
+            _cts.Dispose();
+        }
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/DelayedCancellationTokenSourceTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/DelayedCancellationTokenSourceTests.cs
@@ -49,6 +49,49 @@ public sealed class DelayedCancellationTokenSourceTests
         await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(30));
     }
 
+    [Theory]
+    [InlineData(-2)]
+    [InlineData(-1000)]
+    [InlineData(4294967295)]
+    public void Constructor_ThrowsWhenTheDelayIsOutOfRange(double milliseconds)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var cts = new DelayedCancellationTokenSource(CancellationToken.None, TimeSpan.FromMilliseconds(milliseconds));
+        });
+    }
+
+    [Fact]
+    public async Task Token_IsNotCancelled_WhenTheDelayIsInfinite()
+    {
+        using var source = new CancellationTokenSource();
+        using var cts = new DelayedCancellationTokenSource(source.Token, Timeout.InfiniteTimeSpan);
+
+        await source.CancelAsync();
+
+        await Task.Delay(200);
+        Assert.False(cts.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RethrowsTheExceptionThrownByARegisteredCallback()
+    {
+        using var source = new CancellationTokenSource();
+        using var cts = new DelayedCancellationTokenSource(source.Token, TimeSpan.FromMilliseconds(10));
+        using var cancelling = new ManualResetEventSlim(initialState: false);
+        using var registration = cts.Token.Register(() =>
+        {
+            cancelling.Set();
+            throw new InvalidOperationException("Callback failure");
+        });
+
+        await source.CancelAsync();
+        Assert.True(cancelling.Wait(TimeSpan.FromSeconds(30)));
+
+        var exception = await Assert.Throws<AggregateException>(async () => await cts.DisposeAsync());
+        Assert.IsType<InvalidOperationException>(Assert.Single(exception.InnerExceptions));
+    }
+
     [Fact]
     public void Token_IsNotCancelled_WhenTheSourceTokenIsNotCancelled()
     {


### PR DESCRIPTION
## What

`DelayedCancellationTokenSource` registered an `async void` callback on the source token:

```csharp
_cancelRegistration = cancellationToken.Register(async () =>
{
    try
    {
        await Task.Delay(delay, _disposeCts.Token).ConfigureAwait(false);
        _cts.Cancel();
    }
    catch (OperationCanceledException) { }
    catch (ObjectDisposedException) { }
});
```

Two failures escape it:

- **An out-of-range delay.** The constructor accepted any `TimeSpan`, including values `Task.Delay` rejects (anything below `-1 ms`, or above `4294967294 ms`). The `ArgumentOutOfRangeException` was only raised later, when the source token was cancelled.
- **A throwing callback on the delayed token.** `_cts.Cancel()` collects callback exceptions and throws an `AggregateException`.

Neither matches the two `catch` clauses, and neither has a caller to return to, so the `async void` state machine hands them to `Task.ThrowAsync`, which rethrows on a thread pool thread and aborts the process.

## Fix

1. **Validate `delay` in the constructor**, against the same bounds `Task.Delay` accepts, so a bad value is reported to the caller that supplied it.
2. **Replace the `async void` callback with a synchronous one** that starts `CancelAfterDelayAsync` and publishes the returned task to a field. A callback exception now faults that task instead of being rethrown on the thread pool. The `MA0147` suppression is gone.
3. **Define how the failure is observed.** `DisposeAsync` awaits the task and rethrows the `AggregateException`; `Dispose` cannot await, so there it reaches `TaskScheduler.UnobservedTaskException`, which does not end the process. Both are documented on the members.

Disposing the registration waits for a running callback to finish, so the task is always published before `DisposeAsync` reads the field. That is also why `DisposeAsync` now disposes the two sources in a `finally` *after* the pending cancellation completes, rather than racing it.

## Notes for reviewers

- **`CancelAfter` would not have fixed this.** Its timer callback calls `NotifyCancellation` directly, so a throwing user callback still ends up unhandled on the timer thread. It only addresses the delay-validation half.
- **`Timeout.InfiniteTimeSpan` stays legal** and means "never cancel", matching `Task.Delay` and `CancelAfter`.
- **The public API is unchanged**, so `ref/Meziantou.Framework.Threading.cs` needs no update.
- No `<Version>` bump — that happens in the separate "Bump package versions" PRs.

## Verification

- `dotnet build … /p:TreatsWarningsAsErrors=true` succeeds, as does `-c Release /p:IsOfficialBuild=true` (the strict analyzer configuration), with `ref/` unchanged.
- Full `Meziantou.Framework.Threading.Tests`: **364 passed, 0 failed** (182 × net10.0/net11.0).
- New tests cover the out-of-range delays (`-2 ms`, `-1000 ms`, `4294967295 ms`), `Timeout.InfiniteTimeSpan` never cancelling, and `DisposeAsync` rethrowing a throwing callback's exception.
- End-to-end probe: a verbatim copy of the **old** implementation with a throwing token callback aborts the process (exit 134, stack through `Task.ThrowAsync` → `ThreadPoolWorkQueue.Dispatch`); the new one survives, and the invalid delay throws at construction.
- `dotnet run ./eng/update-all.cs` exits 0 with no files changed.