### PR TITLE
Return an empty string from ConsumeSegmentUntilSegment.ToString()

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/Segments/ConsumeSegmentUntilSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/ConsumeSegmentUntilSegment.cs
@@ -38,4 +38,11 @@ internal sealed class ConsumeSegmentUntilSegment : Segment
 
         return true;
     }
+
+    public override string ToString()
+    {
+        // The segment is a pure prefilter that scans ahead to the next character the following subsegment could
+        // match, so it doesn't contribute anything to the textual pattern.
+        return "";
+    }
 }

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -184,6 +184,8 @@ public class GlobParserTests
     [InlineData("{a,b}.cs")]
     [InlineData("[a-z].cs")]
     [InlineData("p?th/a")]
+    [InlineData("*[abc]d")]
+    [InlineData("*{a,ab}c")]
     public void ToStringRoundTripsToAnEquivalentPattern(string pattern)
     {
         var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);


### PR DESCRIPTION
## What

`Meziantou.Framework.Globbing.Internals.Segments.ConsumeSegmentUntilSegment` did not override `ToString()`, so `Glob.ToString()` fell back to `object.ToString()` and leaked the .NET type name into the rendered pattern for every pattern where that optimization kicks in:

```csharp
Glob.Parse("*{a,ab}c", GlobDialect.Standard).ToString()
// "Meziantou.Framework.Globbing.Internals.Segments.ConsumeSegmentUntilSegment*{a,ab}c"
```

The result is not a valid glob and does not round-trip back through `Glob.Parse`.

## Why this fix

The segment is a pure prefilter: it scans ahead to the next character the following subsegment could match, and the subsegments after it render the actual pattern text. It contributes nothing textual, so `ToString()` now returns an empty string.

## Test coverage

`GlobParserTests.ToStringRoundTripsToAnEquivalentPattern` already asserted `Assert.DoesNotContain("Meziantou.Framework.Globbing", text)`, but none of its `[InlineData]` patterns produced a `ConsumeSegmentUntilSegment`, so the invariant was never actually exercised. Added `*[abc]d` and `*{a,ab}c` to the theory.

I verified these are real coverage rather than incidental passes: with the `ToString()` override reverted, the filtered run fails 4 tests (2 new cases × 2 TFMs) with exactly the reported leak, and passes once the override is restored.

## Notes for the reviewer

The linked description cited `DirectoryContentSegment` as the precedent for an empty `ToString()`, but no such type exists in this repo and no segment previously returned an empty string — this is the first one. That is why the override carries a short comment explaining why empty is correct here, rather than looking like an oversight.

## Verification

- `dotnet test --project tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj /p:TreatsWarningsAsErrors=true` — **908 passed, 0 failed** (454 per TFM, net10.0 + net11.0). Confirmed via the `.trx` that both new theory cases ran.
- `dotnet run ./eng/update-all.cs` — completed with no file changes. Expected: `ConsumeSegmentUntilSegment` is `internal`, so nothing under `ref/` moves.
