### PR TITLE
Stream the initial items of MixedConsumerProducer.Process

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducer.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducer.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 
 namespace Meziantou.Framework.Threading;
@@ -35,19 +36,10 @@ public static class MixedConsumerProducer
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(action);
 
+        var cancellationToken = options.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (Enumerable.TryGetNonEnumeratedCount(initialItems, out var count) && count == 0)
-            return;
-
-        var pendingItems = Channel.CreateUnbounded<T>();
-        var context = new MixedConsumerProducerContext<T>(pendingItems.Writer);
-        var hasItem = false;
-        foreach (var item in initialItems)
-        {
-            context.Enqueue(item);
-            hasItem = true;
-        }
-
-        if (!hasItem)
             return;
 
         var degreeOfParallelism = options.MaxDegreeOfParallelism;
@@ -56,9 +48,15 @@ public static class MixedConsumerProducer
             degreeOfParallelism = Environment.ProcessorCount;
         }
 
-        var cancellationToken = options.CancellationToken;
         // ParallelOptions treats a null scheduler as "the current one", so mirror that behavior.
         var scheduler = options.TaskScheduler ?? TaskScheduler.Current;
+
+        var pendingItems = Channel.CreateUnbounded<T>();
+        var context = new MixedConsumerProducerContext<T>(pendingItems.Writer);
+
+        // The initial items are streamed to the consumers while they run, so the enumeration itself
+        // is a producer and must be accounted for until it completes.
+        context.ReserveProducer();
 
         var exceptionsLock = new Lock();
         List<Exception>? exceptions = null;
@@ -73,7 +71,38 @@ public static class MixedConsumerProducer
             consumers[i] = Task.Factory.StartNew(consume, cancellationToken, TaskCreationOptions.DenyChildAttach, scheduler).Unwrap();
         }
 
-        await Task.WhenAll(consumers).ConfigureAwait(false);
+        ExceptionDispatchInfo? enumerationFailure = null;
+        try
+        {
+            foreach (var item in initialItems)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                context.Enqueue(item);
+            }
+        }
+        catch (Exception ex)
+        {
+            enumerationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+        finally
+        {
+            // Must run even when the enumeration fails, otherwise the channel is never completed and
+            // the consumers never stop.
+            context.ReleaseProducer();
+        }
+
+        try
+        {
+            await Task.WhenAll(consumers).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (enumerationFailure is not null)
+        {
+            // The enumeration failed first, so report that failure instead of the cancellation it caused.
+        }
+
+        // A failure while enumerating the initial items cuts the processing short, so it takes
+        // precedence over the exceptions thrown by the actions that did run.
+        enumerationFailure?.Throw();
 
         // All consumers have completed, so nothing can be mutating the list anymore.
         if (exceptions is not null)

--- a/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducerContext.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducerContext.cs
@@ -23,7 +23,8 @@ public sealed class MixedConsumerProducerContext<T>
     public void Enqueue(T item)
     {
         // Count the item before writing it, so the count cannot transiently reach 0 while the item
-        // is in flight. The caller is processing an item of its own, so the count is at least 1 here.
+        // is in flight. The caller is either processing an item of its own or holding a producer
+        // reservation, so the count is at least 1 here.
         Interlocked.Increment(ref _pendingItems);
         if (!_writer.TryWrite(item))
         {
@@ -31,6 +32,13 @@ public sealed class MixedConsumerProducerContext<T>
             throw new InvalidOperationException("Item cannot be enqueued");
         }
     }
+
+    // Accounts for a producer that can enqueue items while not processing an item of its own. The
+    // enumeration of the initial items is such a producer: without the reservation, the count could
+    // reach 0 between two initial items and complete the channel while more items are still coming.
+    internal void ReserveProducer() => Interlocked.Increment(ref _pendingItems);
+
+    internal void ReleaseProducer() => OnItemProcessed();
 
     internal void OnItemProcessed()
     {

--- a/tests/Meziantou.Framework.Threading.Tests/MixedConsumerProducerTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/MixedConsumerProducerTests.cs
@@ -104,6 +104,114 @@ public sealed class MixedConsumerProducerTests
     }
 
     [Fact]
+    public async Task Process_PreCanceledToken_DoesNotEnumerateInitialItems()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var enumerated = false;
+        var options = new ParallelOptions() { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => MixedConsumerProducer.Process(GetItems(), options, (context, item, cancellationToken) => ValueTask.CompletedTask));
+
+        Assert.False(enumerated);
+
+        IEnumerable<int> GetItems()
+        {
+            enumerated = true;
+            yield return 1;
+        }
+    }
+
+    [Fact]
+    public async Task Process_StreamsInitialItemsWhileConsumersRun()
+    {
+        var firstItemProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processed = new ConcurrentBag<int>();
+
+        await MixedConsumerProducer.Process(GetItems(), new ParallelOptions() { MaxDegreeOfParallelism = 2 }, (context, item, cancellationToken) =>
+        {
+            processed.Add(item);
+            if (item == 0)
+            {
+                firstItemProcessed.TrySetResult();
+            }
+
+            return ValueTask.CompletedTask;
+        });
+
+        Assert.HasCount(2, processed);
+        Assert.Contains(0, processed);
+        Assert.Contains(1, processed);
+
+        IEnumerable<int> GetItems()
+        {
+            yield return 0;
+
+            // The consumers must already be draining the channel while the initial items are being
+            // enumerated, otherwise the first item is never processed and this never completes.
+            Assert.True(firstItemProcessed.Task.Wait(TimeSpan.FromSeconds(60)), "The first item was not processed while the initial items were still being enumerated");
+            yield return 1;
+        }
+    }
+
+    [Fact]
+    public async Task Process_CancellationDuringEnumeration_StopsEnumeratingInitialItems()
+    {
+        const int TotalItems = 100_000;
+
+        using var cts = new CancellationTokenSource();
+        var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var enumerated = 0;
+        var options = new ParallelOptions() { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => MixedConsumerProducer.Process(GetItems(), options, async (context, item, cancellationToken) =>
+        {
+            await cts.CancelAsync();
+            canceled.TrySetResult();
+        }));
+
+        Assert.True(enumerated < TotalItems, $"The whole sequence was enumerated ({enumerated} items) instead of stopping once the token was canceled");
+
+        IEnumerable<int> GetItems()
+        {
+            for (var i = 0; i < TotalItems; i++)
+            {
+                enumerated++;
+                yield return i;
+
+                if (i == 0)
+                {
+                    // The first item must reach a consumer while the sequence is still being
+                    // enumerated, otherwise the cancellation never happens during the enumeration.
+                    canceled.Task.Wait(TimeSpan.FromSeconds(60));
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Process_InitialItemsEnumerationThrows_ProcessesEnqueuedItemsAndPropagates()
+    {
+        var processed = new ConcurrentBag<int>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => MixedConsumerProducer.Process(GetItems(), new ParallelOptions() { MaxDegreeOfParallelism = 2 }, (context, item, cancellationToken) =>
+        {
+            processed.Add(item);
+            return ValueTask.CompletedTask;
+        }));
+
+        Assert.Equal("boom", exception.Message);
+        Assert.Contains(1, processed);
+
+        static IEnumerable<int> GetItems()
+        {
+            yield return 1;
+            throw new InvalidOperationException("boom");
+        }
+    }
+
+    [Fact]
     public async Task Process_SingleItemWithoutEnqueue()
     {
         var processed = 0;


### PR DESCRIPTION
## What

`MixedConsumerProducer.Process` enumerated the whole `initialItems` sequence into the unbounded channel *before* reading the cancellation token and *before* starting any consumer. This change checks cancellation up front and during the enumeration, and streams the initial items to the consumers while they run.

## Why

The eager buffering caused several problems:

- A **pre-canceled** token was never observed until the consumers started, so the entire sequence was still enumerated (reproduced with a 10,000-item probe).
- A **very large** sequence was fully materialized in the channel before a single item was processed.
- An **infinite** sequence never started the consumers and never observed cancellation.
- The early `return` for an empty collection bypassed cancellation altogether.

## How

- `options.CancellationToken` is read and `ThrowIfCancellationRequested()` is called on entry, before the `TryGetNonEnumeratedCount` fast path — so an empty collection no longer bypasses cancellation.
- The consumers are started *before* the enumeration, and the `foreach` checks the token on every item.
- `MixedConsumerProducerContext<T>` gained internal `ReserveProducer()` / `ReleaseProducer()`. `Process` holds a reservation for the duration of the enumeration, so the pending count cannot reach 0 — and complete the channel — between two initial items. The `hasItem` bookkeeping is gone: an empty lazy sequence now completes through that same path.
- A failure during the enumeration is captured with `ExceptionDispatchInfo`, the reservation is released in a `finally` (otherwise the channel would never complete and the consumers would never stop), the consumers are awaited, and the failure is rethrown with its original type and stack.

Queue bounding is intentionally left alone — that is a separate concern.

## Notes for the reviewer

Two behavior changes worth calling out:

1. An exception thrown while enumerating `initialItems` now propagates *after* the items already enqueued have been processed. Previously it propagated before any item was processed, because nothing had started yet.
2. That enumeration failure takes precedence over the exceptions collected from the actions, mirroring how cancellation already won over them. Without this, a cancellation observed during the enumeration could be masked by an `AggregateException`, or by the consumers completing normally once the reservation was released.

No public API change (the new context members are `internal`), so `ref/` is unchanged.

## Tests

Four tests added to `MixedConsumerProducerTests`, each verified to **fail against the previous implementation** and pass after the change:

- `Process_PreCanceledToken_DoesNotEnumerateInitialItems`
- `Process_StreamsInitialItemsWhileConsumersRun` — a generator that blocks until item 0 has been processed, which deadlocks under eager buffering
- `Process_CancellationDuringEnumeration_StopsEnumeratingInitialItems`
- `Process_InitialItemsEnumerationThrows_ProcessesEnqueuedItemsAndPropagates`

Verification:

- `dotnet build /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors; also built `-c Release /p:IsOfficialBuild=true` so the IDE analyzers run.
- `dotnet test` on `Meziantou.Framework.Threading.Tests` — 362 passed / 0 failed (181 × net10.0 and net11.0); the 17 `MixedConsumerProducerTests` cases ran on both TFMs.
- `dotnet run ./eng/update-all.cs` — exit 0, no generated files changed.