### PR TITLE
Fix JSONPath filter evaluation, I-Regexp handling and string ordering

### DIFF
--- a/src/Meziantou.Framework.JsonPath/Internals/Ast/AndExpression.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/Ast/AndExpression.cs
@@ -1,16 +1,17 @@
 namespace Meziantou.Framework.Json.Internals;
 
+/// <summary>
+/// A <c>logical-and-expr</c>. The operands of a chain are held flat rather than as nested pairs, for the reason
+/// given on <see cref="OrExpression"/>.
+/// </summary>
 internal sealed class AndExpression : LogicalExpression
 {
-    public AndExpression(LogicalExpression left, LogicalExpression right)
+    public AndExpression(LogicalExpression[] operands)
     {
-        Left = left;
-        Right = right;
+        Operands = operands;
     }
 
     public override LogicalExpressionKind Kind => LogicalExpressionKind.And;
 
-    public LogicalExpression Left { get; }
-
-    public LogicalExpression Right { get; }
+    public LogicalExpression[] Operands { get; }
 }

--- a/src/Meziantou.Framework.JsonPath/Internals/Ast/OrExpression.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/Ast/OrExpression.cs
@@ -1,16 +1,18 @@
 namespace Meziantou.Framework.Json.Internals;
 
+/// <summary>
+/// A <c>logical-or-expr</c>. The operands of a chain are held flat rather than as nested pairs, so that
+/// evaluating a chain of any length costs a single frame: the evaluator recurses per operand, and a nested
+/// shape would let a query such as <c>$[?@ || @ || ...]</c> overflow the stack.
+/// </summary>
 internal sealed class OrExpression : LogicalExpression
 {
-    public OrExpression(LogicalExpression left, LogicalExpression right)
+    public OrExpression(LogicalExpression[] operands)
     {
-        Left = left;
-        Right = right;
+        Operands = operands;
     }
 
     public override LogicalExpressionKind Kind => LogicalExpressionKind.Or;
 
-    public LogicalExpression Left { get; }
-
-    public LogicalExpression Right { get; }
+    public LogicalExpression[] Operands { get; }
 }

--- a/src/Meziantou.Framework.JsonPath/Internals/IRegexpTranslator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/IRegexpTranslator.cs
@@ -1,0 +1,807 @@
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.Json.Internals;
+
+/// <summary>Translates an I-Regexp (RFC 9485) into an equivalent .NET regular expression.</summary>
+/// <remarks>
+/// <para>
+/// RFC 9485 §4 gives I-Regexp the semantics of an XSD regular expression, so everything .NET layers on top of
+/// that subset - <c>^</c> and <c>$</c> as anchors, <c>\d</c>, <c>(?:</c>, inline options, backreferences - is not
+/// part of the language. Handing a pattern straight to <see cref="System.Text.RegularExpressions.Regex"/> would
+/// therefore both accept patterns that are not I-Regexps and change the meaning of ones that are, so the pattern
+/// is parsed against the RFC 9485 grammar and re-emitted rather than patched up.
+/// </para>
+/// <para>
+/// An I-Regexp matches a sequence of Unicode scalar values whereas .NET matches a sequence of UTF-16 code units,
+/// so every construct that matches one character - <c>.</c>, a character class, <c>\p{...}</c> - is emitted as an
+/// alternation of the non-surrogate code units and the surrogate pairs it covers. That keeps a supplementary
+/// character one unit of matching instead of two, and keeps a lone surrogate half from ever matching.
+/// </para>
+/// </remarks>
+internal static class IRegexpTranslator
+{
+    private const int MaxScalarValue = 0x10FFFF;
+    private const int FirstHighSurrogate = 0xD800;
+    private const int LastHighSurrogate = 0xDBFF;
+    private const int FirstLowSurrogate = 0xDC00;
+    private const int LastLowSurrogate = 0xDFFF;
+    private const int FirstSupplementary = 0x10000;
+    private const int LastBmp = 0xFFFF;
+    private const int HighSurrogateCount = LastHighSurrogate - FirstHighSurrogate + 1;
+
+    /// <summary>
+    /// Maximum group nesting. The translator recurses once per <c>(</c>, so an unbounded depth would overflow the
+    /// stack, which cannot be caught and terminates the process. The value matches the nesting depth the JSONPath
+    /// parser itself allows.
+    /// </summary>
+    private const int MaxGroupNestingDepth = 64;
+
+    /// <summary>
+    /// A character class that matches nothing, for a set that turned out to be empty. <c>(?!)</c> would read
+    /// better but <see cref="System.Text.RegularExpressions.RegexOptions.NonBacktracking"/> rejects lookarounds.
+    /// </summary>
+    private const string EmptySetPattern = @"[^\u0000-\uFFFF]";
+
+    /// <summary>What <c>.</c> matches: any scalar value but LF and CR (RFC 9485 §5.3).</summary>
+    private static readonly ScalarRange[] DotRanges =
+    [
+        new(0x0000, 0x0009),
+        new(0x000B, 0x000C),
+        new(0x000E, MaxScalarValue),
+    ];
+
+    /// <summary>Scalar ranges of a <c>\p{...}</c> category, which cost a scan of the whole scalar space to build.</summary>
+    private static readonly ConcurrentDictionary<(string CharProp, bool Complement), ScalarRange[]> CategoryRanges = new();
+
+    /// <summary>Translates an I-Regexp into a .NET pattern.</summary>
+    /// <param name="pattern">The I-Regexp, as written in the JSONPath query.</param>
+    /// <param name="anchored">Whether the result must match the whole string (<c>match()</c>) or any substring (<c>search()</c>).</param>
+    /// <returns>The .NET pattern.</returns>
+    /// <exception cref="FormatException"><paramref name="pattern"/> is not a valid I-Regexp.</exception>
+    public static string Translate(string pattern, bool anchored)
+    {
+        var builder = new StringBuilder(pattern.Length * 4);
+
+        // RFC 9485 §5.4. \A and \z rather than ^ and $, which would also let a final line feed go unmatched.
+        if (anchored)
+        {
+            builder.Append(@"\A(?:");
+        }
+
+        new Parser(pattern, builder).ParsePattern();
+
+        if (anchored)
+        {
+            builder.Append(@")\z");
+        }
+
+        return builder.ToString();
+    }
+
+    private static int HighSurrogateOf(int scalar) => FirstHighSurrogate + ((scalar - FirstSupplementary) >> 10);
+
+    private static int LowSurrogateOf(int scalar) => FirstLowSurrogate + ((scalar - FirstSupplementary) & 0x3FF);
+
+    /// <summary>Appends a pattern matching exactly one scalar value of <paramref name="ranges"/>.</summary>
+    /// <param name="builder">Receives the pattern.</param>
+    /// <param name="ranges">The scalar values to match, in any order and possibly overlapping.</param>
+    private static void EmitScalarSet(StringBuilder builder, IReadOnlyList<ScalarRange> ranges)
+    {
+        var normalized = NormalizeScalarRanges(ranges);
+        var bmp = BuildBmpClass(normalized);
+        var alternatives = BuildSupplementaryAlternatives(normalized);
+
+        if (bmp is null && alternatives.Count is 0)
+        {
+            builder.Append(EmptySetPattern);
+            return;
+        }
+
+        if (bmp is not null && alternatives.Count is 0)
+        {
+            // A single character class is already a quantifiable unit, so it needs no group of its own.
+            builder.Append(bmp);
+            return;
+        }
+
+        builder.Append("(?:");
+        if (bmp is not null)
+        {
+            builder.Append(bmp).Append('|');
+        }
+
+        for (var i = 0; i < alternatives.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('|');
+            }
+
+            builder.Append(alternatives[i]);
+        }
+
+        builder.Append(')');
+    }
+
+    /// <summary>Builds the character class for the BMP part of a normalized set, or <see langword="null"/> when it is empty.</summary>
+    private static string? BuildBmpClass(List<ScalarRange> normalized)
+    {
+        var builder = new StringBuilder();
+        foreach (var range in normalized)
+        {
+            if (range.Low > LastBmp)
+            {
+                break;
+            }
+
+            AppendClassRange(builder, range.Low, Math.Min(range.High, LastBmp));
+        }
+
+        return builder.Length is 0 ? null : $"[{builder}]";
+    }
+
+    /// <summary>
+    /// Builds one alternative per run of high surrogates that share the same low surrogates. Emitting a range at a
+    /// time instead would produce hundreds of alternatives for a category such as <c>\P{Lu}</c>, and the
+    /// non-backtracking engine takes a long time to build an automaton out of those.
+    /// </summary>
+    private static List<string> BuildSupplementaryAlternatives(List<ScalarRange> normalized)
+    {
+        var alternatives = new List<string>();
+        List<ScalarRange>?[]? lowSurrogates = null;
+
+        foreach (var range in normalized)
+        {
+            if (range.High < FirstSupplementary)
+            {
+                continue;
+            }
+
+            lowSurrogates ??= new List<ScalarRange>?[HighSurrogateCount];
+
+            var low = Math.Max(range.Low, FirstSupplementary);
+            var firstHigh = HighSurrogateOf(low);
+            var lastHigh = HighSurrogateOf(range.High);
+            for (var high = firstHigh; high <= lastHigh; high++)
+            {
+                var lowStart = high == firstHigh ? LowSurrogateOf(low) : FirstLowSurrogate;
+                var lowEnd = high == lastHigh ? LowSurrogateOf(range.High) : LastLowSurrogate;
+                (lowSurrogates[high - FirstHighSurrogate] ??= []).Add(new ScalarRange(lowStart, lowEnd));
+            }
+        }
+
+        if (lowSurrogates is null)
+        {
+            return alternatives;
+        }
+
+        string? runClass = null;
+        var runStart = 0;
+        for (var index = 0; index <= HighSurrogateCount; index++)
+        {
+            var current = index < HighSurrogateCount && lowSurrogates[index] is { } lows ? BuildClass(lows) : null;
+            if (string.Equals(current, runClass, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (runClass is not null)
+            {
+                alternatives.Add(BuildHighSurrogateClass(runStart, index - 1) + runClass);
+            }
+
+            runClass = current;
+            runStart = index;
+        }
+
+        return alternatives;
+    }
+
+    private static string BuildHighSurrogateClass(int firstIndex, int lastIndex)
+    {
+        var builder = new StringBuilder();
+        if (firstIndex == lastIndex)
+        {
+            AppendEscapedChar(builder, FirstHighSurrogate + firstIndex);
+            return builder.ToString();
+        }
+
+        AppendClassRange(builder, FirstHighSurrogate + firstIndex, FirstHighSurrogate + lastIndex);
+        return $"[{builder}]";
+    }
+
+    private static string BuildClass(List<ScalarRange> ranges)
+    {
+        var builder = new StringBuilder("[");
+        foreach (var range in MergeScalarRanges(ranges))
+        {
+            AppendClassRange(builder, range.Low, range.High);
+        }
+
+        return builder.Append(']').ToString();
+    }
+
+    private static void AppendClassRange(StringBuilder builder, int low, int high)
+    {
+        AppendEscapedChar(builder, low);
+        if (high == low)
+        {
+            return;
+        }
+
+        // A two-value range reads better spelled out than as a range.
+        if (high > low + 1)
+        {
+            builder.Append('-');
+        }
+
+        AppendEscapedChar(builder, high);
+    }
+
+    private static void AppendEscapedChar(StringBuilder builder, int value)
+    {
+        if (value is (>= '0' and <= '9') or (>= 'A' and <= 'Z') or (>= 'a' and <= 'z'))
+        {
+            builder.Append((char)value);
+            return;
+        }
+
+        builder.Append(CultureInfo.InvariantCulture, $@"\u{value:X4}");
+    }
+
+    /// <summary>Drops the surrogate code points, which are not scalar values, then sorts and merges.</summary>
+    private static List<ScalarRange> NormalizeScalarRanges(IReadOnlyList<ScalarRange> ranges)
+    {
+        var scalars = new List<ScalarRange>(ranges.Count);
+        foreach (var range in ranges)
+        {
+            AddScalarRange(scalars, range.Low, range.High);
+        }
+
+        return MergeScalarRanges(scalars);
+    }
+
+    private static List<ScalarRange> MergeScalarRanges(List<ScalarRange> ranges)
+    {
+        ranges.Sort(static (x, y) => x.Low.CompareTo(y.Low));
+
+        var merged = new List<ScalarRange>(ranges.Count);
+        foreach (var range in ranges)
+        {
+            if (merged.Count > 0 && range.Low <= merged[^1].High + 1)
+            {
+                if (range.High > merged[^1].High)
+                {
+                    merged[^1] = new ScalarRange(merged[^1].Low, range.High);
+                }
+
+                continue;
+            }
+
+            merged.Add(range);
+        }
+
+        return merged;
+    }
+
+    private static void AddScalarRange(List<ScalarRange> ranges, int low, int high)
+    {
+        if (low > LastLowSurrogate || high < FirstHighSurrogate)
+        {
+            ranges.Add(new ScalarRange(low, high));
+            return;
+        }
+
+        if (low < FirstHighSurrogate)
+        {
+            ranges.Add(new ScalarRange(low, FirstHighSurrogate - 1));
+        }
+
+        if (high > LastLowSurrogate)
+        {
+            ranges.Add(new ScalarRange(LastLowSurrogate + 1, high));
+        }
+    }
+
+    private static List<ScalarRange> ComplementScalarRanges(List<ScalarRange> ranges)
+    {
+        var normalized = NormalizeScalarRanges(ranges);
+        var complement = new List<ScalarRange>(normalized.Count + 1);
+        var next = 0;
+        foreach (var range in normalized)
+        {
+            if (range.Low > next)
+            {
+                AddScalarRange(complement, next, range.Low - 1);
+            }
+
+            next = range.High + 1;
+        }
+
+        if (next <= MaxScalarValue)
+        {
+            AddScalarRange(complement, next, MaxScalarValue);
+        }
+
+        return complement;
+    }
+
+    private static ScalarRange[] GetCategoryRanges(string charProp, bool complement)
+    {
+        // The mask is resolved first so an unknown property never reaches the cache: a pattern taken from the
+        // document could otherwise grow it without bound.
+        var mask = GetCategoryMask(charProp);
+        return CategoryRanges.GetOrAdd((charProp, complement), key => BuildCategoryRanges(mask, key.Complement));
+    }
+
+    private static ScalarRange[] BuildCategoryRanges(int mask, bool complement)
+    {
+        var ranges = new List<ScalarRange>();
+        var start = -1;
+        for (var scalar = 0; scalar <= MaxScalarValue; scalar++)
+        {
+            if (scalar is FirstHighSurrogate)
+            {
+                if (start >= 0)
+                {
+                    ranges.Add(new ScalarRange(start, FirstHighSurrogate - 1));
+                    start = -1;
+                }
+
+                scalar = LastLowSurrogate;
+                continue;
+            }
+
+            var member = (mask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(scalar))) is not 0;
+            if (member != complement)
+            {
+                if (start < 0)
+                {
+                    start = scalar;
+                }
+            }
+            else if (start >= 0)
+            {
+                ranges.Add(new ScalarRange(start, scalar - 1));
+                start = -1;
+            }
+        }
+
+        if (start >= 0)
+        {
+            ranges.Add(new ScalarRange(start, MaxScalarValue));
+        }
+
+        return [.. ranges];
+    }
+
+    /// <summary>Maps an <c>IsCategory</c> to the <see cref="UnicodeCategory"/> values it stands for.</summary>
+    /// <param name="charProp">The text between <c>\p{</c> and <c>}</c>.</param>
+    /// <returns>A bit mask of <see cref="UnicodeCategory"/> values.</returns>
+    /// <exception cref="FormatException"><paramref name="charProp"/> is not an <c>IsCategory</c>.</exception>
+    private static int GetCategoryMask(string charProp)
+    {
+        return charProp switch
+        {
+            "L" => Mask(UnicodeCategory.UppercaseLetter, UnicodeCategory.LowercaseLetter, UnicodeCategory.TitlecaseLetter, UnicodeCategory.ModifierLetter, UnicodeCategory.OtherLetter),
+            "Lu" => Mask(UnicodeCategory.UppercaseLetter),
+            "Ll" => Mask(UnicodeCategory.LowercaseLetter),
+            "Lt" => Mask(UnicodeCategory.TitlecaseLetter),
+            "Lm" => Mask(UnicodeCategory.ModifierLetter),
+            "Lo" => Mask(UnicodeCategory.OtherLetter),
+            "M" => Mask(UnicodeCategory.NonSpacingMark, UnicodeCategory.SpacingCombiningMark, UnicodeCategory.EnclosingMark),
+            "Mn" => Mask(UnicodeCategory.NonSpacingMark),
+            "Mc" => Mask(UnicodeCategory.SpacingCombiningMark),
+            "Me" => Mask(UnicodeCategory.EnclosingMark),
+            "N" => Mask(UnicodeCategory.DecimalDigitNumber, UnicodeCategory.LetterNumber, UnicodeCategory.OtherNumber),
+            "Nd" => Mask(UnicodeCategory.DecimalDigitNumber),
+            "Nl" => Mask(UnicodeCategory.LetterNumber),
+            "No" => Mask(UnicodeCategory.OtherNumber),
+            "P" => Mask(UnicodeCategory.ConnectorPunctuation, UnicodeCategory.DashPunctuation, UnicodeCategory.OpenPunctuation, UnicodeCategory.ClosePunctuation, UnicodeCategory.InitialQuotePunctuation, UnicodeCategory.FinalQuotePunctuation, UnicodeCategory.OtherPunctuation),
+            "Pc" => Mask(UnicodeCategory.ConnectorPunctuation),
+            "Pd" => Mask(UnicodeCategory.DashPunctuation),
+            "Pe" => Mask(UnicodeCategory.ClosePunctuation),
+            "Pf" => Mask(UnicodeCategory.FinalQuotePunctuation),
+            "Pi" => Mask(UnicodeCategory.InitialQuotePunctuation),
+            "Po" => Mask(UnicodeCategory.OtherPunctuation),
+            "Ps" => Mask(UnicodeCategory.OpenPunctuation),
+            "Z" => Mask(UnicodeCategory.SpaceSeparator, UnicodeCategory.LineSeparator, UnicodeCategory.ParagraphSeparator),
+            "Zl" => Mask(UnicodeCategory.LineSeparator),
+            "Zp" => Mask(UnicodeCategory.ParagraphSeparator),
+            "Zs" => Mask(UnicodeCategory.SpaceSeparator),
+            "S" => Mask(UnicodeCategory.MathSymbol, UnicodeCategory.CurrencySymbol, UnicodeCategory.ModifierSymbol, UnicodeCategory.OtherSymbol),
+            "Sc" => Mask(UnicodeCategory.CurrencySymbol),
+            "Sk" => Mask(UnicodeCategory.ModifierSymbol),
+            "Sm" => Mask(UnicodeCategory.MathSymbol),
+            "So" => Mask(UnicodeCategory.OtherSymbol),
+            "C" => Mask(UnicodeCategory.Control, UnicodeCategory.Format, UnicodeCategory.Surrogate, UnicodeCategory.PrivateUse, UnicodeCategory.OtherNotAssigned),
+            "Cc" => Mask(UnicodeCategory.Control),
+            "Cf" => Mask(UnicodeCategory.Format),
+            "Cn" => Mask(UnicodeCategory.OtherNotAssigned),
+            "Co" => Mask(UnicodeCategory.PrivateUse),
+            _ => throw new FormatException($"'{charProp}' is not a Unicode category an I-Regexp can name."),
+        };
+
+        static int Mask(params ReadOnlySpan<UnicodeCategory> categories)
+        {
+            var mask = 0;
+            foreach (var category in categories)
+            {
+                mask |= 1 << (int)category;
+            }
+
+            return mask;
+        }
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    private readonly struct ScalarRange
+    {
+        public ScalarRange(int low, int high)
+        {
+            Low = low;
+            High = high;
+        }
+
+        public int Low { get; }
+
+        public int High { get; }
+    }
+
+    /// <summary>A recursive-descent parser over the RFC 9485 §3 grammar that emits the .NET pattern as it goes.</summary>
+    private sealed class Parser
+    {
+        private readonly string _pattern;
+        private readonly StringBuilder _builder;
+        private int _position;
+
+        public Parser(string pattern, StringBuilder builder)
+        {
+            _pattern = pattern;
+            _builder = builder;
+        }
+
+        public void ParsePattern()
+        {
+            ParseAlternation(depth: 0);
+            if (_position < _pattern.Length)
+            {
+                throw Invalid($"'{_pattern[_position]}' is not allowed here");
+            }
+        }
+
+        // i-regexp = branch *( "|" branch )
+        private void ParseAlternation(int depth)
+        {
+            ParseBranch(depth);
+            while (Peek() is '|')
+            {
+                _position++;
+                _builder.Append('|');
+                ParseBranch(depth);
+            }
+        }
+
+        // branch = *piece
+        private void ParseBranch(int depth)
+        {
+            while (Peek() is not (null or '|' or ')'))
+            {
+                ParseAtom(depth);
+                ParseQuantifier();
+            }
+        }
+
+        // atom = NormalChar / charClass / ( "(" i-regexp ")" )
+        private void ParseAtom(int depth)
+        {
+            var ch = _pattern[_position];
+            switch (ch)
+            {
+                case '(':
+                    if (depth >= MaxGroupNestingDepth)
+                    {
+                        throw Invalid($"group nesting exceeds the maximum depth of {MaxGroupNestingDepth}");
+                    }
+
+                    _position++;
+                    _builder.Append("(?:");
+                    ParseAlternation(depth + 1);
+                    Expect(')');
+                    _builder.Append(')');
+                    break;
+
+                case '.':
+                    _position++;
+                    EmitScalarSet(_builder, DotRanges);
+                    break;
+
+                case '\\':
+                    ParseEscapedAtom();
+                    break;
+
+                case '[':
+                    ParseCharClassExpression();
+                    break;
+
+                // The characters NormalChar leaves out. "(" and "[" are handled above and the rest can only
+                // appear escaped, or - for a quantifier - after an atom.
+                case ')' or '*' or '+' or '?' or ']' or '{' or '|' or '}':
+                    throw Invalid($"'{ch}' is not allowed here");
+
+                default:
+                    EmitLiteral(ReadScalarValue());
+                    break;
+            }
+        }
+
+        // charClass = SingleCharEsc / charClassEsc, for the escapes that start an atom
+        private void ParseEscapedAtom()
+        {
+            if (PeekAt(1) is not { } escaped)
+            {
+                throw Invalid("a trailing '\\' is not an escape");
+            }
+
+            if (escaped is 'p' or 'P')
+            {
+                EmitScalarSet(_builder, ReadCategoryEscape());
+                return;
+            }
+
+            _position += 2;
+            EmitLiteral(TranslateSingleCharEscape(escaped));
+        }
+
+        // catEsc = "\p{" charProp "}" / complEsc = "\P{" charProp "}"
+        private ScalarRange[] ReadCategoryEscape()
+        {
+            var complement = _pattern[_position + 1] is 'P';
+            _position += 2;
+            Expect('{');
+
+            var start = _position;
+            while (Peek() is not (null or '}'))
+            {
+                _position++;
+            }
+
+            if (Peek() is null)
+            {
+                throw Invalid("the category escape is not closed by '}'");
+            }
+
+            var charProp = _pattern[start.._position];
+            _position++;
+            return GetCategoryRanges(charProp, complement);
+        }
+
+        // charClassExpr = "[" [ "^" ] ( "-" / CCE1 ) *CCE1 [ "-" ] "]"
+        private void ParseCharClassExpression()
+        {
+            _position++;
+            var negated = Peek() is '^';
+            if (negated)
+            {
+                _position++;
+            }
+
+            var ranges = new List<ScalarRange>();
+            var items = 0;
+            while (true)
+            {
+                if (Peek() is not { } ch)
+                {
+                    throw Invalid("the character class is not closed by ']'");
+                }
+
+                if (ch is ']')
+                {
+                    if (items is 0)
+                    {
+                        throw Invalid("an empty character class matches nothing");
+                    }
+
+                    _position++;
+                    break;
+                }
+
+                if (ch is '-')
+                {
+                    // A "-" stands for itself only as the first or as the last item of the class.
+                    if (items is not 0 && PeekAt(1) is not ']')
+                    {
+                        throw Invalid("'-' is not allowed here");
+                    }
+
+                    _position++;
+                    ranges.Add(new ScalarRange('-', '-'));
+                    items++;
+                    continue;
+                }
+
+                if (ch is '\\' && PeekAt(1) is 'p' or 'P')
+                {
+                    ranges.AddRange(ReadCategoryEscape());
+                    items++;
+                    continue;
+                }
+
+                var low = ReadCharClassChar();
+                var high = low;
+                if (Peek() is '-' && PeekAt(1) is not (null or ']'))
+                {
+                    _position++;
+                    high = ReadCharClassChar();
+                    if (high < low)
+                    {
+                        throw Invalid("the range ends below where it starts");
+                    }
+                }
+
+                ranges.Add(new ScalarRange(low, high));
+                items++;
+            }
+
+            EmitScalarSet(_builder, negated ? ComplementScalarRanges(ranges) : ranges);
+        }
+
+        // CCchar = ( %x00-2C / %x2E-5A / %x5E-D7FF / %xE000-10FFFF ) / SingleCharEsc
+        private int ReadCharClassChar()
+        {
+            var ch = _pattern[_position];
+            if (ch is '\\')
+            {
+                if (PeekAt(1) is not { } escaped)
+                {
+                    throw Invalid("a trailing '\\' is not an escape");
+                }
+
+                _position += 2;
+                return TranslateSingleCharEscape(escaped);
+            }
+
+            if (ch is '[')
+            {
+                throw Invalid("'[' has to be escaped inside a character class");
+            }
+
+            return ReadScalarValue();
+        }
+
+        // quantifier = ( "*" / "+" / "?" ) / range-quantifier
+        private void ParseQuantifier()
+        {
+            switch (Peek())
+            {
+                case '*' or '+' or '?':
+                    _builder.Append(_pattern[_position]);
+                    _position++;
+                    break;
+
+                case '{':
+                    ParseRangeQuantifier();
+                    break;
+            }
+        }
+
+        // range-quantifier = "{" QuantExact [ "," [ QuantExact ] ] "}"
+        private void ParseRangeQuantifier()
+        {
+            _position++;
+            var min = ReadQuantExact();
+            int? max = min;
+            if (Peek() is ',')
+            {
+                _position++;
+                max = Peek() is '}' ? null : ReadQuantExact();
+            }
+
+            Expect('}');
+
+            if (max < min)
+            {
+                throw Invalid($"the quantifier {{{min},{max}}} has a maximum below its minimum");
+            }
+
+            _builder.Append('{').Append(min);
+            if (max is null)
+            {
+                _builder.Append(',');
+            }
+            else if (max.GetValueOrDefault() != min)
+            {
+                _builder.Append(',').Append(max.GetValueOrDefault());
+            }
+
+            _builder.Append('}');
+        }
+
+        // QuantExact = 1*%x30-39
+        private int ReadQuantExact()
+        {
+            var start = _position;
+            while (Peek() is >= '0' and <= '9')
+            {
+                _position++;
+            }
+
+            if (_position == start)
+            {
+                throw Invalid("the quantifier needs a number");
+            }
+
+            if (!int.TryParse(_pattern.AsSpan(start, _position - start), NumberStyles.None, CultureInfo.InvariantCulture, out var value))
+            {
+                throw Invalid("the quantifier is out of range");
+            }
+
+            return value;
+        }
+
+        /// <summary>Reads one scalar value, which the pattern holds as either one char or one surrogate pair.</summary>
+        private int ReadScalarValue()
+        {
+            var ch = _pattern[_position];
+            if (char.IsHighSurrogate(ch) && PeekAt(1) is { } next && char.IsLowSurrogate(next))
+            {
+                _position += 2;
+                return char.ConvertToUtf32(ch, next);
+            }
+
+            if (char.IsSurrogate(ch))
+            {
+                // The grammar skips the surrogate code points: an unpaired one is not a scalar value.
+                throw Invalid("an unpaired surrogate is not a Unicode scalar value");
+            }
+
+            _position++;
+            return ch;
+        }
+
+        // SingleCharEsc = "\" ( %x28-2B / "-" / "." / "?" / %x5B-5E / "n" / "r" / "t" / %x7B-7D )
+        private char TranslateSingleCharEscape(char escaped)
+        {
+            return escaped switch
+            {
+                '(' or ')' or '*' or '+' or '-' or '.' or '?' or '[' or '\\' or ']' or '^' or '{' or '|' or '}' => escaped,
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => throw Invalid($"'\\{escaped}' is not an I-Regexp escape"),
+            };
+        }
+
+        private void EmitLiteral(int scalar)
+        {
+            if (scalar <= LastBmp)
+            {
+                AppendEscapedChar(_builder, scalar);
+                return;
+            }
+
+            // The pair has to stay one unit so that a quantifier applies to the whole scalar value.
+            _builder.Append("(?:");
+            AppendEscapedChar(_builder, HighSurrogateOf(scalar));
+            AppendEscapedChar(_builder, LowSurrogateOf(scalar));
+            _builder.Append(')');
+        }
+
+        private void Expect(char expected)
+        {
+            if (Peek() != expected)
+            {
+                throw Invalid($"'{expected}' is missing");
+            }
+
+            _position++;
+        }
+
+        private char? Peek() => PeekAt(0);
+
+        private char? PeekAt(int offset) => _position + offset < _pattern.Length ? _pattern[_position + offset] : null;
+
+        private FormatException Invalid(string reason) => new($"The I-Regexp is not valid at position {_position}: {reason}.");
+    }
+}

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonNodeNavigator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonNodeNavigator.cs
@@ -87,8 +87,7 @@ internal sealed class JsonNodeNavigator : JsonPathNavigator<JsonNode>
     {
         if (value is JsonValue jsonValue && jsonValue.GetValueKind() is JsonValueKind.Number)
         {
-            result = GetDoubleValue(jsonValue);
-            return true;
+            return TryGetDoubleValue(jsonValue, out result);
         }
 
         result = 0;
@@ -114,69 +113,109 @@ internal sealed class JsonNodeNavigator : JsonPathNavigator<JsonNode>
         return false;
     }
 
-    private static double GetDoubleValue(JsonValue value)
+    /// <summary>
+    /// Reads the numeric value out of a <see cref="JsonValue"/>, whatever CLR type it happens to wrap.
+    /// A representation that is not covered reports failure rather than standing in a value of its own: RFC 9535
+    /// turns a comparison it cannot carry out into no match, whereas a stand-in of 0 would silently make the
+    /// value compare equal to 0.
+    /// </summary>
+    /// <param name="value">A value whose kind is <see cref="JsonValueKind.Number"/>.</param>
+    /// <param name="result">The value as a <see cref="double"/>.</param>
+    /// <returns><see langword="true"/> when the representation is known; otherwise, <see langword="false"/>.</returns>
+    private static bool TryGetDoubleValue(JsonValue value, out double result)
     {
         if (value.TryGetValue<JsonElement>(out var element))
         {
-            return element.GetDouble();
+            result = element.GetDouble();
+            return true;
         }
 
         if (value.TryGetValue<double>(out var d))
         {
-            return d;
+            result = d;
+            return true;
         }
 
         if (value.TryGetValue<float>(out var f))
         {
-            return f;
+            result = f;
+            return true;
+        }
+
+        if (value.TryGetValue<Half>(out var h))
+        {
+            result = (double)h;
+            return true;
         }
 
         if (value.TryGetValue<decimal>(out var dec))
         {
-            return (double)dec;
+            result = (double)dec;
+            return true;
         }
 
         if (value.TryGetValue<long>(out var l))
         {
-            return l;
+            result = l;
+            return true;
         }
 
         if (value.TryGetValue<ulong>(out var ul))
         {
-            return ul;
+            result = ul;
+            return true;
+        }
+
+        if (value.TryGetValue<Int128>(out var i128))
+        {
+            result = (double)i128;
+            return true;
+        }
+
+        if (value.TryGetValue<UInt128>(out var ui128))
+        {
+            result = (double)ui128;
+            return true;
         }
 
         if (value.TryGetValue<int>(out var i))
         {
-            return i;
+            result = i;
+            return true;
         }
 
         if (value.TryGetValue<uint>(out var ui))
         {
-            return ui;
+            result = ui;
+            return true;
         }
 
-        if (value.TryGetValue<short>(out var s))
+        if (value.TryGetValue<short>(out var sh))
         {
-            return s;
+            result = sh;
+            return true;
         }
 
         if (value.TryGetValue<ushort>(out var us))
         {
-            return us;
+            result = us;
+            return true;
         }
 
         if (value.TryGetValue<byte>(out var b))
         {
-            return b;
+            result = b;
+            return true;
         }
 
         if (value.TryGetValue<sbyte>(out var sb))
         {
-            return sb;
+            result = sb;
+            return true;
         }
 
-        return 0;
+        result = 0;
+        return false;
     }
 
     private static string? GetStringValue(JsonValue value)

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
@@ -452,16 +452,50 @@ internal static class JsonPathEvaluator
     {
         return expr switch
         {
-            OrExpression or => EvaluateLogicalExpression(or.Left, currentNode, root, navigator)
-                               || EvaluateLogicalExpression(or.Right, currentNode, root, navigator),
-            AndExpression and => EvaluateLogicalExpression(and.Left, currentNode, root, navigator)
-                                && EvaluateLogicalExpression(and.Right, currentNode, root, navigator),
+            // The operands of a chain are held in a list rather than nested pairwise, so a chain of any length
+            // costs a single evaluation frame. Both operators still short-circuit.
+            OrExpression or => EvaluateAnyOperand(or.Operands, currentNode, root, navigator),
+            AndExpression and => EvaluateEveryOperand(and.Operands, currentNode, root, navigator),
             NotExpression not => !EvaluateLogicalExpression(not.Operand, currentNode, root, navigator),
             ComparisonExpression comp => EvaluateComparison(comp, currentNode, root, navigator),
             ExistenceTestExpression existence => EvaluateExistenceTest(existence, currentNode, root, navigator),
             FunctionCallExpression func => EvaluateFunctionAsLogical(func, currentNode, root, navigator),
             _ => false,
         };
+    }
+
+    private static bool EvaluateAnyOperand<TValue>(
+        LogicalExpression[] operands,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+    {
+        foreach (var operand in operands)
+        {
+            if (EvaluateLogicalExpression(operand, currentNode, root, navigator))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool EvaluateEveryOperand<TValue>(
+        LogicalExpression[] operands,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+    {
+        foreach (var operand in operands)
+        {
+            if (!EvaluateLogicalExpression(operand, currentNode, root, navigator))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool EvaluateExistenceTest<TValue>(
@@ -648,11 +682,45 @@ internal static class JsonPathEvaluator
 
         if (TryGetString(left, navigator, out var leftString) && TryGetString(right, navigator, out var rightString))
         {
-            return string.Compare(leftString, rightString, StringComparison.Ordinal) < 0;
+            return CompareByScalarValue(leftString, rightString) < 0;
         }
 
         return false;
     }
+
+    /// <summary>
+    /// Orders two strings the way RFC 9535 §2.3.5.2.2 does, by their Unicode scalar values. An ordinal comparison
+    /// would order them by UTF-16 code unit instead, which puts every supplementary character before U+E000 to
+    /// U+FFFF because it is written as a surrogate pair.
+    /// </summary>
+    /// <param name="left">The first string.</param>
+    /// <param name="right">The second string.</param>
+    /// <returns>A negative number, zero or a positive number, as <see cref="string.CompareTo(string)"/> does.</returns>
+    private static int CompareByScalarValue(string? left, string? right)
+    {
+        if (left is null || right is null)
+        {
+            return (left is null ? 0 : 1) - (right is null ? 0 : 1);
+        }
+
+        var shared = Math.Min(left.Length, right.Length);
+        for (var i = 0; i < shared; i++)
+        {
+            if (left[i] != right[i])
+            {
+                return ScalarOrderOf(left[i]) - ScalarOrderOf(right[i]);
+            }
+        }
+
+        return left.Length - right.Length;
+    }
+
+    /// <summary>
+    /// Ranks a code unit so that comparing units one by one yields the scalar value order: a surrogate stands for
+    /// a scalar value above the BMP, so it has to rank above every character that is not one. Sorting the halves
+    /// of a pair among themselves keeps their order, since both halves grow with the scalar value they encode.
+    /// </summary>
+    private static int ScalarOrderOf(char value) => char.IsSurrogate(value) ? value + 0x10000 : value;
 
     private static bool ScalarValuesEqual(ScalarValue left, ScalarValue right)
     {
@@ -1098,24 +1166,25 @@ internal static class JsonPathEvaluator
     {
         try
         {
-            var pattern = ConvertIRegexpToRegex(iRegexp);
-            if (anchored)
-            {
-                pattern = $"^(?:{pattern})$";
-            }
-
+            var pattern = IRegexpTranslator.Translate(iRegexp, anchored);
             return new FunctionCallExpression.RegexCacheEntry(
                 new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.NonBacktracking, RegexTimeout));
         }
+        catch (FormatException)
+        {
+            // Not a valid I-Regexp.
+            return FunctionCallExpression.RegexCacheEntry.Unusable;
+        }
         catch (ArgumentException)
         {
-            // Not a valid .NET pattern.
+            // A backstop: the translation is meant to only ever emit patterns .NET accepts, and a bug in it must
+            // still leave match()/search() with a Boolean result rather than throw out of Evaluate.
             return FunctionCallExpression.RegexCacheEntry.Unusable;
         }
         catch (NotSupportedException)
         {
-            // A construct NonBacktracking rejects (backreference, lookaround, atomic group). None of these
-            // are part of I-Regexp, so such a pattern is not a valid argument to match()/search() anyway.
+            // NonBacktracking gave up. It rejects no construct the translation emits, but it does cap how large
+            // an automaton it will build, and a quantifier such as 'a{1000000}' goes past that cap.
             return FunctionCallExpression.RegexCacheEntry.Unusable;
         }
     }
@@ -1240,48 +1309,5 @@ internal static class JsonPathEvaluator
         }
 
         return count;
-    }
-
-    private static string ConvertIRegexpToRegex(string iregexp)
-    {
-        var sb = new StringBuilder(iregexp.Length * 2);
-        var inCharClass = false;
-
-        for (var i = 0; i < iregexp.Length; i++)
-        {
-            var ch = iregexp[i];
-
-            if (ch == '\\' && i + 1 < iregexp.Length)
-            {
-                sb.Append(ch);
-                sb.Append(iregexp[i + 1]);
-                i++;
-                continue;
-            }
-
-            if (ch == '[' && !inCharClass)
-            {
-                inCharClass = true;
-                sb.Append(ch);
-                continue;
-            }
-
-            if (ch == ']' && inCharClass)
-            {
-                inCharClass = false;
-                sb.Append(ch);
-                continue;
-            }
-
-            if (ch == '.' && !inCharClass)
-            {
-                sb.Append(@"(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\n\r])");
-                continue;
-            }
-
-            sb.Append(ch);
-        }
-
-        return sb.ToString();
     }
 }

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathParser.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathParser.cs
@@ -281,29 +281,40 @@ internal ref struct JsonPathParser
     // logical-or-expr
     private LogicalExpression ParseLogicalOrExpression()
     {
-        var left = ParseLogicalAndExpression();
+        var first = ParseLogicalAndExpression();
+        if (_current.Kind is not JsonPathTokenKind.Or)
+        {
+            return first;
+        }
+
+        // A chain is kept flat so that the evaluator does not need a frame per operand.
+        var operands = new List<LogicalExpression> { first };
         while (_current.Kind is JsonPathTokenKind.Or)
         {
             Advance();
-            var right = ParseLogicalAndExpression();
-            left = new OrExpression(left, right);
+            operands.Add(ParseLogicalAndExpression());
         }
 
-        return left;
+        return new OrExpression([.. operands]);
     }
 
     // logical-and-expr
     private LogicalExpression ParseLogicalAndExpression()
     {
-        var left = ParseBasicExpression();
+        var first = ParseBasicExpression();
+        if (_current.Kind is not JsonPathTokenKind.And)
+        {
+            return first;
+        }
+
+        var operands = new List<LogicalExpression> { first };
         while (_current.Kind is JsonPathTokenKind.And)
         {
             Advance();
-            var right = ParseBasicExpression();
-            left = new AndExpression(left, right);
+            operands.Add(ParseBasicExpression());
         }
 
-        return left;
+        return new AndExpression([.. operands]);
     }
 
     // basic-expr = paren-expr / comparison-expr / test-expr

--- a/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit.Sdk;
@@ -7,6 +8,19 @@ namespace Meziantou.Framework.JsonPathTests;
 
 public sealed class ComplianceTests
 {
+    /// <summary>
+    /// Cases of the vendored suite this implementation deliberately does not satisfy, and why. A case listed here
+    /// has to keep failing: the test fails when it starts passing, so the list cannot quietly go stale.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> ExpectedFailures = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        // RFC 9485 §3 lists "^" and "$" among the NormalChars, and §4 - the normative one - gives an I-Regexp the
+        // semantics of an XSD regexp, where neither character is an anchor. The suite follows the mapping sketched
+        // in the non-normative §5.3 instead, which hands both straight to a dialect that does read them as anchors.
+        ["functions, match, explicit caret"] = "'^ab.*' matches a literal '^', not the start of the string",
+        ["functions, match, explicit dollar"] = "'.*bc$' matches a literal '$', not the end of the string",
+    }.ToFrozenDictionary(StringComparer.Ordinal);
+
     private static readonly Lazy<ComplianceTestSuite> TestSuite = new(LoadTestSuite);
 
     private static ComplianceTestSuite LoadTestSuite()
@@ -34,6 +48,32 @@ public sealed class ComplianceTests
     [Theory]
     [MemberData(nameof(GetComplianceTestCases))]
     public void ComplianceTest(ComplianceTestCase testCase)
+    {
+        if (ExpectedFailures.TryGetValue(testCase.Name, out var reason))
+        {
+            RunExpectedFailure(testCase, reason);
+            return;
+        }
+
+        Run(testCase);
+    }
+
+    /// <summary>Runs a case that is known not to pass, and fails when it turns out to pass after all.</summary>
+    private static void RunExpectedFailure(ComplianceTestCase testCase, string reason)
+    {
+        try
+        {
+            Run(testCase);
+        }
+        catch (Exception)
+        {
+            return;
+        }
+
+        Assert.Fail($"Case '{testCase.Name}' ({reason}) is listed as an expected failure but it passes now. Remove it from {nameof(ExpectedFailures)}.");
+    }
+
+    private static void Run(ComplianceTestCase testCase)
     {
         if (testCase.InvalidSelector)
         {

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -515,6 +515,184 @@ public sealed class JsonPathEvaluateTests
         Assert.Empty(path.Evaluate(doc, JsonPathEvaluationMode.Strict));
     }
 
+    [Theory]
+    // RFC 9535 §2.4.6 has match() match the whole string. '$' would also match just before a final line feed,
+    // so the anchors have to be \A and \z.
+    [InlineData("a\n")]
+    [InlineData("a\r\n")]
+    [InlineData("a\r")]
+    public void Evaluate_Function_Match_DoesNotAcceptAnUnmatchedTrailingNewLine(string value)
+    {
+        var doc = new JsonArray { value };
+
+        Assert.Empty(JsonPath.Parse("$[?match(@, 'a')]").Evaluate(doc));
+    }
+
+    [Theory]
+    // A supplementary character is one Unicode scalar value, not the two UTF-16 code units .NET stores it as.
+    [InlineData(".", true)]
+    [InlineData("..", false)]
+    [InlineData("[\U0001F600]", true)]
+    [InlineData("[\U0001F5FF-\U0001F601]", true)]
+    [InlineData("[\U0001F601-\U0001F602]", false)]
+    [InlineData("[^a]", true)]
+    [InlineData("[^\U0001F600]", false)]
+    [InlineData(@"\\p{So}", true)]
+    [InlineData(@"\\P{So}", false)]
+    [InlineData(@"\\p{Lu}", false)]
+    public void Evaluate_Function_Match_TreatsASupplementaryCharacterAsOneScalarValue(string pattern, bool matches)
+    {
+        var doc = new JsonArray { "\U0001F600" };
+
+        var result = JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc);
+
+        Assert.Equal(matches ? 1 : 0, result.Count);
+    }
+
+    [Theory]
+    // RFC 9485 §3 lists '^', '$' and the other characters .NET reads as metacharacters among the NormalChars,
+    // and §4 gives an I-Regexp the semantics of an XSD regexp, where they stand for themselves.
+    [InlineData("^a$", "^a$", true)]
+    [InlineData("^a$", "a", false)]
+    [InlineData("a$", "a$", true)]
+    [InlineData("a$", "a", false)]
+    public void Evaluate_Function_Match_TreatsCaretAndDollarAsLiterals(string pattern, string value, bool matches)
+    {
+        var doc = new JsonArray { value };
+
+        var result = JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc);
+
+        Assert.Equal(matches ? 1 : 0, result.Count);
+    }
+
+    [Theory]
+    // Constructs .NET understands but that are no part of I-Regexp (RFC 9485 §3). Accepting them would let a
+    // pattern mean one thing here and another in every other RFC 9535 implementation.
+    [InlineData("(?i)a", "A")]
+    [InlineData("(?:a)", "a")]
+    [InlineData(@"\\d", "1")]
+    [InlineData(@"\\w", "a")]
+    [InlineData(@"\\s", " ")]
+    [InlineData(@"\\p{IsBasicLatin}", "a")]
+    [InlineData(@"\\x41", "A")]
+    [InlineData("a**", "aa")]
+    [InlineData("*a", "a")]
+    [InlineData("[a", "a")]
+    [InlineData("a]", "a]")]
+    [InlineData("a)", "a")]
+    [InlineData("[]", "")]
+    [InlineData("[b-a]", "a")]
+    [InlineData("a{2,1}", "aa")]
+    public void Evaluate_Function_PatternOutsideIRegexp_YieldsNoMatch(string pattern, string value)
+    {
+        var doc = new JsonArray { value };
+
+        Assert.Empty(JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc));
+        Assert.Empty(JsonPath.Parse($"$[?search(@, '{pattern}')]").Evaluate(doc));
+    }
+
+    [Theory]
+    // Valid I-Regexps that .NET cannot build an automaton for. RFC 9535 turns a pattern that cannot be
+    // evaluated into LogicalFalse, so none of these may escape Evaluate as an exception.
+    [InlineData("a{1000000}")]
+    [InlineData("(a{100000}){100000}")]
+    public void Evaluate_Function_PatternBeyondTheEngineLimits_YieldsNoMatch(string pattern)
+    {
+        var doc = new JsonArray { "aa" };
+
+        Assert.Empty(JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc, JsonPathEvaluationMode.Lax));
+        Assert.Empty(JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc, JsonPathEvaluationMode.Strict));
+    }
+
+    [Theory]
+    // The translation recurses once per group, so the depth has to be capped rather than left to the stack.
+    [InlineData(8, 1)]
+    [InlineData(64, 1)]
+    [InlineData(65, 0)]
+    [InlineData(100_000, 0)]
+    public void Evaluate_Function_Match_DeeplyNestedGroups_AreCappedInsteadOfOverflowingTheStack(int depth, int expected)
+    {
+        var pattern = new string('(', depth) + "a" + new string(')', depth);
+        var doc = new JsonArray { "a" };
+
+        var result = JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc);
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Theory]
+    // The rest of the grammar still has to work as it did.
+    [InlineData("a|b", "b", true)]
+    [InlineData("a|", "", true)]
+    [InlineData("(ab)+", "abab", true)]
+    [InlineData("a{2,3}", "aa", true)]
+    [InlineData("a{2,3}", "a", false)]
+    [InlineData("a{2,}", "aaaa", true)]
+    [InlineData("a{2}", "aa", true)]
+    [InlineData("[-a]", "-", true)]
+    [InlineData("[a-]", "-", true)]
+    [InlineData("[^a]", "b", true)]
+    [InlineData(@"\\n", "\n", true)]
+    [InlineData(".", "\n", false)]
+    [InlineData(".", "\r", false)]
+    [InlineData(@"a\\.c", "a.c", true)]
+    [InlineData(@"a\\.c", "abc", false)]
+    public void Evaluate_Function_Match_SupportsTheIRegexpGrammar(string pattern, string value, bool matches)
+    {
+        var doc = new JsonArray { value };
+
+        var result = JsonPath.Parse($"$[?match(@, '{pattern}')]").Evaluate(doc);
+
+        Assert.Equal(matches ? 1 : 0, result.Count);
+    }
+
+    [Theory]
+    [InlineData("||")]
+    [InlineData("&&")]
+    public void Evaluate_LongBooleanChain_DoesNotOverflowTheStack(string op)
+    {
+        // A flat chain does not count towards the parser's nesting limit, so the evaluator cannot afford a frame
+        // per operand: it used to walk a pairwise tree and take the whole process down with it.
+        var expression = "$[?" + string.Join($" {op} ", Enumerable.Repeat("@", 100_000)) + "]";
+        var path = JsonPath.Parse(expression);
+
+        Assert.Single(path.Evaluate(JsonNode.Parse("[1]")));
+    }
+
+    [Fact]
+    public void Evaluate_StringComparison_OrdersByUnicodeScalarValue()
+    {
+        // RFC 9535 §2.3.5.2.2 orders strings by their scalar values. U+1F600 is above U+FFFF, even though the
+        // surrogate pair UTF-16 writes it as sorts below it.
+        var doc = new JsonArray { "\uFFFF", "\U0001F600" };
+
+        var below = JsonPath.Parse("$[?@ < '\U0001F600']").Evaluate(doc);
+        Assert.Single(below);
+        Assert.Equal("\uFFFF", below[0].Value!.GetValue<string>());
+
+        var above = JsonPath.Parse("$[?@ > '\\uFFFF']").Evaluate(doc);
+        Assert.Single(above);
+        Assert.Equal("\U0001F600", above[0].Value!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Evaluate_Comparison_ReadsEveryNumericRepresentationAJsonValueCanHold()
+    {
+        // JsonValue can wrap any CLR numeric type. One the navigator does not know has to compare as no match,
+        // not as a stand-in 0 that silently makes the value equal to 0.
+        var doc = new JsonArray
+        {
+            JsonValue.Create((Half)42),
+            JsonValue.Create((Int128)42),
+            JsonValue.Create((UInt128)42),
+        };
+
+        Assert.Empty(JsonPath.Parse("$[?@ == 0]").Evaluate(doc));
+        Assert.Equal(3, JsonPath.Parse("$[?@ == 42]").Evaluate(doc).Count);
+        Assert.Equal(3, JsonPath.Parse("$[?@ > 41]").Evaluate(doc).Count);
+        Assert.Equal(3, JsonPath.Parse("$[?@ < 43]").Evaluate(doc).Count);
+    }
+
     [Fact]
     public void Evaluate_Path_IsCorrectForNodesSelectedByAFilter()
     {


### PR DESCRIPTION
Addresses the findings of a review of `Meziantou.Framework.JsonPath` against [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535.html) and [RFC 9485](https://www.rfc-editor.org/rfc/rfc9485.html).

## Flat boolean chains no longer overflow the stack

The parser builds a flat chain for `a || b || c`, so it does not count towards the nesting limit — but the AST nested it pairwise and the evaluator recursed once per operand. A query of 100 000 disjuncts parsed fine and then terminated the process with a `StackOverflowException`, which cannot be caught:

```csharp
var expression = "$[?" + string.Join(" || ", Enumerable.Repeat("@", 100_000)) + "]";
JsonPath.Parse(expression).Evaluate(JsonNode.Parse("[1]")); // crash
```

`OrExpression` and `AndExpression` now hold a flat `LogicalExpression[]`; the parser collects operands into a list and the evaluator loops over them, still short-circuiting.

## `match()` and `search()` now parse the pattern

The pattern used to be handed to `Regex` after substituting the dot, which left .NET's own metacharacters in force and ran matching on UTF-16 code units. `IRegexpTranslator` parses it against the RFC 9485 §3 grammar and re-emits it instead. That fixes, for `["😀"]` and friends:

| Expression | Before | Now |
| --- | --- | --- |
| `match(@, 'a')` on `"a\n"` | `true` | `false` — `match()` anchors with `\A`/`\z`, not `^`/`$` |
| `match(@, '..')` | `true` | `false` |
| `match(@, '[😀]')` | `false` | `true` |
| `match(@, '[^a]')` | `false` | `true` |
| `match(@, '\\p{So}')` | `false` | `true` |
| `match(@, '^a$')` on `"a"` | `true` | `false` — `^` and `$` are `NormalChar`s |
| `match(@, '(?i)a')` on `"A"` | `true` | `false` — not an I-Regexp |

Every construct that matches one character (`.`, a character class, `\p{...}`) is emitted as an alternation over the non-surrogate code units and the surrogate pairs it covers, so a supplementary character is one unit of matching and a lone surrogate half never matches. `\p{...}` sets are built by scanning the scalar space with `CharUnicodeInfo.GetUnicodeCategory` (~3 ms) and cached per category.

## Other fixes

- `JsonNodeNavigator` reads `Half`, `Int128` and `UInt128` out of a `JsonValue`, and reports failure for a representation it does not know rather than standing in a `0` — `$[?@ == 0]` used to select `JsonValue.Create((Half)42)`.
- Strings are ordered by Unicode scalar value per RFC 9535 §2.3.5.2.2, instead of by UTF-16 code unit, which sorted every supplementary character below U+E000–U+FFFF.

## Note for the reviewer: two compliance cases now fail on purpose

`cts.json` expects `match(@, '^ab.*')` and `match(@, '.*bc$')` to treat `^` and `$` as anchors. RFC 9485 §3 lists both among the `NormalChar`s and §4 — the normative section — gives an I-Regexp the semantics of an XSD regexp, where neither is an anchor; the suite follows the mapping sketched in the non-normative §5.3, which hands both straight to a dialect that does read them as anchors. Upstream `cts.json` still expects the anchor behaviour and there is no RFC 9485 erratum on this (7990 and 8505 are both about §5.1).

Rather than weaken the fix, `ComplianceTests` gets an `ExpectedFailures` list naming the two cases, mirroring the existing pattern in `UrlPatternWebPlatformTests`. It asserts each listed case still fails, so a `cts.json` refresh that corrects them upstream surfaces as a test failure telling you to remove the entry. Happy to flip this the other way if you would rather match the suite.

Two emission details in the translator are load-bearing rather than stylistic, and are commented as such:

- Supplementary alternatives are grouped by runs of high surrogates sharing a low-surrogate set. One alternative per range instead produces hundreds for a category like `\P{Lu}`, and `RegexOptions.NonBacktracking` needs ~330 ms to build an automaton out of 256 of them.
- `CreateRegex` still catches `NotSupportedException`: `NonBacktracking` caps automaton size, so a valid I-Regexp such as `a{1000000}` throws there, and RFC 9535 requires that to yield no match rather than escape `Evaluate`. There is a test for it.

## Verification

- `dotnet test` on `Meziantou.Framework.JsonPath.Tests`: 1810 passed, 0 failed (905 per TFM, up from 846). 10 new test methods, 57 new cases per TFM.
- Release + `IsOfficialBuild=true` builds of the library and its tests: 0 warnings, 0 errors.
- `Meziantou.Framework.Language.Json`, `Meziantou.Framework.InlineSnapshotTesting` and `Meziantou.Framework.TdsServer` build clean; Language.Json's 202 tests pass.
- `dotnet run ./eng/update-all.cs` ran clean with no file changes. `ref/` is unchanged — everything here is internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
