### PR TITLE
Fix five caller-visible defects in InlineSnapshotTesting

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/CallerContext.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/CallerContext.cs
@@ -103,12 +103,10 @@ internal record struct CallerContext(FullPath FilePath, int LineNumber, int Colu
         if (methodName is null)
             throw new InlineSnapshotException("Cannot find the method to update from the call stack. The code may be optimized (Release configuration).");
 
-        string? assemblyLocation = null;
-        if (settings.AllowedStringFormats.HasFlag(CSharpStringFormats.DetermineFeatureFromPdb))
-        {
-            // Read the language version from the PDB
-            assemblyLocation = callerFrame.GetMethod()?.DeclaringType?.Assembly?.Location;
-        }
+        // The PDB backs both the language-version filtering and the preprocessor symbols used to parse the file,
+        // so the location must be captured whatever the allowed string formats are. FilterFormats is the only
+        // consumer gated on CSharpStringFormats.DetermineFeatureFromPdb.
+        var assemblyLocation = callerFrame.GetMethod()?.DeclaringType?.Assembly?.Location;
 
         return new CallerContext(resolvedFilePath.Value, lineNumber, column, methodName, parameterName, parameterIndex, assemblyLocation);
     }

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Scrubbers/HumanReadableSerializerScrubExtensions.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Scrubbers/HumanReadableSerializerScrubExtensions.cs
@@ -59,6 +59,10 @@ public static class HumanReadableSerializerScrubExtensions
     }
 
     /// <summary>Scrubs XML nodes matching the specified XPath expression.</summary>
+    /// <remarks>
+    /// Returning the matched node replaces nothing, so a scrubber can mutate the node in place. Returning
+    /// <see langword="null"/> removes the node; removing the document element leaves an empty document.
+    /// </remarks>
     public static void ScrubXmlNode(this HumanReadableSerializerOptions options, string xpath, Func<XNode, XNode?> scrubber)
     {
         ScrubXmlNode(options, xpath, nsResolver: null, scrubber);
@@ -75,6 +79,10 @@ public static class HumanReadableSerializerScrubExtensions
     }
 
     /// <summary>Scrubs XML nodes matching the specified XPath expression with namespace resolution.</summary>
+    /// <remarks>
+    /// Returning the matched node replaces nothing, so a scrubber can mutate the node in place. Returning
+    /// <see langword="null"/> removes the node; removing the document element leaves an empty document.
+    /// </remarks>
     public static void ScrubXmlNode(this HumanReadableSerializerOptions options, string xpath, IXmlNamespaceResolver? nsResolver, Func<XNode, XNode?> scrubber)
     {
         var existingFormatter = options.GetFormatter(ValueFormatter.XmlMediaTypeName);
@@ -82,6 +90,11 @@ public static class HumanReadableSerializerScrubExtensions
     }
 
     /// <summary>Scrubs JSON values matching the specified JSONPath expression, returning a string value.</summary>
+    /// <remarks>
+    /// A match whose value is JSON <c language="json">null</c> is left unchanged, as there is no <see cref="JsonNode"/>
+    /// to hand to the scrubber. When the expression matches the document root, the returned value becomes the whole
+    /// document, and returning <see langword="null"/> reduces the document to JSON <c language="json">null</c>.
+    /// </remarks>
     public static void ScrubJsonValue(this HumanReadableSerializerOptions options, string jsonPath, Func<JsonNode, string?> scrubber)
     {
         var existingFormatter = options.GetFormatter(ValueFormatter.JsonMediaTypeName);
@@ -89,6 +102,11 @@ public static class HumanReadableSerializerScrubExtensions
     }
 
     /// <summary>Scrubs JSON values matching the specified JSONPath expression, returning a JSON node.</summary>
+    /// <remarks>
+    /// A match whose value is JSON <c language="json">null</c> is left unchanged, as there is no <see cref="JsonNode"/>
+    /// to hand to the scrubber. When the expression matches the document root, the returned node becomes the whole
+    /// document, and returning <see langword="null"/> reduces the document to JSON <c language="json">null</c>.
+    /// </remarks>
     public static void ScrubJsonValue(this HumanReadableSerializerOptions options, string jsonPath, Func<JsonNode, JsonNode?> scrubber)
     {
         var existingFormatter = options.GetFormatter(ValueFormatter.JsonMediaTypeName);
@@ -202,17 +220,33 @@ public static class HumanReadableSerializerScrubExtensions
             var result = _path.Evaluate(node);
             foreach (var match in result)
             {
-                Debug.Assert(match.Value is not null);
+                // A JSON null has no JsonNode representation, so there is no value to hand to the scrubber. Leave it as-is.
+                if (match.Value is null)
+                    continue;
+
                 var scrubValue = _scrubber(match.Value);
-                ReplaceWith(match.Value, scrubValue);
+                if (ReferenceEquals(match.Value, node))
+                {
+                    // The root has no parent, so replacing it means replacing the document itself.
+                    // Removing it leaves a document whose value is JSON null.
+                    node = scrubValue;
+                }
+                else
+                {
+                    ReplaceWith(match.Value, scrubValue);
+                }
             }
 
-            var json = node.ToJsonString();
+            var json = node is null ? "null" : node.ToJsonString();
             _innerFormatter.Format(writer, json, options);
         }
 
         private static void ReplaceWith(JsonNode oldNode, JsonNode? newNode)
         {
+            // Assigning a node to the slot it already occupies throws for arrays, and is a no-op for objects.
+            if (ReferenceEquals(oldNode, newNode))
+                return;
+
             switch (oldNode.Parent)
             {
                 case JsonObject jsonObject:
@@ -322,20 +356,29 @@ public static class HumanReadableSerializerScrubExtensions
 
             var document = XDocument.Parse(value);
             var result = document.XPathEvaluate(_xpath, _nsResolver);
-            var navigator = (IEnumerable<object>)result;
+
+            // XPathEvaluate is lazy, and replacing a node detaches the subtree the navigator walks.
+            var navigator = ((IEnumerable<object>)result).ToArray();
             foreach (var item in navigator)
             {
                 if (item is XNode node)
                 {
                     var newValue = _scrubber(node);
+                    if (ReferenceEquals(node, newValue))
+                    {
+                        // The scrubber mutated the node in place (or returned it untouched): there is nothing to replace.
+                        continue;
+                    }
+
                     if (newValue is null)
                     {
                         node.Remove();
                     }
                     else
                     {
-                        node.AddBeforeSelf(newValue);
-                        node.Remove();
+                        // Inserting the new node before removing the old one is invalid for the document
+                        // element, as it would momentarily give the document two root elements.
+                        node.ReplaceWith(newValue);
                     }
                 }
             }

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Utils/CSharpStringLiteral.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Utils/CSharpStringLiteral.cs
@@ -79,6 +79,20 @@ internal static class CSharpStringLiteral
                     sb.Append(@"\\");
                     break;
 
+                // NEL, LS and PS are C# newline characters (ECMA-334, 6.3.2): a regular string literal
+                // cannot contain them literally, so they must be escaped to keep the source valid.
+                case '\u0085':
+                    sb.Append(@"\u0085");
+                    break;
+
+                case '\u2028':
+                    sb.Append(@"\u2028");
+                    break;
+
+                case '\u2029':
+                    sb.Append(@"\u2029");
+                    break;
+
                 default:
                     sb.Append(c);
                     break;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/CSharpStringLiteralTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/CSharpStringLiteralTests.cs
@@ -1,4 +1,6 @@
 using Meziantou.Framework.InlineSnapshotTesting.Utils;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Framework.InlineSnapshotTesting.Tests;
 public sealed class CSharpStringLiteralTests
@@ -18,6 +20,24 @@ public sealed class CSharpStringLiteralTests
     {
         var result = CSharpStringLiteral.Create("line1\nline2", CSharpStringFormats.Quoted, "    ", 0, "\n");
         Assert.Equal("\"line1\\nline2\"", result);
+    }
+
+    [Theory]
+    [InlineData("a\rb")]
+    [InlineData("a\nb")]
+    [InlineData("a\r\nb")]
+    [InlineData("a\u0085b")]
+    [InlineData("a\u2028b")]
+    [InlineData("a\u2029b")]
+    public void CreateQuotedString_EscapesNewLineCharacters(string value)
+    {
+        var result = CSharpStringLiteral.Create(value, CSharpStringFormats.Quoted, "    ", 0, "\n");
+
+        var tree = CSharpSyntaxTree.ParseText("_ = " + result + ";");
+        Assert.Empty(tree.GetDiagnostics());
+
+        var literal = Assert.IsType<LiteralExpressionSyntax>(tree.GetRoot().DescendantNodes().Single(node => node is LiteralExpressionSyntax));
+        Assert.Equal(value, literal.Token.ValueText);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -188,6 +189,30 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
             expected: """
             #if SampleDirective
             InlineSnapshot.Validate(new object(), /*start*/expected: /* middle */ "{}" /* after */);
+            #endif
+            """);
+    }
+
+    [Theory]
+    [InlineData(nameof(CSharpStringFormats.Quoted), "\"{}\"")]
+    [InlineData(nameof(CSharpStringFormats.Verbatim), "@\"{}\"")]
+    [InlineData(nameof(CSharpStringFormats.Raw), "\"\"\"\n    {}\n    \"\"\"")]
+    [InlineData(nameof(CSharpStringFormats.LeftAlignedRaw), "\"\"\"\n{}\n\"\"\"")]
+    public async Task UpdateSnapshotSupportIfDirective_WithExplicitStringFormat(string format, string expectedLiteral)
+    {
+        // The compilation symbols come from the PDB. They must be read whatever the allowed string formats are,
+        // otherwise the assertion sits in a disabled region of the syntax tree and cannot be found.
+        await AssertSnapshot(preprocessorSymbols: ["SampleDirective"],
+            source: $$"""
+            #if SampleDirective
+            var settings = InlineSnapshotSettings.Default with { AllowedStringFormats = CSharpStringFormats.{{format}} };
+            InlineSnapshot.Validate(new object(), settings, "");
+            #endif
+            """,
+            expected: $$"""
+            #if SampleDirective
+            var settings = InlineSnapshotSettings.Default with { AllowedStringFormats = CSharpStringFormats.{{format}} };
+            InlineSnapshot.Validate(new object(), settings, {{expectedLiteral}});
             #endif
             """);
     }
@@ -1045,6 +1070,174 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
+    public void Scrub_Json_DocumentRoot_Replace()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => "[redacted]");
+            })
+            .Validate(new JsonObject() { ["secret"] = "sensitive-value" }, """
+                "[redacted]"
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_DocumentRoot_ReplaceWithNode()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => (JsonNode)new JsonObject() { ["scrubbed"] = true });
+            })
+            .Validate(new JsonObject() { ["secret"] = "sensitive-value" }, """
+                {
+                  "scrubbed": true
+                }
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_DocumentRoot_Remove()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => (JsonNode?)null);
+            })
+            .Validate(new JsonObject() { ["secret"] = "sensitive-value" }, "null");
+    }
+
+    [Fact]
+    public void Scrub_Json_DocumentRoot_ReturnSameInstance()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => node);
+            })
+            .Validate(new JsonObject() { ["secret"] = "value" }, """
+                {
+                  "secret": "value"
+                }
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_ArrayDocumentRoot_Replace()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => "[redacted]");
+            })
+            .Validate(new JsonArray("sensitive-value"), """
+                "[redacted]"
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_ArrayDocumentRoot_Remove()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => (JsonNode?)null);
+            })
+            .Validate(new JsonArray("sensitive-value"), "null");
+    }
+
+    [Fact]
+    public void Scrub_Json_ScalarDocumentRoot_Replace()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => "[redacted]");
+            })
+            .Validate(JsonValue.Create("sensitive-value"), """
+                "[redacted]"
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_ScalarDocumentRoot_Remove()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => (JsonNode?)null);
+            })
+            .Validate(JsonValue.Create("sensitive-value"), "null");
+    }
+
+    [Fact]
+    public void Scrub_Json_NullProperty_IsNotScrubbed()
+    {
+        // A JSON null has no JsonNode to hand to the scrubber, so the match is left as-is.
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$.secret", node => "[redacted]");
+            })
+            .Validate(new JsonObject() { ["secret"] = null, ["other"] = "dummy" }, """
+                {
+                  "secret": null,
+                  "other": "dummy"
+                }
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_NullArrayElement_IsNotScrubbed()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$.values[*]", node => "[redacted]");
+            })
+            .Validate(new JsonObject() { ["values"] = new JsonArray("a", null, "b") }, """
+                {
+                  "values": [
+                    "[redacted]",
+                    null,
+                    "[redacted]"
+                  ]
+                }
+                """);
+    }
+
+    [Fact]
+    public void Scrub_Json_NullDocumentRoot_IsNotScrubbed()
+    {
+        using var document = JsonDocument.Parse("null");
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$", node => "[redacted]");
+            })
+            .Validate(document, "null");
+    }
+
+    [Fact]
+    public void Scrub_Json_ArrayElement_ReturnSameInstance()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubJsonValue("$.values[0]", node => node);
+            })
+            .Validate(new JsonObject() { ["values"] = new JsonArray("a", "b") }, """
+                {
+                  "values": [
+                    "a",
+                    "b"
+                  ]
+                }
+                """);
+    }
+
+    [Fact]
     public void ScrubXmlAttribute_Remove()
     {
         InlineSnapshot
@@ -1169,6 +1362,71 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
                   <item a="2">dummy</item>
                 </root>
                 """);
+    }
+
+    [Fact]
+    public void ScrubXmlNode_DocumentElement_ReturnSameInstance()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubXmlNode("/root", node => node);
+            })
+            .Validate(XDocument.Parse("""
+                <root>
+                  <item>test1</item>
+                </root>
+                """), """
+                <root>
+                  <item>test1</item>
+                </root>
+                """);
+    }
+
+    [Fact]
+    public void ScrubXmlNode_DocumentElement_SetValue()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubXmlNode("/root", node => ((XElement)node).SetValue("dummy"));
+            })
+            .Validate(XDocument.Parse("""
+                <root>
+                  <item>sensitive-value</item>
+                </root>
+                """), "<root>dummy</root>");
+    }
+
+    [Fact]
+    public void ScrubXmlNode_DocumentElement_Replace()
+    {
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubXmlNode("/root", node => new XElement("redacted"));
+            })
+            .Validate(XDocument.Parse("""
+                <root>
+                  <item>sensitive-value</item>
+                </root>
+                """), "<redacted />");
+    }
+
+    [Fact]
+    public void ScrubXmlNode_DocumentElement_Remove()
+    {
+        // Removing the document element leaves an empty document.
+        InlineSnapshot
+            .WithSerializer(options =>
+            {
+                options.ScrubXmlNode("/root", node => null);
+            })
+            .Validate(XDocument.Parse("""
+                <root>
+                  <item>sensitive-value</item>
+                </root>
+                """), "");
     }
 
     [Theory]


### PR DESCRIPTION
Addresses five caller-visible defects raised in a review of `Meziantou.Framework.InlineSnapshotTesting`. Each one is reproduced by a new test that fails without its fix.

> The review this came from was pasted starting at its third finding, so findings 1 and 2 are **not** covered here.

## What changed

### JSON scrubber: a match on the document root did nothing

`ScrubJsonFormatter.ReplaceWith` switched on `oldNode.Parent`, and the root has none, so `options.ScrubJsonValue("$", _ => "[redacted]")` left `{"secret":"sensitive-value"}` untouched. That is security-sensitive: scrubbers are a reasonable way to keep credentials and personal data out of snapshots and assertion output.

`Format` now tracks the root node itself and replaces it when it is the match. **Root removal is defined as JSON `null`** — the document becomes `null`, which is what `JsonFormatter` already emits for a null document.

### JSON scrubber: a matched JSON `null` terminated the process

`JsonPathMatch.Value` is documented as nullable for a JSON `null`, but the formatter asserted it was non-null and then dereferenced it. Scrubbing `$.secret` in `{"secret":null}` hit `Debug.Assert` under Debug and was an invalid dereference without it.

A JSON `null` has no `JsonNode` representation, so there is nothing to hand to the `Func<JsonNode, ...>` callback. **Such a match is now left unchanged**, documented on both `ScrubJsonValue` overloads. The alternative — widening the delegate to `Func<JsonNode?, ...>` — is a binary-breaking public API change, and a JSON `null` carries no data to scrub, so it did not seem worth it. Happy to revisit if you disagree.

### Quoted literals containing Unicode line terminators did not compile

`CreateQuotedString` wrote U+0085 NEXT LINE, U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR straight into a regular string literal. These are C# newline characters ([lexical structure](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6435-string-literals)), so Roslyn reported CS1073/CS1010 on the generated source. They are now emitted as the escape sequences `\u0085`, `\u2028` and `\u2029`, which keeps the runtime value identical. Only reachable when `AllowedStringFormats` permits `Quoted` alone, since `IsMultiline` routes these to raw/verbatim otherwise.

### An explicit string format disabled preprocessor-symbol discovery

`CallerContext.Get` captured the caller assembly location only when `AllowedStringFormats` contained `DetermineFeatureFromPdb`, but `GetCompilationDefines` needs the same location. Setting e.g. `CSharpStringFormats.Raw` meant the file was parsed with no defines, so an assertion inside an enabled `#if` block sat in a disabled region and the update failed with `InlineSnapshotException: Cannot find the SyntaxNode to update`.

The location is now captured whenever caller information is created; `FilterFormats` remains the only consumer gated on the flag. This stays off the matching-snapshot fast path — `CallerContext.Get` runs only on a mismatch or a forced update.

### Scrubbing the XML document element threw

`ScrubXmlNodeFormatter` inserted the callback result before the old node and then removed the old node, which momentarily gives a document two root elements. Even the identity scrubber `options.ScrubXmlNode("/root", node => node)` raised `InvalidOperationException: This operation would create an incorrectly structured document`.

Identity now performs no structural edit at all (so an in-place mutation just works), replacement uses `XNode.ReplaceWith`, which is atomic and valid for the document element, and **removing the document element leaves an empty document**.

### Two adjacent defects found while fixing the above

Both are covered by the same guards and noted in code comments:

- `jsonArray[i] = sameInstance` throws `InvalidOperationException: The node already has a parent`, while the `JsonObject` equivalent is a no-op — so `ScrubJsonValue("$.values[0]", n => n)` crashed on arrays only.
- `XPathEvaluate` is lazy, so mutating a match detached the subtree the navigator was still walking. Results are materialized before mutation.

## Tests

52 new cases (26 per TFM):

- JSON object/array/scalar document root — replace, remove, identity
- JSON `null` as an object property, an array element, and the document root
- XML document element — identity, in-place mutation, replacement, removal
- A theory over every C# newline character, asserting Roslyn parses the generated literal with no diagnostics and that its constant value equals the input
- A theory updating a snapshot inside an enabled `#if` block under each of the four explicit string formats

I checked these are genuine regression tests by reverting each fix: 26 of the 32 new scrubber/literal cases fail without them, and the `#if` theory fails with the exact `Cannot find the SyntaxNode to update` error above. The 6 that pass either way pin behaviour that was already correct (root identity, null document root, XML root removal).

## Validation

- **338 passed, 0 failed, 0 skipped** across net10.0 and net11.0 with `/p:TreatsWarningsAsErrors=true /p:TreatWarningsAsErrors=true` — up from 286, matching the 26 new cases per TFM.
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` clean for the library and the test project, so the IDE analyzers ran.
- `dotnet run ./eng/update-all.cs` completed with no file changes.
- `ref/` is unchanged: no public API changed, only doc comments.
