### PR TITLE
Walk the call stack only when a snapshot strategy reads the names

### DIFF
--- a/benchmarks/SnapshotTestingBenchmarks/SnapshotCallerContextBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/SnapshotCallerContextBenchmark.cs
@@ -42,6 +42,6 @@ public class SnapshotCallerContextBenchmark
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     private string CreateCallerContext()
     {
-        return SnapshotCallerContext.Create(_sourceFilePath, lineNumber: 1, memberName: nameof(CreateCallerContext)).MethodName;
+        return SnapshotCallerContext.Create(_sourceFilePath, lineNumber: 1, memberName: nameof(CreateCallerContext), testContext: null).MethodName;
     }
 }

--- a/ref/Meziantou.Framework.SnapshotTesting.cs
+++ b/ref/Meziantou.Framework.SnapshotTesting.cs
@@ -176,6 +176,7 @@ namespace Meziantou.Framework.SnapshotTesting
         public Meziantou.Framework.FullPath SourceFilePath { get => throw null; init { } }
         public string? ClassName { get => throw null; init { } }
         public string MethodName { get => throw null; init { } }
+        public string? MemberName { get => throw null; init { } }
         public int LineNumber { get => throw null; init { } }
         public Meziantou.Framework.SnapshotTesting.SnapshotType Type { get => throw null; init { } }
         public int Index { get => throw null; init { } }
@@ -183,14 +184,13 @@ namespace Meziantou.Framework.SnapshotTesting
         public Meziantou.Framework.SnapshotTesting.SnapshotTestContext? TestContext { get => throw null; init { } }
         public Meziantou.Framework.SnapshotTesting.SnapshotSettings Settings { get => throw null; init { } }
         public int SnapshotCount { get => throw null; init { } }
-        public SnapshotPathContext(Meziantou.Framework.FullPath SourceFilePath, string? ClassName, string MethodName, int LineNumber, Meziantou.Framework.SnapshotTesting.SnapshotType Type, int Index, string? Extension, Meziantou.Framework.SnapshotTesting.SnapshotTestContext? TestContext, Meziantou.Framework.SnapshotTesting.SnapshotSettings Settings, int SnapshotCount = 1) { }
+        public SnapshotPathContext(Meziantou.Framework.FullPath SourceFilePath, string? ClassName, string MethodName, int LineNumber, Meziantou.Framework.SnapshotTesting.SnapshotType Type, int Index, string? Extension, Meziantou.Framework.SnapshotTesting.SnapshotTestContext? TestContext, Meziantou.Framework.SnapshotTesting.SnapshotSettings Settings, int SnapshotCount = 1, string? MemberName = null) { }
         public override string ToString() => throw null;
         public static bool operator !=(Meziantou.Framework.SnapshotTesting.SnapshotPathContext? left, Meziantou.Framework.SnapshotTesting.SnapshotPathContext? right) => throw null;
         public static bool operator ==(Meziantou.Framework.SnapshotTesting.SnapshotPathContext? left, Meziantou.Framework.SnapshotTesting.SnapshotPathContext? right) => throw null;
         public override int GetHashCode() => throw null;
         public override bool Equals(object? obj) => throw null;
         public bool Equals(Meziantou.Framework.SnapshotTesting.SnapshotPathContext? other) => throw null;
-        public void Deconstruct(out Meziantou.Framework.FullPath SourceFilePath, out string? ClassName, out string MethodName, out int LineNumber, out Meziantou.Framework.SnapshotTesting.SnapshotType Type, out int Index, out string? Extension, out Meziantou.Framework.SnapshotTesting.SnapshotTestContext? TestContext, out Meziantou.Framework.SnapshotTesting.SnapshotSettings Settings, out int SnapshotCount) => throw null;
     }
 
     public delegate Meziantou.Framework.FullPath SnapshotPathStrategy(Meziantou.Framework.SnapshotTesting.SnapshotPathContext context);

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -5,7 +5,12 @@ using System.Text.RegularExpressions;
 
 namespace Meziantou.Framework.SnapshotTesting;
 
-internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, string MethodName, string? ContainingTypeName, string? MemberName, int LineNumber, bool TestMethodResolved)
+/// <summary>
+/// Describes the call site of an assertion. The names of the test class and of the test method are read from
+/// the call stack, which is the most expensive part of an assertion, so the walk only runs when something
+/// asks for them: a naming or path strategy that uses neither never pays for it.
+/// </summary>
+internal sealed partial class SnapshotCallerContext
 {
     [GeneratedRegex(@"^<(?<name>[^>]+)>b__[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: -1)]
     private static partial Regex LambdaContainingMethodNameRegex { get; }
@@ -25,14 +30,100 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
     /// </summary>
     private static readonly ConcurrentDictionary<MethodBase, StackFrameMethod> StackFrameMethods = new();
 
-    public static SnapshotCallerContext Create(string? filePath, int lineNumber, string? memberName)
+    private readonly SnapshotTestContext? _testContext;
+    private StackWalkResult? _stackWalk;
+
+    private SnapshotCallerContext(string? filePath, int lineNumber, string? memberName, SnapshotTestContext? testContext)
     {
-        // Resolving the file name of every frame forces the PDBs to be loaded and the sequence points to
-        // be decoded. It is only needed when the caller did not provide a file path.
-        var stackTrace = new StackTrace(fNeedFileInfo: filePath is null);
+        LineNumber = lineNumber;
+        MemberName = memberName;
+        _testContext = testContext;
+
+        if (filePath is not null)
+        {
+            SourceFilePath = ResolveSourceFilePath(filePath);
+            return;
+        }
+
+        // The call stack is the only remaining source for the file path, so the walk is not optional here.
+        // It also needs the file name of the frames, which forces the PDBs to be loaded and the sequence
+        // points to be decoded.
+        var stackWalk = WalkStack(needFileInfo: true);
+        _stackWalk = stackWalk;
+        if (stackWalk.SourceFilePath is null)
+            throw new SnapshotException("Cannot find the file to update from the call stack. The PDB may be missing.");
+
+        SourceFilePath = ResolveSourceFilePath(stackWalk.SourceFilePath);
+    }
+
+    public FullPath SourceFilePath { get; }
+
+    public int LineNumber { get; }
+
+    /// <summary>
+    /// Member name provided by the compiler at the call site. It is always available and never needs the
+    /// call stack.
+    /// </summary>
+    public string? MemberName { get; }
+
+    /// <summary>
+    /// Name of the test method the assertion belongs to. Reading it walks the call stack the first time.
+    /// </summary>
+    public string MethodName
+    {
+        get
+        {
+            // The call stack only contains the test method as long as the assertion runs synchronously below
+            // it. A helper method that awaited before asserting runs on a continuation where the test method
+            // is gone, and the innermost frames then describe the helper. The test framework still knows
+            // which test is running, so its own view wins whenever the stack could not produce one.
+            var stackWalk = ResolveStackWalk();
+            if (stackWalk.TestMethodResolved && stackWalk.MethodName is not null)
+                return stackWalk.MethodName;
+
+            return _testContext?.MethodName ?? stackWalk.MethodName ?? MemberName ?? "Snapshot";
+        }
+    }
+
+    /// <summary>
+    /// Simple name of the type declaring the test method. Reading it walks the call stack the first time.
+    /// </summary>
+    public string? ClassName
+    {
+        get
+        {
+            var stackWalk = ResolveStackWalk();
+            if (stackWalk.TestMethodResolved)
+                return stackWalk.ClassName;
+
+            return _testContext?.ClassName ?? stackWalk.ClassName;
+        }
+    }
+
+    /// <summary>Indicates whether the call stack was actually walked. Used by the tests.</summary>
+    internal bool StackWalkPerformed => _stackWalk is not null && !ReferenceEquals(_stackWalk, StackWalkResult.Unavailable);
+
+    public static SnapshotCallerContext Create(string? filePath, int lineNumber, string? memberName, SnapshotTestContext? testContext)
+    {
+        return new SnapshotCallerContext(filePath, lineNumber, memberName, testContext);
+    }
+
+    /// <summary>
+    /// Prevents any further stack walk. The frames the walk looks for are only on the stack while the
+    /// assertion is running, so a context that outlives its assertion - a strategy may keep the
+    /// <see cref="SnapshotPathContext" /> it received - reports what the test framework knows instead of
+    /// describing an unrelated call stack.
+    /// </summary>
+    public void Freeze() => _stackWalk ??= StackWalkResult.Unavailable;
+
+    private StackWalkResult ResolveStackWalk() => _stackWalk ??= WalkStack(needFileInfo: false);
+
+    private static StackWalkResult WalkStack(bool needFileInfo)
+    {
+        var stackTrace = new StackTrace(needFileInfo);
         var stackAnalysisStartIndex = GetStackAnalysisStartIndex(stackTrace);
         string? discoveredMethodName = null;
-        string? discoveredContainingTypeName = null;
+        string? discoveredClassName = null;
         var testMethodResolved = false;
 
         for (var i = stackAnalysisStartIndex; i < stackTrace.FrameCount; i++)
@@ -47,17 +138,17 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
             if (stackFrameMethod.IsTestMethod)
             {
                 discoveredMethodName = stackFrameMethod.NormalizedMethodName;
-                discoveredContainingTypeName = stackFrameMethod.NormalizedTypeName;
+                discoveredClassName = stackFrameMethod.NormalizedTypeName;
                 testMethodResolved = true;
                 break;
             }
 
             discoveredMethodName ??= stackFrameMethod.NormalizedMethodName;
-            discoveredContainingTypeName ??= stackFrameMethod.NormalizedTypeName;
+            discoveredClassName ??= stackFrameMethod.NormalizedTypeName;
         }
 
-        var sourceFilePath = filePath;
-        if (sourceFilePath is null)
+        string? sourceFilePath = null;
+        if (needFileInfo)
         {
             for (var i = stackAnalysisStartIndex; i < stackTrace.FrameCount; i++)
             {
@@ -71,19 +162,16 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
             }
         }
 
-        if (sourceFilePath is null)
-            throw new SnapshotException("Cannot find the file to update from the call stack. The PDB may be missing.");
-
-        discoveredMethodName ??= memberName ?? "Snapshot";
-        return new SnapshotCallerContext(ResolveSourceFilePath(sourceFilePath), discoveredMethodName, discoveredContainingTypeName, memberName, lineNumber, testMethodResolved);
+        return new StackWalkResult(discoveredMethodName, discoveredClassName, testMethodResolved, sourceFilePath);
     }
 
     private static int GetStackAnalysisStartIndex(StackTrace stackTrace)
     {
-        // The methods decorated with [SnapshotAssertion] form a contiguous run at the innermost end of the
-        // stack: the attribute is internal and is only applied to the Snapshot.Validate overloads, which
-        // forward to each other. Walking outwards and stopping right after that run avoids reflecting over
-        // the whole stack, which is mostly test framework frames.
+        // The methods decorated with [SnapshotAssertion] form a contiguous run in the middle of the stack:
+        // the attribute is internal and is only applied to the Snapshot.Validate overloads, which forward to
+        // each other. Walking outwards and stopping right after that run avoids reflecting over the whole
+        // stack, which is mostly test framework frames. The frames below the run - the engine, and whatever
+        // strategy asked for a name - are skipped by the same rule, which is what makes the walk deferrable.
         var startIndex = 0;
         for (var i = 0; i < stackTrace.FrameCount; i++)
         {
@@ -207,4 +295,10 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
     }
 
     private sealed record StackFrameMethod(bool IsSnapshotAssertion, bool IsTestMethod, string NormalizedMethodName, string? NormalizedTypeName);
+
+    private sealed record StackWalkResult(string? MethodName, string? ClassName, bool TestMethodResolved, string? SourceFilePath)
+    {
+        /// <summary>Result of a walk that cannot run because the frames of the assertion are gone.</summary>
+        public static StackWalkResult Unavailable { get; } = new(MethodName: null, ClassName: null, TestMethodResolved: false, SourceFilePath: null);
+    }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -13,15 +13,24 @@ internal static class SnapshotEngine
         ArgumentNullException.ThrowIfNull(settings);
 
         type ??= SnapshotType.Default;
-        var callerContext = SnapshotCallerContext.Create(filePath, lineNumber, memberName);
+        testContext ??= SnapshotTestContext.Get();
+        var callerContext = SnapshotCallerContext.Create(filePath, lineNumber, memberName, testContext);
         var serialized = Serialize(settings, type, value);
 
         if (serialized is null || serialized.Count == 0)
             throw new SnapshotException("Serializer returned no snapshot data.");
 
-        testContext ??= SnapshotTestContext.Get();
+        List<SnapshotFile> actualFiles;
+        try
+        {
+            actualFiles = BuildActualFiles(settings, callerContext, type, serialized, testContext);
+        }
+        finally
+        {
+            // The strategies are the only consumers of the call stack, and they have all run by now.
+            callerContext.Freeze();
+        }
 
-        var actualFiles = BuildActualFiles(settings, callerContext, type, serialized, testContext);
         var expectedFilePaths = DiscoverExpectedFilePaths(actualFiles);
         var expectedFiles = LoadSnapshotFiles(expectedFilePaths);
 
@@ -256,28 +265,13 @@ internal static class SnapshotEngine
         IReadOnlyList<SnapshotData> serialized,
         SnapshotTestContext? testContext)
     {
-        // The call stack only contains the test method as long as the assertion runs synchronously below it.
-        // A helper method that awaited before asserting runs on a continuation where the test method is gone,
-        // and the innermost frames then describe the helper. The test framework still knows which test is
-        // running, so its own view wins whenever the stack could not produce one.
-        var className = callerContext.ContainingTypeName;
-        var methodName = callerContext.MethodName;
-        if (!callerContext.TestMethodResolved)
-        {
-            className = testContext?.ClassName ?? className;
-            methodName = testContext?.MethodName ?? methodName;
-        }
-
         var result = new List<SnapshotFile>(serialized.Count);
         for (var index = 0; index < serialized.Count; index++)
         {
             var snapshotData = serialized[index];
             var extension = ResolveSnapshotExtension(type, snapshotData);
             var path = settings.SnapshotPathStrategy(new SnapshotPathContext(
-                callerContext.SourceFilePath,
-                className,
-                methodName,
-                callerContext.LineNumber,
+                callerContext,
                 type,
                 index,
                 extension,

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotPathContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotPathContext.cs
@@ -1,13 +1,113 @@
 namespace Meziantou.Framework.SnapshotTesting;
 
-public sealed record SnapshotPathContext(
-    FullPath SourceFilePath,
-    string? ClassName,
-    string MethodName,
-    int LineNumber,
-    SnapshotType Type,
-    int Index,
-    string? Extension,
-    SnapshotTestContext? TestContext,
-    SnapshotSettings Settings,
-    int SnapshotCount = 1);
+public sealed record SnapshotPathContext
+{
+    private readonly SnapshotCallerContext? _callerContext;
+    private readonly string? _className;
+    private readonly string? _methodName;
+
+    // The parameter names are part of the public API: this type used to be a positional record, and callers
+    // pass them as named arguments.
+#pragma warning disable IDE1006 // Naming Styles
+    public SnapshotPathContext(
+        FullPath SourceFilePath,
+        string? ClassName,
+        string MethodName,
+        int LineNumber,
+        SnapshotType Type,
+        int Index,
+        string? Extension,
+        SnapshotTestContext? TestContext,
+        SnapshotSettings Settings,
+        int SnapshotCount = 1,
+        string? MemberName = null)
+    {
+        this.SourceFilePath = SourceFilePath;
+        _className = ClassName;
+        _methodName = MethodName;
+        this.LineNumber = LineNumber;
+        this.Type = Type;
+        this.Index = Index;
+        this.Extension = Extension;
+        this.TestContext = TestContext;
+        this.Settings = Settings;
+        this.SnapshotCount = SnapshotCount;
+        this.MemberName = MemberName;
+    }
+#pragma warning restore IDE1006 // Naming Styles
+
+    internal SnapshotPathContext(
+        SnapshotCallerContext callerContext,
+        SnapshotType type,
+        int index,
+        string? extension,
+        SnapshotTestContext? testContext,
+        SnapshotSettings settings,
+        int snapshotCount)
+    {
+        _callerContext = callerContext;
+        SourceFilePath = callerContext.SourceFilePath;
+        LineNumber = callerContext.LineNumber;
+        MemberName = callerContext.MemberName;
+        Type = type;
+        Index = index;
+        Extension = extension;
+        TestContext = testContext;
+        Settings = settings;
+        SnapshotCount = snapshotCount;
+    }
+
+    public FullPath SourceFilePath { get; init; }
+
+    /// <summary>
+    /// Simple name of the type declaring the test, or <see langword="null" /> when it is unknown.
+    /// </summary>
+    /// <remarks>
+    /// Unless the value was provided explicitly, reading this walks the call stack the first time, which is
+    /// the most expensive part of an assertion. A strategy that reads neither this nor <see cref="MethodName" />
+    /// never pays for that walk.
+    /// </remarks>
+    public string? ClassName
+    {
+        get => _className ?? _callerContext?.ClassName;
+        init => _className = value;
+    }
+
+    /// <summary>
+    /// Name of the test method the snapshot belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Unless the value was provided explicitly, reading this walks the call stack the first time, which is
+    /// the most expensive part of an assertion. Use <see cref="MemberName" /> when the name the compiler
+    /// captured at the call site is enough.
+    /// </remarks>
+    public string MethodName
+    {
+        get => _methodName ?? _callerContext?.MethodName ?? "";
+        init => _methodName = value;
+    }
+
+    /// <summary>
+    /// Member name captured by the compiler at the call site, or <see langword="null" /> when the assertion
+    /// did not provide one. Unlike <see cref="MethodName" />, it never walks the call stack, but it describes
+    /// the method that called the assertion rather than the test method.
+    /// </summary>
+    public string? MemberName { get; init; }
+
+    public int LineNumber { get; init; }
+
+    public SnapshotType Type { get; init; }
+
+    public int Index { get; init; }
+
+    public string? Extension { get; init; }
+
+    public SnapshotTestContext? TestContext { get; init; }
+
+    public SnapshotSettings Settings { get; init; }
+
+    public int SnapshotCount { get; init; }
+
+    /// <summary>Indicates whether reading a name walked the call stack. Used by the tests.</summary>
+    internal bool StackWalkPerformed => _callerContext?.StackWalkPerformed ?? false;
+}

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -167,6 +167,12 @@ Use `SnapshotSettings` to customize behavior:
 - `SnapshotUpdateStrategy` (`Disallow`, `Overwrite`, `OverwriteWithoutFailure`, `MergeTool`, `MergeToolSync`)
 - `SnapshotPathStrategy` for full path generation
 
+A custom `SnapshotNamingStrategy` or `SnapshotPathStrategy` receives a `SnapshotPathContext`. Its `ClassName`
+and `MethodName` are read from the call stack, which is the most expensive part of an assertion, so they are
+only resolved when a strategy reads them: a strategy that uses neither never pays for that walk. Use
+`MemberName` when the name of the method that called the assertion - captured by the compiler, always
+available - is enough.
+
 You can also set the default strategy using the `SNAPSHOTTESTING_STRATEGY` environment variable.
 The value is case-insensitive and must match one of the `SnapshotUpdateStrategy` static property names (for example: `DISALLOW`, `MergeTool`, `overwritewithoutfailure`).
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -341,6 +341,7 @@ public sealed partial class SnapshotTests
         Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
         Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromHelperMethod), capturedContext.MethodName);
         Assert.Equal(nameof(Validate_ResolvesTestMethod_WhenCalledFromHelperMethod), capturedContext.TestContext?.TestName);
+        Assert.Equal(nameof(ValidateThroughHelper), capturedContext.MemberName);
         Assert.Equal("SnapshotTests.cs", capturedContext.SourceFilePath.Name);
 
         var files = Directory.GetFiles(directory.FullPath);
@@ -374,6 +375,63 @@ public sealed partial class SnapshotTests
         var files = Directory.GetFiles(directory.FullPath);
         Assert.Single(files);
         Assert.Equal("SnapshotTests_Validate_ResolvesTestMethod_WhenCalledFromAsyncHelperMethodInAnotherClass.verified.txt", Path.GetFileName(files[0]));
+    }
+
+    [Fact]
+    public void Validate_DoesNotWalkTheStack_WhenTheStrategyDoesNotReadTheTestNames()
+    {
+        using var directory = TemporaryDirectory.Create();
+        SnapshotPathContext? capturedContext = null;
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context =>
+            {
+                capturedContext = context;
+                return directory / "snapshot.verified.txt";
+            },
+        };
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.NotNull(capturedContext);
+        Assert.False(capturedContext.StackWalkPerformed);
+        Assert.Equal(nameof(Validate_DoesNotWalkTheStack_WhenTheStrategyDoesNotReadTheTestNames), capturedContext.MemberName);
+
+        // The frames of the assertion are gone by now, so the names are read from the test framework instead
+        // of describing an unrelated call stack.
+        Assert.Equal(nameof(Validate_DoesNotWalkTheStack_WhenTheStrategyDoesNotReadTheTestNames), capturedContext.MethodName);
+        Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
+        Assert.False(capturedContext.StackWalkPerformed);
+    }
+
+    [Fact]
+    public void Validate_WalksTheStack_WhenTheStrategyReadsTheTestNames()
+    {
+        using var directory = TemporaryDirectory.Create();
+        SnapshotPathContext? capturedContext = null;
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context =>
+            {
+                capturedContext = context;
+                return directory / (context.MethodName + ".verified.txt");
+            },
+        };
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.NotNull(capturedContext);
+        Assert.True(capturedContext.StackWalkPerformed);
+        Assert.Equal(nameof(Validate_WalksTheStack_WhenTheStrategyReadsTheTestNames), capturedContext.MethodName);
+        Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
+
+        var files = Directory.GetFiles(directory.FullPath);
+        Assert.Single(files);
+        Assert.Equal(nameof(Validate_WalksTheStack_WhenTheStrategyReadsTheTestNames) + ".verified.txt", Path.GetFileName(files[0]));
     }
 
     private static class SnapshotHelpers


### PR DESCRIPTION
## What

`SnapshotCallerContext` resolved the test class and test method names from a stack walk on **every** assertion, even when nothing used them. Those names are consumed only by `SnapshotNamingStrategy` / `SnapshotPathStrategy`, so the walk is now deferred until one of them reads `ClassName` or `MethodName`.

`SnapshotPathContext` also exposes **`MemberName`** — the name the compiler captured at the call site — for strategies that only need to know which method called the assertion, since it never needs the stack.

## Why

Measured with `SnapshotValidateBenchmark` (net10.0, Apple M5 Pro), whose path strategy already ignored the context:

| | Before | After |
|---|---:|---:|
| `Validate` | 20.90 us / 9.88 KB | **17.91 us / 4.66 KB** |
| `Validate`, 100 sibling snapshots | 21.34 us / 9.89 KB | **18.08 us / 4.73 KB** |
| `Create` + read `MethodName` (walk forced) | 3.83 / 5.62 us | 3.93 / 5.53 us |

−14 % time and −53 % allocations when the names are unused, and no regression when they are read.

## How

- `SourceFilePath` is resolved from `[CallerFilePath]`, so the walk is only mandatory when the caller provides no path.
- The test-framework fallback moved out of `SnapshotEngine.BuildActualFiles` into the getters. **Precedence is unchanged**: the stack wins when it resolved a test method, the test framework fills in otherwise.
- `GetStackAnalysisStartIndex` anchors on the run of `[SnapshotAssertion]` frames rather than a fixed skip count, so the extra frames a deferred read adds below the assertion are skipped by the same rule — no change was needed there.
- The engine freezes the caller context in a `finally` once the strategies have run. The frames the walk looks for only exist while the assertion runs, so a strategy that keeps its `SnapshotPathContext` (the tests do) later reports what the test framework knows instead of describing an unrelated call stack.

## Reviewer notes — public API

`SnapshotPathContext` stays a `record` (so `with`, `==` and `ToString` still work) but is no longer positional:

- The constructor gains a trailing optional `string? MemberName = null`. Parameter names stay PascalCase so existing named arguments (`Index:`, `Extension:`, `TestContext:`) keep compiling; that needs a scoped `#pragma warning disable IDE1006`, since IDE1006 applies to a real constructor but not to record parameters.
- The synthesized **`Deconstruct` is removed**. Happy to hand-write it back if you want to keep it.
- Equality now compares the caller-context reference plus explicitly set names rather than the resolved ones, so two engine-built contexts from different assertions no longer compare equal just because they resolve to the same names. Nothing in the repo compares contexts, so I kept the synthesized `Equals`/`GetHashCode` instead of hand-writing resolution-forcing ones.

`ref/Meziantou.Framework.SnapshotTesting.cs` is regenerated accordingly.

## Tests

- Two new tests in `SnapshotTests`: the walk is skipped when a strategy reads neither name (and the frozen context still reports the right names afterwards), and it is performed when a strategy reads them.
- `Validate_ResolvesTestMethod_WhenCalledFromHelperMethod` now also asserts `MemberName` is the helper while `MethodName` is the test.
- `Meziantou.Framework.SnapshotTesting.Tests` 394/394 pass on net10.0 and net11.0. `Meziantou.Framework.QRCode.Tests` (2724) and `Meziantou.Framework.Avatar.Tests` (160) pass too — they use the default naming strategy against committed snapshot files, so no snapshot file name changed.
- `dotnet build -c Release /p:IsOfficialBuild=true` is clean for the library and the test project; `dotnet run ./eng/update-all.cs` produced no further changes.
