### PR TITLE
Resolve the test class from the test framework when the call stack cannot

### DIFF
--- a/ref/Meziantou.Framework.SnapshotTesting.cs
+++ b/ref/Meziantou.Framework.SnapshotTesting.cs
@@ -266,6 +266,8 @@ namespace Meziantou.Framework.SnapshotTesting
     {
         public string? TestName { get => throw null; init { } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string?>? Metadata { get => throw null; init { } }
+        public string? ClassName { get => throw null; init { } }
+        public string? MethodName { get => throw null; init { } }
         public SnapshotTestContext(string? TestName = null, System.Collections.Generic.IReadOnlyDictionary<string, string?>? Metadata = null) { }
         public override string ToString() => throw null;
         public static bool operator !=(Meziantou.Framework.SnapshotTesting.SnapshotTestContext? left, Meziantou.Framework.SnapshotTesting.SnapshotTestContext? right) => throw null;

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace Meziantou.Framework.SnapshotTesting;
 
-internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, string MethodName, string? ContainingTypeName, string? MemberName, int LineNumber)
+internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, string MethodName, string? ContainingTypeName, string? MemberName, int LineNumber, bool TestMethodResolved)
 {
     [GeneratedRegex(@"^<(?<name>[^>]+)>b__[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: -1)]
     private static partial Regex LambdaContainingMethodNameRegex { get; }
@@ -33,6 +33,7 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
         var stackAnalysisStartIndex = GetStackAnalysisStartIndex(stackTrace);
         string? discoveredMethodName = null;
         string? discoveredContainingTypeName = null;
+        var testMethodResolved = false;
 
         for (var i = stackAnalysisStartIndex; i < stackTrace.FrameCount; i++)
         {
@@ -47,6 +48,7 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
             {
                 discoveredMethodName = stackFrameMethod.NormalizedMethodName;
                 discoveredContainingTypeName = stackFrameMethod.NormalizedTypeName;
+                testMethodResolved = true;
                 break;
             }
 
@@ -73,7 +75,7 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
             throw new SnapshotException("Cannot find the file to update from the call stack. The PDB may be missing.");
 
         discoveredMethodName ??= memberName ?? "Snapshot";
-        return new SnapshotCallerContext(ResolveSourceFilePath(sourceFilePath), discoveredMethodName, discoveredContainingTypeName, memberName, lineNumber);
+        return new SnapshotCallerContext(ResolveSourceFilePath(sourceFilePath), discoveredMethodName, discoveredContainingTypeName, memberName, lineNumber, testMethodResolved);
     }
 
     private static int GetStackAnalysisStartIndex(StackTrace stackTrace)

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -256,6 +256,18 @@ internal static class SnapshotEngine
         IReadOnlyList<SnapshotData> serialized,
         SnapshotTestContext? testContext)
     {
+        // The call stack only contains the test method as long as the assertion runs synchronously below it.
+        // A helper method that awaited before asserting runs on a continuation where the test method is gone,
+        // and the innermost frames then describe the helper. The test framework still knows which test is
+        // running, so its own view wins whenever the stack could not produce one.
+        var className = callerContext.ContainingTypeName;
+        var methodName = callerContext.MethodName;
+        if (!callerContext.TestMethodResolved)
+        {
+            className = testContext?.ClassName ?? className;
+            methodName = testContext?.MethodName ?? methodName;
+        }
+
         var result = new List<SnapshotFile>(serialized.Count);
         for (var index = 0; index < serialized.Count; index++)
         {
@@ -263,8 +275,8 @@ internal static class SnapshotEngine
             var extension = ResolveSnapshotExtension(type, snapshotData);
             var path = settings.SnapshotPathStrategy(new SnapshotPathContext(
                 callerContext.SourceFilePath,
-                callerContext.ContainingTypeName,
-                callerContext.MethodName,
+                className,
+                methodName,
                 callerContext.LineNumber,
                 type,
                 index,

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotTestContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotTestContext.cs
@@ -4,37 +4,80 @@ namespace Meziantou.Framework.SnapshotTesting;
 
 public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDictionary<string, string?>? Metadata = null)
 {
-    private static Func<string?>? s_xunitV3GetDisplayName;
-    private static Func<string?>? s_tunitGetDisplayName;
-    private static Func<string?>? s_nunitGetDisplayName;
+    private static Func<SnapshotTestContext?>? s_xunitV3GetContext;
+    private static Func<SnapshotTestContext?>? s_tunitGetContext;
+    private static Func<SnapshotTestContext?>? s_nunitGetContext;
+
+    /// <summary>
+    /// Simple name of the class declaring the running test, when the test framework exposes it. It is used
+    /// when the call stack does not contain the test method, which happens when the assertion runs in a
+    /// helper method that awaited before calling <see cref="Snapshot.Validate(object?, SnapshotType?, SnapshotSettings?, string?, int, string?)" />.
+    /// </summary>
+    public string? ClassName { get; init; }
+
+    /// <summary>
+    /// Name of the running test method, when the test framework exposes it. Unlike <see cref="TestName" />,
+    /// it never contains the test arguments.
+    /// </summary>
+    public string? MethodName { get; init; }
 
     internal static SnapshotTestContext Get()
     {
-        var displayName = GetDisplayName(ref s_xunitV3GetDisplayName, TryCreateXunitV3GetDisplayName)?.Invoke() ??
-                          GetDisplayName(ref s_tunitGetDisplayName, TryCreateTUnitGetDisplayName)?.Invoke() ??
-                          GetDisplayName(ref s_nunitGetDisplayName, TryCreateNUnitGetDisplayName)?.Invoke();
-        if (displayName is not null)
-            return new SnapshotTestContext(TestName: displayName);
-
-        return new();
+        return GetContext(ref s_xunitV3GetContext, TryCreateXunitV3GetContext)?.Invoke() ??
+               GetContext(ref s_tunitGetContext, TryCreateTUnitGetContext)?.Invoke() ??
+               GetContext(ref s_nunitGetContext, TryCreateNUnitGetContext)?.Invoke() ??
+               new SnapshotTestContext();
     }
 
-    private static Func<string?>? GetDisplayName(ref Func<string?>? cachedFactory, Func<Func<string?>?> factory)
+    private static Func<SnapshotTestContext?>? GetContext(ref Func<SnapshotTestContext?>? cachedFactory, Func<Func<SnapshotTestContext?>?> factory)
     {
-        var getDisplayName = cachedFactory;
-        if (getDisplayName is not null)
-            return getDisplayName;
+        var getContext = cachedFactory;
+        if (getContext is not null)
+            return getContext;
 
-        getDisplayName = factory();
-        if (getDisplayName is not null)
+        getContext = factory();
+        if (getContext is not null)
         {
-            Interlocked.CompareExchange(ref cachedFactory, getDisplayName, comparand: null);
+            Interlocked.CompareExchange(ref cachedFactory, getContext, comparand: null);
         }
 
-        return getDisplayName;
+        return getContext;
     }
 
-    private static Func<string?>? TryCreateXunitV3GetDisplayName()
+    private static SnapshotTestContext? Create(string? testName, string? className, string? methodName)
+    {
+        className = NormalizeClassName(className);
+        if (testName is null && className is null && methodName is null)
+            return null;
+
+        return new SnapshotTestContext(TestName: testName) { ClassName = className, MethodName = methodName };
+    }
+
+    /// <summary>
+    /// Reduces a type name to the simple name produced by the call stack analysis, so both sources agree:
+    /// no namespace, no declaring types and no generic arity suffix.
+    /// </summary>
+    private static string? NormalizeClassName(string? className)
+    {
+        if (string.IsNullOrWhiteSpace(className))
+            return null;
+
+        var separatorIndex = className.LastIndexOfAny(['.', '+']);
+        if (separatorIndex >= 0)
+        {
+            className = className[(separatorIndex + 1)..];
+        }
+
+        var genericSeparatorIndex = className.IndexOf('`', StringComparison.Ordinal);
+        if (genericSeparatorIndex >= 0)
+        {
+            className = className[..genericSeparatorIndex];
+        }
+
+        return string.IsNullOrWhiteSpace(className) ? null : className;
+    }
+
+    private static Func<SnapshotTestContext?>? TryCreateXunitV3GetContext()
     {
         // Xunit v3: Xunit.TestContext.Current?.Test?.TestDisplayName
         // We use reflection so we don't take a hard dependency on xunit.
@@ -67,14 +110,20 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
                     var displayName = GetStringPropertyValue(test, "TestDisplayName") ??
                                       GetStringPropertyValue(test, "DisplayName");
                     var methodName = GetStringPropertyValue(test, "MethodName") ?? GetMethodName(displayName);
+
+                    // The class and the undecorated method name are only exposed by the test case.
+                    var testCase = GetPropertyValue(test, "TestCase");
+                    var className = testCase is null ? null : GetStringPropertyValue(testCase, "TestClassSimpleName") ?? GetStringPropertyValue(testCase, "TestClassName");
+                    var testMethodName = testCase is null ? methodName : GetStringPropertyValue(testCase, "TestMethodName") ?? methodName;
+
                     if (methodName is null)
-                        return displayName;
+                        return Create(displayName, className, testMethodName);
 
                     var arguments = GetObjectArrayPropertyValue(test, "TestMethodArguments");
                     if (arguments is null || arguments.Length == 0)
-                        return methodName;
+                        return Create(methodName, className, testMethodName);
 
-                    return methodName + "_" + string.Join('_', arguments.Select(FormatArgument));
+                    return Create(methodName + "_" + string.Join('_', arguments.Select(FormatArgument)), className, testMethodName);
                 }
                 catch
                 {
@@ -88,7 +137,7 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
         }
     }
 
-    private static Func<string?>? TryCreateTUnitGetDisplayName()
+    private static Func<SnapshotTestContext?>? TryCreateTUnitGetContext()
     {
         // TUnit: TUnit.Core.TestContext.Current?.Metadata?.DisplayName
         // We use reflection so we don't take a hard dependency on TUnit.
@@ -109,6 +158,7 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
             var metadataType = metadataProperty.PropertyType;
             var displayNameProperty = metadataType.GetProperty("DisplayName", BindingFlags.Public | BindingFlags.Instance);
             var testNameProperty = metadataType.GetProperty("TestName", BindingFlags.Public | BindingFlags.Instance);
+            var testDetailsProperty = metadataType.GetProperty("TestDetails", BindingFlags.Public | BindingFlags.Instance);
 
             return () =>
             {
@@ -122,8 +172,15 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
                     if (metadata is null)
                         return null;
 
-                    return displayNameProperty?.GetValue(metadata) as string ??
-                           testNameProperty?.GetValue(metadata) as string;
+                    var displayName = displayNameProperty?.GetValue(metadata) as string ??
+                                      testNameProperty?.GetValue(metadata) as string;
+
+                    // The class and the undecorated method name are only exposed by the test details.
+                    var testDetails = testDetailsProperty?.GetValue(metadata);
+                    var className = testDetails is null ? null : (GetPropertyValue(testDetails, "ClassType") as Type)?.Name;
+                    var methodName = testDetails is null ? null : GetStringPropertyValue(testDetails, "MethodName");
+
+                    return Create(displayName, className, methodName);
                 }
                 catch
                 {
@@ -137,7 +194,7 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
         }
     }
 
-    private static Func<string?>? TryCreateNUnitGetDisplayName()
+    private static Func<SnapshotTestContext?>? TryCreateNUnitGetContext()
     {
         // NUnit: NUnit.Framework.TestContext.CurrentContext?.Test
         // We use reflection so we don't take a hard dependency on NUnit.
@@ -173,18 +230,21 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
                                       GetStringPropertyValue(test, "FullName");
 
                     var methodName = GetMethodName(displayName);
+                    var className = (GetPropertyValue(test, "Type") as Type)?.Name ?? GetStringPropertyValue(test, "ClassName");
+                    var testMethodName = GetStringPropertyValue(test, "MethodName") ?? methodName;
+
                     if (methodName is null)
-                        return displayName;
+                        return Create(displayName, className, testMethodName);
 
                     var arguments = GetObjectArrayPropertyValue(test, "Arguments");
                     if (arguments is null || arguments.Length == 0)
-                        return displayName ?? methodName;
+                        return Create(displayName ?? methodName, className, testMethodName);
 
                     var displayNameHasParameters = displayName?.IndexOf('(', StringComparison.Ordinal) >= 0;
                     if (ShouldPreferDisplayName(displayName, methodName) || !displayNameHasParameters)
-                        return GetMethodName(displayName) ?? displayName;
+                        return Create(GetMethodName(displayName) ?? displayName, className, testMethodName);
 
-                    return methodName + "_" + string.Join('_', arguments.Select(FormatArgument));
+                    return Create(methodName + "_" + string.Join('_', arguments.Select(FormatArgument)), className, testMethodName);
                 }
                 catch
                 {
@@ -198,16 +258,22 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
         }
     }
 
-    private static string? GetStringPropertyValue(object instance, string propertyName)
+    // The parameter is deliberately not named propertyName: these are properties of the test framework
+    // types read through reflection, not members of this type, so nameof does not apply to them.
+    private static object? GetPropertyValue(object instance, string name)
     {
-        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
-        return property?.GetValue(instance) as string;
+        var property = instance.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+        return property?.GetValue(instance);
     }
 
-    private static object?[]? GetObjectArrayPropertyValue(object instance, string propertyName)
+    private static string? GetStringPropertyValue(object instance, string name)
     {
-        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
-        return property?.GetValue(instance) as object?[];
+        return GetPropertyValue(instance, name) as string;
+    }
+
+    private static object?[]? GetObjectArrayPropertyValue(object instance, string name)
+    {
+        return GetPropertyValue(instance, name) as object?[];
     }
 
     private static string? GetMethodName(string? displayName)

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -77,6 +77,49 @@ You can choose how snapshot names are generated using `SnapshotSettings.Snapshot
 - `SnapshotNamingStrategies.ClassName_TestName` (default)
 - `SnapshotNamingStrategies.FullName`
 
+## Calling `Snapshot.Validate` from a helper method
+
+Wrapping `Snapshot.Validate` in a helper method is supported. The test method is resolved by walking the
+stack until a method carrying a test attribute (`[Fact]`, `[Theory]`, `[Test]`, `[TestMethod]`) is found, so
+the helper frames are skipped and the snapshot is still named after the test, not after the helper.
+
+The snapshot directory, however, comes from `[CallerFilePath]`, which points at the file declaring the
+helper. Forward the caller information so the snapshots are created next to the test file:
+
+```csharp
+public static class ApiSnapshot
+{
+    public static void ValidateOpenApiSpec(
+        string spec,
+        [CallerFilePath] string? filePath = null,
+        [CallerLineNumber] int lineNumber = -1)
+    {
+        var settings = SnapshotSettings.Default with { /* shared configuration */ };
+        Snapshot.Validate(spec, "yaml", settings, filePath, lineNumber);
+    }
+}
+
+public sealed class OpenApiTests
+{
+    [Fact]
+    public void ValidateSpec()
+    {
+        ApiSnapshot.ValidateOpenApiSpec(GetSpec());
+        // => __snapshots__/OpenApiTests_ValidateSpec.verified.yaml
+    }
+}
+```
+
+No custom `SnapshotNamingStrategy` or `SnapshotPathStrategy` is needed for this scenario.
+
+This also works when the helper is `async` and awaits before asserting. The test method is then no longer on
+the call stack, so the test name and class name are read from the test framework context instead (Xunit v3,
+TUnit, and NUnit). Under a test framework that exposes no context (Xunit v2, MSTest), await inside the helper
+*after* the call to `Snapshot.Validate` rather than before it, so the test method is still on the stack.
+
+If the same test calls the helper several times, set `Snapshot.TestContext` to give each call a distinct name
+(see [Test context](#test-context)).
+
 ## Snapshots stored as source files
 
 Some snapshots are source files (for example the output of a source generator, see [`Meziantou.Framework.SnapshotTesting.Roslyn`](https://www.nuget.org/packages/Meziantou.Framework.SnapshotTesting.Roslyn)).
@@ -111,6 +154,9 @@ Snapshot naming uses test context when available:
 
 - `Snapshot.TestContext` (`AsyncLocal<SnapshotTestContext?>`) can be set explicitly.
 - Xunit v3, TUnit, and NUnit display names are auto-detected to improve generated file names.
+- The test class and method names are auto-detected from the same frameworks. They are used when the call
+  stack does not contain the test method, which happens when the assertion runs in a helper method that
+  awaited before asserting.
 
 ## Customization
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -681,6 +681,20 @@ public sealed partial class SnapshotEndToEndTests
         ]);
     }
 
+    [Theory]
+    [InlineData(SnapshotTestFramework.XunitV3)]
+    [InlineData(SnapshotTestFramework.NUnit)]
+    [InlineData(SnapshotTestFramework.TUnit)]
+    public async Task Validate_EndToEnd_UsesTestClassName_WhenCalledFromAsyncHelperInAnotherClass(SnapshotTestFramework testFramework)
+    {
+        var snapshotFiles = await AssertSnapshot(GetAsyncHelperSource(testFramework), testFramework: testFramework);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
     [Fact]
     public async Task Validate_EndToEnd_Works_WhenUsingArtifactsOutput()
     {
@@ -916,6 +930,65 @@ public sealed partial class SnapshotEndToEndTests
         File.WriteAllText(snapshotPath, "-- not valid Visual Basic --");
 
         await ExecuteDotNetWithRetry(directory.FullPath, dotnetPath, ["build", "--disable-build-servers"], expectedExitCode: 0);
+    }
+
+    private static string GetAsyncHelperSource(SnapshotTestFramework framework)
+    {
+        // The helper awaits before asserting, so the test method is no longer on the call stack and only the
+        // test framework context can tell which test is running.
+        const string Helper = """
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+
+            public static class SnapshotHelpers
+            {
+                public static async Task ValidateAsync(object value, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = -1)
+                {
+                    await Task.Yield();
+                    Snapshot.Validate(value, null, SnapshotTestUtilities.CreateSuccessSettings(), filePath, lineNumber);
+                }
+            }
+
+            """;
+
+        return Helper + framework switch
+        {
+            SnapshotTestFramework.XunitV3 =>
+                """
+                public sealed class GeneratedSnapshotTests
+                {
+                    [Fact]
+                    public async Task SampleTest()
+                    {
+                        await SnapshotHelpers.ValidateAsync("sample");
+                    }
+                }
+                """,
+            SnapshotTestFramework.NUnit =>
+                """
+                [TestFixture]
+                public sealed class GeneratedSnapshotTests
+                {
+                    [Test]
+                    public async Task SampleTest()
+                    {
+                        await SnapshotHelpers.ValidateAsync("sample");
+                    }
+                }
+                """,
+            SnapshotTestFramework.TUnit =>
+                """
+                public sealed class GeneratedSnapshotTests
+                {
+                    [Test]
+                    public async Task SampleTest()
+                    {
+                        await SnapshotHelpers.ValidateAsync("sample");
+                    }
+                }
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(framework), framework, null),
+        };
     }
 
     private static string GetFrameworkSmokeSource(SnapshotTestFramework framework)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -341,7 +341,7 @@ public sealed partial class SnapshotTests
         Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
         Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromHelperMethod), capturedContext.MethodName);
         Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromHelperMethod), capturedContext.TestContext?.TestName);
-        Assert.Equal(FullPath.FromPath(GetCurrentFilePath()), capturedContext.SourceFilePath);
+        Assert.Equal("SnapshotTests.cs", capturedContext.SourceFilePath.Name);
 
         var files = Directory.GetFiles(directory.FullPath);
         Assert.Single(files);
@@ -369,7 +369,7 @@ public sealed partial class SnapshotTests
         Assert.NotNull(capturedContext);
         Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
         Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromAsyncHelperMethodInAnotherClass), capturedContext.MethodName);
-        Assert.Equal(FullPath.FromPath(GetCurrentFilePath()), capturedContext.SourceFilePath);
+        Assert.Equal("SnapshotTests.cs", capturedContext.SourceFilePath.Name);
 
         var files = Directory.GetFiles(directory.FullPath);
         Assert.Single(files);
@@ -391,8 +391,6 @@ public sealed partial class SnapshotTests
     {
         Snapshot.Validate(value, type: null, settings, filePath, lineNumber);
     }
-
-    private static string GetCurrentFilePath([CallerFilePath] string? filePath = null) => filePath!;
 
     [Fact]
     public void Validate_UsesSnapshotTypeExtensionWhenSerializerDoesNotProvideOne()

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
 using Meziantou.Framework.SnapshotTesting.SnapshotUpdateStrategies;
@@ -317,6 +318,81 @@ public sealed partial class SnapshotTests
         Assert.Matches(SnapshotNameWithHashAndIndexRegex(), path.Name);
         Assert.HasCountLessThanOrEqual(settings.MaxSnapshotFileNameLength, path.Name);
     }
+
+    [Fact]
+    public void Validate_ResolvesTestMethod_WhenCalledFromHelperMethod()
+    {
+        using var directory = TemporaryDirectory.Create();
+        SnapshotPathContext? capturedContext = null;
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context =>
+            {
+                capturedContext = context;
+                return directory / (SnapshotSettings.Default.SnapshotPathStrategy(context).Name);
+            },
+        };
+
+        ValidateThroughHelper("sample", settings);
+
+        Assert.NotNull(capturedContext);
+        Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
+        Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromHelperMethod), capturedContext.MethodName);
+        Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromHelperMethod), capturedContext.TestContext?.TestName);
+        Assert.Equal(FullPath.FromPath(GetCurrentFilePath()), capturedContext.SourceFilePath);
+
+        var files = Directory.GetFiles(directory.FullPath);
+        Assert.Single(files);
+        Assert.Equal("SnapshotTests_Validate_ResolvesTestMethod_WhenCalledFromHelperMethod.verified.txt", Path.GetFileName(files[0]));
+    }
+
+    [Fact]
+    public async Task Validate_ResolvesTestMethod_WhenCalledFromAsyncHelperMethodInAnotherClass()
+    {
+        using var directory = TemporaryDirectory.Create();
+        SnapshotPathContext? capturedContext = null;
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context =>
+            {
+                capturedContext = context;
+                return directory / (SnapshotSettings.Default.SnapshotPathStrategy(context).Name);
+            },
+        };
+
+        await SnapshotHelpers.ValidateThroughAsyncHelper("sample", settings);
+
+        Assert.NotNull(capturedContext);
+        Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
+        Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromAsyncHelperMethodInAnotherClass), capturedContext.MethodName);
+        Assert.Equal(FullPath.FromPath(GetCurrentFilePath()), capturedContext.SourceFilePath);
+
+        var files = Directory.GetFiles(directory.FullPath);
+        Assert.Single(files);
+        Assert.Equal("SnapshotTests_Validate_ResolvesTestMethod_WhenCalledFromAsyncHelperMethodInAnotherClass.verified.txt", Path.GetFileName(files[0]));
+    }
+
+    private static class SnapshotHelpers
+    {
+        public static async Task ValidateThroughAsyncHelper(object? value, SnapshotSettings settings, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
+        {
+            // Yielding drops the test method from the call stack, so only the test framework still knows
+            // which test is running.
+            await Task.Yield();
+            Snapshot.Validate(value, type: null, settings, filePath, lineNumber);
+        }
+    }
+
+    private static void ValidateThroughHelper(object? value, SnapshotSettings settings, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
+    {
+        Snapshot.Validate(value, type: null, settings, filePath, lineNumber);
+    }
+
+    private static string GetCurrentFilePath([CallerFilePath] string? filePath = null) => filePath!;
 
     [Fact]
     public void Validate_UsesSnapshotTypeExtensionWhenSerializerDoesNotProvideOne()


### PR DESCRIPTION
Fixes the naming caveat found while answering #3089.

## The problem

Snapshot names are built from the test method located by walking the call stack. That already works for a helper method that calls `Snapshot.Validate` synchronously — the walk skips the helper frames and stops on the frame carrying a test attribute (`[Fact]`, `[Theory]`, `[Test]`, `[TestMethod]`), so the snapshot is named after the test rather than the helper.

It breaks once the helper `await`s before asserting. The continuation no longer has the test method on the stack, and the innermost frames describe the helper instead. The test name stayed correct (it comes from the test framework context), but the class prefix became the helper's class:

```
__snapshots__/SnapshotHelpers_MyTest.verified.txt   ← before
__snapshots__/MyTests_MyTest.verified.txt           ← after
```

No stack-based mechanism can fix this: after an `await` the test method is genuinely gone from the stack. Marking the helper with an attribute the way `InlineSnapshotTesting` does would make it worse — that attribute exists there to find the *immediate caller frame* so the string literal can be rewritten, and skipping past the helper here leaves only threadpool internals.

## The fix

The test frameworks know which test is running — that is already how `TestName` is resolved. This extends the same path to carry the class and method:

- `SnapshotTestContext` gains `ClassName` and `MethodName`, read from xunit v3 (`TestCase.TestClassSimpleName` / `TestMethodName`), NUnit (`Test.Type` / `MethodName`) and TUnit (`TestDetails.ClassType` / `MethodName`), all through reflection so no hard dependency is taken.
- Names are normalized to the simple form the stack analysis produces (no namespace, no declaring types, no generic arity suffix) so the two sources agree.
- `SnapshotCallerContext` now records whether the stack walk actually found a test-attributed frame, and `SnapshotEngine` prefers the framework's view **only** when it did not.

That gate is what keeps this safe: every case that resolves from the stack today is byte-for-byte unchanged. It matters in particular for an inherited test method, where the declaring type from the stack and the test class from the framework legitimately differ — the stack still wins there.

## Reviewer notes

- **Public API is additive**: two init-only properties on `SnapshotTestContext`. The primary constructor and `Deconstruct` are untouched, so this is source- and binary-compatible. `ref/` regenerated.
- **Behaviour change for existing users**: anyone who has an async helper today has snapshots named after the helper class. After this change they are named after the test class and will need renaming. That is the reported bug being fixed.
- **Xunit v2 and MSTest expose no test context**, so the caveat remains there. The readme documents the workaround (await *after* the assertion, not before).
- `GetPropertyValue`'s parameter is deliberately not named `propertyName` — CA1507 would otherwise flag the reflected framework property names as candidates for `nameof`, which would be wrong since they are members of other types.
- The readme gains a "Calling `Snapshot.Validate` from a helper method" section answering #3089: forwarding `[CallerFilePath]` is all that is required, and no custom `SnapshotNamingStrategy` or `SnapshotPathStrategy` is needed.

## Testing

The new tests were confirmed to catch the bug rather than pass vacuously: with the fallback disabled all four fail with `SnapshotHelpers_SampleTest`, and pass with it enabled.

- `SnapshotTests.Validate_ResolvesTestMethod_WhenCalledFromHelperMethod` — the synchronous helper case that already worked, now locked in.
- `SnapshotTests.Validate_ResolvesTestMethod_WhenCalledFromAsyncHelperMethodInAnotherClass` — asserts the resolved class, method and path.
- `SnapshotEndToEndTests.Validate_EndToEnd_UsesTestClassName_WhenCalledFromAsyncHelperInAnotherClass` — a theory building and running real projects on xunit v3, NUnit and TUnit.

Full suite: **390 passed, 0 failed** (195 × net10.0 + net11.0, end-to-end included), built with `/p:TreatsWarningsAsErrors=true`. Release + `IsOfficialBuild=true` builds clean for the library and the five dependent projects. `dotnet run ./eng/update-all.cs` exits 0 with no further changes.
