### PR TITLE
Decode LOGIN7 passwords by XORing before swapping nibbles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,20 @@ jobs:
 
       - name: Run tests
         if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ matrix.additionalArguments }}
+        run: |
+          dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ matrix.additionalArguments }}
+
+          # Exit code 8 is 'Zero tests ran'. A group can legitimately run no test at all when every project it
+          # contains skips all of its tests on the current configuration, such as the Windows-only APIs on Linux
+          # or the database servers under invariant globalization. Those projects opt in by setting
+          # 'MinimumExpectedTests' to 0; a project that does expect tests and runs none keeps the default of 1
+          # and fails with exit code 9 instead, so tolerating 8 here does not hide a regression.
+          if ($LASTEXITCODE -eq 8) {
+            Write-Host "Every test of the group was skipped on this configuration"
+            exit 0
+          }
+
+          exit $LASTEXITCODE
 
       - name: Cleanup test results
         if: steps.build-project.outputs.has-project == 'true'

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsLoginParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsLoginParser.cs
@@ -66,9 +66,9 @@ internal static class TdsLoginParser
         var decoded = new byte[byteLength];
         for (var i = 0; i < encoded.Length; i++)
         {
-            var value = encoded[i];
-            var swapped = (byte)(((value & 0x0F) << 4) | ((value & 0xF0) >> 4));
-            decoded[i] = (byte)(swapped ^ 0xA5);
+            // The client XORs each byte with 0xA5 and then swaps its nibbles, so decoding must undo both in reverse order.
+            var value = (byte)(encoded[i] ^ 0xA5);
+            decoded[i] = (byte)(((value & 0x0F) << 4) | ((value & 0xF0) >> 4));
         }
 
         return Encoding.Unicode.GetString(decoded);

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -123,8 +123,64 @@ public sealed class TdsServerProtocolTests
 
         var capturedContext = await authenticationContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(UserName, capturedContext.UserName);
-        Assert.NotNull(capturedContext.Password);
+        Assert.Equal(Password, capturedContext.Password);
         Assert.Equal("master", capturedContext.Database);
+    }
+
+    [Fact]
+    public async Task SqlClient_AuthenticationCallback_WithMatchingPassword_Succeeds()
+    {
+        const string UserName = "sa";
+        const string Password = "P@ssw0rd!<>&\u00e9\u4e2d";
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(
+                context.UserName == UserName && context.Password == Password
+                    ? TdsAuthenticationResult.Success("master")
+                    : TdsAuthenticationResult.Fail("Login failed.")),
+            (context, cancellationToken) => ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1)));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port, UserName, Password));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        var result = await command.ExecuteScalarAsync();
+
+        Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task SqlClient_AuthenticationCallback_WithWrongPassword_Fails()
+    {
+        const string UserName = "sa";
+        const string ExpectedPassword = "P@ssw0rd!<>&\u00e9\u4e2d";
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(
+                context.UserName == UserName && context.Password == ExpectedPassword
+                    ? TdsAuthenticationResult.Success("master")
+                    : TdsAuthenticationResult.Fail("Login failed.")),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port, UserName, ExpectedPassword + "x"));
+        var exception = await Assert.ThrowsAsync<SqlException>(() => connection.OpenAsync());
+
+        Assert.Contains("Login failed.", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## What

`TdsLoginParser.ReadPassword` decoded LOGIN7 passwords in the wrong order: it swapped each byte's nibbles and then XORed with `0xA5`. The correct inverse is XOR first, then swap.

## Why

SqlClient obfuscates each password byte as `swap_nibbles(b) ^ 0xA5` ([MS-TDS](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/773a62b6-ee89-4c02-9e5e-344882630aac)).

Nibble-swapping is a bit permutation, so it distributes over XOR:

- correct decode: `swap(y ^ 0xA5)` == `swap(y) ^ 0x5A`
- old code: `swap(y) ^ 0xA5`

Since `0xA5 ^ 0x5A == 0xFF`, every decoded byte came out bit-complemented. The password handed to the authentication callback was never the one the client sent, so any callback comparing the received password against the expected one rejected valid credentials.

Worth noting for review: the two operations look commutative at a glance, which is probably how the original order slipped through — they aren't, because `swap(0xA5) == 0x5A != 0xA5`.

## Tests

- `SqlClient_AuthenticationCallback_ReceivesCredentials` now asserts exact password equality. It previously used `Assert.NotNull(capturedContext.Password)`, which happily accepted the corrupted string.
- Added `SqlClient_AuthenticationCallback_WithMatchingPassword_Succeeds` — a callback that compares the received password against the expected one, then opens a connection and runs a query.
- Added `SqlClient_AuthenticationCallback_WithWrongPassword_Fails` — the same callback rejecting a wrong password, asserting `SqlException` carries the failure message.

Both new tests use a password with punctuation and non-ASCII characters (`é`, `中`) so the UCS-2 round trip is covered, not just ASCII.

## Second commit: a CI failure this PR was the first to trigger

The `build_and_test (macos-26, Debug, invariant, shard-1)` job failed with no failing test — 236 tests, 0 failed, 236 skipped, step exit code 1.

Microsoft.Testing.Platform returns exit code 8 (`Zero tests ran`) when a run executes no test at all, and every class in `Meziantou.Framework.TdsServer.Tests` is `[RunIf(NotInvariant)]`, so the invariant globalization leg has nothing to execute. It does not show up on `main` because a test group almost always holds at least one project that runs tests — but the delta build reduces a group to the projects a change touches, and this PR touches only that one project, leaving it alone in the group.

The project already sets `<MinimumExpectedTests>0</MinimumExpectedTests>` with the comment `All the tests are skipped when globalization is invariant`, but that property only drops the `--minimum-expected-tests` argument; the SDK README notes the platform still expects at least one test to run. So the intent was already declared, the mechanism just could not deliver it. `--ignore-exit-code 8` does not help either: the individual test apps already exit 0 here, and the 8 comes from the `dotnet test` orchestrator, which neither that argument nor `TESTINGPLATFORM_EXITCODE_IGNORE` reaches (both verified locally).

The workflow's test step now treats exit code 8 as success. This is not a loss of signal: a project that *expects* tests and runs none keeps the default of `--minimum-expected-tests 1` and fails with exit code **9**, which still fails the step. Verified both codes locally.

This is a pre-existing, repo-wide condition rather than something this change introduced — the same is true of the Win32 test projects on non-Windows agents (checked: `Meziantou.Framework.Win32.AccessToken.Tests` exits 8 on macOS), so any future PR touching only one of those would have hit it too.

Since `.github/workflows/ci.yml` is a full-rebuild trigger, this PR's run now covers every project rather than the delta.

## Verification

On net10.0 and net11.0 with `/p:TreatsWarningsAsErrors=true`:

- Full `Meziantou.Framework.TdsServer.Tests` run: 472 passed, 0 failed, 0 skipped.
- Confirmed the tests actually catch the bug: reverting the parser fix and re-running the three auth tests fails 4 of 6 (`ReceivesCredentials` on the equality assert, `WithMatchingPassword_Succeeds` with `Login failed.`); restoring the fix returns them to green. The rejection test passes either way by design — it guards the negative path, not the decoder.
- Reproduced the CI failure locally (`/p:InvariantGlobalization=true` → `Zero tests ran`, exit 8) and confirmed the new step logic exits 0 for it, exits 9 for a minimum-expected-tests violation, and exits 0 for a normal passing run.
- `dotnet run ./eng/update-all.cs` completed and produced no file changes.
