### PR TITLE
Fix correctness, compliance and pruning defects in the globbing library

### DIFF
--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -30,15 +30,19 @@ namespace Meziantou.Framework.Globbing;
 ///         </item>
 ///         <item>
 ///             <term>[a-z]</term>
-///             <description>matches one character from the range given in the brackets. <c>GlobOptions.IgnoreCase</c> is only supported for ASCII letters.</description>
+///             <description>matches one character from the range given in the brackets. With <c>GlobOptions.IgnoreCase</c>, a character matches when it, its lowercase form or its uppercase form is in the range.</description>
 ///         </item>
 ///         <item>
 ///             <term>[!a-z]</term>
-///             <description>matches one character that is not from the range given in the brackets. <c>GlobOptions.IgnoreCase</c> is only supported for ASCII letters.</description>
+///             <description>matches one character that is not from the range given in the brackets, using the same rule as <c>[a-z]</c> for <c>GlobOptions.IgnoreCase</c>.</description>
+///         </item>
+///         <item>
+///             <term>[[:alpha:]]</term>
+///             <description>matches one character of a POSIX character class. Only supported by <see cref="GlobDialect.Posix"/> and <see cref="GlobDialect.PosixPath"/>. The supported classes are <c>alnum</c>, <c>alpha</c>, <c>blank</c>, <c>cntrl</c>, <c>digit</c>, <c>graph</c>, <c>lower</c>, <c>print</c>, <c>punct</c>, <c>space</c>, <c>upper</c> and <c>xdigit</c>.</description>
 ///         </item>
 ///         <item>
 ///             <term>{abc,123}</term>
-///             <description>comma-delimited set of literals, matches 'abc' or '123'</description>
+///             <description>comma-delimited set of literals, matches 'abc' or '123'. Only supported by <see cref="GlobDialect.Standard"/>; the other dialects read the braces as ordinary characters.</description>
 ///         </item>
 ///         <item>
 ///             <term>**</term>
@@ -53,7 +57,11 @@ namespace Meziantou.Framework.Globbing;
 ///             <description>escapes the following character. For instance, '\*' matches the literal character '*' instead of being a wildcard.</description>
 ///         </item>
 ///     </list>
-///     <para>If the pattern ends with a <c>/</c>, only directories are matched. Otherwise, only files are matched.</para>
+///     <para>
+///         If the pattern ends with a <c>/</c>, only directories are matched. Otherwise, only files are matched.
+///         A <see cref="GlobDialect.Git"/> pattern matches both a file and a directory, and one ending with a
+///         <c>/</c> matches the directory itself as well as everything below it.
+///     </para>
 ///     <para>
 ///         Matching backtracks, so the cost of a single <see cref="IsMatch(ReadOnlySpan{char}, ReadOnlySpan{char}, PathItemType?)"/>
 ///         call grows exponentially with the number of <c>*</c> wildcards in one path segment. Ordinary patterns and
@@ -171,6 +179,19 @@ public sealed class Glob : IGlobEvaluatable
         return GlobParser.TryParse(pattern, dialect, options, out result, out errorMessage);
     }
 
+    /// <summary>
+    ///     Parses one line of gitignore content on behalf of <see cref="GlobCollection"/>, which excludes the whole
+    ///     content of an excluded directory itself. An entry ending with a '/' therefore only has to match the
+    ///     directory here, unlike the same pattern parsed on its own.
+    /// </summary>
+    internal static Glob ParseGitIgnoreEntry(ReadOnlySpan<char> pattern)
+    {
+        if (GlobParser.TryParse(pattern, GlobDialect.Git, GlobOptions.None, matchGitDirectoryContent: false, out var result, out var errorMessage))
+            return result;
+
+        throw new ArgumentException($"The pattern '{pattern.ToString()}' is invalid: {errorMessage}", nameof(pattern));
+    }
+
     /// <summary>Determines whether the specified path matches this glob pattern.</summary>
     /// <param name="directory">The directory part of the path to match.</param>
     /// <param name="filename">The filename part of the path to match.</param>
@@ -201,6 +222,21 @@ public sealed class Glob : IGlobEvaluatable
 
             if (_matchType is GlobMatchType.Directory && !pathReader.IsDirectory)
                 return false;
+        }
+
+        if (!_pathSeparatorAware)
+        {
+            // A pattern that is not path-separator aware matches a plain string, which may be empty, and it always
+            // holds a single segment as no character separates segments. The path-oriented matcher below rejects an
+            // empty path before reaching the segment, so match the segments directly. That dialect always allows
+            // leading dots, so there is no per-segment check to run.
+            foreach (var segment in _segments)
+            {
+                if (!segment.IsMatch(ref pathReader))
+                    return false;
+            }
+
+            return pathReader.IsEndOfPath;
         }
 
         return IsMatchCore(pathReader, _segments, _segmentAnchors, _matchLeadingDot);
@@ -262,10 +298,12 @@ public sealed class Glob : IGlobEvaluatable
                     pathReader.ConsumeSegment();
                 }
 
-                return false;
+                // The path is exhausted. Only a segment that can match an empty path is still worth trying: a
+                // gitignore entry ending with a '/' matches the directory the path stops at.
+                return IsMatchCore(pathReader, remainingPatternSegments, remainingAnchors, remainingMatchLeadingDot);
             }
 
-            if (pathReader.IsEndOfPath)
+            if (pathReader.IsEndOfPath && !patternSegment.CanMatchEmptyPath)
                 return false;
 
             if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
@@ -323,10 +361,16 @@ public sealed class Glob : IGlobEvaluatable
             if (!patternSegment.IsMatch(ref pathReader))
                 return false;
 
-            pathReader.ConsumeSegment();
+            // The segment must match the folder name as a whole: 'src' does not match the folder 'src2'.
+            if (!pathReader.IsEndOfCurrentSegment)
+                return false;
+
+            pathReader.ConsumeEndOfSegment();
         }
 
-        return true;
+        // The folder consumed every pattern segment, including the one that matches the file name, so no file below
+        // it can match.
+        return false;
     }
 
     private static bool CanMatchLeadingDot(PathReader pathReader, bool matchLeadingDot)
@@ -341,70 +385,34 @@ public sealed class Glob : IGlobEvaluatable
 
     private static bool TryGetSegmentAnchor(Segment segment, out SegmentAnchor anchor)
     {
-        switch (segment)
+        var characters = GetAnchorCharacters(segment);
+        if (characters is not null)
         {
-            case LiteralSegment literal when literal.Value.Length > 0:
-                anchor = new SegmentAnchor(CreateCharacterSet([literal.Value[0]], literal.IgnoreCase));
-                return true;
-
-            case StartsWithSegment startsWith when startsWith.Value.Length > 0:
-                anchor = new SegmentAnchor(CreateCharacterSet([startsWith.Value[0]], startsWith.IgnoreCase));
-                return true;
-
-            case CharacterSetSegment set:
-                anchor = new SegmentAnchor(CreateCharacterSet(set.Set.AsSpan(), set.IgnoreCase));
-                return true;
-
-            case CharacterRangeSegment range when range.Range.Length <= 8:
-            {
-                var characters = new char[range.Range.Length];
-                var index = 0;
-                for (var c = range.Range.Min; c <= range.Range.Max; c++)
-                {
-                    characters[index] = c;
-                    index++;
-                }
-
-                anchor = new SegmentAnchor(SearchValues.Create(characters));
-                return true;
-            }
-
-            case LiteralSetSegment literalSet:
-            {
-                var characters = new List<char>(literalSet.Values.Length);
-                foreach (var value in literalSet.Values)
-                {
-                    if (value.Length > 0)
-                    {
-                        characters.Add(value[0]);
-                    }
-                }
-
-                if (characters.Count == 0)
-                    break;
-
-                anchor = new SegmentAnchor(CreateCharacterSet([.. characters], literalSet.IgnoreCase));
-                return true;
-            }
+            anchor = new SegmentAnchor(SearchValues.Create(characters));
+            return true;
         }
 
         anchor = default;
         return false;
 
-        static SearchValues<char> CreateCharacterSet(ReadOnlySpan<char> characters, bool ignoreCase)
+        // The anchor rejects a path segment before it is matched, so it must list every character the segment can
+        // start with. Anything that cannot be enumerated exactly returns null and runs without an anchor.
+        static char[]? GetAnchorCharacters(Segment segment)
         {
-            if (!ignoreCase)
-                return SearchValues.Create(characters);
-
-            var result = new HashSet<char>();
-            foreach (var character in characters)
+            return segment switch
             {
-                result.Add(character);
-                result.Add(char.ToLowerInvariant(character));
-                result.Add(char.ToUpperInvariant(character));
-            }
+                LiteralSegment literal when literal.Value.Length > 0 => CreateCharacterSet([literal.Value[0]], literal.IgnoreCase),
+                StartsWithSegment startsWith when startsWith.Value.Length > 0 => CreateCharacterSet([startsWith.Value[0]], startsWith.IgnoreCase),
+                CharacterSetSegment set => CreateCharacterSet(set.Set.AsSpan(), set.IgnoreCase),
+                CharacterRangeSegment range when range.Range.Length <= 8 => range.Range.EnumerateCharacters(),
+                RaggedSegment ragged => ragged.FirstRequiredCharacters,
+                _ => null,
+            };
+        }
 
-            return SearchValues.Create([.. result]);
+        static char[]? CreateCharacterSet(ReadOnlySpan<char> characters, bool ignoreCase)
+        {
+            return IgnoreCaseExpansion.TryExpand(characters, ignoreCase, out var result) ? result : null;
         }
     }
 

--- a/src/Meziantou.Framework.Globbing/GlobCollection.cs
+++ b/src/Meziantou.Framework.Globbing/GlobCollection.cs
@@ -21,6 +21,8 @@ namespace Meziantou.Framework.Globbing;
 [System.Runtime.CompilerServices.CollectionBuilder(typeof(GlobCollection), nameof(Create))]
 public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvaluatable
 {
+    private static readonly char[] DirectorySeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
+
     private readonly IGlobEvaluatable[] _globs;
 
     // gitignore resolves a path against the last pattern that matches it, whereas a hand-built collection uses
@@ -113,16 +115,17 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
         if (line[0] == '#')
             return;
 
-        globs.Add(Glob.Parse(line, GlobDialect.Git));
+        globs.Add(Glob.ParseGitIgnoreEntry(line));
     }
 
     private static ReadOnlySpan<char> TrimGitIgnoreLineEnd(ReadOnlySpan<char> line)
     {
+        // git only drops trailing spaces. A trailing tab is part of the pattern.
         var end = line.Length;
         while (end > 0)
         {
             var c = line[end - 1];
-            if (c is not (' ' or '\t'))
+            if (c is not ' ')
                 break;
 
             var backslashCount = 0;
@@ -162,7 +165,8 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
     /// <returns>
     ///     <see langword="true"/> if the path matches any include pattern and no exclude pattern; otherwise,
     ///     <see langword="false"/>. A collection created from gitignore content resolves the path against the last
-    ///     pattern that matches it instead, as git does.
+    ///     pattern that matches it instead, as git does, and reports a path as matched when one of its ancestor
+    ///     directories is: git cannot re-include a path whose parent directory is excluded.
     /// </returns>
     public bool IsMatch(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
     {
@@ -189,12 +193,54 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
 
     private bool IsLastMatch(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
     {
+        // git cannot re-include a path whose parent directory is excluded, so an excluded ancestor decides on its
+        // own and the patterns written for the path itself are not even looked at.
+        if (HasExcludedAncestor(directory, filename))
+            return true;
+
+        return IsLastMatchCore(directory, filename, itemType);
+    }
+
+    private bool IsLastMatchCore(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
+    {
         // The last pattern that matches decides, so walk backwards and stop at the first hit.
         for (var i = _globs.Length - 1; i >= 0; i--)
         {
             var glob = _globs[i];
             if (glob.IsMatch(directory, filename, itemType))
                 return glob.Mode is GlobMode.Include;
+        }
+
+        return false;
+    }
+
+    private bool HasExcludedAncestor(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename)
+    {
+        directory = directory.TrimEnd(DirectorySeparators.AsSpan());
+
+        var length = directory.Length;
+        if (filename.IsEmpty)
+        {
+            // The whole path is in 'directory', so its last segment is the item itself, not one of its ancestors.
+            length = directory.LastIndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (length < 0)
+                return false;
+        }
+
+        // Walk the ancestors from the root: the first excluded one decides, so the ones below it are never reached
+        // and their own patterns cannot re-include anything.
+        var index = 0;
+        while (index < length)
+        {
+            var separatorIndex = directory[index..length].IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var end = separatorIndex < 0 ? length : index + separatorIndex;
+            if (IsLastMatchCore(directory[..end], [], PathItemType.Directory))
+                return true;
+
+            if (separatorIndex < 0)
+                break;
+
+            index = end + 1;
         }
 
         return false;

--- a/src/Meziantou.Framework.Globbing/Internals/CharacterRange.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/CharacterRange.cs
@@ -25,8 +25,16 @@ internal readonly struct CharacterRange
 
     public bool IsInRange(char c) => c >= Min && c <= Max;
 
+    /// <summary>
+    ///     Tests the character and both of its case variants against the range instead of normalizing the range,
+    ///     which would change the characters it contains: '[@-B]' contains 'A', and lowering its bounds would drop
+    ///     both '@' and 'A'.
+    /// </summary>
+    public bool IsInRangeIgnoreCase(char c) => IsInRange(c) || IsInRange(char.ToLowerInvariant(c)) || IsInRange(char.ToUpperInvariant(c));
+
     public char[] EnumerateCharacters()
     {
+        // The index is an int on purpose: a 'char' counter wraps around when the range ends at char.MaxValue.
         var array = new char[Length];
         for (var i = 0; i < array.Length; i++)
         {

--- a/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Meziantou.Framework.Globbing.Internals;
 using Meziantou.Framework.Globbing.Internals.Segments;
 
@@ -9,6 +10,17 @@ internal static class GlobParser
     private static readonly char[] DirectorySeparator = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
 
     public static bool TryParse(ReadOnlySpan<char> pattern, GlobDialect dialect, GlobOptions options, [NotNullWhen(true)] out Glob? result, [NotNullWhen(false)] out string? errorMessage)
+    {
+        return TryParse(pattern, dialect, options, matchGitDirectoryContent: true, out result, out errorMessage);
+    }
+
+    /// <param name="matchGitDirectoryContent">
+    ///     Whether a gitignore entry ending with a '/' also matches the paths below the directory. A standalone glob
+    ///     has to, as it is the only rule the caller evaluates, but a <see cref="GlobCollection"/> built from
+    ///     gitignore content resolves an excluded ancestor directory on its own and passes <see langword="false"/> so
+    ///     that the same path is not excluded twice, which would let a directory entry outrank a later negation.
+    /// </param>
+    public static bool TryParse(ReadOnlySpan<char> pattern, GlobDialect dialect, GlobOptions options, bool matchGitDirectoryContent, [NotNullWhen(true)] out Glob? result, [NotNullWhen(false)] out string? errorMessage)
     {
         result = null;
         if (pattern.IsEmpty)
@@ -25,6 +37,7 @@ internal static class GlobParser
         List<Segment>? subSegments = null;
         List<string>? setSubsegment = null;
         List<CharacterRange>? rangeSubsegment = null;
+        List<NamedCharacterClass>? classSubsegment = null;
         char? rangeStart = null;
         var rangeInverse = false;
         var currentSegmentMatchLeadingDot = settings.MatchLeadingDot;
@@ -167,6 +180,7 @@ internal static class GlobParser
                     else if (c == '[' && dialect is not GlobDialect.MSBuild) // Range
                     {
                         Debug.Assert(rangeSubsegment is null);
+                        Debug.Assert(classSubsegment is null);
                         AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, subSegment: null);
                         parserContext = GlobParserContext.Range;
                         rangeSubsegment = [];
@@ -208,6 +222,17 @@ internal static class GlobParser
                 else if (parserContext == GlobParserContext.Range)
                 {
                     Debug.Assert(rangeSubsegment is not null);
+
+                    // POSIX character class, for instance [[:digit:]]. A class cannot be a range bound, so an
+                    // opened range keeps reading '[' as an ordinary character.
+                    if (c == '[' && !rangeStart.HasValue && settings.SupportsNamedCharacterClass && TryReadNamedCharacterClass(pattern[i..], out var namedCharacterClass, out var namedCharacterClassLength))
+                    {
+                        classSubsegment ??= [];
+                        classSubsegment.Add(namedCharacterClass);
+                        i += namedCharacterClassLength - 1;
+                        continue;
+                    }
+
                     if (c == ']') // end of literal set, except if empty []] or [!]]
                     {
                         // [a-] => '-' is considered as a character
@@ -218,7 +243,7 @@ internal static class GlobParser
                             rangeStart = null;
                         }
 
-                        if (rangeSubsegment.Count > 0)
+                        if (rangeSubsegment.Count > 0 || classSubsegment is not null)
                         {
                             if (settings.PathSeparatorAware && rangeSubsegment.Exists(s => s.IsInRange(Path.DirectorySeparatorChar) || s.IsInRange(Path.AltDirectorySeparatorChar)))
                             {
@@ -226,8 +251,9 @@ internal static class GlobParser
                                 return false;
                             }
 
-                            AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, CreateRangeSubsegment(rangeSubsegment, rangeInverse, settings.IgnoreCase));
+                            AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, CreateRangeSubsegment(rangeSubsegment, classSubsegment, rangeInverse, settings.IgnoreCase));
                             rangeSubsegment = null;
+                            classSubsegment = null;
                             parserContext = GlobParserContext.Segment;
                             continue;
                         }
@@ -301,16 +327,16 @@ internal static class GlobParser
             {
                 if (pattern[^1] == '/')
                 {
-                    segments.Add(RecursiveMatchAllSegment.Instance);
-                    matchLeadingDot.Add(settings.MatchLeadingDot);
-                    segments.Add(MatchAllSegment.Instance);
+                    // A gitignore entry ending with a '/' matches the directory itself. Excluding a directory also
+                    // excludes its content, but re-including one does not re-include its content, so a negated
+                    // entry never matches the paths below the directory.
+                    segments.Add(matchGitDirectoryContent && !exclude ? DirectoryContentSegment.IncludingContent : DirectoryContentSegment.DirectoryOnly);
                     matchLeadingDot.Add(settings.MatchLeadingDot);
                 }
-                else
-                {
-                    // A gitignore entry without a trailing '/' matches a file or a directory with that name.
-                    matchType = GlobMatchType.Any;
-                }
+
+                // A gitignore entry matches a file or a directory with that name. Whether the item must be a
+                // directory is decided by DirectoryContentSegment, which knows where the path ends.
+                matchType = GlobMatchType.Any;
             }
             else
             {
@@ -438,7 +464,7 @@ internal static class GlobParser
                 segments.Add(lastSegment);
                 matchLeadingDot.Add(true);
             }
-            else if (segments[^2] is RecursiveMatchAllSegment) // **/segment
+            else if (segments[^2] is RecursiveMatchAllSegment && !segments[^1].IsRecursiveMatchAll) // **/segment
             {
                 var lastSegment = new LastSegment(segments[^1]);
                 segments.RemoveRange(segments.Count - 2, 2);
@@ -509,7 +535,42 @@ internal static class GlobParser
         }
     }
 
-    private static Segment CreateRangeSubsegment(List<CharacterRange> ranges, bool inverse, bool ignoreCase)
+    private static bool TryReadNamedCharacterClass(ReadOnlySpan<char> pattern, out NamedCharacterClass result, out int length)
+    {
+        result = default;
+        length = 0;
+
+        // The shortest class is "[::]", and the caller already knows the first character is '['.
+        if (pattern.Length < 4 || pattern[1] != ':')
+            return false;
+
+        var nameLength = pattern[2..].IndexOf(":]".AsSpan(), StringComparison.Ordinal);
+        if (nameLength < 0)
+            return false;
+
+        var name = pattern.Slice(2, nameLength);
+        switch (name)
+        {
+            case "alnum": result = NamedCharacterClass.Alnum; break;
+            case "alpha": result = NamedCharacterClass.Alpha; break;
+            case "blank": result = NamedCharacterClass.Blank; break;
+            case "cntrl": result = NamedCharacterClass.Cntrl; break;
+            case "digit": result = NamedCharacterClass.Digit; break;
+            case "graph": result = NamedCharacterClass.Graph; break;
+            case "lower": result = NamedCharacterClass.Lower; break;
+            case "print": result = NamedCharacterClass.Print; break;
+            case "punct": result = NamedCharacterClass.Punct; break;
+            case "space": result = NamedCharacterClass.Space; break;
+            case "upper": result = NamedCharacterClass.Upper; break;
+            case "xdigit": result = NamedCharacterClass.XDigit; break;
+            default: return false;
+        }
+
+        length = nameLength + 4;
+        return true;
+    }
+
+    private static Segment CreateRangeSubsegment(List<CharacterRange> ranges, List<NamedCharacterClass>? classes, bool inverse, bool ignoreCase)
     {
         List<char>? singleCharRanges = null;
         List<CharacterRange>? rangeCharRanges = null;
@@ -527,19 +588,26 @@ internal static class GlobParser
             }
         }
 
-        if (singleCharRanges is not null)
+        if (classes is null)
         {
-            if (rangeCharRanges is null)
-                return CreateCharacterSet([.. singleCharRanges], inverse, ignoreCase);
+            if (singleCharRanges is not null)
+            {
+                if (rangeCharRanges is null)
+                    return CreateCharacterSet([.. singleCharRanges], inverse, ignoreCase);
+            }
+            else if (rangeCharRanges is not null && rangeCharRanges.Count == 1)
+            {
+                return CreateCharacterRange(rangeCharRanges[0], ignoreCase, inverse);
+            }
         }
-        else if (rangeCharRanges is not null && rangeCharRanges.Count == 1)
+        else if (!inverse && singleCharRanges is null && rangeCharRanges is null && classes.Count == 1)
         {
-            return CreateCharacterRange(rangeCharRanges[0], ignoreCase, inverse);
+            return new CharacterClassSegment(classes[0], ignoreCase);
         }
 
         // Inverse flags is set on the combination
         var segments = new List<Segment>(
-            (rangeCharRanges?.Count ?? 0) + (singleCharRanges is null ? 0 : 1));
+            (rangeCharRanges?.Count ?? 0) + (singleCharRanges is null ? 0 : 1) + (classes?.Count ?? 0));
         if (singleCharRanges is not null)
         {
             segments.Add(CreateCharacterSet([.. singleCharRanges], inverse: false, ignoreCase));
@@ -550,6 +618,14 @@ internal static class GlobParser
             foreach (var range in rangeCharRanges)
             {
                 segments.Add(CreateCharacterRange(range, ignoreCase, inverse: false));
+            }
+        }
+
+        if (classes is not null)
+        {
+            foreach (var characterClass in classes)
+            {
+                segments.Add(new CharacterClassSegment(characterClass, ignoreCase));
             }
         }
 
@@ -650,39 +726,42 @@ internal static class GlobParser
                             break;
 
                         case CharacterRangeSegment characterRange when characterRange.Range.Length < 3:
-                            nextCharacters = [];
-                            for (var c = characterRange.Range.Min; c <= characterRange.Range.Max; c++)
-                            {
-                                nextCharacters.Add(c);
-                            }
-
+                            nextCharacters = [.. characterRange.Range.EnumerateCharacters()];
                             break;
 
                         case LiteralSetSegment literalSet:
                             nextCharacters = [];
                             foreach (var value in literalSet.Values)
                             {
-                                if (value.Length > 0)
+                                // An empty alternative consumes nothing, so the next character is the one the rest
+                                // of the pattern requires and no character can be required here.
+                                if (value.Length == 0)
                                 {
-                                    nextCharacters.Add(value[0]);
+                                    nextCharacters = null;
+                                    break;
                                 }
+
+                                nextCharacters.Add(value[0]);
                             }
 
                             break;
                     }
 
-                    if (nextCharacters is not null)
+                    // The segment skips ahead to the next character the following subsegment could match, so it is
+                    // only sound when every one of those characters is known.
+                    if (nextCharacters is not null && IgnoreCaseExpansion.TryExpand(CollectionsMarshal.AsSpan(nextCharacters), ignoreCase, out var expandedCharacters))
                     {
+                        var stopCharacters = new List<char>(expandedCharacters);
                         if (pathSeparatorAware)
                         {
-                            nextCharacters.Add(Path.DirectorySeparatorChar);
+                            stopCharacters.Add(Path.DirectorySeparatorChar);
                             if (Path.DirectorySeparatorChar != Path.AltDirectorySeparatorChar)
                             {
-                                nextCharacters.Add(Path.AltDirectorySeparatorChar);
+                                stopCharacters.Add(Path.AltDirectorySeparatorChar);
                             }
                         }
 
-                        parts.Insert(i, new ConsumeSegmentUntilSegment([.. nextCharacters], ignoreCase));
+                        parts.Insert(i, new ConsumeSegmentUntilSegment([.. stopCharacters]));
                         i++;
                     }
                 }
@@ -694,7 +773,9 @@ internal static class GlobParser
             parts[^1] = MatchAllEndOfSegment.Instance;
         }
 
-        if (parts.Count == 1)
+        // A literal set is a branch point that only the backtracking matcher in RaggedSegment can resolve, so it
+        // never becomes a standalone segment.
+        if (parts.Count == 1 && parts[0] is not LiteralSetSegment)
             return parts[0];
 
         return new RaggedSegment(parts.ToArray());
@@ -716,7 +797,10 @@ internal static class GlobParser
         public bool NormalizeDotSegments => _dialect is not (GlobDialect.Posix or GlobDialect.PosixPath);
         public bool PathSeparatorAware => _dialect is not GlobDialect.Posix;
         public bool SupportsLeadingExclude => _dialect is GlobDialect.Standard or GlobDialect.Git;
-        public bool SupportsLiteralSet => _dialect is GlobDialect.Standard or GlobDialect.Git;
+
+        // git treats '{' and '}' as ordinary characters.
+        public bool SupportsLiteralSet => _dialect is GlobDialect.Standard;
+        public bool SupportsNamedCharacterClass => _dialect is GlobDialect.Posix or GlobDialect.PosixPath;
         public bool SupportsRecursiveWildcard => _dialect is GlobDialect.Standard or GlobDialect.Git or GlobDialect.MSBuild;
         public Segment AnyCharacterSegment => _dialect is GlobDialect.Posix ? MatchAnyTextCharacterSegment.Instance : MatchAnyCharacterSegment.Instance;
 

--- a/src/Meziantou.Framework.Globbing/Internals/IgnoreCaseExpansion.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/IgnoreCaseExpansion.cs
@@ -1,0 +1,44 @@
+namespace Meziantou.Framework.Globbing.Internals;
+
+internal static class IgnoreCaseExpansion
+{
+    /// <summary>
+    ///     Expands <paramref name="characters"/> with every character that <see cref="StringComparison.OrdinalIgnoreCase"/>
+    ///     considers equal to one of them.
+    /// </summary>
+    /// <remarks>
+    ///     The result feeds prefilters that reject a path before the segment is matched, so it must not miss any
+    ///     character. Ordinal case-insensitive comparison relates more than two characters to each other (it treats
+    ///     'Σ', 'σ' and 'ς' as equal, for instance), and <see cref="char.ToLowerInvariant(char)"/> and
+    ///     <see cref="char.ToUpperInvariant(char)"/> do not enumerate all of them. The expansion is exact for ASCII
+    ///     characters, as no other character is ordinal case-insensitive equal to an ASCII one, so anything else
+    ///     returns <see langword="false"/> and the caller must drop the prefilter instead of using an incomplete set.
+    /// </remarks>
+    public static bool TryExpand(ReadOnlySpan<char> characters, bool ignoreCase, [NotNullWhen(true)] out char[]? result)
+    {
+        if (!ignoreCase)
+        {
+            result = characters.ToArray();
+            return true;
+        }
+
+        foreach (var character in characters)
+        {
+            if (!char.IsAscii(character))
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        var expanded = new HashSet<char>(characters.Length * 2);
+        foreach (var character in characters)
+        {
+            expanded.Add(char.ToLowerInvariant(character));
+            expanded.Add(char.ToUpperInvariant(character));
+        }
+
+        result = [.. expanded];
+        return true;
+    }
+}

--- a/src/Meziantou.Framework.Globbing/Internals/NamedCharacterClass.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/NamedCharacterClass.cs
@@ -1,0 +1,18 @@
+namespace Meziantou.Framework.Globbing.Internals;
+
+/// <summary>POSIX character classes usable in a bracket expression, such as <c>[[:digit:]]</c>.</summary>
+internal enum NamedCharacterClass
+{
+    Alnum,
+    Alpha,
+    Blank,
+    Cntrl,
+    Digit,
+    Graph,
+    Lower,
+    Print,
+    Punct,
+    Space,
+    Upper,
+    XDigit,
+}

--- a/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
@@ -28,20 +28,25 @@ internal ref struct PathReader
 
         if (itemType is null)
         {
-            if (!_filename.IsEmpty)
+            // A pattern that is not path-separator aware matches a plain string: a trailing '/' belongs to it and
+            // says nothing about the kind of item, so it must not be trimmed.
+            if (_pathSeparatorAware)
             {
-                if (IsPathSeparator(_filename[^1]))
+                if (!_filename.IsEmpty)
                 {
-                    _filename = _filename[..^1];
-                    IsDirectory = true;
+                    if (IsPathSeparator(_filename[^1]))
+                    {
+                        _filename = _filename[..^1];
+                        IsDirectory = true;
+                    }
                 }
-            }
-            else
-            {
-                if (!CurrentText.IsEmpty && IsPathSeparator(CurrentText[^1]))
+                else
                 {
-                    CurrentText = CurrentText[..^1];
-                    IsDirectory = true;
+                    if (!CurrentText.IsEmpty && IsPathSeparator(CurrentText[^1]))
+                    {
+                        CurrentText = CurrentText[..^1];
+                        IsDirectory = true;
+                    }
                 }
             }
         }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterClassSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterClassSegment.cs
@@ -1,0 +1,76 @@
+namespace Meziantou.Framework.Globbing.Internals;
+
+internal sealed class CharacterClassSegment : Segment
+{
+    private readonly NamedCharacterClass _characterClass;
+    private readonly bool _ignoreCase;
+
+    public CharacterClassSegment(NamedCharacterClass characterClass, bool ignoreCase)
+    {
+        _characterClass = characterClass;
+        _ignoreCase = ignoreCase;
+    }
+
+    public override bool IsMatch(ref PathReader pathReader)
+    {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
+        var result = IsMatch(pathReader.CurrentText[0]);
+        if (result)
+        {
+            pathReader.ConsumeInSegment(1);
+        }
+
+        return result;
+    }
+
+    private bool IsMatch(char c)
+    {
+        // '[[:upper:]]' must accept 'a' when the case is ignored, as 'A' is accepted.
+        if (_ignoreCase && _characterClass is NamedCharacterClass.Lower or NamedCharacterClass.Upper)
+            return char.IsLower(c) || char.IsUpper(c);
+
+        return _characterClass switch
+        {
+            NamedCharacterClass.Alnum => char.IsLetterOrDigit(c),
+            NamedCharacterClass.Alpha => char.IsLetter(c),
+            NamedCharacterClass.Blank => c is ' ' or '\t',
+            NamedCharacterClass.Cntrl => char.IsControl(c),
+            // POSIX defines the digit class as the characters '0' to '9' in every locale.
+            NamedCharacterClass.Digit => char.IsAsciiDigit(c),
+            NamedCharacterClass.Graph => IsGraph(c),
+            NamedCharacterClass.Lower => char.IsLower(c),
+            NamedCharacterClass.Print => IsGraph(c) || c is ' ',
+            NamedCharacterClass.Punct => char.IsPunctuation(c) || char.IsSymbol(c),
+            NamedCharacterClass.Space => char.IsWhiteSpace(c),
+            NamedCharacterClass.Upper => char.IsUpper(c),
+            NamedCharacterClass.XDigit => char.IsAsciiHexDigit(c),
+            _ => false,
+        };
+
+        static bool IsGraph(char c) => !char.IsWhiteSpace(c) && !char.IsControl(c);
+    }
+
+    public override string ToString()
+    {
+        var name = _characterClass switch
+        {
+            NamedCharacterClass.Alnum => "alnum",
+            NamedCharacterClass.Alpha => "alpha",
+            NamedCharacterClass.Blank => "blank",
+            NamedCharacterClass.Cntrl => "cntrl",
+            NamedCharacterClass.Digit => "digit",
+            NamedCharacterClass.Graph => "graph",
+            NamedCharacterClass.Lower => "lower",
+            NamedCharacterClass.Print => "print",
+            NamedCharacterClass.Punct => "punct",
+            NamedCharacterClass.Space => "space",
+            NamedCharacterClass.Upper => "upper",
+            NamedCharacterClass.XDigit => "xdigit",
+            _ => "",
+        };
+
+        return "[[:" + name + ":]]";
+    }
+}

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseInverseSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseInverseSegment.cs
@@ -6,14 +6,7 @@ internal sealed class CharacterRangeIgnoreCaseInverseSegment : Segment
 
     public CharacterRangeIgnoreCaseInverseSegment(CharacterRange range)
     {
-        if (CharacterRangeSegment.IsAsciiUpper(range.Min) && CharacterRangeSegment.IsAsciiUpper(range.Max))
-        {
-            _range = new CharacterRange(char.ToLowerInvariant(range.Min), char.ToLowerInvariant(range.Max));
-        }
-        else
-        {
-            _range = range;
-        }
+        _range = range;
     }
 
     public override bool IsMatch(ref PathReader pathReader)
@@ -21,13 +14,9 @@ internal sealed class CharacterRangeIgnoreCaseInverseSegment : Segment
         if (pathReader.IsEndOfCurrentSegment)
             return false;
 
-        var c = pathReader.CurrentText[0];
-        if (CharacterRangeSegment.IsAsciiUpper(c))
-        {
-            c = char.ToLowerInvariant(c);
-        }
-
-        var result = !_range.IsInRange(c);
+        // The negation applies to the complete case-insensitive membership, otherwise a character that the range
+        // contains as written would be reported as being outside of it.
+        var result = !_range.IsInRangeIgnoreCase(pathReader.CurrentText[0]);
         if (result)
         {
             pathReader.ConsumeInSegment(1);

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseSegment.cs
@@ -6,14 +6,7 @@ internal sealed class CharacterRangeIgnoreCaseSegment : Segment
 
     public CharacterRangeIgnoreCaseSegment(CharacterRange range)
     {
-        if (CharacterRangeSegment.IsAsciiUpper(range.Min) && CharacterRangeSegment.IsAsciiUpper(range.Max))
-        {
-            _range = new CharacterRange(char.ToLowerInvariant(range.Min), char.ToLowerInvariant(range.Max));
-        }
-        else
-        {
-            _range = range;
-        }
+        _range = range;
     }
 
     public override bool IsMatch(ref PathReader pathReader)
@@ -21,13 +14,7 @@ internal sealed class CharacterRangeIgnoreCaseSegment : Segment
         if (pathReader.IsEndOfCurrentSegment)
             return false;
 
-        var c = pathReader.CurrentText[0];
-        if (CharacterRangeSegment.IsAsciiUpper(c))
-        {
-            c = char.ToLowerInvariant(c);
-        }
-
-        var result = _range.IsInRange(c);
+        var result = _range.IsInRangeIgnoreCase(pathReader.CurrentText[0]);
         if (result)
         {
             pathReader.ConsumeInSegment(1);

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/ConsumeSegmentUntilSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/ConsumeSegmentUntilSegment.cs
@@ -6,23 +6,12 @@ internal sealed class ConsumeSegmentUntilSegment : Segment
 {
     private readonly SearchValues<char> _characters;
 
-    public ConsumeSegmentUntilSegment(char[] characters, bool ignoreCase)
+    // The characters are expanded by the parser through IgnoreCaseExpansion when the case is ignored: this segment
+    // skips ahead to the next character the following subsegment could match, so a missing character would silently
+    // reject a matching path.
+    public ConsumeSegmentUntilSegment(char[] characters)
     {
-        if (!ignoreCase)
-        {
-            _characters = SearchValues.Create(characters);
-            return;
-        }
-
-        var expandedCharacters = new HashSet<char>();
-        foreach (var character in characters)
-        {
-            expandedCharacters.Add(character);
-            expandedCharacters.Add(char.ToLowerInvariant(character));
-            expandedCharacters.Add(char.ToUpperInvariant(character));
-        }
-
-        _characters = SearchValues.Create([.. expandedCharacters]);
+        _characters = SearchValues.Create(characters);
     }
 
     public override bool IsMatch(ref PathReader pathReader)

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/DirectoryContentSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/DirectoryContentSegment.cs
@@ -1,0 +1,40 @@
+namespace Meziantou.Framework.Globbing.Internals;
+
+/// <summary>
+///     Matches a directory, and optionally everything below it, for a gitignore entry ending with a '/'.
+/// </summary>
+internal sealed class DirectoryContentSegment : Segment
+{
+    private readonly bool _matchContent;
+
+    private DirectoryContentSegment(bool matchContent)
+    {
+        _matchContent = matchContent;
+    }
+
+    /// <summary>An entry that excludes a directory also excludes its whole content, so the segment matches any path below the directory.</summary>
+    public static DirectoryContentSegment IncludingContent { get; } = new DirectoryContentSegment(matchContent: true);
+
+    /// <summary>A negated entry only re-includes the directory: git does not re-include the content of a directory, so the segment stops at the directory itself.</summary>
+    public static DirectoryContentSegment DirectoryOnly { get; } = new DirectoryContentSegment(matchContent: false);
+
+    public override bool IsMatch(ref PathReader pathReader)
+    {
+        if (pathReader.IsEndOfPath)
+            return pathReader.IsDirectory;
+
+        if (!_matchContent)
+            return false;
+
+        pathReader.ConsumeToEnd();
+        return true;
+    }
+
+    // The segment consumes the rest of the path itself, so the matcher must not collapse it with a preceding '**'.
+    public override bool IsRecursiveMatchAll => true;
+
+    public override bool CanMatchEmptyPath => true;
+
+    // Segments are joined with a '/', so an empty text renders the trailing '/' of the original pattern.
+    public override string ToString() => "";
+}

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/LiteralSetSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/LiteralSetSegment.cs
@@ -2,32 +2,23 @@ namespace Meziantou.Framework.Globbing.Internals;
 
 internal sealed class LiteralSetSegment : Segment
 {
-    private readonly StringComparison _comparison;
-
     public LiteralSetSegment(string[] values, bool ignoreCase)
     {
         Values = values;
         IgnoreCase = ignoreCase;
-        _comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        Comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
     }
 
     public bool IgnoreCase { get; }
 
+    public StringComparison Comparison { get; }
+
     public string[] Values { get; }
 
-    public override bool IsMatch(ref PathReader pathReader)
-    {
-        foreach (var value in Values)
-        {
-            if (pathReader.CurrentText.StartsWith(value.AsSpan(), _comparison))
-            {
-                pathReader.ConsumeInSegment(value.Length);
-                return true;
-            }
-        }
-
-        return false;
-    }
+    // A literal set is a branch point: '{a,ab}' must try 'ab' when the rest of the pattern does not match after
+    // 'a'. Only the backtracking matcher in RaggedSegment can do that, and GlobParser always wraps a literal set in
+    // a RaggedSegment, so a set is never matched through this method.
+    public override bool IsMatch(ref PathReader pathReader) => throw new NotSupportedException();
 
     public override string ToString()
     {

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/OrSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/OrSegment.cs
@@ -13,17 +13,20 @@ internal sealed class OrSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
-        var copy = pathReader;
-        var result = MatchCore(ref copy);
-        if (_inverse)
-        {
-            result = !result;
-            if (result)
-                return true;
-        }
+        if (!_inverse)
+            return MatchCore(ref pathReader);
 
-        pathReader = copy;
-        return result;
+        // A bracket expression matches exactly one character, negated or not. The end-of-segment check also keeps
+        // the inverse from consuming a path separator.
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
+        var copy = pathReader;
+        if (MatchCore(ref copy))
+            return false;
+
+        pathReader.ConsumeInSegment(1);
+        return true;
     }
 
     private bool MatchCore(ref PathReader pathReader)

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/RaggedSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/RaggedSegment.cs
@@ -7,6 +7,7 @@ internal sealed class RaggedSegment : Segment
     private readonly char[]? _firstRequiredCharacters;
     private readonly int _matchAllSubSegmentCount;
     private readonly int _firstMatchAllSubSegmentIndex;
+    private readonly bool _hasLiteralSet;
 
     public RaggedSegment(Segment[] segments)
     {
@@ -27,6 +28,10 @@ internal sealed class RaggedSegment : Segment
 
                 _matchAllSubSegmentCount++;
             }
+            else if (segment is LiteralSetSegment)
+            {
+                _hasLiteralSet = true;
+            }
         }
 
         if (_segments.Length > 0)
@@ -34,6 +39,9 @@ internal sealed class RaggedSegment : Segment
             _firstRequiredCharacters = GetLeadingCharacters(_segments[0]);
         }
     }
+
+    /// <summary>The characters the first character of the path segment must be one of, or <see langword="null"/> when the segment does not require any.</summary>
+    internal char[]? FirstRequiredCharacters => _firstRequiredCharacters;
 
     public override bool IsMatch(ref PathReader pathReader)
     {
@@ -50,11 +58,17 @@ internal sealed class RaggedSegment : Segment
         }
 
         ReadOnlySpan<Segment> patternSegments = _segments;
-        if (_matchAllSubSegmentCount == 0)
-            return MatchCompleteNoStar(ref pathReader, patternSegments);
 
-        if (_matchAllSubSegmentCount == 1)
-            return MatchSingleStar(ref pathReader, patternSegments, _firstMatchAllSubSegmentIndex);
+        // A literal set can be consumed in several ways, and the choice only pays off once the rest of the pattern
+        // is matched, so it needs the backtracking matcher even when the segment holds no '*'.
+        if (!_hasLiteralSet)
+        {
+            if (_matchAllSubSegmentCount == 0)
+                return MatchCompleteNoStar(ref pathReader, patternSegments);
+
+            if (_matchAllSubSegmentCount == 1)
+                return MatchSingleStar(ref pathReader, patternSegments, _firstMatchAllSubSegmentIndex);
+        }
 
         return Match(ref pathReader, patternSegments);
 
@@ -91,6 +105,24 @@ internal sealed class RaggedSegment : Segment
 
                     return false;
                 }
+                else if (patternSegment is LiteralSetSegment literalSet)
+                {
+                    var remainingPatternSegments = patternSegments[(i + 1)..];
+                    foreach (var value in literalSet.Values)
+                    {
+                        var copyReader = pathReader;
+                        if (!TryConsumeLiteral(ref copyReader, value, literalSet.Comparison))
+                            continue;
+
+                        if (Match(ref copyReader, remainingPatternSegments))
+                        {
+                            pathReader = copyReader;
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
                 else
                 {
                     if (!patternSegment.IsMatch(ref pathReader))
@@ -99,6 +131,19 @@ internal sealed class RaggedSegment : Segment
             }
 
             return pathReader.IsEndOfPath || pathReader.IsPathSeparator();
+        }
+
+        static bool TryConsumeLiteral(ref PathReader pathReader, string value, StringComparison comparison)
+        {
+            // '{,a}' has an empty alternative, which consumes nothing.
+            if (value.Length == 0)
+                return true;
+
+            if (!pathReader.CurrentText.StartsWith(value.AsSpan(), comparison))
+                return false;
+
+            pathReader.ConsumeInSegment(value.Length);
+            return true;
         }
 
         static bool MatchSegmentsNoStar(ref PathReader pathReader, ReadOnlySpan<Segment> patternSegments)
@@ -170,6 +215,7 @@ internal sealed class RaggedSegment : Segment
             CharacterRangeInverseSegment => 1,
             CharacterRangeIgnoreCaseSegment => 1,
             CharacterRangeIgnoreCaseInverseSegment => 1,
+            CharacterClassSegment => 1,
             OrSegment => 1,
 
             _ => 0,
@@ -204,27 +250,18 @@ internal sealed class RaggedSegment : Segment
                 return CreateCharacterSet(set.Set.AsSpan(), set.IgnoreCase);
 
             case CharacterRangeSegment range when range.Range.Length <= 8:
-            {
-                var result = new char[range.Range.Length];
-                var index = 0;
-                for (var c = range.Range.Min; c <= range.Range.Max; c++)
-                {
-                    result[index] = c;
-                    index++;
-                }
-
-                return result;
-            }
+                return range.Range.EnumerateCharacters();
 
             case LiteralSetSegment literalSet:
             {
                 var result = new List<char>(literalSet.Values.Length);
                 foreach (var value in literalSet.Values)
                 {
-                    if (value.Length > 0)
-                    {
-                        result.Add(value[0]);
-                    }
+                    // An empty alternative consumes nothing, so the segment does not require any first character.
+                    if (value.Length == 0)
+                        return null;
+
+                    result.Add(value[0]);
                 }
 
                 if (result.Count == 0)
@@ -236,20 +273,9 @@ internal sealed class RaggedSegment : Segment
 
         return null;
 
-        static char[] CreateCharacterSet(ReadOnlySpan<char> characters, bool ignoreCase)
+        static char[]? CreateCharacterSet(ReadOnlySpan<char> characters, bool ignoreCase)
         {
-            if (!ignoreCase)
-                return characters.ToArray();
-
-            var result = new HashSet<char>();
-            foreach (var character in characters)
-            {
-                result.Add(character);
-                result.Add(char.ToLowerInvariant(character));
-                result.Add(char.ToUpperInvariant(character));
-            }
-
-            return [.. result];
+            return IgnoreCaseExpansion.TryExpand(characters, ignoreCase, out var result) ? result : null;
         }
     }
 

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/Segment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/Segment.cs
@@ -11,4 +11,10 @@ internal abstract class Segment
     public abstract bool IsMatch(ref PathReader pathReader);
 
     public virtual bool IsRecursiveMatchAll => false;
+
+    /// <summary>
+    ///     Whether the segment can still match once the whole path has been consumed. The matcher stops as soon as
+    ///     the path is exhausted, so only a segment that says otherwise is given a chance to match nothing.
+    /// </summary>
+    public virtual bool CanMatchEmptyPath => false;
 }

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
@@ -56,6 +56,114 @@ bin/
     }
 
     [Fact]
+    public void GitIgnoreEntryWithTrailingSlashMatchesTheDirectoryItself()
+    {
+        var globs = GlobCollection.ParseGitIgnore("bin/\n".AsSpan());
+
+        Assert.True(globs.IsMatch("", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("src", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("src/a", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("bin", "test.txt", PathItemType.File));
+        Assert.True(globs.IsMatch("bin/nested", "test.txt", PathItemType.File));
+
+        Assert.False(globs.IsMatch("", "bin", PathItemType.File));
+        Assert.False(globs.IsMatch("", "binary", PathItemType.Directory));
+        Assert.True(((IGlobEvaluatable)globs).CanMatchDirectories);
+    }
+
+    [Fact]
+    public void GitIgnoreExcludesTheContentOfAnExcludedDirectory()
+    {
+        // 'node_modules' matches the directory, and everything below an excluded directory is excluded too.
+        var globs = GlobCollection.ParseGitIgnore("node_modules\n".AsSpan());
+
+        Assert.True(globs.IsMatch("", "node_modules", PathItemType.Directory));
+        Assert.True(globs.IsMatch("node_modules", "package.json", PathItemType.File));
+        Assert.True(globs.IsMatch("node_modules/a/b", "package.json", PathItemType.File));
+        Assert.True(globs.IsMatch("node_modules/package.json"));
+        Assert.False(globs.IsMatch("src", "package.json", PathItemType.File));
+    }
+
+    [Fact]
+    public void GitIgnoreCannotReIncludeAPathUnderAnExcludedDirectory()
+    {
+        var globs = GlobCollection.ParseGitIgnore("""
+bin/
+!bin/keep.txt
+""".AsSpan());
+
+        Assert.True(globs.IsMatch("bin", "keep.txt", PathItemType.File));
+        Assert.True(globs.IsMatch("bin", "other.txt", PathItemType.File));
+    }
+
+    [Fact]
+    public void GitIgnoreAppliesTheChildRulesWhenTheParentIsReIncluded()
+    {
+        var globs = GlobCollection.ParseGitIgnore("""
+bin/
+!bin/
+""".AsSpan());
+
+        Assert.False(globs.IsMatch("", "bin", PathItemType.Directory));
+        Assert.False(globs.IsMatch("bin", "keep.txt", PathItemType.File));
+    }
+
+    [Fact]
+    public void GitIgnoreResolvesEachAncestorAgainstTheLastMatchingPattern()
+    {
+        var globs = GlobCollection.ParseGitIgnore("""
+/*
+!/bin/
+bin/keep.txt
+""".AsSpan());
+
+        Assert.False(globs.IsMatch("", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("bin", "keep.txt", PathItemType.File));
+        Assert.False(globs.IsMatch("bin", "other.txt", PathItemType.File));
+    }
+
+    [Fact]
+    public void GitIgnoreNegatedDirectoryEntryDoesNotReIncludeTheDirectoryContent()
+    {
+        // git re-includes the directory so that it is walked into, but not the files it holds.
+        var globs = GlobCollection.ParseGitIgnore("""
+*
+!*/
+""".AsSpan());
+
+        Assert.False(globs.IsMatch("", "bin", PathItemType.Directory));
+        Assert.False(globs.IsMatch("src", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("bin", "keep.txt", PathItemType.File));
+        Assert.True(globs.IsMatch("src/bin", "f.txt", PathItemType.File));
+    }
+
+    [Fact]
+    public void GitIgnoreDirectoryEntryMatchingEveryDirectory()
+    {
+        // The recursive wildcard has to consume the whole path before the directory entry matches what is left.
+        var globs = GlobCollection.ParseGitIgnore("**/\n".AsSpan());
+
+        Assert.True(globs.IsMatch("", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("src/a", "bin", PathItemType.Directory));
+        Assert.True(globs.IsMatch("src/a", "b.txt", PathItemType.File)); // below an excluded directory
+        Assert.False(globs.IsMatch("", "b.txt", PathItemType.File));
+    }
+
+    [Fact]
+    public void GitIgnoreTrimsTrailingSpacesButNotTrailingTabs()
+    {
+        Assert.True(GlobCollection.ParseGitIgnore("foo\t".AsSpan()).IsMatch("foo\t"));
+        Assert.False(GlobCollection.ParseGitIgnore("foo\t".AsSpan()).IsMatch("foo"));
+
+        Assert.True(GlobCollection.ParseGitIgnore("foo  ".AsSpan()).IsMatch("foo"));
+        Assert.False(GlobCollection.ParseGitIgnore("foo  ".AsSpan()).IsMatch("foo  "));
+
+        // An escaped space is kept, and so is a tab that precedes trimmed spaces.
+        Assert.True(GlobCollection.ParseGitIgnore("foo\\ ".AsSpan()).IsMatch("foo "));
+        Assert.True(GlobCollection.ParseGitIgnore("foo\t  ".AsSpan()).IsMatch("foo\t"));
+    }
+
+    [Fact]
     public void GitIgnoreResolvesAPathAgainstTheLastMatchingPattern()
     {
         var globs = GlobCollection.ParseGitIgnore("""

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -1,3 +1,5 @@
+using System.IO.Enumeration;
+
 namespace Meziantou.Framework.Globbing.Tests;
 
 public class GlobTests
@@ -92,6 +94,8 @@ public class GlobTests
     [InlineData("[,--]", "-")]
     [InlineData("[--.]", "-")]
     [InlineData("[!a-d]", "e")]
+    [InlineData("[!a-df-g][!z]", "eb")]
+    [InlineData("[!a-df-g][!z]", "ee")]
     [InlineData("[a-df-i]", "d")]
     [InlineData("[a-df-i]", "g")]
     [InlineData("[a-df-ik]", "i")]
@@ -288,8 +292,8 @@ public class GlobTests
     [InlineData("[!a-d]", "a")]
     [InlineData("[!abcd]", "d")]
     [InlineData("[!a-d]", "d")]
-    [InlineData("[!a-df-g][!z]", "eb")]
-    [InlineData("[!a-df-g][!z]", "ee")]
+    [InlineData("[!a-df-g][!z]", "az")]
+    [InlineData("[!a-df-g][!z]", "ez")]
     [InlineData("folder[0-1]/**/f{ab,il}[aei]*.{txt,png,ico}", "file001.txt")]
     [InlineData("a/b", "ab")]
     [InlineData("a/b", "acb")]
@@ -895,6 +899,376 @@ public class GlobTests
         directory.CreateEmptyFile("other/c.txt");
 
         AssertEnumerateFiles(directory, Glob.Parse("src/**", GlobDialect.Standard), ["src/a.txt", "src/nested/b.txt"]);
+    }
+
+    [Theory]
+    // A negated bracket expression consumes exactly one character, whichever of its parts rejects the character.
+    [InlineData("[!a-cx]", "z")]
+    [InlineData("[!a-cx]z", "zz")]
+    [InlineData("[!a-cx]*", "zy")]
+    [InlineData("[!a-cx][!a-cx]", "yz")]
+    [InlineData("a[!b-cx]c", "azc")]
+    public void NegatedBracketExpressionWithBothARangeAndACharacterMatchesOneCharacter(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("[!a-cx]", "a")] // in the range
+    [InlineData("[!a-cx]", "x")] // in the character set
+    [InlineData("[!a-cx]", "")] // there is no character to consume
+    [InlineData("[!a-cx]", "yz")] // it consumes a single character
+    [InlineData("[!a-cx]z*", "zy")]
+    [InlineData("a[!x-zq]b", "a/b")] // it does not consume a path separator
+    public void NegatedBracketExpressionWithBothARangeAndACharacterRejectsOtherPaths(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
+    [Theory]
+    // The first alternative that matches is not necessarily the one that lets the rest of the pattern match.
+    [InlineData("{a,ab}", "ab")]
+    [InlineData("{ab,a}", "ab")]
+    [InlineData("{ab,a}b", "ab")]
+    [InlineData("{a,ab}b", "ab")]
+    [InlineData("{a,ab}c", "abc")]
+    [InlineData("*{a,ab}c", "xabc")]
+    [InlineData("{a,ab}*c", "abxc")]
+    public void LiteralSetTriesEveryAlternativeAgainstTheRestOfThePattern(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("{a,ab}", "b")]
+    [InlineData("{a,ab}", "abc")]
+    [InlineData("{a,ab}c", "abbc")]
+    [InlineData("*{a,ab}c", "xabd")]
+    public void LiteralSetStillRejectsNonMatchingPaths(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
+    [Theory]
+    // An empty alternative consumes nothing, so the segment requires no particular first character.
+    [InlineData("{,a}b", "b")]
+    [InlineData("{,a}b", "ab")]
+    [InlineData("{a,}b", "b")]
+    [InlineData("*{,a}b", "xb")]
+    [InlineData("*{,a}b", "xab")]
+    [InlineData("x{,a}", "x")]
+    [InlineData("x{,a}", "xa")]
+    public void LiteralSetWithAnEmptyAlternativeConsumesNothing(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("{,a}b", "cb")]
+    [InlineData("{,a}b", "aab")]
+    [InlineData("x{,a}", "xb")]
+    public void LiteralSetWithAnEmptyAlternativeStillRejectsNonMatchingPaths(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
+    [Theory]
+    // Ordinal case-insensitive comparison relates more than two characters to each other: it treats the greek
+    // capital sigma, the small sigma and the final small sigma as equal.
+    [InlineData("Σ?", "ςx")]
+    [InlineData("*Σ?", "aςx")]
+    [InlineData("σ", "ς")]
+    [InlineData("**/Σ", "a/ς")]
+    [InlineData("**/*Σ", "a/bς")]
+    [InlineData("a/Σ*", "a/ςb")]
+    public void IgnoreCaseMatchesEveryOrdinalCaseInsensitiveEquivalent(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase | GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    // The candidate must be tested against the range as written: lowering the bounds of '[@-B]' would drop both
+    // '@' and 'A', which the range does contain.
+    [InlineData("[@-B]", "A")]
+    [InlineData("[@-B]", "a")]
+    [InlineData("[@-B]", "@")]
+    [InlineData("[@-B]", "B")]
+    [InlineData("[A-Z]", "a")]
+    [InlineData("[a-z]", "A")]
+    [InlineData("[Z-a]", "z")]
+    public void IgnoreCaseRangeKeepsTheCharactersOfTheOriginalRange(string pattern, string path)
+    {
+        Assert.True(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase | GlobOptions.MatchLeadingDot).IsMatch(path));
+        Assert.False(Glob.Parse("[!" + pattern[1..], GlobDialect.Standard, GlobOptions.IgnoreCase | GlobOptions.MatchLeadingDot).IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("[@-B]", "C")]
+    [InlineData("[@-B]", "c")]
+    [InlineData("[@-B]", "?")]
+    [InlineData("[A-Z]", "0")]
+    public void IgnoreCaseRangeRejectsCharactersOutsideOfTheRange(string pattern, string path)
+    {
+        Assert.False(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase | GlobOptions.MatchLeadingDot).IsMatch(path));
+        Assert.True(Glob.Parse("[!" + pattern[1..], GlobDialect.Standard, GlobOptions.IgnoreCase | GlobOptions.MatchLeadingDot).IsMatch(path));
+    }
+
+    [Theory]
+    // A 'char' counter wraps around when a range ends at char.MaxValue, which used to make the parser allocate
+    // until it ran out of memory, or read past the end of the array it was filling.
+    [InlineData("[￾-￿]", "￿")]
+    [InlineData("[￾-￿]x", "￾x")]
+    [InlineData("*[￾-￿]", "a￿")]
+    [InlineData("**/[￾-￿]/x", "a/￿/x")]
+    [InlineData("[￿-￿]", "￿")]
+    [InlineData("[￸-￿]", "￻")]
+    public void RangeEndingAtTheLastCharacterIsParsedAndMatched(string pattern, string path)
+    {
+        Assert.True(Glob.TryParse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot, out var glob));
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    // git reads '{' and '}' as ordinary characters.
+    [InlineData("{a,b}", "{a,b}")]
+    [InlineData("{a,b}.cs", "{a,b}.cs")]
+    [InlineData("a{b}c", "a{b}c")]
+    public void GitDoesNotSupportLiteralSets(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        Assert.True(glob.IsMatch(path));
+        Assert.False(glob.IsMatch("a"));
+        Assert.False(glob.IsMatch("b"));
+    }
+
+    [Theory]
+    [InlineData(GlobDialect.Posix)]
+    [InlineData(GlobDialect.PosixPath)]
+    public void PosixNamedCharacterClasses(GlobDialect dialect)
+    {
+        AssertMatch("[[:digit:]]", "5");
+        AssertNoMatch("[[:digit:]]", "a");
+        AssertMatch("[[:alpha:]]", "a");
+        AssertNoMatch("[[:alpha:]]", "5");
+        AssertMatch("[[:alnum:]]", "1");
+        AssertNoMatch("[[:alnum:]]", "-");
+        AssertMatch("[[:space:]]", " ");
+        AssertNoMatch("[[:space:]]", "a");
+        AssertMatch("[[:blank:]]", "\t");
+        AssertNoMatch("[[:blank:]]", "a");
+        AssertMatch("[[:cntrl:]]", "\u0001");
+        AssertNoMatch("[[:cntrl:]]", "a");
+        AssertMatch("[[:upper:]]", "A");
+        AssertNoMatch("[[:upper:]]", "a");
+        AssertMatch("[[:lower:]]", "a");
+        AssertNoMatch("[[:lower:]]", "A");
+        AssertMatch("[[:xdigit:]]", "F");
+        AssertNoMatch("[[:xdigit:]]", "g");
+        AssertMatch("[[:punct:]]", ".");
+        AssertNoMatch("[[:punct:]]", "a");
+        AssertMatch("[[:graph:]]", "a");
+        AssertNoMatch("[[:graph:]]", " ");
+        AssertMatch("[[:print:]]", " ");
+        AssertNoMatch("[[:print:]]", "\u0001");
+
+        // A negated class, and a class combined with ordinary characters, another class or a wildcard.
+        AssertMatch("[![:digit:]]", "a");
+        AssertNoMatch("[![:digit:]]", "5");
+        AssertMatch("[[:digit:]abc]", "b");
+        AssertMatch("[[:digit:]abc]", "5");
+        AssertNoMatch("[[:digit:]abc]", "z");
+        AssertMatch("[[:upper:][:digit:]]", "A");
+        AssertMatch("[[:upper:][:digit:]]", "5");
+        AssertNoMatch("[[:upper:][:digit:]]", "a");
+        AssertMatch("x[[:digit:]]y", "x5y");
+        AssertNoMatch("x[[:digit:]]y", "xay");
+        AssertMatch("[[:alpha:]]*", "abc");
+
+        void AssertMatch(string pattern, string path) => Assert.True(Glob.Parse(pattern, dialect).IsMatch(path));
+        void AssertNoMatch(string pattern, string path) => Assert.False(Glob.Parse(pattern, dialect).IsMatch(path));
+    }
+
+    [Fact]
+    public void NamedCharacterClassesAreOnlySupportedByThePosixDialects()
+    {
+        // The other dialects keep reading '[[:digit:]' as an ordinary bracket expression holding the characters
+        // '[', ':', 'd', 'i', 'g', 't' and ']', followed by a literal ']'.
+        var glob = Glob.Parse("[[:digit:]]", GlobDialect.Standard);
+        Assert.False(glob.IsMatch("5"));
+        Assert.True(glob.IsMatch("g]"));
+    }
+
+    [Theory]
+    // A Posix pattern matches a plain string: it can be empty, and a trailing '/' is part of it.
+    [InlineData("*", "")]
+    [InlineData("**", "")]
+    [InlineData("*", "a")]
+    [InlineData("foo/", "foo/")]
+    [InlineData("*/", "foo/")]
+    [InlineData("foo*", "foo/")]
+    public void MatchPosixString(string pattern, string path)
+    {
+        Assert.True(Glob.Parse(pattern, GlobDialect.Posix).IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("?", "")]
+    [InlineData("a*", "")]
+    [InlineData("*a", "")]
+    [InlineData("foo/", "foo")]
+    public void DoesNotMatchPosixString(string pattern, string path)
+    {
+        Assert.False(Glob.Parse(pattern, GlobDialect.Posix).IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData(GlobDialect.Standard)]
+    [InlineData(GlobDialect.PosixPath)]
+    public void AnEmptyPathIsNotMatchedByThePathSeparatorAwareDialects(GlobDialect dialect)
+    {
+        Assert.False(Glob.Parse("*", dialect, GlobOptions.MatchLeadingDot).IsMatch(""));
+    }
+
+    [Theory]
+    // A gitignore entry ending with a '/' matches the directory itself, at any depth.
+    [InlineData("bin/", "", "bin")]
+    [InlineData("bin/", "src", "bin")]
+    [InlineData("bin/", "src/a/b", "bin")]
+    [InlineData("/bin/", "", "bin")]
+    public void GitDirectoryPatternMatchesTheDirectoryItself(string pattern, string directory, string filename)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        Assert.True(glob.IsMatch(directory, filename, PathItemType.Directory));
+        Assert.False(glob.IsMatch(directory, filename, PathItemType.File));
+    }
+
+    [Theory]
+    // The wildcard has to consume the whole path before the trailing directory entry is given a chance to match
+    // what is left, which is nothing.
+    [InlineData("**/", "", "bin")]
+    [InlineData("**/", "src/a", "bin")]
+    [InlineData("*/", "", "bin")]
+    [InlineData("**/b*/", "src", "bin")]
+    public void GitDirectoryPatternWithAWildcardMatchesTheDirectoryItself(string pattern, string directory, string filename)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        Assert.True(glob.IsMatch(directory, filename, PathItemType.Directory));
+    }
+
+    [Theory]
+    [InlineData("bin/", "bin", "a.txt")]
+    [InlineData("bin/", "bin/nested", "a.txt")]
+    [InlineData("bin/", "src/bin", "a.txt")]
+    [InlineData("/bin/", "bin", "a.txt")]
+    public void GitDirectoryPatternMatchesTheDirectoryContent(string pattern, string directory, string filename)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        Assert.True(glob.IsMatch(directory, filename, PathItemType.File));
+        Assert.True(glob.IsMatch(directory, filename, PathItemType.Directory));
+    }
+
+    [Theory]
+    [InlineData("bin/", "", "obj")]
+    [InlineData("bin/", "", "binary")]
+    [InlineData("bin/", "obj", "a.txt")]
+    [InlineData("/bin/", "src", "bin")] // anchored to the root
+    public void GitDirectoryPatternRejectsOtherPaths(string pattern, string directory, string filename)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        Assert.False(glob.IsMatch(directory, filename, PathItemType.Directory));
+        Assert.False(glob.IsMatch(directory, filename, PathItemType.File));
+    }
+
+    [Fact]
+    public void GitNegatedDirectoryPatternMatchesTheDirectoryOnly()
+    {
+        // Excluding a directory excludes its content, but re-including one does not re-include its content.
+        var glob = Glob.Parse("!bin/", GlobDialect.Git);
+
+        Assert.True(glob.IsMatch("", "bin", PathItemType.Directory));
+        Assert.True(glob.IsMatch("src", "bin", PathItemType.Directory));
+        Assert.False(glob.IsMatch("bin", "keep.txt", PathItemType.File));
+        Assert.False(glob.IsMatch("bin", "nested", PathItemType.Directory));
+    }
+
+    [Fact]
+    public void EnumerateFileSystemEntries_GitDirectoryPattern()
+    {
+        using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile("bin/a.txt");
+        directory.CreateEmptyFile("src/bin/b.txt");
+        directory.CreateEmptyFile("src/c.txt");
+
+        AssertEnumerateFileSystemEntries(directory, Glob.Parse("bin/", GlobDialect.Git), ["bin", "bin/a.txt", "src/bin", "src/bin/b.txt"]);
+    }
+
+    [Theory]
+    // A folder is only worth visiting when a pattern segment is left to match the file name below it.
+    [InlineData("src/*.txt", "src2")]
+    [InlineData("src/*.txt", "srcx/a")]
+    [InlineData("src/*.txt", "src/archive.txt")]
+    [InlineData("src/*.txt", "src/archive.txt/nested")]
+    [InlineData("src/a/*.txt", "src/ab")]
+    [InlineData("?/a.txt", "ab")]
+    public void ShouldNotRecurseIntoAFolderThatCannotContainAMatch(string pattern, string folderPath)
+    {
+        Assert.False(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot).IsPartialMatch(folderPath));
+        Assert.False(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot | GlobOptions.IgnoreCase).IsPartialMatch(folderPath));
+    }
+
+    [Fact]
+    public void EnumerateFiles_DoesNotVisitFoldersThatCannotContainAMatch()
+    {
+        using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile("src/a.txt");
+        directory.CreateEmptyFile("src2/b.txt");
+        directory.CreateEmptyFile("src/archive.txt/c.txt");
+
+        using var enumerator = new RecordingGlobFileSystemEnumerator(Glob.Parse("src/*.txt", GlobDialect.Standard), directory.FullPath);
+
+        var files = new List<string>();
+        while (enumerator.MoveNext())
+        {
+            files.Add(MakeRelative(enumerator.Current, directory));
+        }
+
+        Assert.Equal(["src/a.txt"], files.Order(StringComparer.Ordinal).ToList());
+        Assert.Equal(["src"], enumerator.RecursedDirectories.Select(path => MakeRelative(path, directory)).Order(StringComparer.Ordinal).ToList());
+    }
+
+    private static string MakeRelative(string path, TemporaryDirectory directory)
+    {
+        return FullPath.FromPath(path).MakePathRelativeTo(directory.FullPath).Replace('\\', '/');
+    }
+
+    private sealed class RecordingGlobFileSystemEnumerator : GlobFileSystemEnumerator<string>
+    {
+        public RecordingGlobFileSystemEnumerator(IGlobEvaluatable glob, string directory)
+            : base(glob, directory, new EnumerationOptions { RecurseSubdirectories = true })
+        {
+        }
+
+        public List<string> RecursedDirectories { get; } = [];
+
+        protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry)
+        {
+            var result = base.ShouldRecurseIntoEntry(ref entry);
+            if (result)
+            {
+                RecursedDirectories.Add(entry.ToFullPath());
+            }
+
+            return result;
+        }
+
+        protected override string TransformEntry(ref FileSystemEntry entry) => entry.ToFullPath();
     }
 
     private static void AssertEnumerateFiles(TemporaryDirectory directory, IGlobEvaluatable glob, string[] expectedResult)

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -995,14 +995,16 @@ public class GlobTests
 
     [Theory]
     // The candidate must be tested against the range as written: lowering the bounds of '[@-B]' would drop both
-    // '@' and 'A', which the range does contain.
+    // '@' and 'A', which the range does contain. '[@-B]' with 'a' covers a range that is not entirely uppercase
+    // matching through the uppercase form of the candidate. A range that runs from an uppercase letter to a
+    // lowercase one cannot be used here: it spans U+005C, which is a path separator on Windows, and the parser
+    // rejects such a range.
     [InlineData("[@-B]", "A")]
     [InlineData("[@-B]", "a")]
     [InlineData("[@-B]", "@")]
     [InlineData("[@-B]", "B")]
     [InlineData("[A-Z]", "a")]
     [InlineData("[a-z]", "A")]
-    [InlineData("[Z-a]", "z")]
     public void IgnoreCaseRangeKeepsTheCharactersOfTheOriginalRange(string pattern, string path)
     {
         Assert.True(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase | GlobOptions.MatchLeadingDot).IsMatch(path));


### PR DESCRIPTION
A review of `Meziantou.Framework.Globbing` listed 13 defects across parsing, matching, git/POSIX compliance and enumeration pruning. All 13 are fixed here, each with a regression test. A differential run against native `fnmatch` and real `git check-ignore` then turned up two more, which are fixed too.

No public API changed (`ref/Meziantou.Framework.Globbing.cs` is untouched).

## Parsing

- **Unbounded allocation.** A range ending at `char.MaxValue` (`*[￾-￿]`) wrapped a `char` loop counter around, so the parser appended characters until it ran out of memory — or, in the fixed-array variants, threw `IndexOutOfRangeException`. A short untrusted pattern with one wildcard was enough; limiting the wildcard count did not help. The three loops now go through `CharacterRange.EnumerateCharacters`, which indexes with an `int`.

## Matching

- **Negated bracket expressions.** `[!a-cx]` (a range *and* a character) did not consume its character, so `[!a-cx]` failed to match `z` while `[!a-cx]z*` wrongly matched `zy`. `OrSegment` now consumes exactly one character, guarded by an end-of-segment check that also keeps it off path separators.
- **Brace alternatives.** The first alternative that matched won permanently, so `{a,ab}` did not match `ab` and `{ab,a}b` did not match `ab`. Alternatives are now a branch point in `RaggedSegment`'s backtracking matcher; `GlobParser` never emits a standalone `LiteralSetSegment`, so its `IsMatch` throws like the other branch-point segments.
- **Prefilters.** The "required first character" filters dropped empty brace alternatives (`{,a}b` did not match `b`) and, under `IgnoreCase`, missed characters that `OrdinalIgnoreCase` treats as equal — it relates `Σ`, `σ` and `ς` to each other, which `ToLowerInvariant`/`ToUpperInvariant` do not enumerate. A new `IgnoreCaseExpansion.TryExpand` is the single gate for all of them: it expands ASCII exactly and refuses anything else so the caller drops the prefilter rather than introducing a false negative.
- **Ignore-case ranges.** The range bounds were normalized to lowercase only when both were uppercase ASCII letters, which removed characters the range genuinely contained: `[@-B]` rejected `A`, and `[!@-B]` accepted it. Membership is now tested against the range as written plus the candidate's case variants, and inversion applies to the complete result.
- **Partial matching.** `IsPartialMatch` accepted a literal prefix without checking the segment boundary and returned `true` once the pattern was exhausted, so `src/*.txt` recursed into `src2` and into `src/archive.txt/nested`. Both are now rejected.

## git and POSIX compliance

- **Directory entries.** `bin/` could not match the directory `bin` itself, only files inside it.
- **Excluded ancestors.** `GlobCollection` evaluated only the complete path, so `node_modules` did not report `node_modules/package.json`, and `bin/` + `!bin/keep.txt` wrongly re-included `keep.txt`.

  These two interact. git's model is that a directory entry matches *only* the directory; the content is excluded by the separate ancestor rule. Implementing both inside the pattern double-counts and lets a directory entry outrank a later negation. So `ParseGitIgnore` now parses entries directory-only (it applies the ancestor rule itself), while a standalone `Glob.Parse(..., GlobDialect.Git)` keeps matching the content, since it is the only rule the caller has.
- **Braces.** The git dialect enabled the Standard literal-set syntax; git reads `{` and `}` literally.
- **Trailing whitespace.** Trailing tabs were trimmed from a gitignore line. git trims only trailing spaces.
- **POSIX character classes.** `[[:digit:]]` was parsed as an ordinary bracket expression terminating at the inner `]`. Named classes are now recognized in `Posix` and `PosixPath` (`alnum`, `alpha`, `blank`, `cntrl`, `digit`, `graph`, `lower`, `print`, `punct`, `space`, `upper`, `xdigit`), including negation and combination with characters or other classes.
- **POSIX string matching.** The reader stripped a trailing `/` and inferred a directory, and matching rejected end-of-path before evaluating a wildcard that can consume nothing. `foo/` now matches `foo/` and `*` matches the empty string, as `fnmatch` does. The path-separator-aware dialects are unaffected.

## Found by differential testing

`GlobDialect.Posix` and `GlobDialect.Git` have exact external oracles, so I ran the library against both: ~100k `pattern`/`string` pairs through native `fnmatch(p, s, 0)`, and ~2k gitignore cases through `git check-ignore --no-index` on a scratch repo with real files. Both are now at **zero mismatches**. Getting there exposed two defects no listed finding covered:

- A **negated** directory entry (`!bin/`, and the common `!*/` idiom) re-included the directory's content. git re-includes the directory so it stays walkable, but not the files it holds — with `*` + `!*/`, `bin` is not ignored but `bin/keep.txt` still is.
- **`**` never retried the rest of the pattern once the path was consumed**, so `**/` matched no directory at all.

If you reproduce the git corpus locally: a repo created on macOS defaults to `core.ignorecase=true`, and `check-ignore` then matches case-insensitively while the library defaults to case-sensitive. Set it to `false` first or the comparison reports bogus mismatches on names like `b.TXT`.

## Note for the reviewer

Two existing `DoesNotMatch` rows asserted that `[!a-df-g][!z]` does **not** match `eb` and `ee`. They were encoding the negated-bracket defect above — both native `fnmatch` and git's wildmatch match those paths — so I moved them to the matching corpus and added `az`/`ez` as the real non-matches.

One latent bug is deliberately left alone as out of scope: `ConsumeSegmentUntilSegment` has no `ToString()` override, so `Glob.ToString()` leaks the internal type name for patterns like `*{a,ab}c`. It is being handled separately.

## Verification

| Check | Result |
| --- | --- |
| `Meziantou.Framework.Globbing.Tests` (net10.0 + net11.0) | 1120 passed, 0 failed, 0 skipped |
| `DependencyScanning`, `DependencyScanning.Tool`, `Html.Tool` tests | 444 passed, 0 failed |
| `dotnet build /p:TreatsWarningsAsErrors=true` | clean, including `-c Release /p:IsOfficialBuild=true` |
| `dotnet run ./eng/update-all.cs` | no changes produced |
| `fnmatch` differential (100,464 cases) | 0 mismatches |
| `git check-ignore` differential (2,079 cases) | 0 mismatches |
