### PR TITLE
Fix five FullPath defects around symlinks, temp files and device paths

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -272,7 +273,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     }
 
     /// <summary>Returns a new path with the specified file extension, optionally replacing all trailing extensions.</summary>
-    /// <param name="extension">The new extension (with or without the leading dot), or <see langword="null"/> to remove the extension.</param>
+    /// <param name="extension">The new extension (with or without the leading dot), or <see langword="null"/> to remove the extension. An empty string sets an empty extension, which leaves a trailing dot.</param>
     /// <param name="replaceAllTrailingExtensions"><see langword="true"/> to replace all trailing extensions; <see langword="false"/> to replace only the last extension.</param>
     /// <returns>A new <see cref="FullPath"/> instance with the specified extension changes.</returns>
     public FullPath WithExtension(string? extension, bool replaceAllTrailingExtensions)
@@ -281,9 +282,10 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     }
 
     /// <summary>Returns a new path with the specified file extension, replacing a specific number of trailing extensions.</summary>
-    /// <param name="extension">The new extension (with or without the leading dot), or <see langword="null"/> to remove the extension.</param>
+    /// <param name="extension">The new extension (with or without the leading dot), or <see langword="null"/> to remove the extension. An empty string sets an empty extension, which leaves a trailing dot.</param>
     /// <param name="extensionCount">The number of trailing extensions to replace. Must be greater than 0.</param>
     /// <returns>A new <see cref="FullPath"/> instance with the specified extension changes.</returns>
+    /// <remarks>Every removal follows <see cref="Path.ChangeExtension(string, string)"/>, so a trailing dot is an empty extension that costs one removal, and <paramref name="extensionCount"/> only changes how many of them are removed.</remarks>
     public FullPath WithExtension(string? extension, int extensionCount)
     {
         if (extensionCount <= 0)
@@ -295,28 +297,31 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        var current = _value;
-        var extensionsRemoved = 0;
-        while (true)
+        var path = _value.AsSpan();
+
+        // Only the file name holds extensions, so the search must never reach into the directory
+        var fileNameStart = path.Length - Path.GetFileName(path).Length;
+        var end = path.Length;
+        for (var i = 0; i < extensionCount; i++)
         {
-            var ext = Path.GetExtension(current);
-            if (string.IsNullOrEmpty(ext))
+            // The dot is located directly rather than through Path.GetExtension, which reports an empty extension for a
+            // trailing dot and would stop the removal there
+            var dotIndex = path[fileNameStart..end].LastIndexOf('.');
+            if (dotIndex < 0)
                 break;
 
-            current = current[..^ext.Length];
-            extensionsRemoved++;
-
-            if (extensionsRemoved >= extensionCount)
-                break;
+            end = fileNameStart + dotIndex;
         }
 
-        if (string.IsNullOrEmpty(extension))
-            return FromPath(current);
+        // A single allocation for the result, instead of one intermediate path per removed extension
+        var withoutExtensions = path[..end];
+        if (extension is null)
+            return FromPath(withoutExtensions.ToString());
 
-        if (!extension.StartsWith('.', StringComparison.Ordinal))
-            extension = "." + extension;
-
-        return FromPath(current + extension);
+        // Like Path.ChangeExtension, an empty extension still gets the separating dot
+        return FromPath(extension.StartsWith('.', StringComparison.Ordinal)
+            ? string.Concat(withoutExtensions, extension)
+            : string.Concat(withoutExtensions, ".", extension));
     }
 
     /// <summary>Returns a new path with the specified name, keeping the same parent directory.</summary>
@@ -361,6 +366,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     /// <summary>Creates a uniquely named, zero-byte temporary file and returns its full path.</summary>
     /// <param name="prefix">A prefix to prepend to the generated file name.</param>
     /// <param name="suffix">A suffix to append to the generated file name. Defaults to <c>.tmp</c>.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="prefix"/> or <paramref name="suffix"/> contains a character that is not valid in a file name, such as a directory separator.</exception>
     /// <exception cref="IOException">Thrown when a unique file could not be created after 10 attempts.</exception>
     public static FullPath CreateTempFile(string? prefix, string? suffix = ".tmp") => CreateTempFile(folder: null, prefix: prefix, suffix: suffix);
 
@@ -368,6 +374,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     /// <param name="folder">The destination folder. If <see langword="null"/> or empty, the system temporary folder is used.</param>
     /// <param name="prefix">A prefix to prepend to the generated file name.</param>
     /// <param name="suffix">A suffix to append to the generated file name. Defaults to <c>.tmp</c>.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="prefix"/> or <paramref name="suffix"/> contains a character that is not valid in a file name, such as a directory separator.</exception>
     /// <exception cref="IOException">Thrown when a unique file could not be created after 10 attempts.</exception>
     public static FullPath CreateTempFile(FullPath? folder, string? prefix, string? suffix = ".tmp")
     {
@@ -377,10 +384,14 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
             destinationFolder = GetTempPath();
         }
 
-        Directory.CreateDirectory(destinationFolder.Value);
-
         prefix ??= string.Empty;
         suffix ??= string.Empty;
+
+        // Validate before touching the file system, so a rejected affix cannot leave a directory behind
+        ThrowIfNotAFileNameFragment(prefix, nameof(prefix));
+        ThrowIfNotAFileNameFragment(suffix, nameof(suffix));
+
+        Directory.CreateDirectory(destinationFolder.Value);
 
         var options = new FileStreamOptions
         {
@@ -414,6 +425,17 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         }
 
         throw new IOException("Could not create a unique temporary file after 10 attempts.", lastException);
+    }
+
+    private static readonly SearchValues<char> InvalidFileNameChars = SearchValues.Create(Path.GetInvalidFileNameChars());
+
+    private static void ThrowIfNotAFileNameFragment(string value, string paramName)
+    {
+        // The affix is concatenated with the random component and the result is interpreted as a path. A directory
+        // separator, or any other character a file name cannot hold, would move the file out of the destination folder
+        // ("../name") or cancel the random component that makes the name unique ("/../name").
+        if (value.AsSpan().ContainsAny(InvalidFileNameChars))
+            throw new ArgumentException("The value contains characters that are not valid in a file name.", paramName);
     }
 
     /// <summary>Gets the path to the system special folder identified by the specified enumeration.</summary>
@@ -460,14 +482,34 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
             return Empty;
 
         // '\' is a regular file name character on Unix, so a path such as @"\\?\a" is a relative file name there, not a device path
+        // Both the Win32 spelling (@"\\?\") and the NT one (@"\??\") are extended paths, and the reparse point of a
+        // symbolic link stores its absolute target in the NT form, so both of them reach this method.
         if (OperatingSystem.IsWindows() && PathInternal.IsExtended(path))
         {
             // The extended form of a UNC path is @"\\?\UNC\server\share". Dropping the 4-character device prefix would
             // leave the relative @"UNC\server\share", which Path.GetFullPath would then resolve against the current
             // directory, so restore the @"\\" prefix instead. This is the inverse of PathInternal.EnsureExtendedPrefix.
-            path = path.StartsWith(PathInternal.UncExtendedPathPrefix, StringComparison.OrdinalIgnoreCase)
-                ? string.Concat(PathInternal.UncPathPrefix, path.AsSpan(PathInternal.UncExtendedPathPrefix.Length))
-                : path[PathInternal.DevicePrefixLength..];
+            if (path.StartsWith(PathInternal.UncExtendedPathPrefix, StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith(PathInternal.UncNTPathPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                path = string.Concat(PathInternal.UncPathPrefix, path.AsSpan(PathInternal.UncExtendedPathPrefix.Length));
+            }
+            else
+            {
+                var withoutPrefix = path.AsSpan(PathInternal.DevicePrefixLength);
+                if (!PathInternal.IsPartiallyQualified(withoutPrefix))
+                {
+                    // A drive-rooted path such as @"\\?\C:\dir" has an ordinary spelling
+                    path = withoutPrefix.ToString();
+                }
+                else if (path.StartsWith(PathInternal.NTPathPrefix, StringComparison.Ordinal))
+                {
+                    // Anything else names a device namespace, such as @"\\?\Volume{...}\dir", and has no ordinary
+                    // spelling: removing the prefix would leave a relative path. Only the NT form is rewritten, so the
+                    // value stays a path the Win32 file APIs accept.
+                    path = string.Concat(PathInternal.ExtendedDevicePathPrefix, withoutPrefix);
+                }
+            }
         }
 
         var fullPath = Path.GetFullPath(path);
@@ -565,7 +607,8 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return false;
 
-        return Symlink.IsSymbolicLink(_value);
+        // Value, not _value: a real file named "NUL.txt" is only reachable through the extended path
+        return Symlink.IsSymbolicLink(Value);
     }
 
     /// <summary>Attempts to resolve this path to its canonical final existing path.</summary>
@@ -577,7 +620,8 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     /// </remarks>
     public bool TryGetCanonicalPath([NotNullWhen(true)] out FullPath? result)
     {
-        if (!IsEmpty && CanonicalPath.TryGetCanonicalPath(_value, out var path))
+        // Value, not _value: a real file named "NUL.txt" is only reachable through the extended path
+        if (!IsEmpty && CanonicalPath.TryGetCanonicalPath(Value, out var path))
         {
             result = FromPath(path);
             return true;
@@ -615,7 +659,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     public bool TryFindGitRepositoryRoot(out FullPath result)
     {
         var start = this;
-        if (!start.IsEmpty && File.Exists(start._value))
+        if (!start.IsEmpty && File.Exists(start.Value))
         {
             start = start.Parent;
         }
@@ -667,7 +711,8 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
             switch (resolutionMode)
             {
                 case SymbolicLinkResolutionMode.Immediate:
-                    if (Symlink.TryGetSymLinkTarget(_value, out var path))
+                    // Value, not _value: a link named "NUL.txt" is only reachable through the extended path
+                    if (Symlink.TryGetSymLinkTarget(Value, out var path))
                     {
                         result = FromPath(path);
                         return true;
@@ -676,19 +721,19 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                     break;
 
                 case SymbolicLinkResolutionMode.FinalTarget:
-                    var value = _value;
+                    var target = this;
                     var depth = 0;
-                    while (Symlink.TryGetSymLinkTarget(value, out path))
+                    while (Symlink.TryGetSymLinkTarget(target.Value, out path))
                     {
                         if (++depth > MaxSymbolicLinkDepth)
                             throw CreateTooManyLevelsOfSymbolicLinksException();
 
-                        value = path;
+                        target = FromPath(path);
                     }
 
-                    if (value != _value)
+                    if (depth > 0)
                     {
-                        result = FromPath(value);
+                        result = target;
                         return true;
                     }
 
@@ -705,7 +750,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                     var resolvedLinkCount = 0;
                     while (!current.IsEmpty)
                     {
-                        if (Symlink.TryGetSymLinkTarget(current._value, out path))
+                        if (Symlink.TryGetSymLinkTarget(current.Value, out path))
                         {
                             if (++resolvedLinkCount > MaxSymbolicLinkDepth)
                                 throw CreateTooManyLevelsOfSymbolicLinksException();

--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -183,6 +183,8 @@ namespace System.IO
         internal const string UncDevicePrefixToInsert = @"?\UNC\";
         internal const string UncExtendedPathPrefix = @"\\?\UNC\";
         internal const string DevicePathPrefix = @"\\.\";
+        internal const string NTPathPrefix = @"\??\";
+        internal const string UncNTPathPrefix = @"\??\UNC\";
 
         internal const int MaxShortPath = 260;
 
@@ -291,7 +293,7 @@ namespace System.IO
         /// for C: (rooted, but relative). "C:\a" is rooted and not relative (the current directory
         /// will not be used to modify the path).
         /// </remarks>
-        internal static bool IsPartiallyQualified(string path)
+        internal static bool IsPartiallyQualified(ReadOnlySpan<char> path)
         {
             if (path.Length < 2)
             {

--- a/src/Meziantou.Framework.FullPath/Symlink.cs
+++ b/src/Meziantou.Framework.FullPath/Symlink.cs
@@ -31,6 +31,46 @@ internal static partial class Symlink
         }
     }
 
+    /// <summary>Resolves a relative symbolic link target against the directory that contains the link.</summary>
+    private static string ResolveRelativeTarget(string linkDirectory, string linkTarget)
+    {
+        var combined = Path.Combine(linkDirectory, linkTarget);
+
+        // Without a ".." segment the combined path opens the same file as the link does, whatever the directory is made
+        // of, so the extra work is only needed for the targets that can walk out of it
+        if (!ContainsParentDirectorySegment(linkTarget))
+            return combined;
+
+        // Normalizing "dir/../name" lexically cancels "dir" even when it is a symbolic link, which makes the result name
+        // a different file than the one the link opens. Canonicalizing the directory of the combined path resolves those
+        // links first, and covers a link the target itself walks through before the ".." segment.
+        var directory = Path.GetDirectoryName(combined);
+        if (!string.IsNullOrEmpty(directory) && CanonicalPath.TryGetCanonicalPath(directory, out var canonicalDirectory))
+            return Path.Combine(canonicalDirectory, Path.GetFileName(combined));
+
+        // A dangling or unreadable component cannot be canonicalized, so the lexical result is the best answer available
+        return combined;
+    }
+
+    private static bool ContainsParentDirectorySegment(string path)
+    {
+        var remaining = path.AsSpan();
+        while (!remaining.IsEmpty)
+        {
+            var separatorIndex = remaining.IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var segment = separatorIndex < 0 ? remaining : remaining[..separatorIndex];
+            if (segment is "..")
+                return true;
+
+            if (separatorIndex < 0)
+                break;
+
+            remaining = remaining[(separatorIndex + 1)..];
+        }
+
+        return false;
+    }
+
     private static partial class UnixSymlink
     {
         internal static bool TryGetSymLinkTarget(string path, [NotNullWhen(true)] out string? target)
@@ -38,14 +78,7 @@ internal static partial class Symlink
             if (TryReadLink(path, out var linkTarget))
             {
                 var root = Path.GetDirectoryName(path);
-                if (root is null)
-                {
-                    target = linkTarget;
-                }
-                else
-                {
-                    target = Path.Combine(root, linkTarget);
-                }
+                target = root is null ? linkTarget : ResolveRelativeTarget(root, linkTarget);
 
                 return true;
             }
@@ -190,30 +223,19 @@ internal static partial class Symlink
                         var target = Encoding.Unicode.GetString(validBuffer.Slice(sizeHeader + header.SubstituteNameOffset, header.SubstituteNameLength));
                         if ((header.Flags & Interop.Kernel32.SYMLINK_FLAG_RELATIVE) != 0)
                         {
-                            if (PathInternal.IsExtended(path))
-                            {
-                                var rootPath = Path.GetDirectoryName(path[4..]);
-                                if (rootPath is not null)
-                                {
-                                    target = string.Concat(path.AsSpan(0, 4), Path.GetFullPath(Path.Combine(rootPath, target)));
-                                }
-                                else
-                                {
-                                    target = string.Concat(path.AsSpan(0, 4), Path.GetFullPath(target));
-                                }
-                            }
-                            else
-                            {
-                                var rootPath = Path.GetDirectoryName(path);
-                                if (rootPath is not null)
-                                {
-                                    target = Path.GetFullPath(Path.Combine(rootPath, target));
-                                }
-                                else
-                                {
-                                    target = Path.GetFullPath(target);
-                                }
-                            }
+                            // The device prefix is taken off first, so the relative target is combined with an ordinary path
+                            var isExtended = PathInternal.IsExtended(path);
+                            var linkPath = isExtended ? path[PathInternal.DevicePrefixLength..] : path;
+                            var rootPath = Path.GetDirectoryName(linkPath);
+                            var resolved = rootPath is null
+                                ? Path.GetFullPath(target)
+                                : Path.GetFullPath(ResolveRelativeTarget(rootPath, target));
+
+                            // Canonicalizing can turn a mapped drive into a UNC path, which the extended prefix cannot be
+                            // put back in front of, so it is only restored for a path that still accepts it
+                            target = isExtended && !PathInternal.IsDevice(resolved) && !resolved.StartsWith(PathInternal.UncPathPrefix, StringComparison.Ordinal)
+                                ? string.Concat(path.AsSpan(0, PathInternal.DevicePrefixLength), resolved)
+                                : resolved;
                         }
 
                         return target;

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -211,6 +211,51 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void ChangeMultipleExtensions_CountBeyondTheAvailableExtensions()
+    {
+        var path = FullPath.FromPath("test") / "a" / "b.gz";
+        Assert.Equal(FullPath.FromPath("test") / "a" / "b.zip", path.WithExtension(".zip", extensionCount: 5));
+    }
+
+    [Fact]
+    public void ChangeMultipleExtensions_ConsecutiveDotsCountOneEach()
+    {
+        var path = FullPath.FromPath("test") / "a" / "b..gz";
+
+        Assert.Equal(FullPath.FromPath("test") / "a" / "b..zip", path.WithExtension(".zip", extensionCount: 1));
+        Assert.Equal(FullPath.FromPath("test") / "a" / "b.zip", path.WithExtension(".zip", extensionCount: 2));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void ChangeMultipleExtensions_TrailingDotIsAnEmptyExtension()
+    {
+        // Windows path normalization eats a trailing dot, so the name only survives on Unix
+        var path = FullPath.FromPath("test") / "a" / "archive.tar.";
+
+        // Path.ChangeExtension replaces the empty extension the trailing dot stands for, and every removal here has to
+        // behave the same way, so only the number of removed extensions changes with the count
+        Assert.Equal("archive.tar.zip", path.WithExtension("zip").Name);
+        Assert.Equal("archive.zip", path.WithExtension("zip", extensionCount: 2).Name);
+        Assert.Equal("archive.zip", path.WithExtension("zip", replaceAllTrailingExtensions: true).Name);
+        Assert.Equal("archive", path.WithExtension(null, extensionCount: 2).Name);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void ChangeMultipleExtensions_EmptyExtensionKeepsTheDot()
+    {
+        // Windows path normalization eats a trailing dot, so the name only survives on Unix
+        var path = FullPath.FromPath("test") / "a" / "file.txt";
+
+        // An empty extension is not the same as no extension, which is what null asks for
+        Assert.Equal("file.", path.WithExtension("").Name);
+        Assert.Equal("file.", path.WithExtension("", extensionCount: 2).Name);
+        Assert.Equal("file.", path.WithExtension("", replaceAllTrailingExtensions: true).Name);
+        Assert.Equal("file", path.WithExtension(null, extensionCount: 2).Name);
+    }
+
+    [Fact]
     public void CombinePath()
     {
         var actual = FullPath.FromPath("test") / "a" / ".." / "a" / "." / "b";
@@ -688,6 +733,33 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public async Task ResolveSymlink_RelativeTargetWithParentSegmentBelowALinkedDirectory()
+    {
+        // real/sub/link -> ../target, reached through alias -> real/sub. Collapsing "alias/../target" lexically names
+        // <root>/target, which is a different file than the one opening the link reads.
+        await using var temp = TemporaryDirectory.Create();
+        temp.CreateDirectory("real/sub");
+        var expected = temp.CreateTextFile("real/target", "actual target");
+        temp.CreateTextFile("target", "wrong target");
+        CreateSymlink(temp.GetFullPath("alias"), Path.Combine("real", "sub"), isDirectory: true);
+        CreateSymlink(temp.GetFullPath("real/sub/link"), Path.Combine("..", "target"), isDirectory: false);
+
+        var link = temp.GetFullPath("alias/link");
+        Assert.Equal("actual target", File.ReadAllText(link.Value));
+        Assert.True(expected.TryGetCanonicalPath(out var canonicalExpected));
+
+        foreach (var mode in Enum.GetValues<SymbolicLinkResolutionMode>())
+        {
+            Assert.True(link.TryGetSymbolicLinkTarget(mode, out var target));
+            Assert.Equal(canonicalExpected.Value, target.Value);
+            Assert.Equal("actual target", File.ReadAllText(target.Value.Value));
+        }
+
+        Assert.True(link.TryGetCanonicalPath(out var canonical));
+        Assert.Equal(canonicalExpected.Value, canonical.Value);
+    }
+
+    [Fact]
     public async Task TryGetCanonicalPath_File()
     {
         await using var temp = TemporaryDirectory.Create();
@@ -832,9 +904,43 @@ public sealed class FullPathTests
     public void CreateTempFile_ThrowsAfterMaxAttempts()
     {
         var folder = FullPath.GetTempPath();
-        var invalidSuffix = $"{Path.DirectorySeparatorChar}invalid";
-        var exception = Assert.Throws<IOException>(() => FullPath.CreateTempFile(folder, prefix: null, suffix: invalidSuffix));
+
+        // Longer than the maximum length of a file name, so every attempt fails while the affix stays a valid fragment
+        var tooLongSuffix = new string('a', 300);
+        var exception = Assert.Throws<IOException>(() => FullPath.CreateTempFile(folder, prefix: null, suffix: tooLongSuffix));
         Assert.Contains("10 attempts", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("../outside-")]
+    [InlineData("sub/")]
+    [InlineData("\0")]
+    public void CreateTempFile_ThrowsWhenThePrefixIsNotAFileName(string prefix)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => FullPath.CreateTempFile(FullPath.GetTempPath(), prefix, suffix: ".tmp"));
+        Assert.Equal("prefix", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("/../fixed.txt")]
+    [InlineData("/outside.txt")]
+    public void CreateTempFile_ThrowsWhenTheSuffixIsNotAFileName(string suffix)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => FullPath.CreateTempFile(FullPath.GetTempPath(), prefix: null, suffix));
+        Assert.Equal("suffix", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task CreateTempFile_RejectedAffixCreatesNothing()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var folder = temp.GetFullPath("destination");
+
+        // The affix would otherwise put the file next to the destination folder rather than inside it
+        Assert.Throws<ArgumentException>(() => FullPath.CreateTempFile(folder, prefix: "../outside-"));
+
+        Assert.False(Directory.Exists(folder));
+        Assert.Empty(Directory.GetFileSystemEntries(temp.FullPath));
     }
 
     [Fact]
@@ -1055,6 +1161,41 @@ public sealed class FullPathTests
         var extended = path.ToWindowsExtendedPath();
         Assert.StartsWith(@"\\?\", extended);
         Assert.Contains(longSegment, extended);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void FromPath_NTExtendedUncPath()
+    {
+        // A reparse point stores an absolute target in the NT form, so FromPath has to give it back its UNC root
+        Assert.Equal(FullPath.FromPath(@"\\server\share\folder\file.txt"), FullPath.FromPath(@"\??\UNC\server\share\folder\file.txt"));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void FromPath_NTExtendedDrivePath()
+    {
+        Assert.Equal(FullPath.FromPath(@"C:\temp\test.txt"), FullPath.FromPath(@"\??\C:\temp\test.txt"));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void FromPath_VolumeGuidPathKeepsItsRoot()
+    {
+        // A volume GUID path has no ordinary spelling, so dropping the prefix would leave a relative path that
+        // Path.GetFullPath resolves against the current directory
+        const string VolumePath = @"\\?\Volume{12345678-1234-1234-1234-123456789abc}\folder\file.txt";
+
+        Assert.Equal(VolumePath, FullPath.FromPath(VolumePath).RawValue);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void FromPath_NTVolumeGuidPathUsesTheWin32Spelling()
+    {
+        Assert.Equal(
+            @"\\?\Volume{12345678-1234-1234-1234-123456789abc}\folder\file.txt",
+            FullPath.FromPath(@"\??\Volume{12345678-1234-1234-1234-123456789abc}\folder\file.txt").RawValue);
     }
 
     private static FullPath GetRootDirectory()

--- a/tests/Meziantou.Framework.FullPath.Tests/ReservedDeviceNameTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/ReservedDeviceNameTests.cs
@@ -89,4 +89,35 @@ public sealed class ReservedDeviceNameTests
         Assert.Equal(@"C:\temp\CON\b.txt", path.RawValue);
         Assert.Equal(FullPath.FromPath(@"C:\temp\CON\b.txt"), path);
     }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public async Task TryGetCanonicalPath_ReservedName_FindsTheRealFile()
+    {
+        await using var temp = TemporaryDirectory.Create();
+
+        // Only the extended path creates a real file; the ordinary one addresses the NUL device, and so does a
+        // canonical lookup that is given the unprotected value
+        var file = temp.GetFullPath("NUL.txt");
+        File.WriteAllText(file.Value, "content");
+
+        Assert.False(file.IsSymbolicLink());
+        Assert.True(file.TryGetCanonicalPath(out var canonical));
+        Assert.Equal("NUL.txt", canonical.Value.Name);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public async Task TryGetSymbolicLinkTarget_ReservedName_FindsTheRealLink()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var target = temp.CreateTextFile("target.txt", "content");
+
+        var link = temp.GetFullPath("NUL.txt");
+        File.CreateSymbolicLink(link.Value, target.Value);
+
+        Assert.True(link.IsSymbolicLink());
+        Assert.True(link.TryGetSymbolicLinkTarget(out var resolved));
+        Assert.Equal(target, resolved.Value);
+    }
 }


### PR DESCRIPTION
Addresses five defects found in a review of `FullPath.cs`. Each one is a case where the type returns or acts on something other than the path the caller is holding.

## Changes

**Symbolic link targets containing `..`** — a relative link target was combined with the link's directory lexically, so a `..` segment cancelled a parent component that was itself a symbolic link. Given `alias -> real/sub` and `real/sub/link -> ../target`, reading `alias/link` reads `real/target`, but all three `SymbolicLinkResolutionMode` values returned the top-level `target` — a different file. A relative target with no `..` segment is still combined lexically (it opens the same file, and there is no syscall to pay for); one that has a `..` segment now has the directory of the combined path canonicalized first. That also covers a link the target itself walks through before the `..`. A dangling component falls back to the lexical result, so dangling links still resolve.

**`CreateTempFile` affixes** — the prefix and suffix were concatenated with the random component and the result interpreted as a path, so `prefix: "../outside-"` created the file next to the destination folder and `suffix: "/../fixed.txt"` cancelled the random component and produced a fixed name. Both are now validated against `Path.GetInvalidFileNameChars()` and rejected with `ArgumentException`, before `Directory.CreateDirectory`, so a rejected call leaves nothing behind.

**`WithExtension(extension, count)`** — `Path.GetExtension` reports an empty extension for a trailing dot, so the removal loop stopped there: `archive.tar.` with `count: 2` produced `archive.tar..zip`. The overload also treated an empty replacement like `null`, unlike the single-extension overload. Removal now locates the dot directly, and every overload matches `Path.ChangeExtension`, so a trailing dot is an empty extension costing one removal, `""` keeps its dot, `null` removes, and `count` only changes how many extensions go.

**NT and volume-GUID roots in `FromPath`** — `PathInternal.IsExtended` matches both `\\?\` and `\??\`, but only the Win32 UNC prefix was special-cased, so `\??\UNC\server\share\file` lost its root and was resolved against the current directory. `\\?\Volume{GUID}\file` had the same problem. This is reachable in practice: a Windows reparse point stores its absolute target in the NT form. A prefix is now only removed when what remains is drive-rooted; a device namespace keeps it, rewritten from `\??\` to `\\?\` so the value stays a path the Win32 file APIs accept.

**Reserved device names** — `IsSymbolicLink`, `TryGetCanonicalPath`, all three symlink modes and `TryFindGitRepositoryRoot` passed `_value` instead of `Value`, so a real file named `NUL.txt` — creatable only through the extended path that `Value` produces — was looked up through the ordinary namespace and addressed the `NUL` device. `FinalTarget` needed restructuring to carry a `FullPath` across hops rather than a raw string, so every hop keeps the protection.

## Behavior changes worth flagging

- `WithExtension("", count)` and `WithExtension("", replaceAllTrailingExtensions: true)` now leave a trailing dot, matching the single-extension overload and `Path.ChangeExtension`. Previously they removed the extension outright.
- `CreateTempFile` now throws `ArgumentException` for an affix containing a directory separator. `CreateTempFile_ThrowsAfterMaxAttempts` relied on exactly that input to reach the 10-attempt loop, so it was rewritten to use a 300-character suffix — a valid file name fragment that no file system accepts.
- No public API surface change: `ref/Meziantou.Framework.FullPath.cs` is unchanged.

## Testing

11 new tests, plus 6 Windows-only ones. `dotnet test` on `Meziantou.Framework.FullPath.Tests` passes on macOS: 119 passed / 0 failed / 38 skipped per target framework, up from 108 / 0 / 32. Release + `IsOfficialBuild=true` builds clean for the library and the test project, and `dotnet run ./eng/update-all.cs` reports no changes.

The symlink, temp-file and extension fixes were reproduced before the change and verified after it on macOS. The two Windows findings rest on inspection plus tests marked `[RunIf(TestOperatingSystems.Windows)]`, which skip locally — **CI is the first place those actually run.**
