### PR TITLE
Implement IAsyncDisposable on ResettableCancellationTokenSource

### DIFF
--- a/ref/Meziantou.Framework.Threading.cs
+++ b/ref/Meziantou.Framework.Threading.cs
@@ -178,7 +178,7 @@ namespace Meziantou.Framework.Threading
         protected override bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) => throw null;
     }
 
-    public sealed class ResettableCancellationTokenSource : System.IDisposable
+    public sealed class ResettableCancellationTokenSource : System.IAsyncDisposable, System.IDisposable
     {
         public System.Threading.CancellationToken Token { get => throw null; }
         public bool IsCancellationRequested { get => throw null; }
@@ -188,6 +188,7 @@ namespace Meziantou.Framework.Threading
         public void CancelAfter(System.TimeSpan delay) { }
         public void Reset() { }
         public void Dispose() { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
     }
 
     [System.Flags]

--- a/src/Meziantou.Framework.Threading/Threading/ResettableCancellationTokenSource.cs
+++ b/src/Meziantou.Framework.Threading/Threading/ResettableCancellationTokenSource.cs
@@ -4,6 +4,8 @@ namespace Meziantou.Framework.Threading;
 /// <remarks>
 /// All members are safe to call concurrently. Note that the callbacks registered on <see cref="Token"/> run while the
 /// internal lock is held, so a callback must not block waiting on another thread that uses the same instance.
+/// <see cref="DisposeAsync"/> is the exception: it runs them on another thread and does not hold the lock while they
+/// complete.
 /// <para>
 /// <see cref="Reset"/> reuses the underlying <see cref="CancellationTokenSource"/> when it can, so whether a
 /// <see cref="CancellationToken"/> obtained before the reset belongs to the previous generation depends on the state
@@ -36,7 +38,7 @@ namespace Meziantou.Framework.Threading;
 /// await DoWorkAsync(cts.Token);
 /// ]]></code>
 /// </example>
-public sealed class ResettableCancellationTokenSource : IDisposable
+public sealed class ResettableCancellationTokenSource : IDisposable, IAsyncDisposable
 {
     private readonly ResettableCancellationTokenSourceOptions _options;
     private readonly Lock _lock = new();
@@ -174,6 +176,62 @@ public sealed class ResettableCancellationTokenSource : IDisposable
             finally
             {
                 _cts.Dispose();
+            }
+        }
+    }
+
+    /// <summary>Releases the resources used by this <see cref="ResettableCancellationTokenSource"/>, without running the cancellation callbacks on the calling thread.</summary>
+    /// <remarks>
+    /// Unlike <see cref="Dispose"/>, this method relies on <see cref="CancellationTokenSource.CancelAsync"/>, so the
+    /// callbacks registered on <see cref="Token"/> run on another thread and are awaited instead of blocking the
+    /// caller. A callback is therefore free to use this instance, which is not the case with <see cref="Dispose"/>.
+    /// <para>
+    /// The underlying <see cref="CancellationTokenSource"/> is disposed even when a callback throws: the exception
+    /// raised by <see cref="CancellationTokenSource.CancelAsync"/> propagates to the caller only after the resources
+    /// are released. Subsequent calls do nothing, whether they go through <see cref="Dispose"/> or this method, but a
+    /// call made while this one is still awaiting the callbacks returns before the resources are released.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="AggregateException">A callback registered on the current <see cref="Token"/> threw.</exception>
+    public ValueTask DisposeAsync()
+    {
+        Task cancellation;
+        CancellationTokenSource cts;
+        lock (_lock)
+        {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+
+            _disposed = true;
+            cts = _cts;
+
+            if (!_options.HasFlag(ResettableCancellationTokenSourceOptions.CancelOnDispose))
+            {
+                cts.Dispose();
+                return ValueTask.CompletedTask;
+            }
+
+            // CancelAsync never runs the callbacks on the calling thread, so starting it while the lock is held cannot
+            // deadlock, and it orders the cancellation before any member that is waiting for the lock.
+            cancellation = cts.CancelAsync();
+        }
+
+        return DisposeAsyncCore(cancellation, cts);
+    }
+
+    private async ValueTask DisposeAsyncCore(Task cancellation, CancellationTokenSource cts)
+    {
+        try
+        {
+            await cancellation.ConfigureAwait(false);
+        }
+        finally
+        {
+            // Disposing while the lock is held keeps a concurrent member from using the source as it is disposed, the
+            // same way Reset does when it replaces the source.
+            lock (_lock)
+            {
+                cts.Dispose();
             }
         }
     }

--- a/tests/Meziantou.Framework.Threading.Tests/ResettableCancellationTokenSourceTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ResettableCancellationTokenSourceTests.cs
@@ -167,6 +167,100 @@ public sealed class ResettableCancellationTokenSourceTests
     }
 
     [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+        await cts.DisposeAsync();
+        await cts.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent_WithoutCancelOnDispose()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);
+        await cts.DisposeAsync();
+        await cts.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsTheToken_WhenCancelOnDisposeIsSet()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        var token = cts.Token;
+        await cts.DisposeAsync();
+
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DoesNotCancelTheToken_WhenCancelOnDisposeIsNotSet()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.None);
+        var token = cts.Token;
+        await cts.DisposeAsync();
+
+        Assert.False(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesTheUnderlyingSource()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        _ = cts.Token;
+
+        await cts.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(() => cts.Token);
+        Assert.Throws<ObjectDisposedException>(cts.Reset);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesTheUnderlyingSource_WhenACancellationCallbackThrows()
+    {
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        cts.Token.Register(() => throw new InvalidOperationException("callback"));
+
+        await Assert.ThrowsAsync<AggregateException>(() => cts.DisposeAsync().AsTask());
+
+        // The underlying source must be disposed even though the callback threw, otherwise the resources it holds
+        // (such as an allocated wait handle) stay alive until the finalizer runs.
+        Assert.Throws<ObjectDisposedException>(() => cts.Token);
+        Assert.Throws<ObjectDisposedException>(cts.Reset);
+        await cts.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RunsTheCallbacksOutsideTheLock()
+    {
+        // The callback uses the instance, which deadlocks if the callbacks are awaited while the lock is held.
+        var cts = new ResettableCancellationTokenSource(ResettableCancellationTokenSourceOptions.CancelOnDispose);
+        var canceled = false;
+        cts.Token.Register(() => canceled = cts.IsCancellationRequested);
+
+        await cts.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(60));
+
+        Assert.True(canceled);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_AfterDispose_DoesNothing()
+    {
+        var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+        cts.Dispose();
+
+        await cts.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Dispose_AfterDisposeAsync_DoesNothing()
+    {
+        var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+        await cts.DisposeAsync();
+
+        cts.Dispose();
+    }
+
+    [Fact]
     public async Task ConcurrentResetAndCancel_DoesNotThrow()
     {
         // Reset replaces (and disposes) the underlying source. Without synchronization a concurrent reader observes
@@ -210,6 +304,21 @@ public sealed class ResettableCancellationTokenSourceTests
         {
             start.SignalAndWait();
             cts.Dispose();
+        })).ToArray();
+
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task ConcurrentDisposeAsync_DisposesOnlyOnce()
+    {
+        await using var cts = new ResettableCancellationTokenSource(cancelOnResetAndDispose: true);
+        using var start = new Barrier(4);
+
+        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(async () =>
+        {
+            start.SignalAndWait();
+            await cts.DisposeAsync();
         })).ToArray();
 
         await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(30));


### PR DESCRIPTION
`ResettableCancellationTokenSource` now implements `IAsyncDisposable`.

## Why

`Dispose` cancels through `CancellationTokenSource.Cancel` while the internal lock is held. That has two consequences for the caller:

- the callbacks registered on `Token` run on the calling thread, so the caller is blocked until every one of them completes;
- a callback cannot use the instance, because every member takes the same lock.

`DisposeAsync` relies on `CancellationTokenSource.CancelAsync` instead, so neither applies.

## What changed

`DisposeAsync` starts the cancellation while the lock is held — `CancelAsync` never runs the callbacks on the calling thread, so that cannot deadlock, and it orders the cancellation before any member waiting for the lock — then awaits the callbacks outside the lock.

It keeps the guarantees `Dispose` already offers:

- the underlying source is disposed in a `finally`, so the `AggregateException` from a throwing callback surfaces only after the resources are released;
- that disposal happens under the lock, the same invariant `Reset` relies on when it replaces the source, so a concurrent `Cancel` / `Token` cannot touch a source mid-disposal;
- it is idempotent, and interchangeable with `Dispose` in either order.

Without `CancelOnDispose` it disposes the source and returns `ValueTask.CompletedTask`, so there is no state machine and no allocation on that path.

## Notes for reviewers

- `await cts.CancelAsync()` surfaces callback exceptions as `AggregateException`, matching the documented behavior of `Dispose`, so the two stay consistent. I verified this rather than assuming it, since awaiting a faulted task normally unwraps to the first inner exception.
- `ref/Meziantou.Framework.Threading.cs` was regenerated by the build.

## Tests

10 new tests mirroring the synchronous ones, plus:

- a test where the cancellation callback uses the instance — it would hang if the callbacks were awaited with the lock held;
- a concurrent `DisposeAsync` test.

`dotnet test` on `Meziantou.Framework.Threading.Tests` with `/p:TreatWarningsAsErrors=true`: 540 passed (270 per TFM), 0 failed, 0 skipped, 26 of them in `ResettableCancellationTokenSourceTests`. `dotnet run ./eng/update-all.cs` is clean and produces no further changes.