### PR TITLE
Fix snapshot file ownership, name portability and image decoding

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/BmpImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/BmpImageLoader.cs
@@ -13,6 +13,9 @@ internal static class BmpImageLoader
     {
         const int BmpFileHeaderSize = 14;
         const int BmpInfoHeaderSize = 40;
+        const int BmpV4HeaderSize = 108;
+        const int BmpV4AlphaMaskOffset = BmpFileHeaderSize + 52;
+        const uint StandardAlphaMask = 0xFF000000;
 
         if (data.Length < BmpFileHeaderSize + BmpInfoHeaderSize)
             throw new InvalidDataException("The BMP data is too small.");
@@ -49,6 +52,15 @@ internal static class BmpImageLoader
         if (pixelDataOffset < BmpFileHeaderSize + dibHeaderSize || pixelDataOffset >= data.Length)
             throw new InvalidDataException("The BMP pixel data offset is invalid.");
 
+        // The fourth byte of a 32-bit pixel is only an alpha channel when the header declares an alpha mask,
+        // which BITMAPV4HEADER is the first to carry. A plain BITMAPINFOHEADER leaves that byte unused, and
+        // writers commonly leave it at zero, so reading it as alpha makes an opaque image fully transparent.
+        var alphaMask = bitsPerPixel == 32 && dibHeaderSize >= BmpV4HeaderSize
+            ? ReadUInt32LittleEndian(data, BmpV4AlphaMaskOffset)
+            : 0;
+        if (alphaMask is not 0 and not StandardAlphaMask)
+            throw new NotSupportedException("Unsupported BMP alpha mask.");
+
         var bytesPerPixel = bitsPerPixel / 8;
         var absoluteHeight = Math.Abs(height);
         var topDown = height < 0;
@@ -72,7 +84,7 @@ internal static class BmpImageLoader
                 var b = data[pixelOffset];
                 var g = data[pixelOffset + 1];
                 var r = data[pixelOffset + 2];
-                var a = bitsPerPixel == 32 ? data[pixelOffset + 3] : (byte)0xFF;
+                var a = alphaMask is StandardAlphaMask ? data[pixelOffset + 3] : (byte)0xFF;
                 pixels[destinationOffset + x] = new Argb((uint)(a << 24 | r << 16 | g << 8 | b));
             }
         }

--- a/src/Meziantou.Framework.SnapshotTesting/Images/TiffImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/TiffImageLoader.cs
@@ -21,6 +21,7 @@ internal static class TiffImageLoader
     private const ushort TagStripByteCounts = 279;
     private const ushort TagPlanarConfiguration = 284;
     private const ushort TagPredictor = 317;
+    private const ushort TagExtraSamples = 338;
 
     private const ushort CompressionNone = 1;
     private const ushort CompressionLzw = 5;
@@ -34,6 +35,9 @@ internal static class TiffImageLoader
     private const ushort PlanarConfigurationChunky = 1;
     private const ushort PredictorNone = 1;
     private const ushort PredictorHorizontalDifferencing = 2;
+
+    private const uint ExtraSampleAssociatedAlpha = 1;
+    private const uint ExtraSampleUnassociatedAlpha = 2;
 
     internal static bool IsTiff(ReadOnlySpan<byte> data)
     {
@@ -93,6 +97,7 @@ internal static class TiffImageLoader
         if (predictor is not PredictorNone and not PredictorHorizontalDifferencing)
             throw new NotSupportedException("Unsupported TIFF predictor.");
 
+        var alphaMode = ReadAlphaMode(entries, data, isLittleEndian);
         var bitsPerSampleValues = ReadBitsPerSample(entries, data, isLittleEndian, samplesPerPixel);
         foreach (var bitsPerSample in bitsPerSampleValues)
         {
@@ -125,7 +130,8 @@ internal static class TiffImageLoader
                 rowsInStrip,
                 width,
                 samplesPerPixel,
-                photometric);
+                photometric,
+                alphaMode);
 
             rowIndex += rowsInStrip;
         }
@@ -311,14 +317,17 @@ internal static class TiffImageLoader
             byte firstValue;
             if (code == nextCode)
             {
-                if (previousCode < 0 || !TryExpandCode(previousCode, prefixes, suffixes, stack, ref stackLength, out firstValue))
+                // The code is not in the table yet: it stands for the previous string followed by that
+                // string's own first character. The stack holds the string in reverse, so the character that
+                // comes last goes in at the bottom, below the expansion of the previous code.
+                if (previousCode < 0)
                     throw new InvalidDataException("Invalid TIFF LZW data.");
 
-                if (stackLength >= stack.Length)
+                stackLength = 1;
+                if (!TryExpandCode(previousCode, prefixes, suffixes, stack, ref stackLength, out firstValue))
                     throw new InvalidDataException("Invalid TIFF LZW data.");
 
-                stack[stackLength] = firstValue;
-                stackLength++;
+                stack[0] = firstValue;
             }
             else if (!TryExpandCode(code, prefixes, suffixes, stack, ref stackLength, out firstValue))
             {
@@ -340,7 +349,9 @@ internal static class TiffImageLoader
                 suffixes[nextCode] = firstValue;
                 nextCode++;
 
-                if (nextCode == (1 << codeBitCount) && codeBitCount < 12)
+                // TIFF LZW switches to a longer code one entry earlier than textbook LZW: a writer emits
+                // 10-bit codes as soon as 511 is in the table, 11-bit ones from 1023, 12-bit ones from 2047.
+                if (nextCode == (1 << codeBitCount) - 1 && codeBitCount < 12)
                     codeBitCount++;
             }
 
@@ -402,6 +413,41 @@ internal static class TiffImageLoader
         return true;
     }
 
+    /// <summary>
+    /// Reads how the sample that follows the colour samples must be interpreted.
+    /// </summary>
+    /// <remarks>
+    /// A fourth sample is only an alpha channel when ExtraSamples says so. Its default, and its value 0, mean
+    /// "unspecified data": reading that as alpha turns an opaque image into a fully transparent one.
+    /// </remarks>
+    private static TiffAlphaMode ReadAlphaMode(
+        Dictionary<ushort, (ushort Type, uint Count, uint ValueOffset)> entries,
+        ReadOnlySpan<byte> data,
+        bool isLittleEndian)
+    {
+        if (!entries.TryGetValue(TagExtraSamples, out var entry))
+            return TiffAlphaMode.None;
+
+        var values = ReadEntryValues(entry, data, isLittleEndian);
+        return values[0] switch
+        {
+            ExtraSampleAssociatedAlpha => TiffAlphaMode.Associated,
+            ExtraSampleUnassociatedAlpha => TiffAlphaMode.Unassociated,
+            _ => TiffAlphaMode.None,
+        };
+    }
+
+    private static byte Unpremultiply(byte value, byte alpha)
+    {
+        if (alpha == 0)
+            return 0;
+
+        if (value >= alpha)
+            return byte.MaxValue;
+
+        return (byte)(((value * 255) + (alpha / 2)) / alpha);
+    }
+
     private static void ApplyHorizontalPredictor(Span<byte> data, int bytesPerRow, int samplesPerPixel)
     {
         for (var row = 0; row < data.Length; row += bytesPerRow)
@@ -421,8 +467,11 @@ internal static class TiffImageLoader
         int rowCount,
         int width,
         int samplesPerPixel,
-        ushort photometricInterpretation)
+        ushort photometricInterpretation,
+        TiffAlphaMode alphaMode)
     {
+        var hasAlphaSample = samplesPerPixel == 4 && alphaMode is not TiffAlphaMode.None;
+        var isPremultiplied = hasAlphaSample && alphaMode is TiffAlphaMode.Associated;
         var sourceOffset = 0;
         for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
         {
@@ -438,7 +487,16 @@ internal static class TiffImageLoader
                         var r = stripBytes[sourceOffset];
                         var g = stripBytes[sourceOffset + 1];
                         var b = stripBytes[sourceOffset + 2];
-                        var a = samplesPerPixel == 4 ? stripBytes[sourceOffset + 3] : (byte)0xFF;
+                        var a = hasAlphaSample ? stripBytes[sourceOffset + 3] : (byte)0xFF;
+                        if (isPremultiplied)
+                        {
+                            // Associated alpha stores the samples premultiplied; every other format this
+                            // library reads keeps them straight, so undo the multiplication here.
+                            r = Unpremultiply(r, a);
+                            g = Unpremultiply(g, a);
+                            b = Unpremultiply(b, a);
+                        }
+
                         pixels[destinationOffset + x] = new Argb(a, r, g, b);
                         sourceOffset += samplesPerPixel;
                     }
@@ -600,6 +658,13 @@ internal static class TiffImageLoader
         return isLittleEndian
             ? BinaryPrimitives.ReadUInt32LittleEndian(data.Slice(offset, 4))
             : BinaryPrimitives.ReadUInt32BigEndian(data.Slice(offset, 4));
+    }
+
+    private enum TiffAlphaMode
+    {
+        None,
+        Unassociated,
+        Associated,
     }
 
     private ref struct TiffLzwBitReader(ReadOnlySpan<byte> data)

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -44,7 +44,13 @@ internal static class SnapshotEngine
 
         if (settings.ForceUpdateSnapshots)
         {
-            filesToUpdate = BuildSnapshotFilesToUpdate(actualFiles, [.. actualFiles.Select(item => item.FilePath)]);
+            // WriteActualSnapshots only wrote the files that differ. A forced update consumes every actual
+            // file, so the ones whose snapshot already matched must be written too: otherwise the update
+            // either fails on a missing file or promotes whatever an earlier failed run left there.
+            var writtenPaths = new HashSet<FullPath>(filesToUpdate.Select(item => item.VerifiedPath));
+            var remainingFiles = BuildSnapshotFilesToUpdate(actualFiles, [.. actualFiles.Select(item => item.FilePath).Where(path => !writtenPaths.Contains(path))]);
+            WriteActualSnapshots(remainingFiles);
+            filesToUpdate.AddRange(remainingFiles);
         }
 
         ApplySnapshotUpdates(settings, filesToUpdate, comparison.ExtraPaths);
@@ -92,16 +98,22 @@ internal static class SnapshotEngine
 
     private static SnapshotComparisonResult Compare(SnapshotSettings settings, SnapshotType type, List<SnapshotFile> actualFiles, Dictionary<FullPath, SnapshotData> expectedFiles)
     {
-        // A single snapshot that matches its verified file is what every passing test does, and the
-        // bookkeeping below - two dictionaries, three sets and a couple of LINQ passes - is only needed to
-        // describe a difference.
+        // A single snapshot compared with its verified file is what every test does, and the bookkeeping
+        // below - two dictionaries, three sets and a couple of LINQ passes - is only needed to describe a
+        // difference between two sets of files. Both outcomes are decided here so that a mismatch does not
+        // run the comparer a second time on the same pair.
         if (actualFiles.Count == 1 && expectedFiles.Count == 1)
         {
             var actualFile = actualFiles[0];
-            if (expectedFiles.TryGetValue(actualFile.FilePath, out var expectedData) &&
-                GetComparer(settings, type, actualFile.Data).Equals(expectedData, actualFile.Data))
+            if (expectedFiles.TryGetValue(actualFile.FilePath, out var expectedData))
             {
-                return SnapshotComparisonResult.NoDifference;
+                if (GetComparer(settings, type, actualFile.Data).Equals(expectedData, actualFile.Data))
+                    return SnapshotComparisonResult.NoDifference;
+
+                // The two sets hold the same single path, so its content is the only thing that can differ.
+                FullPath[] changedPath = [actualFile.FilePath];
+                var summary = FormatSummary(changedPath);
+                return new SnapshotComparisonResult(HasDifferences: true, BuildMessage([], [], changedPath), summary, summary, changedPath, [], [], changedPath);
             }
         }
 
@@ -127,9 +139,10 @@ internal static class SnapshotEngine
             return SnapshotComparisonResult.NoDifference;
         }
 
-        var message = BuildMessage(missingPaths, extraPaths, changedPaths);
+        FullPath[] changedPathArray = [.. changedPaths];
+        var message = BuildMessage(missingPaths, extraPaths, changedPathArray);
         var pathsToUpdate = missingPaths.Concat(changedPaths).Distinct().ToArray();
-        return new SnapshotComparisonResult(HasDifferences: true, message, FormatSummary(expectedPaths), FormatSummary(actualPaths), [.. changedPaths], missingPaths, extraPaths, pathsToUpdate);
+        return new SnapshotComparisonResult(HasDifferences: true, message, FormatSummary(expectedPaths), FormatSummary(actualPaths), changedPathArray, missingPaths, extraPaths, pathsToUpdate);
     }
 
     /// <summary>
@@ -154,7 +167,7 @@ internal static class SnapshotEngine
     private static string BuildMessage(
         FullPath[] missingPaths,
         FullPath[] extraPaths,
-        List<FullPath> changedPaths)
+        FullPath[] changedPaths)
     {
         var sb = new StringBuilder();
         sb.AppendLine("Snapshots do not match.");
@@ -193,7 +206,7 @@ internal static class SnapshotEngine
             }
         }
 
-        if (changedPaths.Count > 0)
+        if (changedPaths.Length > 0)
         {
             sb.AppendLine();
             sb.AppendLine("Changed snapshot files:");
@@ -305,30 +318,71 @@ internal static class SnapshotEngine
         if (firstName is null)
             return actualPaths.Where(path => File.Exists(path.Value)).ToArray();
 
-        var indexedPrefix = GetIndexedPrefix(firstName, actualFiles.Count);
+        var snapshotName = GetSnapshotName(firstName, actualFiles.Count);
+        var indexedPrefix = snapshotName + "_";
 
-        var expected = new HashSet<FullPath>();
+        var expected = new HashSet<FullPath>(actualPaths);
+        Dictionary<int, string>? indexedCandidates = null;
         foreach (var candidate in GetVerifiedSnapshotFiles(directory, directoryInfo.LastWriteTimeUtc))
         {
-            if (!string.Equals(candidate.BaseName, firstName, StringComparison.Ordinal))
+            if (string.Equals(candidate.BaseName, snapshotName, StringComparison.Ordinal))
             {
-                if (!candidate.BaseName.StartsWith(indexedPrefix, StringComparison.Ordinal))
-                    continue;
-
-                var suffix = candidate.BaseName.AsSpan(indexedPrefix.Length);
-                if (!int.TryParse(suffix, NumberStyles.None, CultureInfo.InvariantCulture, out _))
-                    continue;
+                // The file without an index is this assertion's own snapshot when it produces a single one,
+                // and the file it left behind when it used to produce a single one and now produces several.
+                expected.Add(directory / candidate.FileName);
             }
-
-            expected.Add(directory / candidate.FileName);
+            else if (TryGetSnapshotIndex(candidate.BaseName, indexedPrefix, out var index))
+            {
+                (indexedCandidates ??= [])[index] = candidate.FileName;
+            }
         }
 
-        foreach (var path in actualPaths)
+        if (indexedCandidates is not null)
         {
-            expected.Add(path);
+            AddIndexedFilesOfThisAssertion(actualFiles, directory, indexedPrefix, indexedCandidates, expected);
         }
 
         return expected;
+    }
+
+    /// <summary>
+    /// Adds the indexed files that this assertion wrote in an earlier run, when it produced more snapshots
+    /// than it does now.
+    /// </summary>
+    /// <remarks>
+    /// An assertion numbers its files from zero without a gap, so an index only identifies it when every
+    /// index below belongs to it too. A lone <c>Name_1.verified.txt</c> sitting next to
+    /// <c>Name.verified.txt</c> with no <c>Name_0.verified.txt</c> is the snapshot of a test called
+    /// <c>Name_1</c>: reporting it here would fail this assertion for a file it does not own, and deleting it
+    /// would take out the other test's baseline.
+    /// </remarks>
+    private static void AddIndexedFilesOfThisAssertion(
+        List<SnapshotFile> actualFiles,
+        FullPath directory,
+        string indexedPrefix,
+        Dictionary<int, string> indexedCandidates,
+        HashSet<FullPath> expected)
+    {
+        var actualIndexes = new HashSet<int>();
+        foreach (var actualFile in actualFiles)
+        {
+            var baseName = GetVerifiedBaseName(actualFile.FilePath);
+            if (baseName is not null && TryGetSnapshotIndex(baseName, indexedPrefix, out var actualIndex))
+            {
+                actualIndexes.Add(actualIndex);
+            }
+        }
+
+        for (var index = 0; ; index++)
+        {
+            if (actualIndexes.Contains(index))
+                continue;
+
+            if (!indexedCandidates.TryGetValue(index, out var fileName))
+                break;
+
+            expected.Add(directory / fileName);
+        }
     }
 
     /// <summary>
@@ -376,20 +430,41 @@ internal static class SnapshotEngine
         return snapshotName[..^".verified".Length].ToString();
     }
 
-    private static string GetIndexedPrefix(string snapshotName, int actualFileCount)
+    /// <summary>
+    /// Recovers the name an assertion stores its snapshots under from the name of its first file. Several
+    /// snapshots are stored as <c>Name_0</c>, <c>Name_1</c>, ... while a single one keeps the bare
+    /// <c>Name</c>, and finding the files written when the assertion produced a different number of
+    /// snapshots starts from that common name.
+    /// </summary>
+    private static string GetSnapshotName(string firstFileName, int actualFileCount)
     {
         if (actualFileCount > 1)
         {
-            var separatorIndex = snapshotName.LastIndexOf('_', StringComparison.Ordinal);
+            var separatorIndex = firstFileName.LastIndexOf('_', StringComparison.Ordinal);
             if (separatorIndex >= 0)
             {
-                var suffix = snapshotName[(separatorIndex + 1)..];
+                var suffix = firstFileName[(separatorIndex + 1)..];
                 if (int.TryParse(suffix, NumberStyles.None, CultureInfo.InvariantCulture, out _))
-                    return snapshotName[..(separatorIndex + 1)];
+                    return firstFileName[..separatorIndex];
             }
         }
 
-        return snapshotName + "_";
+        return firstFileName;
+    }
+
+    private static bool TryGetSnapshotIndex(string baseName, string indexedPrefix, out int index)
+    {
+        index = 0;
+        if (!baseName.StartsWith(indexedPrefix, StringComparison.Ordinal))
+            return false;
+
+        var suffix = baseName.AsSpan(indexedPrefix.Length);
+
+        // '_01' is not how an index is written, and mapping it onto 1 would let two files claim one index.
+        if (suffix.Length > 1 && suffix[0] == '0')
+            return false;
+
+        return int.TryParse(suffix, NumberStyles.None, CultureInfo.InvariantCulture, out index);
     }
 
     private static List<SnapshotFileToUpdate> BuildSnapshotFilesToUpdate(IReadOnlyList<SnapshotFile> actualFiles, IReadOnlyCollection<FullPath> pathsToUpdate)

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
@@ -144,8 +144,12 @@ public sealed record SnapshotSettings
             }
         }
 
-        var rawStartPart = context.Settings.SnapshotNamingStrategy(context);
-        var startPart = SanitizeFragment(rawStartPart ?? "");
+        var rawStartPart = context.Settings.SnapshotNamingStrategy(context) ?? "";
+        var startPart = SanitizeFragment(rawStartPart);
+
+        // Sanitizing loses information - 'Case_a/b' and 'Case_a?b' both become 'Case_a_b' - so a name it
+        // changed only stays distinct once the hash of the original name is part of the file name.
+        var isNameSanitized = !string.Equals(startPart, rawStartPart, StringComparison.Ordinal);
         if (startPart.Length == 0)
         {
             startPart = "snapshot";
@@ -155,6 +159,7 @@ public sealed record SnapshotSettings
         var indexPart = context.Index.ToString(CultureInfo.InvariantCulture);
         var suffixWithoutHash = hasMultipleSnapshots ? "_" + indexPart + ".verified." + extension : ".verified." + extension;
         var shouldAddHashSuffix =
+            isNameSanitized ||
             startPart.Length > context.Settings.MaxSnapshotFileNameLength - suffixWithoutHash.Length ||
             IsReservedSnapshotName(startPart);
 
@@ -164,7 +169,10 @@ public sealed record SnapshotSettings
             // The line number is deliberately not part of the hash: it would rename the snapshot whenever
             // anything above the assertion moves, and it adds no uniqueness since two assertions in one
             // test are already separated by the index suffix.
-            var hashInput = $"{context.SourceFilePath}|{context.MethodName}|{context.ClassName}|{context.Type.Type}|{rawStartPart}|{context.TestContext?.TestName}|{FormatMetadata(context.TestContext?.Metadata)}";
+            // The source file name is used rather than its full path: the snapshot is stored next to the
+            // source file, so the name is enough to tell two files of that directory apart, while the
+            // absolute path would tie the file name to where the repository happens to be checked out.
+            var hashInput = $"{context.SourceFilePath.Name}|{context.MethodName}|{context.ClassName}|{context.Type.Type}|{rawStartPart}|{context.TestContext?.TestName}|{FormatMetadata(context.TestContext?.Metadata)}";
             var hash = ToHexSha256(hashInput, length: 8);
             suffix = hasMultipleSnapshots ? "_" + hash + "_" + indexPart + ".verified." + extension : "_" + hash + ".verified." + extension;
         }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotTestContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotTestContext.cs
@@ -109,6 +109,7 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
             var metadataType = metadataProperty.PropertyType;
             var displayNameProperty = metadataType.GetProperty("DisplayName", BindingFlags.Public | BindingFlags.Instance);
             var testNameProperty = metadataType.GetProperty("TestName", BindingFlags.Public | BindingFlags.Instance);
+            var testDetailsProperty = metadataType.GetProperty("TestDetails", BindingFlags.Public | BindingFlags.Instance);
 
             return () =>
             {
@@ -122,8 +123,28 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
                     if (metadata is null)
                         return null;
 
-                    return displayNameProperty?.GetValue(metadata) as string ??
-                           testNameProperty?.GetValue(metadata) as string;
+                    var displayName = displayNameProperty?.GetValue(metadata) as string ??
+                                      testNameProperty?.GetValue(metadata) as string;
+
+                    var testDetails = testDetailsProperty?.GetValue(metadata);
+                    if (testDetails is null)
+                        return displayName;
+
+                    var methodName = GetStringPropertyValue(testDetails, "MethodName") ?? GetMethodName(displayName);
+                    if (methodName is null)
+                        return displayName;
+
+                    // The display name of a parameterized test spells the arguments out between parentheses.
+                    // Rebuilding the name from the method name and the arguments keeps the snapshot file name
+                    // readable, as the xunit and NUnit contexts do, while a name the user chose is kept.
+                    if (ShouldPreferDisplayName(displayName, methodName))
+                        return displayName;
+
+                    var arguments = GetObjectArrayPropertyValue(testDetails, "TestMethodArguments");
+                    if (arguments is null || arguments.Length == 0)
+                        return methodName;
+
+                    return methodName + "_" + string.Join('_', arguments.Select(FormatArgument));
                 }
                 catch
                 {

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategy.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategy.cs
@@ -7,7 +7,11 @@ namespace Meziantou.Framework.SnapshotTesting;
 public abstract class SnapshotUpdateStrategy
 {
     private const string SnapshotUpdateStrategyEnvironmentVariableName = "SNAPSHOTTESTING_STRATEGY";
-    private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties = typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
+    // Default is excluded on purpose: its getter calls GetStrategyFromEnvironmentVariable, so resolving it from
+    // here would re-enter the getter and recurse until the process died with an uncatchable StackOverflowException.
+    private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties =
+        [.. typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static).Where(property => property.Name is not nameof(Default))];
 
     /// <summary>Do not update the snapshots and fail the tests if the snapshots are different.</summary>
     public static SnapshotUpdateStrategy Disallow { get; } = new DisallowStrategy();

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -51,7 +51,10 @@ Notes:
 - By default, snapshot names include class name and test name to avoid collisions across test classes.
 - `.actual` files are always written when a snapshot does not match.
 - If a single assertion serializes multiple files, an index suffix (`_0`, `_1`, ...) is appended.
-- If names are too long (or already end with `.verified` / `.actual`), a stable hash is added.
+- If names are too long, already end with `.verified` / `.actual`, or contain characters that are not
+  valid in a file name, a stable hash is added. Removing those characters would let two test names -
+  `Case_a/b` and `Case_a?b`, say - claim the same snapshot file, and the hash keeps them apart. The hash
+  does not depend on where the repository is checked out.
 
 ## Storing snapshots in git
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/BmpImageLoaderTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/BmpImageLoaderTests.cs
@@ -79,6 +79,45 @@ public sealed class BmpImageLoaderTests
     }
 
     [Fact]
+    public void Image_Load_IgnoresTheFourthByteOfAPixelWhenTheHeaderDeclaresNoAlphaMask()
+    {
+        // A BITMAPINFOHEADER leaves that byte unused and writers commonly leave it at zero.
+        var imageData = ImageTestData.CreateBmp32(width: 1, height: 1, pixels: [0x00112233u]);
+
+        var image = Image.Load(imageData);
+
+        Assert.Equal([new Argb(0xFF112233u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Image_Load_IgnoresTheFourthByteOfAPixelWhenTheAlphaMaskIsEmpty()
+    {
+        var imageData = ImageTestData.CreateBmp32(width: 1, height: 1, pixels: [0x00112233u], dibHeaderSize: 108, alphaMask: 0);
+
+        var image = Image.Load(imageData);
+
+        Assert.Equal([new Argb(0xFF112233u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Image_Load_UsesTheFourthByteOfAPixelWhenTheHeaderDeclaresAnAlphaMask()
+    {
+        var imageData = ImageTestData.CreateBmp32(width: 1, height: 1, pixels: [0x80112233u], dibHeaderSize: 108, alphaMask: 0xFF000000);
+
+        var image = Image.Load(imageData);
+
+        Assert.Equal([new Argb(0x80112233u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Image_Load_ReportsAnUnsupportedAlphaMask()
+    {
+        var imageData = ImageTestData.CreateBmp32(width: 1, height: 1, pixels: [0xFF112233u], dibHeaderSize: 108, alphaMask: 0x0000FF00);
+
+        Assert.Throws<NotSupportedException>(() => Image.Load(imageData));
+    }
+
+    [Fact]
     public void ImageComparer_ReportsADifferenceForCorruptImageData()
     {
         var expected = ImageTestData.CreateBmp24(width: 1, height: 1, pixels: [0xFF112233u], pixelsPerMeter: 2835);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageTestData.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageTestData.cs
@@ -391,6 +391,190 @@ internal static class ImageTestData
     /// Encodes the pixels without ever growing the LZW dictionary: every pixel is preceded by a clear code, so
     /// all codes keep the same size. The output is larger than a real encoder would produce but is valid.
     /// </summary>
+    public static byte[] CreateBmp32(int width, int height, IReadOnlyList<uint> pixels, int dibHeaderSize = 40, uint alphaMask = 0)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(pixels);
+        ArgumentOutOfRangeException.ThrowIfLessThan(dibHeaderSize, 40);
+
+        if (pixels.Count != checked(width * height))
+            throw new ArgumentOutOfRangeException(nameof(pixels));
+
+        const int FileHeaderSize = 14;
+        const int BmpV4HeaderSize = 108;
+
+        // A 32-bit row is always a multiple of four bytes, so there is no padding to add.
+        var rowStride = checked(width * 4);
+        var pixelDataSize = checked(rowStride * height);
+        var data = new byte[FileHeaderSize + dibHeaderSize + pixelDataSize];
+
+        data[0] = (byte)'B';
+        data[1] = (byte)'M';
+        WriteUInt32LittleEndian(data, 2, (uint)data.Length);
+        WriteUInt32LittleEndian(data, 10, (uint)(FileHeaderSize + dibHeaderSize));
+        WriteUInt32LittleEndian(data, 14, (uint)dibHeaderSize);
+        WriteInt32LittleEndian(data, 18, width);
+        WriteInt32LittleEndian(data, 22, height);
+        WriteUInt16LittleEndian(data, 26, 1);
+        WriteUInt16LittleEndian(data, 28, 32);
+        WriteUInt32LittleEndian(data, 30, 0);
+        WriteUInt32LittleEndian(data, 34, (uint)pixelDataSize);
+        if (dibHeaderSize >= BmpV4HeaderSize)
+        {
+            WriteUInt32LittleEndian(data, FileHeaderSize + 40, 0x00FF0000);
+            WriteUInt32LittleEndian(data, FileHeaderSize + 44, 0x0000FF00);
+            WriteUInt32LittleEndian(data, FileHeaderSize + 48, 0x000000FF);
+            WriteUInt32LittleEndian(data, FileHeaderSize + 52, alphaMask);
+        }
+
+        for (var y = 0; y < height; y++)
+        {
+            var sourceOffset = (height - y - 1) * width;
+            var destinationOffset = FileHeaderSize + dibHeaderSize + (y * rowStride);
+            for (var x = 0; x < width; x++)
+            {
+                var pixel = pixels[sourceOffset + x];
+                data[destinationOffset + (x * 4)] = (byte)pixel;
+                data[destinationOffset + (x * 4) + 1] = (byte)(pixel >> 8);
+                data[destinationOffset + (x * 4) + 2] = (byte)(pixel >> 16);
+                data[destinationOffset + (x * 4) + 3] = (byte)(pixel >> 24);
+            }
+        }
+
+        return data;
+    }
+
+    public static byte[] CreateTiff(
+        int width,
+        int height,
+        int samplesPerPixel,
+        ushort photometricInterpretation,
+        ushort compression,
+        byte[] stripData,
+        ushort? extraSample = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(samplesPerPixel);
+        ArgumentNullException.ThrowIfNull(stripData);
+
+        const int HeaderSize = 8;
+        const ushort TypeShort = 3;
+        const ushort TypeLong = 4;
+
+        var entryCount = extraSample.HasValue ? 10 : 9;
+        var directorySize = 2 + (entryCount * 12) + 4;
+        var bitsPerSampleSize = checked(samplesPerPixel * 2);
+        var hasExternalBitsPerSample = bitsPerSampleSize > 4;
+        var bitsPerSampleOffset = HeaderSize + directorySize;
+        var stripOffset = bitsPerSampleOffset + (hasExternalBitsPerSample ? bitsPerSampleSize : 0);
+        var data = new byte[stripOffset + stripData.Length];
+
+        data[0] = (byte)'I';
+        data[1] = (byte)'I';
+        WriteUInt16LittleEndian(data, 2, 42);
+        WriteUInt32LittleEndian(data, 4, HeaderSize);
+        WriteUInt16LittleEndian(data, HeaderSize, (ushort)entryCount);
+
+        var entryOffset = HeaderSize + 2;
+        void WriteEntry(ushort tag, ushort type, uint count, uint value)
+        {
+            WriteUInt16LittleEndian(data, entryOffset, tag);
+            WriteUInt16LittleEndian(data, entryOffset + 2, type);
+            WriteUInt32LittleEndian(data, entryOffset + 4, count);
+            WriteUInt32LittleEndian(data, entryOffset + 8, value);
+            entryOffset += 12;
+        }
+
+        // Every sample is 8 bits; two of them still fit in the entry itself.
+        var inlineBitsPerSample = samplesPerPixel == 1 ? 8u : 0x0008_0008u;
+
+        WriteEntry(256, TypeLong, 1, (uint)width);
+        WriteEntry(257, TypeLong, 1, (uint)height);
+        WriteEntry(258, TypeShort, (uint)samplesPerPixel, hasExternalBitsPerSample ? (uint)bitsPerSampleOffset : inlineBitsPerSample);
+        WriteEntry(259, TypeShort, 1, compression);
+        WriteEntry(262, TypeShort, 1, photometricInterpretation);
+        WriteEntry(273, TypeLong, 1, (uint)stripOffset);
+        WriteEntry(277, TypeShort, 1, (uint)samplesPerPixel);
+        WriteEntry(278, TypeLong, 1, (uint)height);
+        WriteEntry(279, TypeLong, 1, (uint)stripData.Length);
+        if (extraSample.HasValue)
+        {
+            WriteEntry(338, TypeShort, 1, extraSample.Value);
+        }
+
+        if (hasExternalBitsPerSample)
+        {
+            for (var i = 0; i < samplesPerPixel; i++)
+            {
+                WriteUInt16LittleEndian(data, bitsPerSampleOffset + (i * 2), 8);
+            }
+        }
+
+        stripData.CopyTo(data, stripOffset);
+        return data;
+    }
+
+    /// <summary>
+    /// Packs LZW codes the way a TIFF writer does: most significant bit first, and widening the code one
+    /// entry before the table would need the extra bit.
+    /// </summary>
+    public static byte[] EncodeTiffLzwCodes(IReadOnlyList<int> codes)
+    {
+        ArgumentNullException.ThrowIfNull(codes);
+
+        const int ClearCode = 256;
+        const int EndOfInformationCode = 257;
+
+        var output = new List<byte>();
+        var buffer = 0;
+        var bufferBitCount = 0;
+        var codeBitCount = 9;
+        var nextCode = 258;
+        var hasPreviousCode = false;
+
+        foreach (var code in codes)
+        {
+            buffer = (buffer << codeBitCount) | code;
+            bufferBitCount += codeBitCount;
+            while (bufferBitCount >= 8)
+            {
+                bufferBitCount -= 8;
+                output.Add((byte)(buffer >> bufferBitCount));
+            }
+
+            buffer &= (1 << bufferBitCount) - 1;
+
+            if (code == ClearCode)
+            {
+                codeBitCount = 9;
+                nextCode = 258;
+                hasPreviousCode = false;
+            }
+            else if (code != EndOfInformationCode)
+            {
+                if (hasPreviousCode && nextCode < 4096)
+                {
+                    nextCode++;
+                    if (nextCode == (1 << codeBitCount) - 1 && codeBitCount < 12)
+                    {
+                        codeBitCount++;
+                    }
+                }
+
+                hasPreviousCode = true;
+            }
+        }
+
+        if (bufferBitCount > 0)
+        {
+            output.Add((byte)(buffer << (8 - bufferBitCount)));
+        }
+
+        return [.. output];
+    }
+
     private static byte[] EncodeGifPixels(IReadOnlyList<byte> pixelIndexes, int minimumCodeSize)
     {
         var clearCode = 1 << minimumCodeSize;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -141,19 +141,42 @@ public sealed partial class SnapshotEndToEndTests
     [Fact]
     public async Task Validate_EndToEnd_Fails_WhenExpectedHasMoreFilesThanActual()
     {
+        // The assertion used to produce two snapshots and now produces one, so the indexed files it left
+        // behind are reported as unexpected and the file it produces now is reported as missing.
         var snapshotFiles = await AssertSnapshot(
             CreateFixedCountSerializerSource(count: 1),
             expectFailure: true,
             existingFiles:
             [
-                new SnapshotFile("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.txt", "value_0"u8.ToArray()),
+                new SnapshotFile("__snapshots__/GeneratedSnapshotTests_SampleTest_0.verified.txt", "value_0"u8.ToArray()),
                 new SnapshotFile("__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.txt", "value_1"u8.ToArray()),
             ]);
 
         AssertSnapshotContent(snapshotFiles,
         [
-            ("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.txt", "value_0"),
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest.actual.txt", "value_0"),
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest_0.verified.txt", "value_0"),
             ("__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.txt", "value_1"),
+        ]);
+    }
+
+    [Fact]
+    public async Task Validate_EndToEnd_Succeeds_WhenAnotherTestOwnsAFileWithAnIndexSuffix()
+    {
+        // 'SampleTest_1' is the snapshot of a test called SampleTest_1, not a file this assertion left
+        // behind: there is no 'SampleTest_0' to make it the tail of an index sequence.
+        var snapshotFiles = await AssertSnapshot(
+            CreateFixedCountSerializerSource(count: 1),
+            existingFiles:
+            [
+                new SnapshotFile("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.txt", "value_0"u8.ToArray()),
+                new SnapshotFile("__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.txt", "unrelated"u8.ToArray()),
+            ]);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.txt", "value_0"),
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.txt", "unrelated"),
         ]);
     }
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -107,7 +107,7 @@ public sealed partial class SnapshotTests
             Type: SnapshotType.Default,
             Index: 2,
             Extension: "png",
-            TestContext: new SnapshotTestContext(TestName: "Image snapshot"),
+            TestContext: new SnapshotTestContext(TestName: "Image_snapshot"),
             Settings: settings,
             SnapshotCount: 3);
 
@@ -129,7 +129,7 @@ public sealed partial class SnapshotTests
             Type: SnapshotType.Default,
             Index: 0,
             Extension: "png",
-            TestContext: new SnapshotTestContext(TestName: "Image snapshot"),
+            TestContext: new SnapshotTestContext(TestName: "Image_snapshot"),
             Settings: settings,
             SnapshotCount: 1);
 
@@ -1843,4 +1843,273 @@ public sealed partial class SnapshotTests
 
     [GeneratedRegex("Line[2]", RegexOptions.None, matchTimeoutMilliseconds: 10000)]
     private static partial Regex Line2Regex();
+
+    [Fact]
+    public void Validate_ForceUpdate_WritesTheCurrentSnapshotOverAStaleActualFile()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateDeterministicSnapshotSettings(directory, "correct") with
+        {
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            ForceUpdateSnapshots = true,
+        };
+
+        var verifiedPath = directory.GetFullPath("snapshot.verified.txt");
+        File.WriteAllText(verifiedPath, "correct");
+        File.WriteAllText(directory.GetFullPath("snapshot.actual.txt"), "wrong");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal("correct", File.ReadAllText(verifiedPath));
+    }
+
+    [Fact]
+    public void Validate_ForceUpdate_SucceedsWhenTheSnapshotMatchesAndNoActualFileExists()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateDeterministicSnapshotSettings(directory, "correct") with
+        {
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            ForceUpdateSnapshots = true,
+        };
+
+        var verifiedPath = directory.GetFullPath("snapshot.verified.txt");
+        File.WriteAllText(verifiedPath, "correct");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal("correct", File.ReadAllText(verifiedPath));
+    }
+
+    [Fact]
+    public void Validate_ForceUpdate_WritesEverySnapshotWhenOnlySomeOfThemChanged()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context => directory / ("snapshot_" + context.Index.ToString(CultureInfo.InvariantCulture) + ".verified.txt"),
+            ForceUpdateSnapshots = true,
+        };
+        settings.Serializers.Add(new FixedCountSerializer(count: 2));
+
+        File.WriteAllText(directory.GetFullPath("snapshot_0.verified.txt"), "value_0");
+        File.WriteAllText(directory.GetFullPath("snapshot_0.actual.txt"), "stale");
+        File.WriteAllText(directory.GetFullPath("snapshot_1.verified.txt"), "outdated");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal("value_0", File.ReadAllText(directory.GetFullPath("snapshot_0.verified.txt")));
+        Assert.Equal("value_1", File.ReadAllText(directory.GetFullPath("snapshot_1.verified.txt")));
+    }
+
+    [Fact]
+    public void Validate_KeepsTheSnapshotOfATestWhoseNameEndsWithAnIndex()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = CreateIndexedSnapshotPathStrategy(directory),
+        };
+        settings.Serializers.Add(new FixedValueSerializer("value"));
+
+        var siblingPath = directory.GetFullPath("snapshot_1.verified.txt");
+        File.WriteAllText(directory.GetFullPath("snapshot.verified.txt"), "value");
+        File.WriteAllText(siblingPath, "sibling");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.True(File.Exists(siblingPath));
+        Assert.Equal("sibling", File.ReadAllText(siblingPath));
+    }
+
+    [Fact]
+    public void Validate_DoesNotReportTheSnapshotOfATestWhoseNameEndsWithAnIndex()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow,
+            SnapshotPathStrategy = CreateIndexedSnapshotPathStrategy(directory),
+        };
+        settings.Serializers.Add(new FixedValueSerializer("value"));
+
+        File.WriteAllText(directory.GetFullPath("snapshot.verified.txt"), "value");
+        File.WriteAllText(directory.GetFullPath("snapshot_1.verified.txt"), "sibling");
+
+        Snapshot.Validate("sample", settings);
+    }
+
+    [Fact]
+    public void Validate_DeletesTheIndexedSnapshotsLeftBehindWhenTheAssertionProducesASingleOne()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = CreateIndexedSnapshotPathStrategy(directory),
+        };
+        settings.Serializers.Add(new FixedValueSerializer("value"));
+
+        File.WriteAllText(directory.GetFullPath("snapshot_0.verified.txt"), "value_0");
+        File.WriteAllText(directory.GetFullPath("snapshot_1.verified.txt"), "value_1");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal("value", File.ReadAllText(directory.GetFullPath("snapshot.verified.txt")));
+        Assert.False(File.Exists(directory.GetFullPath("snapshot_0.verified.txt")));
+        Assert.False(File.Exists(directory.GetFullPath("snapshot_1.verified.txt")));
+    }
+
+    [Fact]
+    public void Validate_DeletesTheSingleSnapshotLeftBehindWhenTheAssertionProducesSeveral()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = CreateIndexedSnapshotPathStrategy(directory),
+        };
+        settings.Serializers.Add(new FixedCountSerializer(count: 2));
+
+        File.WriteAllText(directory.GetFullPath("snapshot.verified.txt"), "value_0");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.False(File.Exists(directory.GetFullPath("snapshot.verified.txt")));
+        Assert.Equal("value_0", File.ReadAllText(directory.GetFullPath("snapshot_0.verified.txt")));
+        Assert.Equal("value_1", File.ReadAllText(directory.GetFullPath("snapshot_1.verified.txt")));
+    }
+
+    [Fact]
+    public void Validate_ReportsTheSingleSnapshotLeftBehindWhenTheAssertionProducesSeveral()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow,
+            SnapshotPathStrategy = CreateIndexedSnapshotPathStrategy(directory),
+        };
+        settings.Serializers.Add(new FixedCountSerializer(count: 2));
+
+        var obsoletePath = directory.GetFullPath("snapshot.verified.txt");
+        File.WriteAllText(obsoletePath, "value_0");
+        File.WriteAllText(directory.GetFullPath("snapshot_0.verified.txt"), "value_0");
+        File.WriteAllText(directory.GetFullPath("snapshot_1.verified.txt"), "value_1");
+
+        var exception = Assert.Throws<SnapshotAssertionException>(() => Snapshot.Validate("sample", settings));
+
+        Assert.Contains("Unexpected snapshot files:", exception.Message);
+        Assert.Contains(obsoletePath.Value, exception.Message);
+    }
+
+    [Fact]
+    public void Validate_ComparesEachSnapshotFileOnce()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var comparer = new RecordingSnapshotComparer();
+        var settings = CreateDeterministicSnapshotSettings(directory, "actual");
+        settings.Comparers.Set(SnapshotType.Default, comparer);
+        File.WriteAllText(directory.GetFullPath("snapshot.verified.txt"), "expected");
+
+        Assert.Throws<SnapshotAssertionException>(() => Snapshot.Validate("sample", settings));
+
+        Assert.Equal(1, comparer.InvocationCount);
+    }
+
+    [Fact]
+    public void DefaultSnapshotPath_DoesNotDependOnTheCheckoutDirectory()
+    {
+        var settings = new SnapshotSettings();
+        var methodName = "SampleTest" + new string('a', 200);
+
+        SnapshotPathContext CreateContext(string root) => new(
+            FullPath.FromPath(Path.Combine(root, "Tests", "SampleTests.cs")),
+            "SampleTests",
+            methodName,
+            LineNumber: 12,
+            SnapshotType.Default,
+            Index: 0,
+            Extension: "txt",
+            TestContext: null,
+            settings);
+
+        var firstCheckout = settings.SnapshotPathStrategy(CreateContext(Path.Combine(Path.GetTempPath(), "repo-a")));
+        var secondCheckout = settings.SnapshotPathStrategy(CreateContext(Path.Combine(Path.GetTempPath(), "repo-b")));
+
+        Assert.Equal(firstCheckout.Name, secondCheckout.Name);
+        Assert.Matches(SnapshotNameWithHashSuffixRegex(), firstCheckout.Name);
+    }
+
+    [Fact]
+    public void DefaultSnapshotPath_DistinguishesTestNamesThatSanitizeToTheSameFileName()
+    {
+        var settings = new SnapshotSettings();
+
+        SnapshotPathContext CreateContext(string testName) => new(
+            FullPath.FromPath(Path.Combine(Path.GetTempPath(), "SampleTests.cs")),
+            "SampleTests",
+            "SampleTheory",
+            LineNumber: 12,
+            SnapshotType.Default,
+            Index: 0,
+            Extension: "txt",
+            new SnapshotTestContext(TestName: testName),
+            settings);
+
+        var slash = settings.SnapshotPathStrategy(CreateContext("Case_a/b"));
+        var question = settings.SnapshotPathStrategy(CreateContext("Case_a?b"));
+
+        Assert.NotEqual(slash.Name, question.Name);
+        Assert.Matches(SnapshotNameWithHashSuffixRegex(), slash.Name);
+        Assert.Matches(SnapshotNameWithHashSuffixRegex(), question.Name);
+    }
+
+    [Fact]
+    public void DefaultSnapshotPath_DoesNotHashANameThatSanitizationLeavesUnchanged()
+    {
+        var settings = new SnapshotSettings();
+        var context = new SnapshotPathContext(
+            FullPath.FromPath(Path.Combine(Path.GetTempPath(), "SampleTests.cs")),
+            "SampleTests",
+            "SampleTest",
+            LineNumber: 12,
+            SnapshotType.Default,
+            Index: 0,
+            Extension: "txt",
+            TestContext: null,
+            settings);
+
+        var path = settings.SnapshotPathStrategy(context);
+
+        Assert.Equal("SampleTests_SampleTest.verified.txt", path.Name);
+    }
+
+    // Sets the process-wide SNAPSHOTTESTING_STRATEGY variable, which every 'new SnapshotSettings()' reads, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
+    public void SnapshotUpdateStrategy_Default_EnvironmentVariableNamingTheDefaultStrategy_UsesDisallow()
+    {
+        // Resolving 'Default' through the property lookup it is computed by used to recurse until the
+        // process ran out of stack.
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, nameof(SnapshotUpdateStrategy.Default));
+
+        var settings = new SnapshotSettings();
+
+        Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
+    }
+
+    // Mirrors the default path strategy: several snapshots get an index suffix, a single one keeps the bare name.
+    private static SnapshotPathStrategy CreateIndexedSnapshotPathStrategy(TemporaryDirectory directory)
+    {
+        return context => directory / (context.SnapshotCount > 1
+            ? "snapshot_" + context.Index.ToString(CultureInfo.InvariantCulture) + ".verified.txt"
+            : "snapshot.verified.txt");
+    }
 }

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/TiffImageLoaderTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/TiffImageLoaderTests.cs
@@ -2,6 +2,11 @@ namespace Meziantou.Framework.SnapshotTesting.Tests;
 
 public sealed class TiffImageLoaderTests
 {
+    private const ushort PhotometricBlackIsZero = 1;
+    private const ushort PhotometricRgb = 2;
+    private const ushort CompressionNone = 1;
+    private const ushort CompressionLzw = 5;
+
     [Theory]
     [InlineData("tiff-rgb24-none")]
     [InlineData("tiff-rgb24-packbits")]
@@ -38,5 +43,112 @@ public sealed class TiffImageLoaderTests
         ];
 
         await Assert.ThrowsAsync<NotSupportedException>(() => Image.LoadAsync(new MemoryStream(bigTiffHeader)));
+    }
+
+    [Fact]
+    public void Image_Load_AppendsTheFirstCharacterOfTheCodeThatIsNotInTheTableYet()
+    {
+        // 256 clears the table, then 'A', 'B' and 258 ("AB") build it up. 260 is not in the table yet: it
+        // stands for the previous string followed by that string's own first character, so "AB" + "A".
+        var stripData = ImageTestData.EncodeTiffLzwCodes([256, 'A', 'B', 258, 260, 257]);
+        var tiffData = ImageTestData.CreateTiff(
+            width: 7,
+            height: 1,
+            samplesPerPixel: 1,
+            photometricInterpretation: PhotometricBlackIsZero,
+            compression: CompressionLzw,
+            stripData);
+
+        var image = Image.Load(tiffData);
+
+        Assert.Equal(CreateGrayscalePixels("ABABABA"), image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Image_Load_WidensTheLzwCodeOneEntryBeforeTheTableNeedsIt()
+    {
+        // The 254 literals after the clear code fill the table up to 511, which is where a TIFF writer
+        // starts emitting 10-bit codes. A decoder that waits for 512 reads the two codes that follow at the
+        // wrong width and decodes everything after them from the wrong bits.
+        var codes = new List<int> { 256 };
+        for (var value = 0; value <= 255; value++)
+        {
+            codes.Add(value);
+        }
+
+        var stripData = ImageTestData.EncodeTiffLzwCodes(codes);
+        var tiffData = ImageTestData.CreateTiff(
+            width: 256,
+            height: 1,
+            samplesPerPixel: 1,
+            photometricInterpretation: PhotometricBlackIsZero,
+            compression: CompressionLzw,
+            stripData);
+
+        var image = Image.Load(tiffData);
+
+        var expectedPixels = new Argb[256];
+        for (var value = 0; value < expectedPixels.Length; value++)
+        {
+            expectedPixels[value] = new Argb(0xFF, (byte)value, (byte)value, (byte)value);
+        }
+
+        Assert.Equal(expectedPixels, image.Pixels.ToArray());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData((ushort)0)]
+    public void Image_Load_IgnoresTheFourthTiffSampleWhenItIsNotAnAlphaChannel(ushort? extraSample)
+    {
+        var tiffData = CreateRgbaTiff([10, 20, 30, 0], extraSample);
+
+        var image = Image.Load(tiffData);
+
+        Assert.Equal([new Argb(0xFF, 10, 20, 30)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Image_Load_UsesTheFourthTiffSampleAsAlphaWhenItIsUnassociated()
+    {
+        var tiffData = CreateRgbaTiff([10, 20, 30, 128], extraSample: 2);
+
+        var image = Image.Load(tiffData);
+
+        Assert.Equal([new Argb(128, 10, 20, 30)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Image_Load_UndoesThePremultiplicationOfAssociatedTiffAlpha()
+    {
+        var tiffData = CreateRgbaTiff([64, 128, 32, 128], extraSample: 1);
+
+        var image = Image.Load(tiffData);
+
+        Assert.Equal([new Argb(128, 128, 255, 64)], image.Pixels.ToArray());
+    }
+
+    private static byte[] CreateRgbaTiff(byte[] samples, ushort? extraSample)
+    {
+        return ImageTestData.CreateTiff(
+            width: 1,
+            height: 1,
+            samplesPerPixel: 4,
+            photometricInterpretation: PhotometricRgb,
+            compression: CompressionNone,
+            samples,
+            extraSample);
+    }
+
+    private static Argb[] CreateGrayscalePixels(string values)
+    {
+        var pixels = new Argb[values.Length];
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = (byte)values[i];
+            pixels[i] = new Argb(0xFF, value, value, value);
+        }
+
+        return pixels;
     }
 }


### PR DESCRIPTION
A review of `Meziantou.Framework.SnapshotTesting` turned up eleven defects. Two of them can destroy a correct baseline, so the whole batch is fixed here rather than split across follow-ups.

Every fix has a test that fails against the unfixed code and passes against the fixed one (verified by reverting each source file in turn).

## Snapshot bookkeeping

| Fix | Effect before |
| --- | --- |
| Write the complete forced-update set before applying it | A snapshot that matched entered a forced update with no `.actual` file (`FileNotFoundException`) or with one an earlier failed run left there, which then replaced the correct verified file |
| Only claim an indexed sibling when every index below it is the assertion's too | Validating `Name` deleted `Name_1.verified.txt` — the baseline of a test called `Name_1` — and reported it as unexpected under `Disallow` |
| Discover the un-indexed file left behind when an assertion starts producing several snapshots | That file survived forever; the opposite direction was already cleaned up |
| Decide both outcomes in the single-file fast path | The comparer ran twice on the same pair whenever a single snapshot did not match |

## File naming

- **The hash no longer depends on the checkout directory.** It included the absolute source path, so a committed snapshot with a long or reserved name was reported missing on another machine. It now uses the source file name, which is enough to tell apart two files in the directory the snapshot is stored next to.
- **A name that sanitization changed now carries the hash of the original.** `Case_a/b` and `Case_a?b` both sanitized to `Case_a_b` and claimed the same file, so parameterized tests could overwrite each other's snapshots depending on execution order.

## Image decoding

- **TIFF LZW**: the character of a not-yet-in-table code was prepended instead of appended (`ABABAAB` for a stream that means `ABABABA`), and the code width widened one entry too late — writers switch as soon as 511 is in the table, so everything after the 254th code of a strip was read from the wrong bits.
- **TIFF alpha**: the fourth sample was read as alpha even when `ExtraSamples` said it was unspecified data, turning opaque images fully transparent. Associated (premultiplied) alpha is now converted to straight alpha to match every other format the library reads.
- **BMP alpha**: the fourth byte of a 32-bit pixel was read as alpha even in a plain `BITMAPINFOHEADER`, where it is unused and commonly zero. It is now read only when the header declares an alpha mask (`BITMAPV4HEADER` and later); an unrecognized mask is an explicit `NotSupportedException`.

## Environment variable

`SNAPSHOTTESTING_STRATEGY=Default` resolved `Default` through the property lookup that its own getter runs, recursing until the process died with an uncatchable `StackOverflowException`. `InlineSnapshotTesting` already excluded that property; this library now does too.

## Notes for the reviewer

**Two changes rename snapshot files for consumers upgrading past 3.1.6**, both deliberately:

- Hashed names change, because the hash input changed. This only affects names that were long or ended in `.verified` / `.actual`.
- Names carrying characters that are not filename-safe gain a hash. That is the point of the fix, but it is the widest-reaching change here. It showed up immediately for TUnit, whose display name is `SampleTheory(alpha)` — every parameterized TUnit snapshot would have been renamed. Rather than accept that, `SnapshotTestContext` now rebuilds TUnit names from `MethodName` + `TestMethodArguments`, the way the xunit v3 and NUnit paths already did, so `GeneratedSnapshotTests_SampleTheory_alpha` is unchanged. A user-chosen `[DisplayName]` is still honored.

No snapshot committed in this repository is renamed by either change.

**The indexed-sibling fix is a mitigation, not a proof of ownership.** Requiring a contiguous index sequence removes the reproduced case and any realistic accident, but `Name_0` / `Name_1` written by two independent tests is still indistinguishable from one assertion's two snapshots. Making ownership unambiguous needs a separator that sanitization cannot produce (`Name#0`), which renames every multi-snapshot file for every consumer — too costly to do unasked, and easy to add later if you want it.

**One existing E2E fixture changed.** `Validate_EndToEnd_Fails_WhenExpectedHasMoreFilesThanActual` paired `SampleTest.verified.txt` with `SampleTest_1.verified.txt`, a combination the engine never produces, and encoded exactly the false positive fixed here. It now uses a realistic `_0`/`_1` shrink, and a new test covers the sibling case it used to assert.

## Verification

- `Meziantou.Framework.SnapshotTesting.Tests`: 428/428 on net10.0 and net11.0 (22 new tests).
- Dependent suites: Avatar 160/160, QRCode 2724/2724, SnapshotTesting.Roslyn 44/44, SnapshotTesting.Tool 8/8.
- `dotnet run ./eng/update-all.cs` exits 0 with no changes.
- Release + `IsOfficialBuild=true` builds clean with `TreatsWarningsAsErrors=true`; `ref/` is untouched since every fix is internal.
