### PR TITLE
Add a TdsServer test for a rejected password

### DIFF
--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -128,6 +128,32 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task SqlClient_AuthenticationCallback_WithWrongPassword_Fails()
+    {
+        const string UserName = "sa";
+        const string ExpectedPassword = "P@ssw0rd!<>&\u00e9\u4e2d";
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(
+                context.UserName == UserName && context.Password == ExpectedPassword
+                    ? TdsAuthenticationResult.Success("master")
+                    : TdsAuthenticationResult.Fail("Login failed.")),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port, UserName, ExpectedPassword + "x"));
+        var exception = await Assert.ThrowsAsync<SqlException>(() => connection.OpenAsync());
+
+        Assert.Contains("Login failed.", exception.Message);
+    }
+
+    [Fact]
     public async Task SqlClient_TextQuery_WithoutParameters_UsesSqlBatch()
     {
         const string Marker = "TextQueryWithoutParametersMarker";


### PR DESCRIPTION
## Summary

Adds `SqlClient_AuthenticationCallback_WithWrongPassword_Fails` to `TdsServerProtocolTests`, copied from the closed PR #3079.

The test starts a `TdsServer` whose authentication callback only accepts one specific password (including non-ASCII characters), connects with `Microsoft.Data.SqlClient` using a wrong password, and asserts that `OpenAsync` throws a `SqlException` carrying the callback's "Login failed." message.

## Why

The LOGIN7 password decoding fix from #3079 already landed on `main`, but this negative test did not. It guards against two regressions: a decoding bug that would make the server accept or garble passwords, and an error-propagation bug that would swallow the callback's failure instead of surfacing it to the client.

## Notes for reviewers

- Only the test file changes. The companion positive test from #3079 was intentionally not included.
- Verified locally: the build with `TreatWarningsAsErrors` succeeds and both authentication callback tests pass on net10.0 and net11.0. `dotnet run ./eng/update-all.cs` produced no changes.