### PR TITLE
Preserve SQL NULL semantics in the string scalar functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,20 @@ jobs:
 
       - name: Run tests
         if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ matrix.additionalArguments }}
+        run: |
+          dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ matrix.additionalArguments }}
+
+          # Exit code 8 is 'zero tests ran'. A delta build can legitimately select only projects that
+          # skip every test on this leg, such as the TDS tests, which need ICU and are therefore all
+          # skipped by the invariant globalization jobs. Those projects already declare that running
+          # no test is expected by setting 'MinimumExpectedTests' to 0, but that only silences the
+          # per-project check, not the run-level one.
+          if ($LASTEXITCODE -eq 8) {
+            Write-Host "No test ran: every project selected for this shard skipped all of its tests."
+            exit 0
+          }
+
+          exit $LASTEXITCODE
 
       - name: Cleanup test results
         if: steps.build-project.outputs.has-project == 'true'

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/SqlFunctions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/SqlFunctions.cs
@@ -62,19 +62,22 @@ internal static class SqlFunctions
     private static Expression BuildUpperInvariantFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 1, "UPPER");
-        return Expression.Call(EnsureString(arguments[0]), typeof(string).GetMethod(nameof(string.ToUpperInvariant), Type.EmptyTypes)!);
+        var value = EnsureString(arguments[0]);
+        return PropagateNull(Expression.Call(value, typeof(string).GetMethod(nameof(string.ToUpperInvariant), Type.EmptyTypes)!), value);
     }
 
     private static Expression BuildLowerInvariantFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 1, "LOWER");
-        return Expression.Call(EnsureString(arguments[0]), typeof(string).GetMethod(nameof(string.ToLowerInvariant), Type.EmptyTypes)!);
+        var value = EnsureString(arguments[0]);
+        return PropagateNull(Expression.Call(value, typeof(string).GetMethod(nameof(string.ToLowerInvariant), Type.EmptyTypes)!), value);
     }
 
     private static Expression BuildLenFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 1, "LEN");
-        return Expression.Property(EnsureString(arguments[0]), nameof(string.Length));
+        var value = EnsureString(arguments[0]);
+        return PropagateNull(Expression.Property(value, nameof(string.Length)), value);
     }
 
     private static Expression BuildConcatFunction(IReadOnlyList<Expression> arguments)
@@ -96,43 +99,40 @@ internal static class SqlFunctions
     private static Expression BuildLTrimFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 1, "LTRIM");
-        return Expression.Call(EnsureString(arguments[0]), typeof(string).GetMethod(nameof(string.TrimStart), Type.EmptyTypes)!);
+        var value = EnsureString(arguments[0]);
+        return PropagateNull(Expression.Call(value, typeof(string).GetMethod(nameof(string.TrimStart), Type.EmptyTypes)!), value);
     }
 
     private static Expression BuildRTrimFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 1, "RTRIM");
-        return Expression.Call(EnsureString(arguments[0]), typeof(string).GetMethod(nameof(string.TrimEnd), Type.EmptyTypes)!);
+        var value = EnsureString(arguments[0]);
+        return PropagateNull(Expression.Call(value, typeof(string).GetMethod(nameof(string.TrimEnd), Type.EmptyTypes)!), value);
     }
 
     private static Expression BuildTrimFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 1, "TRIM");
-        return Expression.Call(EnsureString(arguments[0]), typeof(string).GetMethod(nameof(string.Trim), Type.EmptyTypes)!);
+        var value = EnsureString(arguments[0]);
+        return PropagateNull(Expression.Call(value, typeof(string).GetMethod(nameof(string.Trim), Type.EmptyTypes)!), value);
     }
 
     private static Expression BuildLeftFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 2, "LEFT");
         return Expression.Call(
-            typeof(SqlFunctions).GetMethod(nameof(SubstringCore), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!,
+            typeof(SqlFunctions).GetMethod(nameof(LeftCore), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!,
             EnsureString(arguments[0]),
-            Expression.Constant(0),
             EnsureInt(arguments[1]));
     }
 
     private static Expression BuildRightFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 2, "RIGHT");
-        var value = EnsureString(arguments[0]);
-        var length = EnsureInt(arguments[1]);
-        var start = Expression.Subtract(Expression.Property(value, nameof(string.Length)), length);
-
         return Expression.Call(
-            typeof(SqlFunctions).GetMethod(nameof(SubstringCore), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!,
-            value,
-            start,
-            length);
+            typeof(SqlFunctions).GetMethod(nameof(RightCore), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!,
+            EnsureString(arguments[0]),
+            EnsureInt(arguments[1]));
     }
 
     private static Expression BuildSubstringFunction(IReadOnlyList<Expression> arguments)
@@ -149,11 +149,14 @@ internal static class SqlFunctions
     private static Expression BuildReplaceFunction(IReadOnlyList<Expression> arguments)
     {
         ValidateArgCount(arguments, expectedCount: 3, "REPLACE");
-        return Expression.Call(
-            EnsureString(arguments[0]),
-            typeof(string).GetMethod(nameof(string.Replace), [typeof(string), typeof(string)])!,
-            EnsureString(arguments[1]),
-            EnsureString(arguments[2]));
+        var value = EnsureString(arguments[0]);
+        var oldValue = EnsureString(arguments[1]);
+        var newValue = EnsureString(arguments[2]);
+        return PropagateNull(
+            Expression.Call(value, typeof(string).GetMethod(nameof(string.Replace), [typeof(string), typeof(string)])!, oldValue, newValue),
+            value,
+            oldValue,
+            newValue);
     }
 
     private static Expression BuildTranslateFunction(IReadOnlyList<Expression> arguments)
@@ -467,6 +470,42 @@ internal static class SqlFunctions
         return Expression.Convert(converted, targetType);
     }
 
+    /// <summary>Builds an expression evaluating to NULL when any of <paramref name="values" /> is NULL, and to <paramref name="result" /> otherwise.</summary>
+    /// <remarks>SQL scalar functions propagate NULL, while the .NET members they map to throw on a null instance or argument.</remarks>
+    private static Expression PropagateNull(Expression result, params Expression[] values)
+    {
+        Expression? isNull = null;
+        foreach (var value in values)
+        {
+            if (!CanBeNull(value))
+            {
+                continue;
+            }
+
+            var check = Expression.Equal(value, Expression.Constant(null, value.Type));
+            isNull = isNull is null ? check : Expression.OrElse(isNull, check);
+        }
+
+        if (isNull is null)
+        {
+            return result;
+        }
+
+        result = EnsureNullable(result);
+        return Expression.Condition(isNull, Expression.Constant(null, result.Type), result);
+    }
+
+    /// <summary>Returns whether the expression can evaluate to NULL at run time.</summary>
+    private static bool CanBeNull(Expression expression)
+    {
+        if (expression.Type.IsValueType && Nullable.GetUnderlyingType(expression.Type) is null)
+        {
+            return false;
+        }
+
+        return expression is not ConstantExpression { Value: not null };
+    }
+
     private static Expression EnsureNullable(Expression expression)
     {
         if (!expression.Type.IsValueType || Nullable.GetUnderlyingType(expression.Type) is not null)
@@ -491,9 +530,18 @@ internal static class SqlFunctions
         }
 
         return Expression.Call(
-            typeof(Convert).GetMethod(nameof(Convert.ToString), [typeof(object), typeof(IFormatProvider)])!,
-            Expression.Convert(expression, typeof(object)),
-            Expression.Constant(CultureInfo.InvariantCulture));
+            typeof(SqlFunctions).GetMethod(nameof(ToStringCore), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!,
+            Expression.Convert(expression, typeof(object)));
+    }
+
+    private static string? ToStringCore(object? value)
+    {
+        if (value is null or DBNull)
+        {
+            return null;
+        }
+
+        return Convert.ToString(value, CultureInfo.InvariantCulture);
     }
 
     private static object? ConvertToTypeCore(object? value, Type targetType)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -377,7 +377,7 @@ public sealed class TdsQueryEngineTests
             UpperName NameLength
             ALICE 5
             """,
-            expectedMaterializedQueries: "Customer[].Where(customer => (customer.Id == 1)).Select(customer2 => new TdsProjection() {UpperName = customer2.Name.ToUpperInvariant(), NameLength = customer2.Name.Length})");
+            expectedMaterializedQueries: "Customer[].Where(customer => (customer.Id == 1)).Select(customer2 => new TdsProjection() {UpperName = IIF((customer2.Name == null), null, customer2.Name.ToUpperInvariant()), NameLength = IIF((customer2.Name == null), null, Convert(customer2.Name.Length, Nullable`1))})");
     }
 
     [Fact]
@@ -833,7 +833,7 @@ public sealed class TdsQueryEngineTests
             Id
             2
             """,
-            expectedMaterializedQueries: "Customer[].Where(customer => (customer.Name.Length == 3)).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+            expectedMaterializedQueries: "Customer[].Where(customer => (IIF((customer.Name == null), null, Convert(customer.Name.Length, Nullable`1)) == 3)).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
     }
 
     [Fact]
@@ -1930,7 +1930,7 @@ public sealed class TdsQueryEngineTests
             Id
             1
             """,
-            expectedMaterializedQueries: "Customer[].Where(customer => ((SubstringCore(customer.Name, 0, 2) == \"Al\") AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+            expectedMaterializedQueries: "Customer[].Where(customer => ((LeftCore(customer.Name, 2) == \"Al\") AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
     }
 
     [Fact]
@@ -1952,7 +1952,7 @@ public sealed class TdsQueryEngineTests
             Id
             1
             """,
-            expectedMaterializedQueries: "Customer[].Where(customer => ((SubstringCore(customer.Name, (customer.Name.Length - 2), 2) == \"ce\") AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+            expectedMaterializedQueries: "Customer[].Where(customer => ((RightCore(customer.Name, 2) == \"ce\") AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
     }
 
     [Fact]
@@ -1996,7 +1996,122 @@ public sealed class TdsQueryEngineTests
             Id
             1
             """,
-            expectedMaterializedQueries: "Customer[].Where(customer => ((customer.Name.Replace(\"li\", \"xx\") == \"Axxce\") AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+            expectedMaterializedQueries: "Customer[].Where(customer => ((IIF((customer.Name == null), null, customer.Name.Replace(\"li\", \"xx\")) == \"Axxce\") AndAlso (customer.Id == 1))).Select(customer2 => new TdsProjection() {Id = customer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_CaseAndLengthFunctions_ReturnNullForNullColumn()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id, UPPER(Name) AS UpperName, LOWER(Name) AS LowerName, LEN(Name) AS NameLength
+                    FROM nullable_customers
+                    """;
+            },
+            """
+            Id UpperName LowerName NameLength
+            1 ALICE alice 5
+            2 BOB bob 3
+            3 NULL NULL NULL
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Select(nullableCustomer => new TdsProjection() {Id = nullableCustomer.Id, UpperName = IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.ToUpperInvariant()), LowerName = IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.ToLowerInvariant()), NameLength = IIF((nullableCustomer.Name == null), null, Convert(nullableCustomer.Name.Length, Nullable`1))})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_TrimFunctions_ReturnNullForNullColumn()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id, LTRIM(Name) AS TrimmedStart, RTRIM(Name) AS TrimmedEnd, TRIM(Name) AS Trimmed
+                    FROM nullable_customers
+                    """;
+            },
+            """
+            Id TrimmedStart TrimmedEnd Trimmed
+            1 Alice Alice Alice
+            2 Bob Bob Bob
+            3 NULL NULL NULL
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Select(nullableCustomer => new TdsProjection() {Id = nullableCustomer.Id, TrimmedStart = IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.TrimStart()), TrimmedEnd = IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.TrimEnd()), Trimmed = IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.Trim())})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_SubstringFunctions_ReturnNullForNullColumn()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id, LEFT(Name, 2) AS LeftName, RIGHT(Name, 2) AS RightName, REPLACE(Name, 'li', 'xx') AS ReplacedName
+                    FROM nullable_customers
+                    """;
+            },
+            """
+            Id LeftName RightName ReplacedName
+            1 Al ce Axxce
+            2 Bo ob Bob
+            3 NULL NULL NULL
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Select(nullableCustomer => new TdsProjection() {Id = nullableCustomer.Id, LeftName = LeftCore(nullableCustomer.Name, 2), RightName = RightCore(nullableCustomer.Name, 2), ReplacedName = IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.Replace(\"li\", \"xx\"))})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereStringFunctionOnNullColumn_ExcludesNullRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE UPPER(Name) = 'BOB' OR LEN(Name) = 5
+                    """;
+            },
+            """
+            Id
+            1
+            2
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => ((IIF((nullableCustomer.Name == null), null, nullableCustomer.Name.ToUpperInvariant()) == \"BOB\") OrElse (IIF((nullableCustomer.Name == null), null, Convert(nullableCustomer.Name.Length, Nullable`1)) == 5))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_StringFunctionOnNullableNonStringColumn_ReturnsNull()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id, LEN(Score) AS ScoreLength
+                    FROM nullable_customers
+                    """;
+            },
+            """
+            Id ScoreLength
+            1 3
+            2 1
+            3 NULL
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Select(nullableCustomer => new TdsProjection() {Id = nullableCustomer.Id, ScoreLength = IIF((ToStringCore(Convert(nullableCustomer.Score, Object)) == null), null, Convert(ToStringCore(Convert(nullableCustomer.Score, Object)).Length, Nullable`1))})");
     }
 
     [Fact]
@@ -3745,9 +3860,9 @@ public sealed class TdsQueryEngineTests
     {
         return
         [
-            new NullableCustomer(1, "Alice"),
-            new NullableCustomer(2, "Bob"),
-            new NullableCustomer(3, null),
+            new NullableCustomer(1, "Alice", 100),
+            new NullableCustomer(2, "Bob", 5),
+            new NullableCustomer(3, null, null),
         ];
     }
 
@@ -3951,7 +4066,7 @@ public sealed class TdsQueryEngineTests
 
     private sealed record Order(int Id, string Region, int Amount);
 
-    private sealed record NullableCustomer(int Id, string? Name);
+    private sealed record NullableCustomer(int Id, string? Name, int? Score);
 
     private sealed record JsonDocumentRow(int Id, string? Payload);
 


### PR DESCRIPTION
## What changed

`UPPER`, `LOWER`, `LEN`, `LTRIM`, `RTRIM`, `TRIM` and `REPLACE` mapped straight onto `string` instance members, with no null propagation. With the default in-memory materializer, `SELECT UPPER(Name) FROM items` threw `NullReferenceException` when a row had a null name, instead of returning SQL NULL for that row and the remaining rows normally.

- Added a `PropagateNull` helper in `SqlFunctions` that wraps a mapped expression in `value == null ? null : <expr>`. The guard is skipped for operands known to be non-null constants (string literals), so the existing literal-argument trees are unchanged.
- Applied it to `UPPER`, `LOWER`, `LEN`, `LTRIM`, `RTRIM`, `TRIM` and `REPLACE`. `LEN` now yields `int?` so the NULL row can actually be represented.
- `RIGHT` had the same defect one level up: it computed `value.Length - length` *before* handing the value to the null-safe `SubstringCore`, so it threw on a null value. It now calls `RightCore`, which already existed but was dead code. `LEFT` now calls `LeftCore` for symmetry — it was already null-safe via `SubstringCore`, but both dead members are now live.
- `EnsureString` coerced non-string arguments with `Convert.ToString(object, IFormatProvider)`, which returns `""` for null — so `LEN(NullableIntColumn)` returned `0` instead of NULL. It now routes through `ToStringCore`, which maps `null`/`DBNull` to `null`.

## Why a conditional instead of a `…Core` helper

The readme documents EF Core as a supported `MaterializeAsync` and states that `UPPER` maps to `string.ToUpperInvariant` (replaceable with a provider-specific mapping). Routing these through private static helpers would have made them untranslatable by a real `IQueryable` provider, so the fix keeps the .NET member in the tree and only adds the null guard. It also matches the null-propagation idiom already used by `TdsQueryEngineExecutor.BuildColumnAccess`.

## Tests

Five new cases in `TdsQueryEngineTests`, all over the `nullable_customers` root (which has a null-`Name` row). Each asserts the NULL row comes back as NULL **and** that the other rows still return values:

- case/length functions (`UPPER`, `LOWER`, `LEN`)
- trim functions (`LTRIM`, `RTRIM`, `TRIM`)
- `LEFT` / `RIGHT` / `REPLACE`
- a `WHERE` predicate over a nullable column (`UPPER(Name) = 'BOB' OR LEN(Name) = 5`), confirming the NULL row is excluded rather than throwing
- a nullable non-string column, for the `EnsureString` path (an `int? Score` was added to the fixture record for it)

## Notes for the reviewer

Five existing `expectedMaterializedQueries` strings changed shape and were updated — the `IIF(...)` guard for `UPPER`/`LEN`/`REPLACE`, and `LeftCore`/`RightCore` in place of `SubstringCore`. No behavior change in those tests, only the printed expression tree.

`LEN` returning `int?` also shows up as `Convert(..., Nullable\`1)` in comparisons; the executor's existing comparison machinery already handles nullable operands with SQL semantics, so `WHERE LEN(Name) = 3` still filters correctly.

## Verification

- `dotnet test` on `Meziantou.Framework.TdsServer.Tests` with `/p:TreatsWarningsAsErrors=true`: 478 passed, 0 failed, 0 skipped (both TFMs).
- Release + `IsOfficialBuild=true` builds of the source and test projects: 0 warnings, 0 errors.
- `dotnet run ./eng/update-all.cs`: no changes. No `ref/` changes — `SqlFunctions` is internal.


## Second commit: a CI change, and why it is here

`61ca831f7` touches `.github/workflows/ci.yml`. It is not part of the library fix — it unblocks this PR.

The invariant globalization jobs skip every test in `Meziantou.Framework.TdsServer.Tests` (both classes are `[RunIf(NotInvariant)]`, because `Microsoft.Data.SqlClient` and the SQL parser need ICU). The delta build for a TdsServer-only PR selects nothing else, so the run executes zero tests and the test platform returns exit code 8 for the run — even though both test applications individually reported `passed [+0/x0/?239]`.

The project already declares that outcome as expected with `MinimumExpectedTests=0`, but per `Meziantou.NET.Sdk.Test` that only omits `--minimum-expected-tests` for each test application; it does not cover the run-level check. The step now treats exit code 8 **alone** as success and keeps every other code failing.

This is pre-existing, not a regression from this PR: the `RunIf` gate came in with the query engine, and this PR only added tests to an assembly that was already fully skipped on that leg (476 skipped before, 478 after). Reproduced locally with `dotnet test <TdsServer.Tests> /p:InvariantGlobalization=true`. I also confirmed the gate is genuinely required — removing it and running invariant makes every test in the class fail — so there is no way to make this assembly contribute a runnable test on that leg.
