### PR TITLE
Emit the base type before the sorted interface list in the public API

### DIFF
--- a/ref/Meziantou.Framework.CodeDom.cs
+++ b/ref/Meziantou.Framework.CodeDom.cs
@@ -232,7 +232,7 @@ namespace Meziantou.Framework.CodeDom
         public ClassDeclaration(string? name) { }
     }
 
-    public abstract class ClassOrStructDeclaration : Meziantou.Framework.CodeDom.IMemberContainer, Meziantou.Framework.CodeDom.IParametrableType, Meziantou.Framework.CodeDom.ITypeDeclarationContainer, Meziantou.Framework.CodeDom.TypeDeclaration
+    public abstract class ClassOrStructDeclaration : Meziantou.Framework.CodeDom.TypeDeclaration, Meziantou.Framework.CodeDom.IMemberContainer, Meziantou.Framework.CodeDom.IParametrableType, Meziantou.Framework.CodeDom.ITypeDeclarationContainer
     {
         public System.Collections.Generic.IList<Meziantou.Framework.CodeDom.TypeReference> Implements { get => throw null; }
         public Meziantou.Framework.CodeDom.CodeObjectCollection<Meziantou.Framework.CodeDom.TypeParameter> Parameters { get => throw null; }
@@ -328,7 +328,7 @@ namespace Meziantou.Framework.CodeDom
         public ConstructorBaseInitializer(System.Collections.Generic.IEnumerable<Meziantou.Framework.CodeDom.Expression> codeExpressions) { }
     }
 
-    public class ConstructorDeclaration : Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.MemberDeclaration
+    public class ConstructorDeclaration : Meziantou.Framework.CodeDom.MemberDeclaration, Meziantou.Framework.CodeDom.IModifiers
     {
         public Meziantou.Framework.CodeDom.MethodArgumentCollection Arguments { get => throw null; }
         public Meziantou.Framework.CodeDom.StatementCollection? Statements { get => throw null; set { } }
@@ -410,7 +410,7 @@ namespace Meziantou.Framework.CodeDom
         public DefaultValueExpression(Meziantou.Framework.CodeDom.TypeReference? type) { }
     }
 
-    public class DelegateDeclaration : Meziantou.Framework.CodeDom.IParametrableType, Meziantou.Framework.CodeDom.TypeDeclaration
+    public class DelegateDeclaration : Meziantou.Framework.CodeDom.TypeDeclaration, Meziantou.Framework.CodeDom.IParametrableType
     {
         public Meziantou.Framework.CodeDom.TypeReference? ReturnType { get => throw null; set { } }
         public Meziantou.Framework.CodeDom.CodeObjectCollection<Meziantou.Framework.CodeDom.TypeParameter> Parameters { get => throw null; }
@@ -446,7 +446,7 @@ namespace Meziantou.Framework.CodeDom
         public EnumerationMember(string? name, Meziantou.Framework.CodeDom.Expression value) { }
     }
 
-    public class EventFieldDeclaration : Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.MemberDeclaration
+    public class EventFieldDeclaration : Meziantou.Framework.CodeDom.MemberDeclaration, Meziantou.Framework.CodeDom.IModifiers
     {
         public Meziantou.Framework.CodeDom.TypeReference? Type { get => throw null; set { } }
         public Meziantou.Framework.CodeDom.StatementCollection? AddAccessor { get => throw null; set { } }
@@ -553,7 +553,7 @@ namespace Meziantou.Framework.CodeDom
         public static Meziantou.Framework.CodeDom.MemberReferenceExpression Member(this Meziantou.Framework.CodeDom.PropertyDeclaration prop, string name, params string[] names) => throw null;
     }
 
-    public class FieldDeclaration : Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.MemberDeclaration
+    public class FieldDeclaration : Meziantou.Framework.CodeDom.MemberDeclaration, Meziantou.Framework.CodeDom.IModifiers
     {
         public Meziantou.Framework.CodeDom.Expression? InitExpression { get => throw null; set { } }
         public Meziantou.Framework.CodeDom.TypeReference? Type { get => throw null; set { } }
@@ -660,7 +660,7 @@ namespace Meziantou.Framework.CodeDom
         public override void WriteLine(uint value) { }
     }
 
-    public class InterfaceDeclaration : Meziantou.Framework.CodeDom.IInheritanceParameters, Meziantou.Framework.CodeDom.IMemberContainer, Meziantou.Framework.CodeDom.IParametrableType, Meziantou.Framework.CodeDom.ITypeDeclarationContainer, Meziantou.Framework.CodeDom.TypeDeclaration
+    public class InterfaceDeclaration : Meziantou.Framework.CodeDom.TypeDeclaration, Meziantou.Framework.CodeDom.IInheritanceParameters, Meziantou.Framework.CodeDom.IMemberContainer, Meziantou.Framework.CodeDom.IParametrableType, Meziantou.Framework.CodeDom.ITypeDeclarationContainer
     {
         public Meziantou.Framework.CodeDom.TypeReference? BaseType { get => throw null; set { } }
         public System.Collections.Generic.IList<Meziantou.Framework.CodeDom.TypeReference> Implements { get => throw null; }
@@ -748,7 +748,7 @@ namespace Meziantou.Framework.CodeDom
         public MethodArgumentDeclaration(Meziantou.Framework.CodeDom.TypeReference? type, string? name) { }
     }
 
-    public class MethodDeclaration : Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.IParametrableType, Meziantou.Framework.CodeDom.MemberDeclaration
+    public class MethodDeclaration : Meziantou.Framework.CodeDom.MemberDeclaration, Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.IParametrableType
     {
         public Meziantou.Framework.CodeDom.TypeReference? ReturnType { get => throw null; set { } }
         public Meziantou.Framework.CodeDom.TypeReference? PrivateImplementationType { get => throw null; set { } }
@@ -856,7 +856,7 @@ namespace Meziantou.Framework.CodeDom
         Disable = 2
     }
 
-    public class OperatorDeclaration : Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.MemberDeclaration
+    public class OperatorDeclaration : Meziantou.Framework.CodeDom.MemberDeclaration, Meziantou.Framework.CodeDom.IModifiers
     {
         public Meziantou.Framework.CodeDom.TypeReference? ReturnType { get => throw null; set { } }
         public Meziantou.Framework.CodeDom.MethodArgumentCollection Arguments { get => throw null; }
@@ -875,7 +875,7 @@ namespace Meziantou.Framework.CodeDom
         public static implicit operator Meziantou.Framework.CodeDom.PropertyAccessorDeclaration(Meziantou.Framework.CodeDom.Statement statement) => throw null;
     }
 
-    public class PropertyDeclaration : Meziantou.Framework.CodeDom.IModifiers, Meziantou.Framework.CodeDom.MemberDeclaration
+    public class PropertyDeclaration : Meziantou.Framework.CodeDom.MemberDeclaration, Meziantou.Framework.CodeDom.IModifiers
     {
         public Meziantou.Framework.CodeDom.Modifiers Modifiers { get => throw null; set { } }
         public Meziantou.Framework.CodeDom.TypeReference? Type { get => throw null; set { } }

--- a/ref/Meziantou.Framework.Http.Recording.cs
+++ b/ref/Meziantou.Framework.Http.Recording.cs
@@ -50,7 +50,7 @@ namespace Meziantou.Framework.Http.Recording
         public System.DateTimeOffset RecordedAt { get => throw null; set { } }
     }
 
-    public sealed class HttpRecordingHandler : System.IAsyncDisposable, System.Net.Http.DelegatingHandler
+    public sealed class HttpRecordingHandler : System.Net.Http.DelegatingHandler, System.IAsyncDisposable
     {
         public HttpRecordingHandler(Meziantou.Framework.Http.Recording.IHttpRecordingStore store, Meziantou.Framework.Http.Recording.HttpRecordingOptions? options = null) { }
         public HttpRecordingHandler(System.Net.Http.HttpMessageHandler innerHandler, Meziantou.Framework.Http.Recording.IHttpRecordingStore store, Meziantou.Framework.Http.Recording.HttpRecordingOptions? options = null) { }

--- a/ref/Meziantou.Framework.PooledMemoryStream.cs
+++ b/ref/Meziantou.Framework.PooledMemoryStream.cs
@@ -4,7 +4,7 @@
 
 namespace Meziantou.Framework
 {
-    public sealed class PooledMemoryStream : System.Buffers.IBufferWriter<byte>, System.IO.MemoryStream
+    public sealed class PooledMemoryStream : System.IO.MemoryStream, System.Buffers.IBufferWriter<byte>
     {
         public override bool CanRead { get => throw null; }
         public override bool CanSeek { get => throw null; }

--- a/ref/Meziantou.Framework.Threading.cs
+++ b/ref/Meziantou.Framework.Threading.cs
@@ -163,7 +163,7 @@ namespace Meziantou.Framework.Threading
         public void Enqueue(T item) { }
     }
 
-    public sealed class MonoThreadedTaskScheduler : System.IDisposable, System.Threading.Tasks.TaskScheduler
+    public sealed class MonoThreadedTaskScheduler : System.Threading.Tasks.TaskScheduler, System.IDisposable
     {
         public bool DequeueOnDispose { get => throw null; set { } }
         public System.TimeSpan DisposeThreadJoinTimeout { get => throw null; set { } }

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -1281,12 +1281,13 @@ internal static class PublicApiModelBuilder
             baseTypes.Add(FormatType(type.BaseType));
         }
 
+        // The interface list is sorted using the formatted names, so the generated API does not depend on the order reported by the runtime.
+        // The base type stays first as C# requires it to precede the interfaces.
         var interfaces = type.GetInterfaces()
             .Where(@interface => IsExternallyVisible(@interface) || @interface.IsPublic)
             .Where(@interface => !isUnionDeclaration || @interface.FullName != IUnionInterfaceFullName)
-            .OrderBy(static @interface => @interface.FullName, StringComparer.Ordinal)
             .Select(static @interface => FormatType(@interface))
-            .ToList();
+            .OrderBy(static value => value, StringComparer.Ordinal);
         baseTypes.AddRange(interfaces);
 
         if (baseTypes.Count == 0)

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -408,6 +408,7 @@ internal static class PublicApiModelReader
             }
         }
 
+        var interfaces = new List<string>();
         foreach (var interfaceImplementationHandle in typeDefinition.GetInterfaceImplementations())
         {
             var interfaceImplementation = metadataReader.GetInterfaceImplementation(interfaceImplementationHandle);
@@ -415,13 +416,18 @@ internal static class PublicApiModelReader
             if (isUnionDeclaration && string.Equals(interfaceTypeName, IUnionInterfaceFullName, StringComparison.Ordinal))
                 continue;
 
-            baseTypes.Add(FormatDecodedTypeWithoutNullable(DecodeTypeFromEntityHandle(metadataReader, interfaceImplementation.Interface, genericContext)));
+            interfaces.Add(FormatDecodedTypeWithoutNullable(DecodeTypeFromEntityHandle(metadataReader, interfaceImplementation.Interface, genericContext)));
         }
+
+        // The interface list is sorted using the formatted names, so the generated API does not depend on the order of the metadata table.
+        // The base type stays first as C# requires it to precede the interfaces.
+        interfaces.Sort(StringComparer.Ordinal);
+        baseTypes.AddRange(interfaces);
 
         if (baseTypes.Count == 0)
             return string.Empty;
 
-        return " : " + string.Join(", ", baseTypes.Distinct(StringComparer.Ordinal).OrderBy(static value => value, StringComparer.Ordinal));
+        return " : " + string.Join(", ", baseTypes.Distinct(StringComparer.Ordinal));
     }
 
     private static List<string> BuildTypeConstraints(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle)

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -245,6 +245,57 @@ public sealed class PublicApiGeneratorTests
     }
 
     [Fact]
+    public async Task Inheritance_BaseTypeIsFirstAndInterfacesAreSorted()
+    {
+        await Validate("""
+            public interface IZeta { }
+            public interface IAlpha { }
+            public interface IMiddle { }
+
+            public abstract class TypeDeclaration { }
+
+            public class Sample : TypeDeclaration, IZeta, IMiddle, IAlpha
+            {
+            }
+
+            public interface IDerived : IZeta, IMiddle, IAlpha
+            {
+            }
+            """, """
+            #nullable enable
+
+            public interface IAlpha
+            {
+            }
+
+
+            public interface IDerived : IAlpha, IMiddle, IZeta
+            {
+            }
+
+
+            public interface IMiddle
+            {
+            }
+
+
+            public interface IZeta
+            {
+            }
+
+
+            public class Sample : TypeDeclaration, IAlpha, IMiddle, IZeta
+            {
+            }
+
+
+            public abstract class TypeDeclaration
+            {
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Struct_Empty()
     {
         await Validate("""


### PR DESCRIPTION
## What

Normalize the base type list emitted by the public API generator: the base type is always written first, followed by the interfaces sorted ordinally **by their formatted name** — the exact string that gets written to the file.

## Why

The two model builders disagreed with each other, and one of them was emitting invalid C#.

`PublicApiModelReader` (metadata path, the one that generates `ref/`) sorted the *whole* list, base class included. When the base class sorted after an interface it landed last, which is a CS1722 (`Base class 'X' must come before any interfaces`). That had already leaked into the checked-in files — for example in `ref/Meziantou.Framework.CodeDom.cs`:

```csharp
public abstract class ClassOrStructDeclaration : ...IMemberContainer, ...IParametrableType, ...ITypeDeclarationContainer, ...TypeDeclaration
```

`PublicApiModelBuilder` (reflection path) kept the base type first, so the same assembly produced different output depending on which entry point was used. It also keyed the interface sort on `Type.FullName` while emitting `FormatType(...)`, so the sort key was not the text being written — and `FullName` is `null` for open generic instantiations.

## Changes

- `PublicApiModelReader.BuildTypeInheritance`: collect the interfaces separately, sort them, and append them after the base type.
- `PublicApiModelBuilder.BuildInheritance`: sort on the formatted name instead of `Type.FullName`.
- New test `Inheritance_BaseTypeIsFirstAndInterfacesAreSorted`, covering a base class that sorts *after* its interfaces. `Validate` compares the reflection and metadata output against each other **and** compiles the result, so it pins both halves of the bug.
- Regenerated `ref/`: 13 declarations across 4 files move their base class back to the front. No interface is reordered — the interface sub-lists were already ordinal-sorted.

## Notes for the reviewer

The whole `ref/` diff is base-class-moves-to-front; there is no API change.

`Meziantou.Framework.OpenTelemetryCollector` could not be rebuilt locally (its `protoc` hangs on macOS/arm64), so its two ref files were not regenerated. I checked them by hand instead: every multi-entry base list there is made up solely of `Google.Protobuf.I*` / `System.IEquatable<>` interfaces, and the only class base types (`OpenTelemetrySampler`, `Grpc.Core.ClientBase<>`) are already single-entry lists, so they regenerate unchanged. A scan across all 111 ref files confirms no declaration is left with a non-interface type in any position but the first — CI will confirm via `--verify-no-change`.

## Verification

- `Meziantou.Framework.PublicApiGenerator.Tests` — 222/222 (111 tests x net10.0/net11.0)
- `Meziantou.Framework.PublicApiGenerator.MSBuild.Tests` — 18/18
- `dotnet run ./eng/update-all.cs` — no changes