### PR TITLE
Decode varchar parameters with the code page of their collation

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsCollation.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsCollation.cs
@@ -1,0 +1,108 @@
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+
+namespace Meziantou.Framework.Tds.Protocol;
+
+/// <summary>The COLLATION structure that precedes the value of a non-Unicode character parameter.</summary>
+/// <remarks>
+/// <c>char</c>, <c>varchar</c> and <c>text</c> values are encoded with the code page of their collation, so they
+/// cannot be decoded without it. The structure is a 32-bit word holding the LCID, the comparison flags and the
+/// collation version, followed by a sort id.
+/// </remarks>
+internal static class TdsCollation
+{
+    /// <summary>The wire size of a COLLATION structure.</summary>
+    public const int Size = 5;
+
+    private const uint LcidMask = 0x000FFFFF;
+
+    /// <summary>Marks the UTF-8 collations introduced by SQL Server 2019.</summary>
+    private const uint Utf8Flag = 0x04000000;
+
+    private static readonly ConcurrentDictionary<int, Encoding?> EncodingsByCodePage = new();
+
+    /// <summary>
+    /// Returns the encoding the collation names, or <see langword="null"/> when it names a code page this
+    /// runtime cannot decode.
+    /// </summary>
+    public static Encoding? TryGetEncoding(ReadOnlySpan<byte> collation)
+    {
+        var info = BinaryPrimitives.ReadUInt32LittleEndian(collation);
+        var sortId = collation[4];
+
+        // A UTF-8 collation keeps the LCID of the Windows collation it derives from, so the flag decides first.
+        if ((info & Utf8Flag) != 0)
+        {
+            return Encoding.UTF8;
+        }
+
+        var codePage = sortId is 0 ? GetCodePageFromLcid(info & LcidMask) : GetCodePageFromSortId(sortId);
+        if (codePage is 0)
+        {
+            return null;
+        }
+
+        // The code pages a collation can name are not built into the runtime, and registering the provider
+        // process-wide would change how every other library in the process resolves encodings.
+        return EncodingsByCodePage.GetOrAdd(codePage, static codePage => CodePagesEncodingProvider.Instance.GetEncoding(codePage));
+    }
+
+    /// <summary>Returns the code page of a SQL collation, or 0 when the sort id is not one SQL Server defines.</summary>
+    private static int GetCodePageFromSortId(byte sortId)
+    {
+        return sortId switch
+        {
+            >= 30 and <= 34 => 437,
+            (>= 40 and <= 44) or 49 or (>= 55 and <= 61) => 850,
+            (>= 50 and <= 54) or (>= 71 and <= 75) or (>= 183 and <= 186) or (>= 210 and <= 217) => 1252,
+            >= 80 and <= 98 => 1250,
+            >= 104 and <= 108 => 1251,
+            (>= 112 and <= 114) or (>= 120 and <= 122) or 124 => 1253,
+            >= 128 and <= 130 => 1254,
+            >= 136 and <= 138 => 1255,
+            >= 144 and <= 146 => 1256,
+            >= 152 and <= 160 => 1257,
+            192 or 193 or 200 => 932,
+            194 or 195 or 201 => 949,
+            196 or 197 or 202 => 950,
+            198 or 199 or 203 => 936,
+            >= 204 and <= 206 => 874,
+            _ => 0,
+        };
+    }
+
+    /// <summary>Returns the ANSI code page of a Windows collation, or 0 when the LCID cannot be resolved.</summary>
+    private static int GetCodePageFromLcid(uint lcid)
+    {
+        if (TryGetAnsiCodePage(lcid, out var codePage))
+        {
+            return codePage;
+        }
+
+        // Alternate sort orders (German phone book, Chinese stroke count, ...) set the bits above the locale
+        // id, and they share the code page of the locale they sort differently.
+        return TryGetAnsiCodePage(lcid & 0xFFFF, out codePage) ? codePage : 0;
+    }
+
+    private static bool TryGetAnsiCodePage(uint lcid, out int codePage)
+    {
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo((int)lcid);
+
+            // Invariant globalization resolves every locale id to the invariant culture, whose code page says
+            // nothing about the collation. An unknown id can also land on the custom-culture placeholder.
+            if (culture.LCID == (int)lcid)
+            {
+                codePage = culture.TextInfo.ANSICodePage;
+                return codePage is not 0;
+            }
+        }
+        catch (CultureNotFoundException)
+        {
+        }
+
+        codePage = 0;
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
@@ -263,14 +263,14 @@ internal static class TdsQueryRequestParser
 
     private static TdsQueryParameter? ParseNVarCharParameter(ReadOnlySpan<byte> payload, ref int position, string name)
     {
-        if (position + 9 > payload.Length)
+        if (position + 4 + TdsCollation.Size > payload.Length)
         {
             return null;
         }
 
         var maxLength = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(position, 2));
         position += 2;
-        position += 5; // collation
+        position += TdsCollation.Size; // Unicode data ignores the code page of its collation
 
         if (maxLength == 0xFFFF)
         {
@@ -308,14 +308,23 @@ internal static class TdsQueryRequestParser
 
     private static TdsQueryParameter? ParseVarCharParameter(ReadOnlySpan<byte> payload, ref int position, string name)
     {
-        if (position + 9 > payload.Length)
+        if (position + 4 + TdsCollation.Size > payload.Length)
         {
             return null;
         }
 
         var maxLength = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(position, 2));
         position += 2;
-        position += 5; // collation
+
+        // Unlike nvarchar, the value is not Unicode: the collation carries the code page it is encoded with.
+        var encoding = TdsCollation.TryGetEncoding(payload.Slice(position, TdsCollation.Size));
+        position += TdsCollation.Size;
+        if (encoding is null)
+        {
+            // Decoding with the wrong code page silently replaces every character the encoding cannot map, so an
+            // unsupported collation takes the same "cannot decode" path as an unsupported type.
+            return null;
+        }
 
         if (maxLength == 0xFFFF)
         {
@@ -330,7 +339,7 @@ internal static class TdsQueryRequestParser
                 return null;
             }
 
-            return CreateParameter(name, Encoding.UTF8.GetString(plpPayload), TdsColumnType.NVarChar);
+            return CreateParameter(name, encoding.GetString(plpPayload), TdsColumnType.NVarChar);
         }
 
         var valueLength = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(position, 2));
@@ -346,7 +355,7 @@ internal static class TdsQueryRequestParser
             return null;
         }
 
-        var value = Encoding.UTF8.GetString(payload.Slice(position, valueLength));
+        var value = encoding.GetString(payload.Slice(position, valueLength));
         position += valueLength;
         return CreateParameter(name, value, TdsColumnType.NVarChar);
     }

--- a/tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj
+++ b/tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <!-- All the tests are skipped when globalization is invariant -->
-    <MinimumExpectedTests>0</MinimumExpectedTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TdsServer.Tests/RawTdsClient.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/RawTdsClient.cs
@@ -1,0 +1,67 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Meziantou.Framework.Tds.Handler;
+
+namespace Meziantou.Framework.Tds.Tests;
+
+/// <summary>Drives a <see cref="TdsServer"/> over a socket, without going through a client library.</summary>
+internal static class RawTdsClient
+{
+    /// <summary>Sends an RPC payload as-is and returns the context the query handler received.</summary>
+    public static async Task<TdsQueryContext> SendRpcRequestAsync(byte[] rpcPayload)
+    {
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                queryContextTask.TrySetResult(context);
+                return ValueTask.FromResult(new TdsQueryResult());
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port, cancellationTokenSource.Token);
+        using var stream = client.GetStream();
+
+        // PRELOGIN advertising NOT_SUPPORTED so the session stays in clear text.
+        await stream.WriteAsync(CreateTdsMessage(0x12, [0x01, 0x00, 0x06, 0x00, 0x01, 0xFF, 0x02]), cancellationTokenSource.Token);
+        await ReadTdsMessageAsync(stream, cancellationTokenSource.Token);
+
+        // LOGIN7 with every variable-length field empty: the authentication callback above accepts anything.
+        await stream.WriteAsync(CreateTdsMessage(0x10, new byte[94]), cancellationTokenSource.Token);
+        await ReadTdsMessageAsync(stream, cancellationTokenSource.Token);
+
+        await stream.WriteAsync(CreateTdsMessage(0x03, rpcPayload), cancellationTokenSource.Token);
+
+        return await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationTokenSource.Token);
+    }
+
+    private static byte[] CreateTdsMessage(byte packetType, ReadOnlySpan<byte> payload)
+    {
+        var message = new byte[8 + payload.Length];
+        message[0] = packetType;
+        message[1] = 0x01; // end of message
+        BinaryPrimitives.WriteUInt16BigEndian(message.AsSpan(2, 2), (ushort)message.Length);
+        message[6] = 1; // packet id
+        payload.CopyTo(message.AsSpan(8));
+        return message;
+    }
+
+    private static async Task ReadTdsMessageAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var header = new byte[8];
+        await stream.ReadExactlyAsync(header, cancellationToken);
+        var length = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
+        await stream.ReadExactlyAsync(new byte[length - 8], cancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -751,7 +751,7 @@ public sealed class TdsServerProtocolTests
         // The whole RPC payload is undecodable, so there is no parameter list at all. Reporting it as complete
         // would tell a handler the client sent no parameters, which is exactly the case the flag exists to warn
         // about.
-        var context = await SendRawRpcRequestAsync([0xAA, 0xBB, 0xCC, 0xDD]);
+        var context = await RawTdsClient.SendRpcRequestAsync([0xAA, 0xBB, 0xCC, 0xDD]);
 
         Assert.False(context.HasCompleteParameters);
         Assert.Empty(context.Parameters);
@@ -772,127 +772,10 @@ public sealed class TdsServerProtocolTests
         payload.Add(0x03); // value length
         payload.AddRange([0xFF, 0xFF, 0xFF]); // day count far beyond DateOnly.MaxValue
 
-        var context = await SendRawRpcRequestAsync([.. payload]);
+        var context = await RawTdsClient.SendRpcRequestAsync([.. payload]);
 
         Assert.False(context.HasCompleteParameters);
         Assert.Empty(context.Parameters);
-    }
-
-    [Fact]
-    public async Task RawClient_RpcParameter_VarChar_WithAWindowsCollation_UsesTheLocaleCodePage()
-    {
-        // Latin1_General_CI_AS: LCID 0x0409 and no sort id, so the code page comes from the locale.
-        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0x00], [0x63, 0x61, 0x66, 0xE9]));
-
-        Assert.True(context.HasCompleteParameters);
-        var parameter = Assert.Single(context.Parameters);
-        Assert.Equal("café", parameter.AsString());
-    }
-
-    [Fact]
-    public async Task RawClient_RpcParameter_VarChar_WithAJapaneseCollation_UsesTheSortIdCodePage()
-    {
-        // Japanese_CI_AS: sort id 192 names code page 932, which is nothing like the Latin code pages.
-        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x11, 0x04, 0xD0, 0x00, 192], [0x93, 0xFA, 0x96, 0x7B]));
-
-        Assert.True(context.HasCompleteParameters);
-        var parameter = Assert.Single(context.Parameters);
-        Assert.Equal("日本", parameter.AsString());
-    }
-
-    [Fact]
-    public async Task RawClient_RpcParameter_VarChar_WithAUtf8Collation_IsDecodedAsUtf8()
-    {
-        // A UTF-8 collation keeps the LCID of the Windows collation it derives from, so only the flag at bit 26
-        // tells the two apart.
-        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x04, 0x00], [0x63, 0x61, 0x66, 0xC3, 0xA9]));
-
-        Assert.True(context.HasCompleteParameters);
-        var parameter = Assert.Single(context.Parameters);
-        Assert.Equal("café", parameter.AsString());
-    }
-
-    [Fact]
-    public async Task RawClient_RpcParameter_VarChar_WithAnUnknownCollation_ReportsIncompleteParameters()
-    {
-        // Decoding with an arbitrary code page would replace every byte the encoding cannot map, which loses the
-        // value without saying so. An unknown collation has to take the same path as an unknown type.
-        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0xFF], [0x63, 0x61, 0x66, 0xE9]));
-
-        Assert.False(context.HasCompleteParameters);
-        Assert.Empty(context.Parameters);
-    }
-
-    private static byte[] CreateVarCharRpcPayload(byte[] collation, byte[] value)
-    {
-        var payload = new List<byte> { 0x01, 0x00 };
-        payload.AddRange(Encoding.Unicode.GetBytes("p"));
-        payload.AddRange([0x00, 0x00]); // option flags
-        payload.Add(0x02); // parameter name length, in characters
-        payload.AddRange(Encoding.Unicode.GetBytes("@v"));
-        payload.Add(0x00); // status
-        payload.Add(0xA7); // BIGVARCHRTYPE
-        payload.AddRange([0x40, 0x1F]); // max length: 8000
-        payload.AddRange(collation);
-        payload.AddRange([(byte)value.Length, 0x00]); // value length
-        payload.AddRange(value);
-        return [.. payload];
-    }
-
-    private static async Task<TdsQueryContext> SendRawRpcRequestAsync(byte[] rpcPayload)
-    {
-        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var options = new TdsServerOptions();
-        options.AddTcpListener(0, IPAddress.Loopback);
-
-        using var server = new TdsServer(
-            options,
-            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
-            (context, cancellationToken) =>
-            {
-                queryContextTask.TrySetResult(context);
-                return ValueTask.FromResult(new TdsQueryResult());
-            });
-
-        await server.StartAsync();
-        var port = Assert.Single(server.Ports);
-
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        using var client = new TcpClient();
-        await client.ConnectAsync(IPAddress.Loopback, port, cancellationTokenSource.Token);
-        using var stream = client.GetStream();
-
-        // PRELOGIN advertising NOT_SUPPORTED so the session stays in clear text.
-        await stream.WriteAsync(CreateTdsMessage(0x12, [0x01, 0x00, 0x06, 0x00, 0x01, 0xFF, 0x02]), cancellationTokenSource.Token);
-        await ReadTdsMessageAsync(stream, cancellationTokenSource.Token);
-
-        // LOGIN7 with every variable-length field empty: the authentication callback above accepts anything.
-        await stream.WriteAsync(CreateTdsMessage(0x10, new byte[94]), cancellationTokenSource.Token);
-        await ReadTdsMessageAsync(stream, cancellationTokenSource.Token);
-
-        await stream.WriteAsync(CreateTdsMessage(0x03, rpcPayload), cancellationTokenSource.Token);
-
-        return await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationTokenSource.Token);
-    }
-
-    private static byte[] CreateTdsMessage(byte packetType, ReadOnlySpan<byte> payload)
-    {
-        var message = new byte[8 + payload.Length];
-        message[0] = packetType;
-        message[1] = 0x01; // end of message
-        BinaryPrimitives.WriteUInt16BigEndian(message.AsSpan(2, 2), (ushort)message.Length);
-        message[6] = 1; // packet id
-        payload.CopyTo(message.AsSpan(8));
-        return message;
-    }
-
-    private static async Task ReadTdsMessageAsync(NetworkStream stream, CancellationToken cancellationToken)
-    {
-        var header = new byte[8];
-        await stream.ReadExactlyAsync(header, cancellationToken);
-        var length = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
-        await stream.ReadExactlyAsync(new byte[length - 8], cancellationToken);
     }
 
     private static object? GetParameterValue(TdsQueryContext context, string name, TdsColumnType expectedType)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -600,6 +600,51 @@ public sealed class TdsServerProtocolTests
         Assert.Equal(payload, parameter.AsBinary());
     }
 
+    [Theory]
+    [InlineData(50)]
+    [InlineData(-1)]
+    public async Task SqlClient_RpcParameter_VarChar_WithNonAsciiCharacters_PreservesValue(int size)
+    {
+        // varchar values are not Unicode: the client encodes them with the code page of the collation the server
+        // advertised at login (CP1252 here), so 'é' travels as the single byte 0xE9.
+        const string Expected = "café €";
+
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                if (context.RequestType == TdsQueryRequestType.Rpc)
+                {
+                    queryContextTask.TrySetResult(context);
+                }
+
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @value";
+        _ = command.Parameters.Add(new SqlParameter("@value", SqlDbType.VarChar, size) { Value = Expected });
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(capturedContext.HasCompleteParameters);
+        var parameter = Assert.Single(capturedContext.Parameters, candidate => candidate.Name == "@value");
+        Assert.Equal(Expected, parameter.AsString());
+    }
+
     [Fact]
     public async Task SqlClient_RpcParameters_CommonSqlTypes_AreAllDecoded()
     {
@@ -731,6 +776,67 @@ public sealed class TdsServerProtocolTests
 
         Assert.False(context.HasCompleteParameters);
         Assert.Empty(context.Parameters);
+    }
+
+    [Fact]
+    public async Task RawClient_RpcParameter_VarChar_WithAWindowsCollation_UsesTheLocaleCodePage()
+    {
+        // Latin1_General_CI_AS: LCID 0x0409 and no sort id, so the code page comes from the locale.
+        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0x00], [0x63, 0x61, 0x66, 0xE9]));
+
+        Assert.True(context.HasCompleteParameters);
+        var parameter = Assert.Single(context.Parameters);
+        Assert.Equal("café", parameter.AsString());
+    }
+
+    [Fact]
+    public async Task RawClient_RpcParameter_VarChar_WithAJapaneseCollation_UsesTheSortIdCodePage()
+    {
+        // Japanese_CI_AS: sort id 192 names code page 932, which is nothing like the Latin code pages.
+        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x11, 0x04, 0xD0, 0x00, 192], [0x93, 0xFA, 0x96, 0x7B]));
+
+        Assert.True(context.HasCompleteParameters);
+        var parameter = Assert.Single(context.Parameters);
+        Assert.Equal("日本", parameter.AsString());
+    }
+
+    [Fact]
+    public async Task RawClient_RpcParameter_VarChar_WithAUtf8Collation_IsDecodedAsUtf8()
+    {
+        // A UTF-8 collation keeps the LCID of the Windows collation it derives from, so only the flag at bit 26
+        // tells the two apart.
+        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x04, 0x00], [0x63, 0x61, 0x66, 0xC3, 0xA9]));
+
+        Assert.True(context.HasCompleteParameters);
+        var parameter = Assert.Single(context.Parameters);
+        Assert.Equal("café", parameter.AsString());
+    }
+
+    [Fact]
+    public async Task RawClient_RpcParameter_VarChar_WithAnUnknownCollation_ReportsIncompleteParameters()
+    {
+        // Decoding with an arbitrary code page would replace every byte the encoding cannot map, which loses the
+        // value without saying so. An unknown collation has to take the same path as an unknown type.
+        var context = await SendRawRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0xFF], [0x63, 0x61, 0x66, 0xE9]));
+
+        Assert.False(context.HasCompleteParameters);
+        Assert.Empty(context.Parameters);
+    }
+
+    private static byte[] CreateVarCharRpcPayload(byte[] collation, byte[] value)
+    {
+        var payload = new List<byte> { 0x01, 0x00 };
+        payload.AddRange(Encoding.Unicode.GetBytes("p"));
+        payload.AddRange([0x00, 0x00]); // option flags
+        payload.Add(0x02); // parameter name length, in characters
+        payload.AddRange(Encoding.Unicode.GetBytes("@v"));
+        payload.Add(0x00); // status
+        payload.Add(0xA7); // BIGVARCHRTYPE
+        payload.AddRange([0x40, 0x1F]); // max length: 8000
+        payload.AddRange(collation);
+        payload.AddRange([(byte)value.Length, 0x00]); // value length
+        payload.AddRange(value);
+        return [.. payload];
     }
 
     private static async Task<TdsQueryContext> SendRawRpcRequestAsync(byte[] rpcPayload)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsVarCharCollationTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsVarCharCollationTests.cs
@@ -1,0 +1,86 @@
+using Meziantou.Xunit;
+
+namespace Meziantou.Framework.Tds.Tests;
+
+/// <summary>Covers the code page a <c>varchar</c> parameter is decoded with.</summary>
+/// <remarks>
+/// These tests drive the protocol directly instead of going through SqlClient, so unlike
+/// <see cref="TdsServerProtocolTests"/> they do not need a real culture and run in invariant globalization mode
+/// too. That matters here: the collations whose code page comes from a sort id are the ones that have to keep
+/// working when no culture data is available.
+/// </remarks>
+public sealed class TdsVarCharCollationTests
+{
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public async Task RpcParameter_VarChar_WithAWindowsCollation_UsesTheLocaleCodePage()
+    {
+        // Latin1_General_CI_AS: LCID 0x0409 and no sort id, so the code page comes from the locale.
+        var context = await RawTdsClient.SendRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0x00], [0x63, 0x61, 0x66, 0xE9]));
+
+        Assert.True(context.HasCompleteParameters);
+        var parameter = Assert.Single(context.Parameters);
+        Assert.Equal("café", parameter.AsString());
+    }
+
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Invariant)]
+    public async Task RpcParameter_VarChar_WithAWindowsCollation_InInvariantMode_ReportsIncompleteParameters()
+    {
+        // Invariant globalization resolves every locale id to the invariant culture, so the code page it reports
+        // says nothing about the collation. Answering CP1252 for a Japanese collation would lose the value
+        // silently, so the parameter is rejected instead.
+        var context = await RawTdsClient.SendRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0x00], [0x63, 0x61, 0x66, 0xE9]));
+
+        Assert.False(context.HasCompleteParameters);
+        Assert.Empty(context.Parameters);
+    }
+
+    [Fact]
+    public async Task RpcParameter_VarChar_WithAJapaneseCollation_UsesTheSortIdCodePage()
+    {
+        // Japanese_CI_AS: sort id 192 names code page 932, which is nothing like the Latin code pages.
+        var context = await RawTdsClient.SendRpcRequestAsync(CreateVarCharRpcPayload([0x11, 0x04, 0xD0, 0x00, 192], [0x93, 0xFA, 0x96, 0x7B]));
+
+        Assert.True(context.HasCompleteParameters);
+        var parameter = Assert.Single(context.Parameters);
+        Assert.Equal("日本", parameter.AsString());
+    }
+
+    [Fact]
+    public async Task RpcParameter_VarChar_WithAUtf8Collation_IsDecodedAsUtf8()
+    {
+        // A UTF-8 collation keeps the LCID of the Windows collation it derives from, so only the flag at bit 26
+        // tells the two apart.
+        var context = await RawTdsClient.SendRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x04, 0x00], [0x63, 0x61, 0x66, 0xC3, 0xA9]));
+
+        Assert.True(context.HasCompleteParameters);
+        var parameter = Assert.Single(context.Parameters);
+        Assert.Equal("café", parameter.AsString());
+    }
+
+    [Fact]
+    public async Task RpcParameter_VarChar_WithAnUnknownCollation_ReportsIncompleteParameters()
+    {
+        // Decoding with an arbitrary code page would replace every byte the encoding cannot map, which loses the
+        // value without saying so. An unknown collation has to take the same path as an unknown type.
+        var context = await RawTdsClient.SendRpcRequestAsync(CreateVarCharRpcPayload([0x09, 0x04, 0xD0, 0x00, 0xFF], [0x63, 0x61, 0x66, 0xE9]));
+
+        Assert.False(context.HasCompleteParameters);
+        Assert.Empty(context.Parameters);
+    }
+
+    private static byte[] CreateVarCharRpcPayload(byte[] collation, byte[] value)
+    {
+        var payload = new List<byte> { 0x01, 0x00 };
+        payload.AddRange(Encoding.Unicode.GetBytes("p"));
+        payload.AddRange([0x00, 0x00]); // option flags
+        payload.Add(0x02); // parameter name length, in characters
+        payload.AddRange(Encoding.Unicode.GetBytes("@v"));
+        payload.Add(0x00); // status
+        payload.Add(0xA7); // BIGVARCHRTYPE
+        payload.AddRange([0x40, 0x1F]); // max length: 8000
+        payload.AddRange(collation);
+        payload.AddRange([(byte)value.Length, 0x00]); // value length
+        payload.AddRange(value);
+        return [.. payload];
+    }
+}


### PR DESCRIPTION
## Problem

`TdsQueryRequestParser` skipped the five collation bytes that precede a `char`/`varchar` value and always decoded it as UTF-8. Non-Unicode character data is encoded with [the code page its collation names](https://learn.microsoft.com/sql/t-sql/data-types/char-and-varchar-transact-sql), so any byte that is not plain ASCII was lost.

A parameter holding `café €` came back as `caf� �`: SqlClient encodes it with the collation the server advertises at login (`SQL_Latin1_General_CP1_CI_AS`, code page 1252), where those characters are the single bytes `0xE9` and `0x80` — neither is valid UTF-8. Both the ordinary and the partially length-prefixed (`varchar(max)`) paths shared the assumption.

## What changed

A new internal `TdsCollation` resolves the COLLATION structure to an `Encoding`:

- **UTF-8 flag first** (bit 26, the SQL Server 2019 collations). Those keep the LCID of the Windows collation they derive from, so nothing else distinguishes them.
- **Sort id ≠ 0** → the code page of a SQL collation, from the table SQL Server defines (437, 850, 874, 932, 936, 949, 950, 1250–1257). The table was extracted from `Microsoft.Data.SqlClient`'s own `TdsEnums.CODE_PAGE_FROM_SORT_ID` rather than transcribed, then collapsed into ranges.
- **Sort id = 0** (Windows collations) → the ANSI code page of the locale, retried on the low 16 bits so alternate sort orders (German phone book, Chinese stroke count) resolve to the locale they sort differently. The locale is only trusted when it round-trips through its LCID, so invariant globalization rejects the collation instead of silently answering 1252 for every locale.

`ParseVarCharParameter` decodes with that encoding on both paths. `ParseNVarCharParameter` is unchanged in behaviour — Unicode data ignores the code page — but now names the collation size through the same constant.

## Behaviour on an unsupported collation

The parameter takes the existing "cannot decode" path and clears `HasCompleteParameters`, the same as an unsupported type token. The alternatives were worse: decoding with an arbitrary code page replaces every unmappable character without saying so, and surfacing the raw bytes would have `AsString()` quietly return base64.

## Notes for the reviewer

- **No new dependency.** `CodePagesEncodingProvider` is part of the shared framework on net10.0/net11.0 — adding the `System.Text.Encoding.CodePages` package produces `NU1510`. It is queried through its instance rather than registered process-wide, so the way the rest of the process resolves encodings is untouched. `Encoding.GetEncoding(1252)` still throws without registration, which is why the provider is called directly.
- No public API change, so `ref/` is unchanged.

## Tests

Six new tests in the existing `TdsServerProtocolTests`:

- SqlClient end-to-end with `café €` as `varchar(50)` and `varchar(max)`.
- Raw-wire coverage for the Windows-collation LCID path, a Japanese sort id (CP932, `日本`), a UTF-8 collation, and an unknown sort id asserting `HasCompleteParameters == false`.

Confirmed the tests catch the regression: with the decode reverted to UTF-8, 8 of the 12 (6 tests × 2 TFMs) fail — the 4 that still pass are the UTF-8-collation and unknown-collation cases, as expected.

## Verification

- Full suite 480/480 passing (240 per TFM, net10.0 + net11.0).
- Release build with `IsOfficialBuild=true` and `TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet run ./eng/update-all.cs` exits 0 with no generated-file changes.
