### PR TITLE
Fix correctness issues found reviewing Meziantou.Framework.Yaml

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -7,6 +7,7 @@
     <Project Path="benchmarks/GlobbingBenchmarks/GlobbingBenchmarks.csproj" />
     <Project Path="benchmarks/SnapshotTestingBenchmarks/SnapshotTestingBenchmarks.csproj" />
     <Project Path="benchmarks/ThreadingBenchmarks/ThreadingBenchmarks.csproj" />
+    <Project Path="benchmarks/YamlBenchmarks/YamlBenchmarks.csproj" />
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/BlazorAppSample/BlazorAppSample.csproj" />

--- a/benchmarks/YamlBenchmarks/Program.cs
+++ b/benchmarks/YamlBenchmarks/Program.cs
@@ -1,0 +1,4 @@
+using BenchmarkDotNet.Running;
+using YamlBenchmarks;
+
+BenchmarkSwitcher.FromAssembly(typeof(RepeatedSerializationBenchmark).Assembly).Run(args);

--- a/benchmarks/YamlBenchmarks/RepeatedSerializationBenchmark.cs
+++ b/benchmarks/YamlBenchmarks/RepeatedSerializationBenchmark.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.Yaml;
+
+namespace YamlBenchmarks;
+
+/// <summary>
+/// Measures repeated calls with the same options instance. The reflection contract of a type is built once per
+/// options instance, so the second and later calls must not pay for rebuilding it.
+/// </summary>
+[MemoryDiagnoser]
+public class RepeatedSerializationBenchmark
+{
+    private static readonly YamlSerializerOptions Options = new();
+
+    private readonly Payload _payload = new() { Name = "name", Count = 42, Enabled = true };
+    private readonly string _yaml = "Name: name\nCount: 42\nEnabled: true\n";
+
+    [Params(1, 100)]
+    public int Iterations { get; set; }
+
+    [Benchmark]
+    public string Serialize()
+    {
+        var result = string.Empty;
+        for (var i = 0; i < Iterations; i++)
+        {
+            result = YamlSerializer.Serialize(_payload, Options);
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public Payload? Deserialize()
+    {
+        Payload? result = null;
+        for (var i = 0; i < Iterations; i++)
+        {
+            result = YamlSerializer.Deserialize<Payload>(_yaml, Options);
+        }
+
+        return result;
+    }
+
+    public sealed class Payload
+    {
+        public string? Name { get; set; }
+
+        public int Count { get; set; }
+
+        public bool Enabled { get; set; }
+    }
+}

--- a/benchmarks/YamlBenchmarks/YamlBenchmarks.csproj
+++ b/benchmarks/YamlBenchmarks/YamlBenchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Meziantou.NET.Sdk">
+
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+   </PropertyGroup>
+
+   <ItemGroup>
+     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+   </ItemGroup>
+
+   <ItemGroup>
+     <ProjectReference Include="../../src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj" />
+   </ItemGroup>
+
+</Project>

--- a/src/Meziantou.Framework.Yaml/CharacterAnalyzer.cs
+++ b/src/Meziantou.Framework.Yaml/CharacterAnalyzer.cs
@@ -5,6 +5,35 @@ namespace Meziantou.Framework.Yaml;
 internal static class CharacterAnalyzer
 {
     /// <summary>
+    /// Check if the character at the specified position can appear in an anchor name.
+    /// </summary>
+    /// <remarks>
+    /// An anchor name is <c>ns-anchor-char+</c>, which is any non-space printable character other than a flow
+    /// indicator, so names such as <c>a.b</c> are valid.
+    /// </remarks>
+    public static bool IsAnchorChar(this ILookAheadBuffer buffer, int offset)
+    {
+        char character = buffer.Peek(offset);
+        if (character is ',' or '[' or ']' or '{' or '}' or '\uFEFF')
+        {
+            return false;
+        }
+
+        // ns-char excludes whitespace, line breaks, and every non-printable character.
+        if (character <= ' ' || (character >= '\x7F' && character <= '\x9F'))
+        {
+            return false;
+        }
+
+        return Emitter.IsPrintable(character);
+    }
+
+    public static bool IsAnchorChar(this ILookAheadBuffer buffer)
+    {
+        return IsAnchorChar(buffer, 0);
+    }
+
+    /// <summary>
     /// Check if the character at the specified position is an alphabetical
     /// character, a digit, '_', or '-'.
     /// </summary>
@@ -142,9 +171,13 @@ internal static class CharacterAnalyzer
     }
 
     /// <summary>Check if the character at the specified position is a line break.</summary>
+    /// <remarks>
+    /// YAML 1.1 also treated NEL (U+0085), LS (U+2028), and PS (U+2029) as line breaks. YAML 1.2 excludes them for
+    /// JSON compatibility and reads them as ordinary content, so folding them here would corrupt scalar values.
+    /// </remarks>
     public static bool IsBreak(this ILookAheadBuffer buffer, int offset)
     {
-        return Check(buffer, "\r\n\x85\x2028\x2029", offset);
+        return Check(buffer, "\r\n", offset);
     }
 
     public static bool IsBreak(this ILookAheadBuffer buffer)

--- a/src/Meziantou.Framework.Yaml/Emitter.cs
+++ b/src/Meziantou.Framework.Yaml/Emitter.cs
@@ -1011,9 +1011,13 @@ public partial class Emitter : IEmitter
         }
     }
 
+    /// <remarks>
+    /// NEL (U+0085), LS (U+2028), and PS (U+2029) were line breaks in YAML 1.1 only. Writing one of them as a line
+    /// break would lose it, because a YAML 1.2 reader treats it as ordinary content.
+    /// </remarks>
     private static bool IsBreak(char character)
     {
-        return character == '\r' || character == '\n' || character == '\x85' || character == '\x2028' || character == '\x2029';
+        return character == '\r' || character == '\n';
     }
 
     private static bool IsBlank(char character)

--- a/src/Meziantou.Framework.Yaml/Events/AnchorAlias.cs
+++ b/src/Meziantou.Framework.Yaml/Events/AnchorAlias.cs
@@ -32,7 +32,7 @@ public class AnchorAlias : ParsingEvent
 
         if (!NodeEvent.AnchorValidator.IsMatch(value))
         {
-            throw new YamlException(start, end, "Anchor value must contain alphanumerical characters only.");
+            throw new YamlException(start, end, "Anchor value must not contain whitespace or a flow indicator.");
         }
 
         Value = value;

--- a/src/Meziantou.Framework.Yaml/Events/NodeEvent.cs
+++ b/src/Meziantou.Framework.Yaml/Events/NodeEvent.cs
@@ -5,7 +5,8 @@ namespace Meziantou.Framework.Yaml.Events;
 /// <summary>Contains the behavior that is common between node events.</summary>
 public abstract partial class NodeEvent : ParsingEvent
 {
-    [GeneratedRegex(@"^[0-9a-zA-Z_\-]+$", RegexOptions.None, matchTimeoutMilliseconds: -1)]
+    /// <summary>Matches <c>ns-anchor-name</c>: one or more printable characters other than whitespace and flow indicators.</summary>
+    [GeneratedRegex(@"^[^\x00-\x20\x7F-\x9F,\[\]{}\uFEFF]+$", RegexOptions.None, matchTimeoutMilliseconds: -1)]
     internal static partial Regex AnchorValidator { get; }
 
     /// <summary>Gets the anchor.</summary>
@@ -39,7 +40,7 @@ public abstract partial class NodeEvent : ParsingEvent
 
             if (!AnchorValidator.IsMatch(anchor))
             {
-                throw new ArgumentException("Anchor value must contain alphanumerical characters only.", nameof(anchor));
+                throw new ArgumentException("Anchor value must not contain whitespace or a flow indicator.", nameof(anchor));
             }
         }
 

--- a/src/Meziantou.Framework.Yaml/Scanner.cs
+++ b/src/Meziantou.Framework.Yaml/Scanner.cs
@@ -78,13 +78,15 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
     private char ReadLine()
     {
-        if (_analyzer.Check("\r\n\x85")) // CR LF -> LF  --- CR|LF|NEL -> LF
+        if (_analyzer.IsBreak())
         {
+            // CR LF -> LF --- CR|LF -> LF
             SkipLine();
             return '\n';
         }
 
-        char nextChar = _analyzer.Peek(0); // LS|PS -> LS|PS
+        // Only reached at the end of the input, where the character is NUL and there is no line to skip.
+        char nextChar = _analyzer.Peek(0);
         SkipLine();
         return nextChar;
     }
@@ -1067,7 +1069,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
         // Consume the value.
 
         var value = new StringBuilder();
-        while (_analyzer.IsAlpha())
+        while (_analyzer.IsAnchorChar())
         {
             value.Append(ReadCurrentCharacter());
         }
@@ -1076,10 +1078,10 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
         // Check if length of the anchor is greater than 0 and it is followed by
         // a whitespace character or one of the indicators:
 
-        //      '?', ':', ',', ']', '}', '%', '@', '`'.
+        //      '?', ':', ',', '[', ']', '{', '}', '%', '@', '`'.
 
 
-        if (value.Length == 0 || !(_analyzer.IsBlankOrBreakOrZero() || _analyzer.Check("?:,]}%@`")))
+        if (value.Length == 0 || !(_analyzer.IsBlankOrBreakOrZero() || _analyzer.Check("?:,[]{}%@`")))
         {
             throw new SyntaxErrorException(start, CurrentPosition, "While scanning an anchor or alias, did not find expected alphabetic or numeric character.");
         }

--- a/src/Meziantou.Framework.Yaml/Schemas/CoreSchema.cs
+++ b/src/Meziantou.Framework.Yaml/Schemas/CoreSchema.cs
@@ -1,5 +1,3 @@
-using Meziantou.Framework.Yaml.Serialization;
-
 namespace Meziantou.Framework.Yaml.Schemas;
 
 /// <summary>Implements the Core schema.</summary>
@@ -22,13 +20,14 @@ public class CoreSchema : JsonSchema
         AddScalarRule("!!bool", @"true|True|TRUE", m => true, null);
         AddScalarRule("!!bool", @"false|False|FALSE", m => false, null);
 
-        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"[-+]?(0|[1-9][0-9_]*)", m => DecodeCoreInteger(m.Value), null);
-        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"[-+]?0x([0-9a-fA-F_]+)", m => DecodeCoreInteger(m.Value), null);
-        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"[-+]?0o([0-7_]+)", m => DecodeCoreInteger(m.Value), null);
-        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"[-+]?0b([01_]+)", m => DecodeCoreInteger(m.Value), null);
+        // 10.2.1.3. Integer. Base 10 accepts leading zeros and a sign; base 8 and base 16 accept neither.
+        // Underscore separators and binary literals are YAML 1.1 spellings, which the extended schema adds back.
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"[-+]?[0-9]+", m => SchemaScalarDecoder.DecodeInteger(m.Value), null);
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"0x[0-9a-fA-F]+", m => SchemaScalarDecoder.DecodeInteger(m.Value), null);
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"0o[0-7]+", m => SchemaScalarDecoder.DecodeInteger(m.Value), null);
 
-        // Make float before tagged integers to keep the common decimal path fast.
-        AddScalarRule("!!float", @"[-+]?(\.[0-9_]+|[0-9][0-9_]*(\.[0-9_]*)?)([eE][-+]?[0-9]+)?", m => Convert.ToDouble(m.Value.Replace("_", "", StringComparison.Ordinal), CultureInfo.InvariantCulture), null);
+        // 10.2.1.4. Floating Point. The integer rules come first so a plain decimal number keeps the !!int tag.
+        AddScalarRule("!!float", @"[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?", m => Convert.ToDouble(m.Value, CultureInfo.InvariantCulture), null);
 
         AddScalarRule("!!float", @"\+?(\.inf|\.Inf|\.INF)", m => double.PositiveInfinity, null);
         AddScalarRule("!!float", @"-(\.inf|\.Inf|\.INF)", m => double.NegativeInfinity, null);
@@ -38,30 +37,5 @@ public class CoreSchema : JsonSchema
 
         // We are not calling the base as we want to completely override scalar rules
         // and in order to have a more concise set of regex
-    }
-
-    private static object DecodeCoreInteger(string text)
-    {
-        if (YamlScalar.TryParseInt64(text.AsSpan(), out var signed))
-        {
-            return signed is >= int.MinValue and <= int.MaxValue ? (object)(int)signed : signed;
-        }
-
-        if (YamlScalar.TryParseUInt64(text.AsSpan(), out var unsigned))
-        {
-            if (unsigned <= int.MaxValue)
-            {
-                return (int)unsigned;
-            }
-
-            if (unsigned <= (ulong)long.MaxValue)
-            {
-                return (long)unsigned;
-            }
-
-            return unsigned;
-        }
-
-        throw new FormatException($"Invalid YAML integer scalar '{text}'.");
     }
 }

--- a/src/Meziantou.Framework.Yaml/Schemas/ExtendedSchema.cs
+++ b/src/Meziantou.Framework.Yaml/Schemas/ExtendedSchema.cs
@@ -44,22 +44,10 @@ public class ExtendedSchema : CoreSchema
     protected override void PrepareScalarRules()
     {
         AddScalarRule<object>("!!null", @"null|Null|NULL|\~|", m => null, null);
-        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"([-+]?(0|[1-9][0-9_]*))", JsonSchema.DecodeInteger, null);
-        AddScalarRule("!!int", @"([-+]?)0b([01_]+)", m =>
-        {
-            var v = Convert.ToInt32(m.Groups[2].Value.Replace("_", "", StringComparison.Ordinal), 2);
-            return m.Groups[1].Value == "-" ? -v : v;
-        }, null);
-        AddScalarRule("!!int", @"([-+]?)0o?([0-7_]+)", m =>
-        {
-            var v = Convert.ToInt32(m.Groups[2].Value.Replace("_", "", StringComparison.Ordinal), 8);
-            return m.Groups[1].Value == "-" ? -v : v;
-        }, null);
-        AddScalarRule("!!int", @"([-+]?)0x([0-9a-fA-F_]+)", m =>
-        {
-            var v = Convert.ToInt32(m.Groups[2].Value.Replace("_", "", StringComparison.Ordinal), 16);
-            return m.Groups[1].Value == "-" ? -v : v;
-        }, null);
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"([-+]?(0|[1-9][0-9_]*))", m => SchemaScalarDecoder.DecodeInteger(m.Value), null);
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"([-+]?)0b([01_]+)", m => SchemaScalarDecoder.DecodeInteger(m.Groups[1].Value, "0b", m.Groups[2].Value), null);
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"([-+]?)0o?([0-7_]+)", m => SchemaScalarDecoder.DecodeInteger(m.Groups[1].Value, "0o", m.Groups[2].Value), null);
+        AddScalarRule(new Type[] { typeof(ulong), typeof(long), typeof(int) }, "!!int", @"([-+]?)0x([0-9a-fA-F_]+)", m => SchemaScalarDecoder.DecodeInteger(m.Groups[1].Value, "0x", m.Groups[2].Value), null);
         // http://yaml.org/type/float.html is wrong  => [0-9.] should be [0-9_]
         AddScalarRule("!!float", @"[-+]?(0|[1-9][0-9_]*)\.[0-9_]*([eE][-+]?[0-9]+)?",
             m => Convert.ToDouble(m.Value.Replace("_", "", StringComparison.Ordinal), CultureInfo.InvariantCulture), null);

--- a/src/Meziantou.Framework.Yaml/Schemas/JsonSchema.cs
+++ b/src/Meziantou.Framework.Yaml/Schemas/JsonSchema.cs
@@ -108,20 +108,13 @@ public class JsonSchema : FailsafeSchema
     }
 
     /// <summary>Decodes a matched integer scalar into an <see cref="int"/>, <see cref="long"/>, or <see cref="ulong"/>.</summary>
+    /// <remarks>
+    /// A scalar too large for any of those types is decoded as a <see cref="double"/>: tag resolution classifies a
+    /// scalar by its spelling, so an unrepresentable value must not fail the surrounding <c>TryParse</c> call.
+    /// </remarks>
     protected static object DecodeInteger(Match m)
     {
-        var valueStr = m.Value.Replace("_", "", StringComparison.Ordinal);
-        // Try plain native int first
-        if (int.TryParse(valueStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
-        {
-            return value;
-        }
-        // Else long
-        if (long.TryParse(valueStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out long result))
-        {
-            return result;
-        }
-        // Else ulong
-        return ulong.Parse(valueStr, CultureInfo.InvariantCulture);
+        ArgumentNullException.ThrowIfNull(m);
+        return SchemaScalarDecoder.DecodeInteger(m.Value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Schemas/SchemaBase.cs
+++ b/src/Meziantou.Framework.Yaml/Schemas/SchemaBase.cs
@@ -140,8 +140,8 @@ public abstract class SchemaBase : IYamlSchema
         defaultTag = null;
         value = null;
 
-        // DoubleQuoted and SingleQuoted string are always decoded
-        if (scalar.Style == ScalarStyle.DoubleQuoted || scalar.Style == ScalarStyle.SingleQuoted)
+        // Implicit tag resolution only applies to plain scalars: an untagged quoted, literal, or folded scalar is a string.
+        if (!IsPlainStyle(scalar.Style))
         {
             defaultTag = StrShortTag;
             if (decodeValue)
@@ -188,9 +188,14 @@ public abstract class SchemaBase : IYamlSchema
 
         value = null;
 
-        // DoubleQuoted and SingleQuoted string are always decoded
-        if (type == typeof(string) && (scalar.Style == ScalarStyle.DoubleQuoted || scalar.Style == ScalarStyle.SingleQuoted))
+        // Implicit tag resolution only applies to plain scalars: an untagged quoted, literal, or folded scalar is a string.
+        if (!IsPlainStyle(scalar.Style))
         {
+            if (type != typeof(string))
+            {
+                return false;
+            }
+
             value = scalar.Value;
             return true;
         }
@@ -232,6 +237,8 @@ public abstract class SchemaBase : IYamlSchema
     protected virtual void PrepareScalarRules()
     {
     }
+
+    private static bool IsPlainStyle(ScalarStyle style) => style is ScalarStyle.Any or ScalarStyle.Plain;
 
     /// <summary>
     /// Add a tag resolution rule that is invoked when <paramref name="regex" /> matches

--- a/src/Meziantou.Framework.Yaml/Schemas/SchemaScalarDecoder.cs
+++ b/src/Meziantou.Framework.Yaml/Schemas/SchemaScalarDecoder.cs
@@ -1,0 +1,42 @@
+using Meziantou.Framework.Yaml.Serialization;
+
+namespace Meziantou.Framework.Yaml.Schemas;
+
+/// <summary>Decodes the scalar spellings shared by the built-in schemas.</summary>
+/// <remarks>
+/// Tag resolution classifies a scalar by its spelling, not by whether a CLR type can hold it, so a decoder must
+/// never throw: the schemas expose their resolution through <c>TryParse</c> methods.
+/// </remarks>
+internal static class SchemaScalarDecoder
+{
+    /// <summary>Decodes an integer scalar into the narrowest CLR type that can represent it.</summary>
+    /// <param name="text">The scalar text, including any sign, base prefix, and underscores.</param>
+    public static object DecodeInteger(string text)
+    {
+        if (YamlScalar.TryParseInt64(text.AsSpan(), out var signed))
+        {
+            return signed is >= int.MinValue and <= int.MaxValue ? (object)(int)signed : signed;
+        }
+
+        if (YamlScalar.TryParseUInt64(text.AsSpan(), out var unsigned))
+        {
+            return unsigned;
+        }
+
+        // No fixed-size integer type can hold the value. A double keeps its magnitude and matches what the
+        // parser used when the schema is disabled returns for the same text.
+        if (YamlScalar.TryParseDouble(text.AsSpan(), out var approximation))
+        {
+            return approximation;
+        }
+
+        return text;
+    }
+
+    /// <summary>Decodes an integer scalar written with an explicit base.</summary>
+    /// <param name="sign">The sign the scalar was written with, which is empty, <c>+</c>, or <c>-</c>.</param>
+    /// <param name="basePrefix">The base prefix to decode the digits with (<c>0b</c>, <c>0o</c>, or <c>0x</c>).</param>
+    /// <param name="digits">The digits, which may contain underscores.</param>
+    public static object DecodeInteger(string sign, string basePrefix, string digits)
+        => DecodeInteger(string.Concat(sign, basePrefix, digits));
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryConverterHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryConverterHelper.cs
@@ -206,7 +206,7 @@ internal static class YamlDictionaryConverterHelper
         var options = reader.Options;
         dictionary ??= createDictionary(options);
         var comparer = options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-        var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+        var mergeEnabled = YamlMergeKey.IsEnabled(options);
         HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(comparer) : null;
         HashSet<string>? seenKeys = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins ? null : new HashSet<string>(comparer);
         if (reader.ReferenceReader is not null && reader.Anchor is not null)
@@ -222,10 +222,11 @@ internal static class YamlDictionaryConverterHelper
                 throw YamlThrowHelper.ThrowExpectedScalarKey(reader);
             }
 
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMerge<TDictionary, TValue>(reader, ref valueConverter, dictionary, explicitKeys, createDictionary, containerKind);
                 continue;
@@ -412,6 +413,10 @@ internal static class YamlDictionaryConverterHelper
         throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge key value must be a mapping or a sequence of mappings.");
     }
 
+    /// <remarks>
+    /// A key an earlier mapping of the merge already provided keeps its value, so the merged key is recorded
+    /// alongside the explicitly declared ones.
+    /// </remarks>
     private static void ApplyMergeDictionary<TValue>(
         IDictionary<string, TValue> target,
         IEnumerable<KeyValuePair<string, TValue>> merged,
@@ -419,7 +424,7 @@ internal static class YamlDictionaryConverterHelper
     {
         foreach (var pair in merged)
         {
-            if (explicitKeys is not null && explicitKeys.Contains(pair.Key))
+            if (explicitKeys is not null && !explicitKeys.Add(pair.Key))
             {
                 continue;
             }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryObjectConverter.cs
@@ -46,7 +46,7 @@ internal sealed class YamlDictionaryObjectConverter : YamlConverter<Dictionary<s
         var options = reader.Options;
         var comparer = options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
         var dict = new Dictionary<string, object?>(comparer);
-        var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+        var mergeEnabled = YamlMergeKey.IsEnabled(options);
         HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(comparer) : null;
         HashSet<string>? seenKeys = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins ? null : new HashSet<string>(comparer);
         if (reader.ReferenceReader is not null && anchor is not null)
@@ -61,10 +61,11 @@ internal sealed class YamlDictionaryObjectConverter : YamlConverter<Dictionary<s
                 throw YamlThrowHelper.ThrowExpectedScalarKey(reader);
             }
 
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMerge(reader, dict, explicitKeys);
                 continue;
@@ -169,11 +170,15 @@ internal sealed class YamlDictionaryObjectConverter : YamlConverter<Dictionary<s
         throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge key value must be a mapping or a sequence of mappings.");
     }
 
+    /// <remarks>
+    /// A key an earlier mapping of the merge already provided keeps its value, so the merged key is recorded
+    /// alongside the explicitly declared ones.
+    /// </remarks>
     private static void ApplyMergeDictionary(Dictionary<string, object?> target, Dictionary<string, object?> merged, HashSet<string>? explicitKeys)
     {
         foreach (var pair in merged)
         {
-            if (explicitKeys is not null && explicitKeys.Contains(pair.Key))
+            if (explicitKeys is not null && !explicitKeys.Add(pair.Key))
             {
                 continue;
             }
@@ -207,7 +212,7 @@ internal sealed class YamlDictionaryObjectConverter : YamlConverter<Dictionary<s
 
         var options = reader.Options;
         var comparer = options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-        var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+        var mergeEnabled = YamlMergeKey.IsEnabled(options);
         HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(comparer) : null;
         HashSet<string>? seenKeys = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins ? null : new HashSet<string>(comparer);
         if (reader.ReferenceReader is not null && reader.Anchor is not null)
@@ -223,10 +228,11 @@ internal sealed class YamlDictionaryObjectConverter : YamlConverter<Dictionary<s
                 throw YamlThrowHelper.ThrowExpectedScalarKey(reader);
             }
 
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMerge(reader, dictionary, explicitKeys);
                 continue;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlMergeKey.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlMergeKey.cs
@@ -1,0 +1,44 @@
+using Meziantou.Framework.Yaml.Schemas;
+
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+/// <summary>Recognizes the <c>&lt;&lt;</c> merge key of the YAML merge extension.</summary>
+internal static class YamlMergeKey
+{
+    /// <summary>The merge key text.</summary>
+    public const string Key = "<<";
+
+    /// <summary>Determines whether the schema in use resolves the merge key.</summary>
+    public static bool IsEnabled(YamlSerializerOptions options)
+        => options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+
+    /// <summary>Determines whether the scalar the reader is positioned on is a merge key.</summary>
+    /// <param name="reader">The reader positioned on a mapping key.</param>
+    /// <remarks>
+    /// The merge key is resolved from a plain <c>&lt;&lt;</c> scalar or from an explicit <c>!!merge</c> tag. A quoted or
+    /// block scalar, and any other tag such as <c>!!str</c>, denote an ordinary key whose name happens to be
+    /// <c>&lt;&lt;</c>. This must be checked before the reader advances past the key, because the style and the tag
+    /// belong to the key token.
+    /// </remarks>
+    public static bool IsMergeKey(YamlReader reader)
+    {
+        if (!IsEnabled(reader.Options))
+        {
+            return false;
+        }
+
+        if (reader.TokenType != YamlTokenType.Scalar || !string.Equals(reader.ScalarValue, Key, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var tag = reader.Tag;
+        if (tag is not null)
+        {
+            return string.Equals(tag, ExtendedSchema.MergeShortTag, StringComparison.Ordinal) ||
+                   string.Equals(tag, ExtendedSchema.MergeLongTag, StringComparison.Ordinal);
+        }
+
+        return reader.ScalarStyle is ScalarStyle.Any or ScalarStyle.Plain;
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -253,7 +253,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         }
 
         var options = reader.Options;
-        var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+        var mergeEnabled = YamlMergeKey.IsEnabled(options);
         HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(reader.PropertyNameComparer) : null;
         HashSet<Member>? seenMembers = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins ? null : new HashSet<Member>();
         var mappingStart = reader.Start;
@@ -269,10 +269,11 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             var keyStart = reader.Start;
             var keyEnd = reader.End;
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMergeToInstance(reader, instance!, contract, explicitKeys!, requiredSeen);
                 continue;
@@ -391,7 +392,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         }
 
         var options = reader.Options;
-        var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+        var mergeEnabled = YamlMergeKey.IsEnabled(options);
         HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(reader.PropertyNameComparer) : null;
         HashSet<Member>? seenMembers = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins ? null : new HashSet<Member>();
         var mappingStart = reader.Start;
@@ -407,10 +408,11 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             var keyStart = reader.Start;
             var keyEnd = reader.End;
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMergeToPopulatedInstance(reader, instance, contract, explicitKeys!, requiredSeen);
                 continue;
@@ -512,7 +514,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         var mappingStart = reader.Start;
         var mappingAnchor = reader.Anchor;
         var options = reader.Options;
-        var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+        var mergeEnabled = YamlMergeKey.IsEnabled(options);
         HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(reader.PropertyNameComparer) : null;
 
         HashSet<string>? seenKeys = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins
@@ -537,10 +539,11 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             var keyStart = reader.Start;
             var keyEnd = reader.End;
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMergeToConstructorBuffers(reader, contract, constructor, args, paramSeen, memberValues, extensionEntries, explicitKeys!, requiredSeen);
                 continue;
@@ -771,9 +774,6 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         return instance;
     }
 
-    private static bool IsMergeKeyEnabled(YamlSerializerOptions options)
-        => options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
-
     private static void SkipOrThrowUnmappedMember(YamlReader reader, Contract contract, string key)
     {
         if (contract.UnmappedMemberHandling == YamlUnmappedMemberHandling.Disallow)
@@ -786,7 +786,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
     private void ReadAndApplyMergeToInstance(YamlReader reader, object instance, Contract contract, HashSet<string> explicitKeys, bool[]? requiredSeen)
     {
-        if (!IsMergeKeyEnabled(reader.Options))
+        if (!YamlMergeKey.IsEnabled(reader.Options))
         {
             reader.Skip();
             return;
@@ -853,16 +853,19 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             var keyStart = reader.Start;
             var keyEnd = reader.End;
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (IsMergeKeyEnabled(reader.Options) && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMergeToInstance(reader, instance, contract, explicitKeys, requiredSeen);
                 continue;
             }
 
-            if (explicitKeys.Contains(key))
+            // The key is provided by the merge. An explicitly declared key, and a key an earlier mapping of the
+            // merge already provided, both take precedence over it.
+            if (!explicitKeys.Add(key))
             {
                 reader.Skip();
                 continue;
@@ -899,7 +902,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
     private static void ReadAndApplyMergeToPopulatedInstance(YamlReader reader, object instance, Contract contract, HashSet<string> explicitKeys, bool[]? requiredSeen)
     {
-        if (!IsMergeKeyEnabled(reader.Options))
+        if (!YamlMergeKey.IsEnabled(reader.Options))
         {
             reader.Skip();
             return;
@@ -966,16 +969,19 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             var keyStart = reader.Start;
             var keyEnd = reader.End;
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (IsMergeKeyEnabled(reader.Options) && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMergeToPopulatedInstance(reader, instance, contract, explicitKeys, requiredSeen);
                 continue;
             }
 
-            if (explicitKeys.Contains(key))
+            // The key is provided by the merge. An explicitly declared key, and a key an earlier mapping of the
+            // merge already provided, both take precedence over it.
+            if (!explicitKeys.Add(key))
             {
                 reader.Skip();
                 continue;
@@ -1176,7 +1182,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         HashSet<string> explicitKeys,
         bool[]? requiredSeen)
     {
-        if (!IsMergeKeyEnabled(reader.Options))
+        if (!YamlMergeKey.IsEnabled(reader.Options))
         {
             reader.Skip();
             return;
@@ -1252,16 +1258,19 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             var keyStart = reader.Start;
             var keyEnd = reader.End;
+            var isMergeKey = YamlMergeKey.IsMergeKey(reader);
             var key = reader.ScalarValue ?? string.Empty;
             reader.Read();
 
-            if (IsMergeKeyEnabled(reader.Options) && string.Equals(key, "<<", StringComparison.Ordinal))
+            if (isMergeKey)
             {
                 ReadAndApplyMergeToConstructorBuffers(reader, contract, constructor, args, paramSeen, memberValues, extensionEntries, explicitKeys, requiredSeen);
                 continue;
             }
 
-            if (explicitKeys.Contains(key))
+            // The key is provided by the merge. An explicitly declared key, and a key an earlier mapping of the
+            // merge already provided, both take precedence over it.
+            if (!explicitKeys.Add(key))
             {
                 reader.Skip();
                 continue;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlUntypedObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlUntypedObjectConverter.cs
@@ -51,7 +51,7 @@ internal sealed class YamlUntypedObjectConverter : YamlConverter
                 reader.Read();
                 var comparer = options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
                 var dict = new Dictionary<string, object?>(comparer);
-                var mergeEnabled = options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
+                var mergeEnabled = YamlMergeKey.IsEnabled(options);
                 HashSet<string>? explicitKeys = mergeEnabled ? new HashSet<string>(comparer) : null;
                 HashSet<string>? seenKeys = options.DuplicateKeyHandling == YamlDuplicateKeyHandling.LastWins ? null : new HashSet<string>(comparer);
                 if (reader.ReferenceReader is not null && mappingAnchor is not null)
@@ -66,10 +66,11 @@ internal sealed class YamlUntypedObjectConverter : YamlConverter
                         throw YamlThrowHelper.ThrowExpectedScalarKey(reader);
                     }
 
+                    var isMergeKey = YamlMergeKey.IsMergeKey(reader);
                     var key = reader.ScalarValue ?? string.Empty;
                     reader.Read();
 
-                    if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
+                    if (isMergeKey)
                     {
                         ReadAndApplyMerge(reader, dict, explicitKeys);
                         continue;
@@ -111,7 +112,16 @@ internal sealed class YamlUntypedObjectConverter : YamlConverter
             return;
         }
 
-        var converter = writer.GetConverter(value.GetType());
+        var runtimeType = value.GetType();
+        if (runtimeType == typeof(object))
+        {
+            // A plain System.Object carries no state, and resolving its runtime type leads back to this converter.
+            writer.WriteStartMapping();
+            writer.WriteEndMapping();
+            return;
+        }
+
+        var converter = writer.GetConverter(runtimeType);
         converter.Write(writer, value);
     }
 
@@ -184,11 +194,15 @@ internal sealed class YamlUntypedObjectConverter : YamlConverter
         throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge key value must be a mapping or a sequence of mappings.");
     }
 
+    /// <remarks>
+    /// A key an earlier mapping of the merge already provided keeps its value, so the merged key is recorded
+    /// alongside the explicitly declared ones.
+    /// </remarks>
     private static void ApplyMergeDictionary(Dictionary<string, object?> target, Dictionary<string, object?> merged, HashSet<string>? explicitKeys)
     {
         foreach (var pair in merged)
         {
-            if (explicitKeys is not null && explicitKeys.Contains(pair.Key))
+            if (explicitKeys is not null && !explicitKeys.Add(pair.Key))
             {
                 continue;
             }

--- a/src/Meziantou.Framework.Yaml/Serialization/References/YamlReferenceReader.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/References/YamlReferenceReader.cs
@@ -1,13 +1,31 @@
+using Meziantou.Framework.Yaml.Events;
+
 namespace Meziantou.Framework.Yaml.Serialization.References;
 
 internal sealed class YamlReferenceReader
 {
     private readonly Dictionary<string, object> _anchors = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Scalar> _scalarAnchors = new(StringComparer.Ordinal);
 
     public void Register(string anchor, object value)
     {
         _anchors[anchor] = value;
+        _scalarAnchors.Remove(anchor);
     }
+
+    /// <summary>Registers the scalar node an anchor names.</summary>
+    /// <remarks>
+    /// A scalar is replayed rather than shared, so an alias to it can be read as whatever type the destination
+    /// member declares instead of the type the anchored occurrence happened to produce.
+    /// </remarks>
+    public void RegisterScalar(string anchor, Scalar scalar)
+    {
+        _scalarAnchors[anchor] = scalar;
+        _anchors.Remove(anchor);
+    }
+
+    public bool TryResolveScalar(string alias, [NotNullWhen(true)] out Scalar? scalar)
+        => _scalarAnchors.TryGetValue(alias, out scalar);
 
     public object Resolve(string alias)
     {

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlBuiltInTypeInfoResolver.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlBuiltInTypeInfoResolver.cs
@@ -11,7 +11,7 @@ internal static class YamlBuiltInTypeInfoResolver
         ArgumentNullException.ThrowIfNull(options);
 
         var converter = GetConverter(type);
-        return converter is null ? null : new BuiltInYamlTypeInfo(type, options, converter);
+        return converter is null ? null : new BuiltInYamlTypeInfo(type, options);
     }
 
     private static YamlConverter? GetConverter(Type type)
@@ -234,24 +234,23 @@ internal static class YamlBuiltInTypeInfoResolver
 
     private sealed class BuiltInYamlTypeInfo : YamlTypeInfo
     {
-        private readonly YamlConverter _converter;
-
-        public BuiltInYamlTypeInfo(Type type, YamlSerializerOptions options, YamlConverter converter)
+        public BuiltInYamlTypeInfo(Type type, YamlSerializerOptions options)
             : base(type, options)
         {
-            _converter = converter ?? throw new ArgumentNullException(nameof(converter));
         }
 
+        // The converter is resolved from the reader or the writer rather than captured, so a converter registered
+        // through YamlSerializerOptions.Converters or a YamlConverterAttribute applies to the root value too.
         public override void Write(YamlWriter writer, object? value)
         {
             ArgumentNullException.ThrowIfNull(writer);
-            _converter.Write(writer, value);
+            writer.GetConverter(Type).Write(writer, value);
         }
 
         public override object? ReadAsObject(YamlReader reader)
         {
             ArgumentNullException.ThrowIfNull(reader);
-            return _converter.Read(reader, Type);
+            return reader.GetConverter(Type).Read(reader, Type);
         }
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlReader.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlReader.cs
@@ -394,16 +394,32 @@ public sealed class YamlReader : YamlReaderWriterBase
                         Tag = scalar.Tag;
                         Anchor = scalar.Anchor;
                         ThrowIfAnchorNotAllowed();
+                        if (Anchor is not null)
+                        {
+                            ReferenceReader?.RegisterScalar(Anchor, scalar);
+                        }
+
                         return true;
 
                     case AnchorAlias alias:
-                        TokenType = YamlTokenType.Alias;
-                        Alias = alias.Value;
                         if (!_allowAliases)
                         {
                             throw new YamlException(SourceName, Start, End, "YAML aliases are not allowed.");
                         }
 
+                        // An alias to a scalar is presented as that scalar, so every converter reads it as the type
+                        // it expects instead of the type the anchored occurrence produced.
+                        if (ReferenceReader is not null && ReferenceReader.TryResolveScalar(alias.Value, out var anchoredScalar))
+                        {
+                            TokenType = YamlTokenType.Scalar;
+                            ScalarValue = anchoredScalar.Value;
+                            ScalarStyle = anchoredScalar.Style;
+                            Tag = anchoredScalar.Tag;
+                            return true;
+                        }
+
+                        TokenType = YamlTokenType.Alias;
+                        Alias = alias.Value;
                         return true;
                 }
 

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
@@ -1,6 +1,8 @@
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Meziantou.Framework.Yaml.Serialization.Converters;
 
 namespace Meziantou.Framework.Yaml.Serialization;
@@ -14,11 +16,17 @@ namespace Meziantou.Framework.Yaml.Serialization;
 /// </remarks>
 public abstract class YamlReaderWriterBase
 {
+    // The caches are shared by every reader and writer created from the same options instance, which is immutable
+    // once constructed. Reusing them keeps the contract a converter builds by reflection alive across calls instead
+    // of rebuilding it for every serializer call. The cache cannot be a field of YamlSerializerOptions: it is a
+    // record, so a 'with' expression would copy the reference and hand the derived options a cache built for a
+    // different configuration.
+    private static readonly ConditionalWeakTable<YamlSerializerOptions, ConverterCache> SharedConverterCaches = new();
+
     private readonly StringComparer _propertyNameComparer;
+    private readonly ConverterCache _converterCache;
     private Dictionary<string, string>? _propertyNameCache;
     private Dictionary<string, string>? _dictionaryKeyCache;
-    private Dictionary<Type, YamlConverter>? _converterCache;
-    private Dictionary<Type, YamlConverter?>? _customConverterCache;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="YamlReaderWriterBase"/> class.
@@ -30,6 +38,7 @@ public abstract class YamlReaderWriterBase
         ArgumentNullException.ThrowIfNull(options);
         Options = options;
         _propertyNameComparer = options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        _converterCache = SharedConverterCaches.GetValue(options, static _ => new ConverterCache());
     }
 
     /// <summary>Gets the options associated with this reader or writer instance.</summary>
@@ -100,8 +109,7 @@ public abstract class YamlReaderWriterBase
     {
         ArgumentNullException.ThrowIfNull(typeToConvert);
 
-        _converterCache ??= new Dictionary<Type, YamlConverter>();
-        if (_converterCache.TryGetValue(typeToConvert, out var cached))
+        if (_converterCache.Converters.TryGetValue(typeToConvert, out var cached))
         {
             return cached;
         }
@@ -109,14 +117,12 @@ public abstract class YamlReaderWriterBase
         var attributeConverter = CreateConverterFromAttribute(typeToConvert);
         if (attributeConverter is not null)
         {
-            _converterCache[typeToConvert] = attributeConverter;
-            return attributeConverter;
+            return _converterCache.Converters.GetOrAdd(typeToConvert, attributeConverter);
         }
 
         if (TryGetCustomConverter(typeToConvert, out var custom) && custom is not null)
         {
-            _converterCache[typeToConvert] = custom;
-            return custom;
+            return _converterCache.Converters.GetOrAdd(typeToConvert, custom);
         }
 
         var created = YamlBuiltInConverters.CreateConverter(typeToConvert);
@@ -125,8 +131,7 @@ public abstract class YamlReaderWriterBase
             throw new NotSupportedException($"No YAML converter is registered for '{typeToConvert}'.");
         }
 
-        _converterCache[typeToConvert] = created;
-        return created;
+        return _converterCache.Converters.GetOrAdd(typeToConvert, created);
     }
 
     private YamlConverter? CreateConverterFromAttribute(Type typeToConvert)
@@ -183,8 +188,7 @@ public abstract class YamlReaderWriterBase
             return false;
         }
 
-        _customConverterCache ??= new Dictionary<Type, YamlConverter?>();
-        if (_customConverterCache.TryGetValue(typeToConvert, out converter))
+        if (_converterCache.CustomConverters.TryGetValue(typeToConvert, out converter))
         {
             return converter is not null;
         }
@@ -211,22 +215,27 @@ public abstract class YamlReaderWriterBase
                     throw new InvalidOperationException($"Converter factory '{factory.GetType()}' returned an invalid converter for '{typeToConvert}'.");
                 }
 
-                converter = created;
-                _customConverterCache[typeToConvert] = converter;
+                converter = _converterCache.CustomConverters.GetOrAdd(typeToConvert, created);
                 return true;
             }
 
             if (candidate.CanConvert(typeToConvert))
             {
-                converter = candidate;
-                _customConverterCache[typeToConvert] = converter;
+                converter = _converterCache.CustomConverters.GetOrAdd(typeToConvert, candidate);
                 return true;
             }
         }
 
         converter = null;
-        _customConverterCache[typeToConvert] = null;
+        _converterCache.CustomConverters.TryAdd(typeToConvert, null);
         return false;
+    }
+
+    private sealed class ConverterCache
+    {
+        public ConcurrentDictionary<Type, YamlConverter> Converters { get; } = new();
+
+        public ConcurrentDictionary<Type, YamlConverter?> CustomConverters { get; } = new();
     }
 
     private static class YamlBuiltInConverters

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlScalar.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlScalar.cs
@@ -582,10 +582,22 @@ public static class YamlScalar
         {
             if (TryResolveSchemaScalar(reader, out var defaultTag, out var value) &&
                 (string.Equals(defaultTag, JsonSchema.FloatShortTag, StringComparison.Ordinal) ||
-                 string.Equals(defaultTag, JsonSchema.IntShortTag, StringComparison.Ordinal)) &&
-                TryConvertToDecimal(value, out result))
+                 string.Equals(defaultTag, JsonSchema.IntShortTag, StringComparison.Ordinal)))
             {
-                return true;
+                // An integer the schema decoded into an integral type converts exactly, and it is the only form
+                // that carries the base the scalar was written in. Any other value went through a floating-point
+                // type, which drops digits a decimal can hold, so the original text is parsed instead.
+                if (IsIntegral(value))
+                {
+                    return TryConvertToDecimal(value, out result);
+                }
+
+                if (TryParseDecimal(reader.ScalarValue.AsSpan(), out result))
+                {
+                    return true;
+                }
+
+                return TryConvertToDecimal(value, out result);
             }
 
             result = default;
@@ -760,6 +772,8 @@ public static class YamlScalar
             YamlSchemaKind.Extended => ExtendedSchema,
             _ => CoreSchema.Instance,
         };
+
+    private static bool IsIntegral(object? value) => value is int or long or ulong;
 
     private static bool TryConvertToInt64(object? value, out long result)
     {
@@ -951,10 +965,16 @@ public static class YamlScalar
                 return false;
             }
 
-            checked
+            // The value can exceed ulong.MaxValue, and this method must report that as a failed parse
+            // instead of throwing, so the overflow is detected before the multiplication happens.
+            var radix = (ulong)numberBase;
+            if (accumulator > (ulong.MaxValue - (ulong)digit) / radix)
             {
-                accumulator = (accumulator * (ulong)numberBase) + (ulong)digit;
+                result = default;
+                return false;
             }
+
+            accumulator = (accumulator * radix) + (ulong)digit;
         }
 
         result = accumulator;

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlUnionTypeStructuralClassifier.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlUnionTypeStructuralClassifier.cs
@@ -1,3 +1,5 @@
+using Meziantou.Framework.Yaml.Serialization.Converters;
+
 namespace Meziantou.Framework.Yaml.Serialization;
 
 /// <summary>
@@ -176,12 +178,13 @@ public sealed class YamlUnionTypeStructuralClassifier : YamlTypeClassifierFactor
                     continue;
                 }
 
+                // A merge key carries the keys of another mapping rather than a member of the case.
+                var isMergeKey = YamlMergeKey.IsMergeKey(reader);
                 var key = reader.ScalarValue ?? string.Empty;
                 reader.Read();
                 reader.Skip();
 
-                // A merge key carries the keys of another mapping rather than a member of the case.
-                if (!string.Equals(key, "<<", StringComparison.Ordinal))
+                if (!isMergeKey)
                 {
                     keys.Add(key);
                 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -64,6 +64,10 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
     internal bool EndsWithNewLine => _hasWrittenChar && _lastWrittenChar == '\n';
 
+    /// <summary>Gets a value indicating whether the next character is written at the first column of a line.</summary>
+    /// <remarks>A document marker (<c>---</c> or <c>...</c>) only ends the current document there.</remarks>
+    private bool IsAtLineStart => !_hasWrittenChar || _lastWrittenChar == '\n';
+
     /// <summary>
     /// Gets a value indicating whether collections are written using the flow style, which keeps the document on a single line.
     /// </summary>
@@ -1372,10 +1376,14 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
     private bool IsPlainSafe(ReadOnlySpan<char> value, bool isKey)
     {
-        _ = isKey; // Currently unused, but may be used in future for stricter key rules.
-
         // Keep it conservative: if in doubt, quote.
         if (value.Length == 0)
+        {
+            return false;
+        }
+
+        // A plain "<<" key is the merge key of the YAML merge extension, so an ordinary key with that name is quoted.
+        if (isKey && value.Equals("<<", StringComparison.Ordinal))
         {
             return false;
         }
@@ -1442,13 +1450,41 @@ public sealed class YamlWriter : YamlReaderWriterBase
             return false;
         }
 
+        // At the first column of a line, "---" and "..." end the current document, so a value starting with one
+        // of them has to be quoted. Elsewhere they are ordinary characters.
+        if (IsAtLineStart && StartsWithDocumentMarker(value))
+        {
+            return false;
+        }
+
         return true;
     }
 
-    /// <summary>Gets a value indicating whether a YAML reader breaks a line on <paramref name="c"/>.</summary>
+    /// <summary>Gets a value indicating whether <paramref name="value"/> starts with a YAML document marker.</summary>
     /// <remarks>
-    /// U+0085, U+2028, and U+2029 are line breaks to a YAML reader but are not control characters, and
-    /// <see cref="Emitter.IsPrintable"/> accepts them. A style that writes text verbatim has to reject them.
+    /// A marker ends at the end of the line or at a separation character, so text such as <c>---hello</c> is an
+    /// ordinary plain scalar.
+    /// </remarks>
+    private static bool StartsWithDocumentMarker(ReadOnlySpan<char> value)
+    {
+        if (value.Length < 3)
+        {
+            return false;
+        }
+
+        if (!value.StartsWith("---", StringComparison.Ordinal) && !value.StartsWith("...", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return value.Length == 3 || value[3] is ' ' or '\t';
+    }
+
+    /// <summary>Gets a value indicating whether <paramref name="c"/> is written as an escape rather than verbatim.</summary>
+    /// <remarks>
+    /// U+0085, U+2028, and U+2029 are ordinary content in YAML 1.2, but they were line breaks in YAML 1.1 and are
+    /// not control characters, so <see cref="Emitter.IsPrintable"/> accepts them. They are escaped rather than
+    /// written verbatim so a reader cannot fold them, which also keeps the output free of invisible line breaks.
     /// </remarks>
     private static bool IsLineBreak(char c) => c is '\n' or '\r' or '\u0085' or '\u2028' or '\u2029';
 

--- a/src/Meziantou.Framework.Yaml/Syntax/YamlSyntaxTree.cs
+++ b/src/Meziantou.Framework.Yaml/Syntax/YamlSyntaxTree.cs
@@ -43,12 +43,14 @@ public sealed class YamlSyntaxTree
         ValidateYaml(yaml);
 
         var tokens = new List<YamlSyntaxToken>();
+        AddScannerTokens(yaml, tokens);
         if (options.IncludeTrivia)
         {
-            AddTriviaTokens(yaml, tokens);
+            // Trivia is read from the text the scanner did not claim: a '#' inside a quoted or block scalar is
+            // content, not the start of a comment.
+            AddTriviaTokens(yaml, tokens, GetUncoveredRanges(yaml, tokens));
         }
 
-        AddScannerTokens(yaml, tokens);
         tokens.Sort(static (left, right) =>
         {
             var position = left.Span.Start.Index.CompareTo(right.Span.Start.Index);
@@ -143,13 +145,61 @@ public sealed class YamlSyntaxTree
         return value;
     }
 
-    private static void AddTriviaTokens(string yaml, List<YamlSyntaxToken> target)
+    /// <summary>Gets the ranges of <paramref name="yaml"/> that no scanner token covers, in source order.</summary>
+    private static List<(int Start, int End)> GetUncoveredRanges(string yaml, List<YamlSyntaxToken> tokens)
     {
-        var index = 0;
-        var line = 0;
-        var column = 0;
+        var covered = new List<(int Start, int End)>(tokens.Count);
+        foreach (var token in tokens)
+        {
+            var start = Clamp(token.Span.Start.Index, 0, yaml.Length);
+            var end = Clamp(token.Span.End.Index, start, yaml.Length);
+            if (end > start)
+            {
+                covered.Add((start, end));
+            }
+        }
 
-        while (index < yaml.Length)
+        covered.Sort(static (left, right) => left.Start.CompareTo(right.Start));
+
+        var result = new List<(int Start, int End)>();
+        var cursor = 0;
+        foreach (var (start, end) in covered)
+        {
+            if (start > cursor)
+            {
+                result.Add((cursor, start));
+            }
+
+            if (end > cursor)
+            {
+                cursor = end;
+            }
+        }
+
+        if (cursor < yaml.Length)
+        {
+            result.Add((cursor, yaml.Length));
+        }
+
+        return result;
+    }
+
+    private static void AddTriviaTokens(string yaml, List<YamlSyntaxToken> target, List<(int Start, int End)> ranges)
+    {
+        foreach (var range in ranges)
+        {
+            AddTriviaTokens(yaml, target, range.Start, range.End);
+        }
+    }
+
+    private static void AddTriviaTokens(string yaml, List<YamlSyntaxToken> target, int rangeStart, int rangeEnd)
+    {
+        var index = rangeStart;
+        var startMark = CreateMark(yaml, rangeStart);
+        var line = startMark.Line;
+        var column = startMark.Column;
+
+        while (index < rangeEnd)
         {
             var start = new Mark(index, line, column);
             var current = yaml[index];
@@ -158,7 +208,7 @@ public sealed class YamlSyntaxTree
                 var cursor = index + 1;
                 var endLine = line;
                 var endColumn = column + 1;
-                while (cursor < yaml.Length && yaml[cursor] != '\r' && yaml[cursor] != '\n')
+                while (cursor < rangeEnd && yaml[cursor] != '\r' && yaml[cursor] != '\n')
                 {
                     cursor++;
                     endColumn++;
@@ -179,7 +229,7 @@ public sealed class YamlSyntaxTree
             if (current == '\r' || current == '\n')
             {
                 var cursor = index;
-                if (current == '\r' && cursor + 1 < yaml.Length && yaml[cursor + 1] == '\n')
+                if (current == '\r' && cursor + 1 < rangeEnd && yaml[cursor + 1] == '\n')
                 {
                     cursor += 2;
                 }
@@ -204,7 +254,7 @@ public sealed class YamlSyntaxTree
             {
                 var cursor = index + 1;
                 var endColumn = column + 1;
-                while (cursor < yaml.Length && (yaml[cursor] == ' ' || yaml[cursor] == '\t'))
+                while (cursor < rangeEnd && (yaml[cursor] == ' ' || yaml[cursor] == '\t'))
                 {
                     cursor++;
                     endColumn++;

--- a/tests/Meziantou.Framework.Yaml.FeatureSwitchSmoke/Program.cs
+++ b/tests/Meziantou.Framework.Yaml.FeatureSwitchSmoke/Program.cs
@@ -88,4 +88,16 @@ if (cList[0] is not null || cList[1] is not string cy || cy != "y")
     return 9;
 }
 
+// A plain System.Object resolves back to the untyped converter. This runs out of process because a converter that
+// recurses instead of stopping there overflows the stack, which cannot be caught inside a test host.
+if (YamlSerializer.Serialize<object>(new object()) is not "{}\n")
+{
+    return 10;
+}
+
+if (YamlSerializer.Serialize<List<object>>([new object()]) is not "- {}\n")
+{
+    return 11;
+}
+
 return 0;

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlConverterSelectionTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlConverterSelectionTests.cs
@@ -70,4 +70,132 @@ public sealed class YamlConverterSelectionTests
         public override YamlConverter CreateConverter(Type typeToConvert, YamlSerializerOptions options)
             => new AlwaysInt32Converter("factory");
     }
+
+    [Fact]
+    public void Serialize_UsesCustomConverterForBuiltInRootType()
+    {
+        var options = new YamlSerializerOptions
+        {
+            Converters = [new Int42Converter()],
+        };
+
+        Assert.Equal("42\n", YamlSerializer.Serialize(5, options));
+        Assert.Equal("42\n", YamlSerializer.Serialize(5, typeof(int), options));
+    }
+
+    [Fact]
+    public void Deserialize_UsesCustomConverterForBuiltInRootType()
+    {
+        var options = new YamlSerializerOptions
+        {
+            Converters = [new Int42Converter()],
+        };
+
+        Assert.Equal(42, YamlSerializer.Deserialize<int>("5", options));
+        Assert.Equal(42, (int)YamlSerializer.Deserialize("5", typeof(int), options)!);
+    }
+
+    [Fact]
+    public void Serialize_UsesConverterFactoryForBuiltInRootType()
+    {
+        var options = new YamlSerializerOptions
+        {
+            Converters = [new Int42FactoryConverter()],
+        };
+
+        Assert.Equal("42\n", YamlSerializer.Serialize(5, options));
+        Assert.Equal(42, YamlSerializer.Deserialize<int>("5", options));
+    }
+
+    [Fact]
+    public void Serialize_UsesCustomConverterForStringRootType()
+    {
+        var options = new YamlSerializerOptions
+        {
+            Converters = [new UpperCaseStringConverter()],
+        };
+
+        Assert.Equal("HELLO\n", YamlSerializer.Serialize("hello", options));
+        Assert.Equal("HELLO", YamlSerializer.Deserialize<string>("hello", options));
+    }
+
+    private sealed class Int42Converter : YamlConverter<int>
+    {
+        public override int Read(YamlReader reader)
+        {
+            reader.Skip();
+            return 42;
+        }
+
+        public override void Write(YamlWriter writer, int value) => writer.WriteScalar(42);
+    }
+
+    private sealed class Int42FactoryConverter : YamlConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(int);
+
+        public override YamlConverter CreateConverter(Type typeToConvert, YamlSerializerOptions options) => new Int42Converter();
+    }
+
+    private sealed class UpperCaseStringConverter : YamlConverter<string?>
+    {
+        public override string? Read(YamlReader reader)
+        {
+            var value = reader.ScalarValue;
+            reader.Skip();
+            return value?.ToUpperInvariant();
+        }
+
+        public override void Write(YamlWriter writer, string? value) => writer.WriteString(value?.ToUpperInvariant());
+    }
+
+    [Fact]
+    public void GetConverter_ReusesConvertersAcrossReadersAndWritersOfTheSameOptions()
+    {
+        var options = new YamlSerializerOptions();
+
+        var fromWriter = new YamlWriter(new StringBuilder(), options).GetConverter(typeof(Payload));
+        var fromOtherWriter = new YamlWriter(new StringBuilder(), options).GetConverter(typeof(Payload));
+        var fromReader = YamlReader.Create("Name: n", options).GetConverter(typeof(Payload));
+
+        Assert.Same(fromWriter, fromOtherWriter);
+        Assert.Same(fromWriter, fromReader);
+    }
+
+    [Fact]
+    public void GetConverter_DoesNotShareConvertersBetweenOptionsInstances()
+    {
+        var first = new YamlSerializerOptions();
+        var second = first with { PropertyNamingPolicy = YamlNamingPolicy.CamelCase };
+
+        var fromFirst = new YamlWriter(new StringBuilder(), first).GetConverter(typeof(Payload));
+        var fromSecond = new YamlWriter(new StringBuilder(), second).GetConverter(typeof(Payload));
+
+        Assert.NotSame(fromFirst, fromSecond);
+    }
+
+    [Fact]
+    public void Serialize_SharedOptionsAreUsableFromSeveralThreads()
+    {
+        var options = new YamlSerializerOptions();
+        var payload = new Payload { Name = "n", Count = 3 };
+        const string ExpectedYaml = "Name: n\nCount: 3\n";
+
+        Parallel.For(0, 200, _ =>
+        {
+            Assert.Equal(ExpectedYaml, YamlSerializer.Serialize(payload, options));
+
+            var roundTrip = YamlSerializer.Deserialize<Payload>(ExpectedYaml, options);
+            Assert.NotNull(roundTrip);
+            Assert.Equal("n", roundTrip.Name);
+            Assert.Equal(3, roundTrip.Count);
+        });
+    }
+
+    private sealed class Payload
+    {
+        public string? Name { get; set; }
+
+        public int Count { get; set; }
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
@@ -43,7 +43,8 @@ public sealed class YamlMergeKeyTests
         var result = YamlSerializer.Deserialize<Dictionary<string, int>>(yaml);
 
         Assert.NotNull(result);
-        Assert.Equal(2, result["a"]);
+        // The merge extension gives mappings earlier in the sequence precedence over later ones.
+        Assert.Equal(1, result["a"]);
         Assert.Equal(3, result["b"]);
         Assert.Equal(4, result["c"]);
     }
@@ -242,6 +243,104 @@ public sealed class YamlMergeKeyTests
         public Dictionary<string, int>? Defaults { get; set; }
 
         public Section? Prod { get; set; }
+    }
+
+    [Fact]
+    public void Deserialize_Object_ShouldApplyMergeSequenceInOrder()
+    {
+        var yaml =
+            "<<:\n" +
+            "  - { A: 1 }\n" +
+            "  - { A: 2, B: 3 }\n";
+
+        var result = YamlSerializer.Deserialize<MergePayload>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.A);
+        Assert.Equal(3, result.B);
+    }
+
+    [Fact]
+    public void Deserialize_UntypedObject_ShouldApplyMergeSequenceInOrder()
+    {
+        var yaml =
+            "<<:\n" +
+            "  - { a: 1 }\n" +
+            "  - { a: 2, b: 3 }\n";
+
+        var result = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal(1L, result["a"]);
+        Assert.Equal(3L, result["b"]);
+    }
+
+    [Fact]
+    public void Deserialize_Dictionary_ShouldApplyMergeAliasSequenceInOrder()
+    {
+        var yaml =
+            "first: &f { a: 1 }\n" +
+            "second: &s { a: 2, b: 3 }\n" +
+            "merged:\n" +
+            "  <<: [*f, *s]\n";
+
+        var result = YamlSerializer.Deserialize<Dictionary<string, Dictionary<string, int>>>(yaml, PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result["merged"]["a"]);
+        Assert.Equal(3, result["merged"]["b"]);
+    }
+
+    [Fact]
+    public void Deserialize_Dictionary_ExplicitKeyWinsOverMergeWhateverItsPosition()
+    {
+        var before = YamlSerializer.Deserialize<Dictionary<string, int>>("a: 5\n<<: { a: 1 }\n");
+        var after = YamlSerializer.Deserialize<Dictionary<string, int>>("<<: { a: 1 }\na: 5\n");
+
+        Assert.NotNull(before);
+        Assert.NotNull(after);
+        Assert.Equal(5, before["a"]);
+        Assert.Equal(5, after["a"]);
+    }
+
+    [Theory]
+    [InlineData("'<<': hello\n")]
+    [InlineData("\"<<\": hello\n")]
+    [InlineData("!!str << : hello\n")]
+    public void Deserialize_Dictionary_QuotedOrTaggedMergeKeyIsAnOrdinaryKey(string yaml)
+    {
+        var result = YamlSerializer.Deserialize<Dictionary<string, string>>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal("hello", result["<<"]);
+    }
+
+    [Theory]
+    [InlineData("'<<': hello\n")]
+    [InlineData("\"<<\": hello\n")]
+    public void Deserialize_UntypedObject_QuotedMergeKeyIsAnOrdinaryKey(string yaml)
+    {
+        var result = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal("hello", result["<<"]);
+    }
+
+    [Fact]
+    public void Serialize_Dictionary_WithMergeKeyName_RoundTrips()
+    {
+        var value = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["<<"] = "hello",
+            ["other"] = "world",
+        };
+
+        var yaml = YamlSerializer.Serialize(value);
+        var roundTrip = YamlSerializer.Deserialize<Dictionary<string, string>>(yaml);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal("hello", roundTrip["<<"]);
+        Assert.Equal("world", roundTrip["other"]);
     }
 }
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlReferenceHandlingTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlReferenceHandlingTests.cs
@@ -150,4 +150,119 @@ public class YamlReferenceHandlingTests
         Assert.NotNull(roundTrip);
         Assert.Same(roundTrip, roundTrip.Next);
     }
+
+    [Fact]
+    public void DeserializeResolvesStringScalarAliases()
+    {
+        var result = YamlSerializer.Deserialize<List<string>>("[&a hello, *a]", PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(["hello", "hello"], result);
+    }
+
+    [Fact]
+    public void DeserializeResolvesNumericScalarAliases()
+    {
+        var result = YamlSerializer.Deserialize<List<int>>("[&a 42, *a]", PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal([42, 42], result);
+    }
+
+    [Fact]
+    public void DeserializeResolvesNullScalarAliases()
+    {
+        var result = YamlSerializer.Deserialize<List<string?>>("[&a null, *a]", PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal([null, null], result);
+    }
+
+    [Fact]
+    public void DeserializeResolvesScalarAliasesIntoObject()
+    {
+        var result = YamlSerializer.Deserialize<List<object?>>("[&a hello, *a, &b 42, *b]", PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(["hello", "hello", 42L, 42L], result);
+    }
+
+    [Fact]
+    public void DeserializeResolvesScalarAliasesInMappingValues()
+    {
+        var yaml =
+            "a: &v hello\n" +
+            "b: *v\n";
+
+        var result = YamlSerializer.Deserialize<Dictionary<string, string>>(yaml, PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal("hello", result["a"]);
+        Assert.Equal("hello", result["b"]);
+    }
+
+    [Fact]
+    public void DeserializeKeepsTheScalarStyleOfAnAliasedScalar()
+    {
+        // The anchored scalar is quoted, so the alias must not be resolved as a boolean either.
+        var result = YamlSerializer.Deserialize<List<object?>>("[&a \"true\", *a]", PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(["true", "true"], result);
+    }
+
+    [Fact]
+    public void DeserializeUsesTheLastDefinitionOfAReusedAnchorName()
+    {
+        var yaml =
+            "- &a hello\n" +
+            "- *a\n" +
+            "- &a world\n" +
+            "- *a\n";
+
+        var result = YamlSerializer.Deserialize<List<string>>(yaml, PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(["hello", "hello", "world", "world"], result);
+    }
+
+    [Fact]
+    public void DeserializeUsesTheLastDefinitionWhenAnAnchorNameChangesFromScalarToMapping()
+    {
+        var yaml =
+            "first: &a hello\n" +
+            "second: *a\n" +
+            "third: &a { Name: n }\n" +
+            "fourth: *a\n";
+
+        var result = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal("hello", result["first"]);
+        Assert.Equal("hello", result["second"]);
+        Assert.IsType<Dictionary<string, object?>>(result["third"]);
+        Assert.Same(result["third"], result["fourth"]);
+    }
+
+    [Fact]
+    public void DeserializeSupportsAnchorNamesBeyondAsciiLettersAndDigits()
+    {
+        foreach (var anchor in new[] { "a.b", "a/b", "a:b", "héllo", "a+b" })
+        {
+            var yaml = $"[&{anchor} hello, *{anchor}]";
+            var result = YamlSerializer.Deserialize<List<string>>(yaml, PreserveOptions);
+
+            Assert.NotNull(result);
+            Assert.Equal(["hello", "hello"], result, anchor);
+        }
+    }
+
+    [Fact]
+    public void DeserializeRejectsAnchorNamesContainingAFlowIndicator()
+    {
+        _ = Assert.Throws<SyntaxErrorException>(() => YamlSerializer.Deserialize<List<string>>("[& hello]", PreserveOptions));
+        _ = Assert.Throws<SyntaxErrorException>(() => YamlSerializer.Deserialize<List<string>>("[&, hello]", PreserveOptions));
+    }
+
+    private static YamlSerializerOptions PreserveOptions { get; } = new() { ReferenceHandling = YamlReferenceHandling.Preserve };
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlScalarTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlScalarTests.cs
@@ -260,4 +260,153 @@ public sealed class YamlScalarTests
     {
         public string? Bar { get; set; }
     }
+
+    [Fact]
+    public void TryParseUInt64_ReturnsFalseWhenTheValueOverflows()
+    {
+        var cases = new (string Text, bool ExpectedSuccess, ulong ExpectedValue)[]
+        {
+            ("0xFFFFFFFFFFFFFFFF", true, ulong.MaxValue),
+            ("0x10000000000000000", false, 0),
+            ("0o1777777777777777777777", true, ulong.MaxValue),
+            ("0o2000000000000000000000", false, 0),
+            ("0b1111111111111111111111111111111111111111111111111111111111111111", true, ulong.MaxValue),
+            ("0b10000000000000000000000000000000000000000000000000000000000000000", false, 0),
+            ("18446744073709551615", true, ulong.MaxValue),
+            ("18446744073709551616", false, 0),
+        };
+
+        foreach (var @case in cases)
+        {
+            var success = YamlScalar.TryParseUInt64(@case.Text.AsSpan(), out var value);
+            Assert.Equal(@case.ExpectedSuccess, success, @case.Text);
+            if (success)
+            {
+                Assert.Equal(@case.ExpectedValue, value, @case.Text);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryParseInt64_ReturnsFalseWhenTheValueOverflows()
+    {
+        var cases = new (string Text, bool ExpectedSuccess, long ExpectedValue)[]
+        {
+            ("0x7FFFFFFFFFFFFFFF", true, long.MaxValue),
+            ("-0x8000000000000000", true, long.MinValue),
+            ("0x8000000000000000", false, 0),
+            ("0x10000000000000000", false, 0),
+            ("0o777777777777777777777", true, long.MaxValue),
+            ("0o2000000000000000000000", false, 0),
+            ("0b111111111111111111111111111111111111111111111111111111111111111", true, long.MaxValue),
+            ("0b10000000000000000000000000000000000000000000000000000000000000000", false, 0),
+        };
+
+        foreach (var @case in cases)
+        {
+            var success = YamlScalar.TryParseInt64(@case.Text.AsSpan(), out var value);
+            Assert.Equal(@case.ExpectedSuccess, success, @case.Text);
+            if (success)
+            {
+                Assert.Equal(@case.ExpectedValue, value, @case.Text);
+            }
+        }
+    }
+
+    [Fact]
+    public void Serialize_StringThatLooksLikeAnOverflowingNumber_RoundTrips()
+    {
+        var cases = new[]
+        {
+            "0x10000000000000000",
+            "0o2000000000000000000000",
+            "0b10000000000000000000000000000000000000000000000000000000000000000",
+            "18446744073709551616",
+        };
+
+        foreach (var text in cases)
+        {
+            var yaml = YamlSerializer.Serialize(text);
+            Assert.Equal(text, YamlSerializer.Deserialize<string>(yaml), text);
+        }
+    }
+
+    [Fact]
+    public void Deserialize_SchemaKeepsDecimalPrecision()
+    {
+        var options = new YamlSerializerOptions { UseSchema = true };
+
+        Assert.Equal(0.1234567890123456789012345678m, YamlSerializer.Deserialize<decimal>("0.1234567890123456789012345678", options));
+        Assert.Equal(1.0000000000000000000000000001m, YamlSerializer.Deserialize<decimal>("1.0000000000000000000000000001", options));
+    }
+
+    [Fact]
+    public void Deserialize_SchemaSupportsDecimalsBeyondUInt64()
+    {
+        var options = new YamlSerializerOptions { UseSchema = true };
+
+        Assert.Equal(decimal.MaxValue, YamlSerializer.Deserialize<decimal>("79228162514264337593543950335", options));
+        Assert.Equal(decimal.MinValue, YamlSerializer.Deserialize<decimal>("-79228162514264337593543950335", options));
+        Assert.Equal(18446744073709551616m, YamlSerializer.Deserialize<decimal>("18446744073709551616", options));
+    }
+
+    [Fact]
+    public void Deserialize_SchemaKeepsTheBaseOfIntegerScalarsForDecimals()
+    {
+        var options = new YamlSerializerOptions { UseSchema = true };
+
+        Assert.Equal(16m, YamlSerializer.Deserialize<decimal>("0x10", options));
+        Assert.Equal(8m, YamlSerializer.Deserialize<decimal>("0o10", options));
+    }
+
+    [Fact]
+    public void Deserialize_SchemaRejectsIntegersThatDoNotFitTheDestination()
+    {
+        var options = new YamlSerializerOptions { UseSchema = true };
+
+        _ = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<int>("79228162514264337593543950335", options));
+        _ = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<long>("79228162514264337593543950335", options));
+    }
+
+    [Theory]
+    [InlineData("|-\n  true\n", "true")]
+    [InlineData("|-\n  null\n", "null")]
+    [InlineData("|-\n  123\n", "123")]
+    [InlineData("|-\n  1.5\n", "1.5")]
+    [InlineData(">-\n  true\n", "true")]
+    [InlineData(">-\n  null\n", "null")]
+    [InlineData(">-\n  123\n", "123")]
+    public void Deserialize_SchemaKeepsBlockScalarsAsStrings(string yaml, string expected)
+    {
+        var options = new YamlSerializerOptions { UseSchema = true };
+
+        var value = YamlSerializer.Deserialize<object>(yaml, options);
+
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("|-\n  true\n", "true")]
+    [InlineData(">-\n  null\n", "null")]
+    public void Deserialize_BlockScalarsAreStringsWithoutSchema(string yaml, string expected)
+    {
+        var value = YamlSerializer.Deserialize<object>(yaml);
+
+        Assert.Equal(expected, value);
+    }
+
+    [Fact]
+    public void Deserialize_SchemaResolvesIntegerSpellings()
+    {
+        var options = new YamlSerializerOptions { UseSchema = true };
+
+        Assert.Equal(12, YamlSerializer.Deserialize<int>("012", options));
+        Assert.Equal(12, YamlSerializer.Deserialize<object>("012", options));
+        Assert.Equal("0b101", YamlSerializer.Deserialize<object>("0b101", options));
+        Assert.Equal("1_000", YamlSerializer.Deserialize<object>("1_000", options));
+
+        var extended = new YamlSerializerOptions { UseSchema = true, Schema = YamlSchemaKind.Extended };
+        Assert.Equal(5, YamlSerializer.Deserialize<object>("0b101", extended));
+        Assert.Equal(1000, YamlSerializer.Deserialize<object>("1_000", extended));
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlUntypedObjectTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlUntypedObjectTests.cs
@@ -74,4 +74,30 @@ public sealed class YamlUntypedObjectTests
         Assert.Contains("ReferenceHandling", ex.Message);
         Assert.Contains("Preserve", ex.Message);
     }
+
+    [Fact]
+    public void SerializePlainObject_WritesAnEmptyMapping()
+    {
+        // Resolving the runtime type of a plain System.Object leads back to the untyped converter, so the converter
+        // has to stop there instead of recursing until the stack overflows.
+        Assert.Equal("{}\n", YamlSerializer.Serialize<object>(new object()));
+        Assert.Equal("{}\n", YamlSerializer.Serialize(new object(), typeof(object)));
+    }
+
+    [Fact]
+    public void SerializePlainObjectInsideACollection_WritesAnEmptyMapping()
+    {
+        Assert.Equal("- {}\n", YamlSerializer.Serialize<List<object>>([new object()]));
+        Assert.Equal("a: {}\n", YamlSerializer.Serialize<Dictionary<string, object>>(new Dictionary<string, object>(StringComparer.Ordinal) { ["a"] = new object() }));
+    }
+
+    [Fact]
+    public void SerializePlainObject_RoundTripsToAnEmptyMapping()
+    {
+        var yaml = YamlSerializer.Serialize<object>(new object());
+
+        var roundTrip = YamlSerializer.Deserialize<object>(yaml);
+
+        Assert.Empty(Assert.IsType<Dictionary<string, object?>>(roundTrip));
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
@@ -885,4 +885,75 @@ public sealed class YamlWriterTests
 
         public List<string>? Tags { get; set; }
     }
+
+    [Fact]
+    public void RootScalar_QuotesDocumentMarkers()
+    {
+        var cases = new (string Value, string ExpectedYaml)[]
+        {
+            ("---", "\"---\""),
+            ("--- hello", "\"--- hello\""),
+            ("---\thello", "\"---\\thello\""),
+            ("...", "\"...\""),
+            ("... hello", "\"... hello\""),
+            // A marker ends at the end of the line or at a separation character, so these are plain scalars.
+            ("---hello", "---hello"),
+            ("...hello", "...hello"),
+            ("a --- b", "a --- b"),
+        };
+
+        foreach (var (value, expectedYaml) in cases)
+        {
+            Assert.Equal(expectedYaml + "\n", YamlSerializer.Serialize(value), value);
+            Assert.Equal(value, YamlSerializer.Deserialize<string>(YamlSerializer.Serialize(value)), value);
+        }
+    }
+
+    [Fact]
+    public void RootScalar_QuotesDocumentMarkersWhenPlainStyleIsPreferred()
+    {
+        var options = new YamlSerializerOptions
+        {
+            ScalarStylePreferences = new YamlScalarStylePreferences { StringStyle = ScalarStyle.Plain },
+        };
+
+        foreach (var value in new[] { "---", "--- hello", "...", "... hello" })
+        {
+            var yaml = YamlSerializer.Serialize(value, options);
+            Assert.Equal("\"" + value + "\"\n", yaml, value);
+            Assert.Equal(value, YamlSerializer.Deserialize<string>(yaml, options), value);
+        }
+    }
+
+    [Fact]
+    public void MappingKey_QuotesDocumentMarkers()
+    {
+        var value = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["--- x"] = "v",
+        };
+
+        var yaml = YamlSerializer.Serialize(value, new YamlSerializerOptions { WriteIndented = true });
+
+        Assert.Equal("\"--- x\": v\n", yaml);
+        var roundTrip = YamlSerializer.Deserialize<Dictionary<string, string>>(yaml);
+        Assert.NotNull(roundTrip);
+        Assert.Equal("v", roundTrip["--- x"]);
+    }
+
+    [Fact]
+    public void MappingKey_QuotesTheMergeKey()
+    {
+        var value = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["<<"] = "hello",
+        };
+
+        var yaml = YamlSerializer.Serialize(value, new YamlSerializerOptions { WriteIndented = true });
+
+        Assert.Equal("\"<<\": hello\n", yaml);
+        var roundTrip = YamlSerializer.Deserialize<Dictionary<string, string>>(yaml);
+        Assert.NotNull(roundTrip);
+        Assert.Equal("hello", roundTrip["<<"]);
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Syntax/YamlSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Syntax/YamlSyntaxTreeTests.cs
@@ -85,4 +85,58 @@ public class YamlSyntaxTreeTests
         Assert.True(ex.Start.Index >= 0);
         Assert.True(ex.End.Index >= ex.Start.Index);
     }
+
+    [Fact]
+    public void ParseDoesNotTreatAHashInsideAQuotedScalarAsAComment()
+    {
+        const string Yaml = "value: \"a#b\" # real\n";
+        var tree = YamlSyntaxTree.Parse(Yaml);
+
+        var comment = Assert.Single(tree.Tokens, token => token.Kind is YamlSyntaxKind.CommentTrivia);
+        Assert.Equal("# real", comment.Text);
+        Assert.Equal(13, comment.Span.Start.Index);
+        Assert.Equal(19, comment.Span.End.Index);
+
+        var scalars = tree.Tokens.Where(token => token.Kind is YamlSyntaxKind.Scalar).ToArray();
+        Assert.Equal("\"a#b\"", scalars[1].Text);
+        Assert.Equal(7, scalars[1].Span.Start.Index);
+        Assert.Equal(12, scalars[1].Span.End.Index);
+    }
+
+    [Fact]
+    public void ParseDoesNotTreatAHashInsideAPlainScalarAsAComment()
+    {
+        const string Yaml = "value: a#b\n";
+        var tree = YamlSyntaxTree.Parse(Yaml);
+
+        Assert.DoesNotContain(tree.Tokens, token => token.Kind is YamlSyntaxKind.CommentTrivia);
+    }
+
+    [Fact]
+    public void ParseDoesNotTreatABlockScalarBodyAsTrivia()
+    {
+        const string Yaml = "a: |\n  x#y\n  z\nb: 1 # c\n";
+        var tree = YamlSyntaxTree.Parse(Yaml);
+
+        var comment = Assert.Single(tree.Tokens, token => token.Kind is YamlSyntaxKind.CommentTrivia);
+        Assert.Equal("# c", comment.Text);
+
+        // The block scalar body is covered by its scalar token, so its indentation is not whitespace trivia either.
+        Assert.DoesNotContain(tree.Tokens, token =>
+            token.Kind is YamlSyntaxKind.WhitespaceTrivia &&
+            token.Span.Start.Index >= 4 &&
+            token.Span.Start.Index < 15);
+    }
+
+    [Fact]
+    public void ParseKeepsTriviaSpansOutsideOfScannerTokens()
+    {
+        const string Yaml = "key: value # c\n";
+        var tree = YamlSyntaxTree.Parse(Yaml);
+
+        foreach (var trivia in tree.Tokens.Where(token => token.Kind is YamlSyntaxKind.WhitespaceTrivia or YamlSyntaxKind.NewLineTrivia or YamlSyntaxKind.CommentTrivia))
+        {
+            Assert.Equal(Yaml[trivia.Span.Start.Index..trivia.Span.End.Index], trivia.Text);
+        }
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Yaml12CoreTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Yaml12CoreTests.cs
@@ -166,9 +166,19 @@ public sealed class Yaml12CoreTests
     }
 
     [Fact]
-    public void CoreSchema_IntegersWithUnderscores()
+    public void CoreSchema_IntegersWithUnderscoresAreStrings()
     {
+        // Underscore separators are a YAML 1.1 spelling that the core schema does not resolve as an integer.
         var schema = new CoreSchema();
+        Assert.True(schema.TryParse(new Scalar("1_000"), true, out var tag, out var val));
+        Assert.Equal(SchemaBase.StrShortTag, tag);
+        Assert.Equal("1_000", val);
+    }
+
+    [Fact]
+    public void ExtendedSchema_IntegersWithUnderscores()
+    {
+        var schema = new ExtendedSchema();
         Assert.True(schema.TryParse(new Scalar("1_000"), true, out var tag, out var val));
         Assert.Equal(JsonSchema.IntShortTag, tag);
         Assert.Equal(1000, val);
@@ -1224,5 +1234,82 @@ public sealed class Yaml12CoreTests
     {
         var scalar = events.OfType<Scalar>().FirstOrDefault(s => s.Value == expectedValue);
         Assert.NotNull(scalar, $"Expected scalar '{expectedValue}' not found");
+    }
+
+    [Theory]
+    // 10.3.2 Tag Resolution: base 10 integers accept a sign and leading zeros.
+    [InlineData("0", JsonSchema.IntShortTag, 0)]
+    [InlineData("12", JsonSchema.IntShortTag, 12)]
+    [InlineData("012", JsonSchema.IntShortTag, 12)]
+    [InlineData("00", JsonSchema.IntShortTag, 0)]
+    [InlineData("-012", JsonSchema.IntShortTag, -12)]
+    [InlineData("+012", JsonSchema.IntShortTag, 12)]
+    // Base 8 and base 16 accept neither a sign nor leading zeros before the prefix.
+    [InlineData("0o10", JsonSchema.IntShortTag, 8)]
+    [InlineData("0x10", JsonSchema.IntShortTag, 16)]
+    [InlineData("0xFF", JsonSchema.IntShortTag, 255)]
+    // Spellings the core schema does not resolve as integers.
+    [InlineData("-0x10", SchemaBase.StrShortTag, "-0x10")]
+    [InlineData("-0o10", SchemaBase.StrShortTag, "-0o10")]
+    [InlineData("0b101", SchemaBase.StrShortTag, "0b101")]
+    [InlineData("1_000", SchemaBase.StrShortTag, "1_000")]
+    [InlineData("0x_10", SchemaBase.StrShortTag, "0x_10")]
+    public void CoreSchema_IntegerSpellings(string text, string expectedTag, object expectedValue)
+    {
+        var schema = new CoreSchema();
+
+        Assert.True(schema.TryParse(new Scalar(text), true, out var tag, out var value), text);
+        Assert.Equal(expectedTag, tag, text);
+        Assert.Equal(expectedValue, value, text);
+    }
+
+    [Fact]
+    public void CoreSchema_IntegerBeyondUInt64IsResolvedWithoutThrowing()
+    {
+        var schema = new CoreSchema();
+
+        Assert.True(schema.TryParse(new Scalar("79228162514264337593543950335"), true, out var tag, out var value));
+        Assert.Equal(JsonSchema.IntShortTag, tag);
+        Assert.Equal(79228162514264337593543950335d, value);
+    }
+
+    [Theory]
+    [InlineData(ScalarStyle.Literal)]
+    [InlineData(ScalarStyle.Folded)]
+    [InlineData(ScalarStyle.SingleQuoted)]
+    [InlineData(ScalarStyle.DoubleQuoted)]
+    public void CoreSchema_NonPlainScalarsAreStrings(ScalarStyle style)
+    {
+        var schema = new CoreSchema();
+
+        foreach (var text in new[] { "true", "null", "~", "123", "1.5", ".inf" })
+        {
+            var scalar = new Scalar(null, null, text, style, isPlainImplicit: false, isQuotedImplicit: true);
+            Assert.True(schema.TryParse(scalar, true, out var tag, out var value), text);
+            Assert.Equal(SchemaBase.StrShortTag, tag, text);
+            Assert.Equal(text, value, text);
+        }
+    }
+
+    [Fact]
+    public void ExtendedSchema_IntegersBeyondInt32()
+    {
+        var schema = new ExtendedSchema();
+
+        Assert.True(schema.TryParse(new Scalar("0xFFFFFFFF"), true, out _, out var hex));
+        Assert.Equal(4294967295L, hex);
+
+        Assert.True(schema.TryParse(new Scalar("0xFFFFFFFFFFFFFFFFFF"), true, out var tag, out _));
+        Assert.Equal(JsonSchema.IntShortTag, tag);
+    }
+
+    [Fact]
+    public void ExtendedSchema_BareLeadingZeroIntegersAreOctal()
+    {
+        var schema = new ExtendedSchema();
+
+        Assert.True(schema.TryParse(new Scalar("010"), true, out var tag, out var value));
+        Assert.Equal(JsonSchema.IntShortTag, tag);
+        Assert.Equal(8, value);
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/YamlLineBreakTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/YamlLineBreakTests.cs
@@ -1,0 +1,112 @@
+using Meziantou.Framework.Yaml.Events;
+using Meziantou.Framework.Yaml.Model;
+using Scalar = Meziantou.Framework.Yaml.Events.Scalar;
+
+namespace Meziantou.Framework.Yaml.Tests;
+
+/// <summary>
+/// YAML 1.1 treated NEL (U+0085), LS (U+2028), and PS (U+2029) as line breaks. YAML 1.2 excludes them, so a reader
+/// keeps them as ordinary scalar content instead of folding them into a space.
+/// </summary>
+public sealed class YamlLineBreakTests
+{
+    public static TheoryData<char> NonBreakCharacters { get; } = ['\u0085', '\u2028', '\u2029'];
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void DoubleQuotedScalarKeepsTheCharacter(char character)
+    {
+        var value = YamlSerializer.Deserialize<string>($"\"a{character}b\"");
+
+        Assert.Equal($"a{character}b", value);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void SingleQuotedScalarKeepsTheCharacter(char character)
+    {
+        var value = YamlSerializer.Deserialize<string>($"'a{character}b'");
+
+        Assert.Equal($"a{character}b", value);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void PlainScalarKeepsTheCharacter(char character)
+    {
+        var value = YamlSerializer.Deserialize<string>($"a{character}b");
+
+        Assert.Equal($"a{character}b", value);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void LiteralBlockScalarKeepsTheCharacter(char character)
+    {
+        var value = YamlSerializer.Deserialize<string>($"|-\n  a{character}b\n");
+
+        Assert.Equal($"a{character}b", value);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void RoundTripKeepsTheCharacter(char character)
+    {
+        var value = $"a{character}b";
+
+        Assert.Equal(value, YamlSerializer.Deserialize<string>(YamlSerializer.Serialize(value)));
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void TheCharacterDoesNotStartANewLine(char character)
+    {
+        var scalar = ReadFirstScalar($"key: a{character}b\n");
+
+        Assert.Equal($"a{character}b", scalar.Value, "scalar value");
+        Assert.Equal(0, scalar.Start.Line, "start line");
+        Assert.Equal(5, scalar.Start.Column, "start column");
+        Assert.Equal(0, scalar.End.Line, "end line");
+        Assert.Equal(8, scalar.End.Column, "end column");
+    }
+
+    [Fact]
+    public void LineFeedStillStartsANewLine()
+    {
+        var scalar = ReadFirstScalar("key: a\n  b\n");
+
+        Assert.Equal("a b", scalar.Value);
+        Assert.Equal(0, scalar.Start.Line);
+        Assert.Equal(1, scalar.End.Line);
+    }
+
+    private static Scalar ReadFirstScalar(string yaml)
+    {
+        var parser = Parser.CreateParser(new StringReader(yaml));
+        while (parser.MoveNext())
+        {
+            if (parser.Current is Scalar scalar && !string.Equals(scalar.Value, "key", StringComparison.Ordinal))
+            {
+                return scalar;
+            }
+        }
+
+        throw new InvalidOperationException("No scalar found.");
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBreakCharacters))]
+    public void EmitterRoundTripKeepsTheCharacter(char character)
+    {
+        var value = $"a{character}b";
+        var stream = new YamlStream { new YamlDocument { Contents = new YamlValue(value) } };
+
+        using var writer = new StringWriter();
+        stream.WriteTo(writer);
+        var text = writer.ToString();
+
+        var reloaded = YamlStream.Load(new EventReader(Parser.CreateParser(new StringReader(text))));
+
+        Assert.Equal(value, ((YamlValue)reloaded[0].Contents!).Value);
+    }
+}


### PR DESCRIPTION
Fixes 13 reproducible correctness defects and one measured performance issue found in a review of `Meziantou.Framework.Yaml`, plus regression coverage for each.

## Serialization

- **Serializing a plain `object` terminated the process.** `Serialize<object>(new object())` resolved the runtime type back to the untyped converter, which called itself until the stack overflowed (exit code 134, ~104k frames). It now writes an empty mapping, matching `JsonSerializer`. Also reachable for a plain object inside an untyped collection.
- **Root strings could become document framing.** `Serialize("---")` produced `---\n`, which deserialized to `null`; `"--- hello"` came back as `"hello"`; `"..."` threw on read. `IsPlainSafe` now quotes a value starting with `---`/`...` when it is written at the first column of a line — which covers a root scalar *and* a root mapping key. `---hello` stays plain, because a marker has to be followed by separation. The same method also quotes a `<<` mapping key so an ordinary key with that name round trips.
- **Built-in root types bypassed registered converters.** A `YamlConverter<int>` writing 42 still emitted `5`. `BuiltInYamlTypeInfo` now resolves its converter from the reader/writer the way `ReflectionYamlTypeInfo` already did, so options converters, factories and `YamlConverterAttribute` apply at the root.
- **`TryParseUInt64` threw on overflow.** The base parser used `checked`, so `Serialize("0x10000000000000000")` threw `OverflowException` — the writer calls it to decide whether quoting is needed. Overflow is now detected before the multiplication and reported as a failed parse.
- **Schema mode lost decimal precision and rejected representable values.** `0.1234567890123456789012345678` came back as `0.1234567890123456773698862321` because the schema converted through `double` first, and `decimal.MaxValue` failed outright. With `UseSchema`, a decimal is now parsed from the scalar's own text unless the schema decoded an exact integral value — which is the only form that carries the base the scalar was written in, so `0x10` and the extended schema's bare-leading-zero octal still decode correctly.

## Schemas

- **Block scalars were implicitly typed.** Only the two quoted styles bypassed implicit resolution, so `|-\n  true` deserialized to boolean `true`. Every non-plain style now resolves to `!!str` ([tag resolution](https://yaml.org/spec/1.2.2/#tag-resolution)).
- **The core schema misclassified integers.** `012` threw "Invalid integer scalar" because the integer rule rejected leading zeros and the float rule claimed it. The rules now follow [§10.3.2](https://yaml.org/spec/1.2.2/#1032-tag-resolution): base 10 accepts a sign and leading zeros, base 8 and 16 accept neither a sign nor underscores, and the YAML 1.1 spellings (underscores, binary, signed prefixes) stay in the extended schema where they belong.
- Integer decoding moved to a shared `SchemaScalarDecoder` that never throws, since these paths sit under `TryParse`. It also replaces `Convert.ToInt32` in the extended schema, which silently wrapped `0xFFFFFFFF` to `-1` and threw beyond `Int32`.

## Merge keys

- **Sequence precedence was backwards.** `<<: [{a: 1}, {a: 2}]` produced `a = 2`; the [merge extension](https://yaml.org/type/merge.html) gives earlier mappings precedence. Merged keys are now recorded alongside explicitly declared ones in all four paths (object, dictionary, untyped, alias-based), so an earlier mapping wins and an explicit key still wins over both regardless of its position.
- **A quoted `<<` key was treated as a merge instruction.** `Deserialize<Dictionary<string, string>>("'<<': hello")` threw. The new `YamlMergeKey` helper checks the key's style and tag *before* the reader advances past it, and is used at all 13 call sites.

## Scanner and reader

- **U+0085 / U+2028 / U+2029 corrupted scalars.** They were folded as line breaks, so a scalar containing one read back with a space in its place. YAML 1.2 [excludes them](https://yaml.org/spec/1.2.2/#54-line-break-characters) and treats them as content. `Emitter.IsBreak` had to change too: left alone, the emitter would write one of them as a real newline for a character the reader now keeps, losing it on a model round trip.
- **Valid anchor names were rejected.** `&a.b` threw because anchor scanning used the tag-handle alphabet. It now follows [`ns-anchor-name`](https://yaml.org/spec/1.2.2/#692-node-anchors); `NodeEvent.AnchorValidator` was widened to match, otherwise the regex would reject what the scanner accepts.
- **Scalar anchors were not registered.** With `ReferenceHandling = Preserve`, `[&a hello, *a]` threw "Unknown YAML alias". Rather than touching ~30 scalar converters, the reader now registers the anchored scalar node and presents an alias to it *as that scalar* — so each converter reads it at its own destination type, and `[&a "true", *a]` stays a string in both positions.

## Syntax tree

- **Trivia scanning labelled scalar content as comments.** For `value: "a#b" # real`, the comment token was `#b" # real`, overlapping the scalar and swallowing the real comment's start. The scanner now runs first and trivia is read only from the gaps between its tokens, which also stops block-scalar indentation from being reported as whitespace trivia.

## Performance

Converter caches were per reader/writer, so every serializer call rebuilt the object converter and its reflection contract. They are now shared per options instance through a `ConditionalWeakTable`. It cannot be a field on `YamlSerializerOptions` — it is a record, and `with` would copy the reference into differently-configured options.

Measured locally on .NET 11, 10,000 serializations of a three-property object:

| | time | allocations |
|---|---|---|
| fresh options per call (old behaviour) | 234 ms | 9,434 B/op |
| reused options instance | 15.9 ms | 568 B/op |

Directional microbenchmark evidence, not a production throughput guarantee. `benchmarks/YamlBenchmarks` adds a repeat-call benchmark; note BenchmarkDotNet 0.15.8 needs `-f net10.0`.

## Notes for the reviewer

- **Two existing tests asserted the wrong behaviour and are corrected**, both flagged by the review: `YamlMergeKeyTests.Deserialize_Dictionary_ShouldApplyMergeSequenceInOrder` asserted last-wins, and `Yaml12CoreTests.CoreSchema_IntegersWithUnderscores` asserted a YAML 1.1 spelling under the core schema (renamed, with a sibling test added for the extended schema).
- **Behaviour changes worth a second look:** under the core schema, `1_000`, `0b101` and `-0x10` now resolve to `!!str` rather than `!!int`; use `YamlSchemaKind.Extended` for those spellings. An untagged literal or folded scalar is now always a string.
- The stack-overflow regression is covered both in-process and in the existing `FeatureSwitchSmoke` executable, since a real overflow cannot be observed from inside the test host — I extended that harness rather than adding a project for one test.
- **Left out deliberately:** the extended schema's timestamp decoder can still throw `FormatException` from inside `TryParse` for something like `2001-13-45`. Same class of defect as the integer decoders, but it was not in the findings and changing it has semantic ripples worth deciding separately.

## Validation

- `dotnet test` on `Meziantou.Framework.Yaml.Tests` with `/p:TreatsWarningsAsErrors=true`: **2,194 passed, 0 failed, 0 skipped** (net11.0: 1,129; net10.0: 1,065), up from 1,996 before these changes.
- `Meziantou.Framework.DependencyScanning.Tests`, the only other consumer: 236/236 passed.
- Release + `IsOfficialBuild=true` builds clean for the library, tests, smoke executable and benchmark. `ref/` is unchanged, confirming no public API surface change.
- `dotnet run ./eng/update-all.cs` completes with no errors; it added `benchmarks/YamlBenchmarks` to `Meziantou.Framework.slnx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
