### PR TITLE
Round ROUND midpoints away from zero in the TDS query engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,10 @@ jobs:
           base-commit: ${{ needs.compute_test_matrix.outputs.base-commit }}
           run-generate: "true"
           test-projects-only: "true"
+          # Lets eng/build.proj drop the projects whose tests cannot run in invariant globalization
+          # mode. A group left with nothing to run skips its steps instead of failing the job with
+          # "Zero tests ran".
+          properties: ${{ case(matrix.additionalArguments == '/p:InvariantGlobalization=true', 'InvariantGlobalization=true', '') }}
           # The projects of the group are the only candidates, so the generated project contains
           # exactly the projects computed by the compute_test_matrix job.
           include: ${{ matrix.test-group.projects }}

--- a/eng/build.proj
+++ b/eng/build.proj
@@ -19,4 +19,13 @@
     <ProjectReference Remove="../tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj" />
     <ProjectReference Remove="../tests/Meziantou.Framework.Threading.Windows.Tests/Meziantou.Framework.Threading.Windows.Tests.csproj" />
   </ItemGroup>
+
+  <!-- The database server tests drive a real client (Microsoft.Data.SqlClient, Npgsql), which
+       needs globalization data, so every test class in these projects is skipped in invariant
+       globalization mode. A traversal left with only these projects runs zero tests, which the
+       test runner reports as a failure, so the traversals that run tests drop them. -->
+  <ItemGroup Condition="'$(SkipUnsupportedPlatforms)' == 'true' AND '$(InvariantGlobalization)' == 'true'">
+    <ProjectReference Remove="../tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj" />
+    <ProjectReference Remove="../tests/Meziantou.Framework.PostgreSqlServer.Tests/Meziantou.Framework.PostgreSqlServer.Tests.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/SqlFunctions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/SqlFunctions.cs
@@ -302,10 +302,13 @@ internal static class SqlFunctions
     private static Expression BuildRoundFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 2, "ROUND");
+
+        // T-SQL rounds midpoint values away from zero whereas Math.Round(double, int) defaults to ties-to-even.
         return Expression.Call(
-            typeof(Math).GetMethod(nameof(Math.Round), [typeof(double), typeof(int)])!,
+            typeof(Math).GetMethod(nameof(Math.Round), [typeof(double), typeof(int), typeof(MidpointRounding)])!,
             EnsureDouble(arguments[0]),
-            EnsureInt(arguments[1]));
+            EnsureInt(arguments[1]),
+            Expression.Constant(MidpointRounding.AwayFromZero));
     }
 
     private static Expression BuildCeilingFunction(IReadOnlyList<Expression> arguments)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -2664,7 +2664,29 @@ public sealed class TdsQueryEngineTests
             Id
             1
             """,
-            expectedMaterializedQueries: "Customer[].Where(customer => ((Round(Convert(ConvertToTypeCore(Convert(1.26, Object), System.Double), Double), 1) == 1.3) AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+            expectedMaterializedQueries: "Customer[].Where(customer => ((Round(Convert(ConvertToTypeCore(Convert(1.26, Object), System.Double), Double), 1, AwayFromZero) == 1.3) AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_RoundFunction_RoundsMidpointAwayFromZero()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT ROUND(2.5, 0) AS PositiveMidpoint, ROUND(-2.5, 0) AS NegativeMidpoint, ROUND(0.25, 1) AS PositiveScaledMidpoint, ROUND(-0.25, 1) AS NegativeScaledMidpoint
+                    FROM customers
+                    WHERE Id = 1
+                    """;
+            },
+            """
+            PositiveMidpoint NegativeMidpoint PositiveScaledMidpoint NegativeScaledMidpoint
+            3 -3 0.3 -0.3
+            """,
+            expectedMaterializedQueries: "Customer[].Where(customer => (customer.Id == 1)).Select(customer2 => new TdsProjection() {PositiveMidpoint = Round(Convert(ConvertToTypeCore(Convert(2.5, Object), System.Double), Double), 0, AwayFromZero), NegativeMidpoint = Round(Convert(ConvertToTypeCore(Convert(-2.5, Object), System.Double), Double), 0, AwayFromZero), PositiveScaledMidpoint = Round(Convert(ConvertToTypeCore(Convert(0.25, Object), System.Double), Double), 1, AwayFromZero), NegativeScaledMidpoint = Round(Convert(ConvertToTypeCore(Convert(-0.25, Object), System.Double), Double), 1, AwayFromZero)})");
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

`ROUND` in the TDS query engine mapped to `Math.Round(double, int)`, whose default midpoint behavior is ties-to-even. It now uses the `Math.Round(double, int, MidpointRounding)` overload with `MidpointRounding.AwayFromZero`.

## Why

[T-SQL `ROUND`](https://learn.microsoft.com/en-us/sql/t-sql/functions/round-transact-sql) breaks ties away from zero, so `ROUND(2.5, 0)` is `3` on SQL Server. The engine returned `2`, silently diverging from the server it emulates.

## Tests

Added `SqlClient_QueryEngine_RoundFunction_RoundsMidpointAwayFromZero`, which projects four midpoint cases that ties-to-even would get wrong in every one:

| Expression | Expected | Ties-to-even would give |
| --- | --- | --- |
| `ROUND(2.5, 0)` | `3` | `2` |
| `ROUND(-2.5, 0)` | `-3` | `-2` |
| `ROUND(0.25, 1)` | `0.3` | `0.2` |
| `ROUND(-0.25, 1)` | `-0.3` | `-0.2` |

The existing `SqlClient_QueryEngine_RoundFunction_ReturnsFilteredRows` keeps its coverage of the non-midpoint path; only its expected expression tree changed to include the new `AwayFromZero` argument, since that assertion compares the materialized tree exactly.

## Notes for reviewers

- Scope is midpoint semantics only. Two other T-SQL/`Math.Round` divergences are left as-is and unchanged by this PR: a negative length (`ROUND(748.58, -1)`) still throws, and the optional third truncate argument is still rejected by the arity check.
- `Meziantou.Framework.TdsServer.Tests` passes in full: 470/470 (235 per TFM, net10.0 + net11.0), built with `/p:TreatsWarningsAsErrors=true`.
- `dotnet run ./eng/update-all.cs` was run and produced no changes; no public API moved, so `ref/` is untouched.

## Second commit: the invariant CI leg

`build_and_test (Debug, invariant)` failed on the first push, and not because of the ROUND change: the delta for this PR is `Meziantou.Framework.TdsServer.Tests` alone, every test class there is `[RunIf(NotInvariant)]`, so the leg skipped all 470 tests and the runner ended with `Zero tests ran` (exit code 8). Any TdsServer-only change hits this today — the same shape of PR (#2939) passed before the .NET 11 RC1 SDK update.

The fix follows the pattern `eng/build.proj` already uses for the WPF and Windows Forms tests off Windows: the delta generation now receives `InvariantGlobalization`, and the traversal drops the projects that have nothing to run in that mode. With no project left, DeltaBuild writes no delta file and the job skips its build and test steps instead of failing.

`Meziantou.Framework.PostgreSqlServer.Tests` is dropped too — every one of its test classes carries the same gate (110 skipped, exit code 8 when run under `/p:InvariantGlobalization=true`), so it would hit this on its next change.

Verified locally: `dotnet msbuild eng/build.proj -getItem:ProjectReference` lists both projects normally and neither with `-p:InvariantGlobalization=true`. Removing the `[RunIf]` gate from the TDS tests and running them invariant makes them fail rather than skip, so the gate itself cannot be narrowed. Note that touching `.github/workflows/ci.yml` and `eng/**/*.proj` is a full-rebuild trigger, so this PR now builds and tests everything.
