### PR TITLE
Run the projection type reclamation test in isolation

### DIFF
--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineProjectionTypeTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineProjectionTypeTests.cs
@@ -41,7 +41,11 @@ public sealed class TdsQueryEngineProjectionTypeTests
         Assert.Equal(freshAlias, await GetColumnNameAsync(laterHandler, $"SELECT Id AS {freshAlias} FROM customers"));
     }
 
-    [Fact]
+    // The type cache is process-wide, so any query running beside this test can pick up a type emitted into the
+    // tracked assembly while it is still alive. Combining it with a newly emitted type -- a join carrier whose
+    // member is a derived table's projection, for instance -- makes the newer assembly reference the tracked one,
+    // and that lasts as long as the newer type is retained, which outlives any wait.
+    [Fact(DisableParallelization = true)]
     public async Task ProjectionTypesLeavingTheCache_AreReclaimed()
     {
         var aliasPrefix = "Reclaim" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
@@ -68,9 +72,8 @@ public sealed class TdsQueryEngineProjectionTypeTests
         }
 
         // Unloading is not synchronous: it completes on a later collection, once the runtime has finished
-        // walking everything that referenced the assembly. Tests also run in parallel, and a query running in
-        // another one can still hold a type emitted into the same assembly, so wait between the sweeps instead
-        // of failing on the first one.
+        // walking everything that referenced the assembly, so wait between the sweeps instead of failing on the
+        // first one.
         for (var index = 0; index < 60 && projectionAssembly.IsAlive; index++)
         {
             GC.Collect();


### PR DESCRIPTION
`TdsQueryEngineProjectionTypeTests.ProjectionTypesLeavingTheCache_AreReclaimed` has been failing intermittently since it was added in #3085. It failed in 8 CI jobs across Windows, Linux x64 and Linux arm64, on net10.0 and net11.0, in Debug and Release (for example [this job](https://github.com/meziantou/Meziantou.Framework/actions/runs/34607899408/job/103308255055)). The assertion is always the same: the tracked projection assembly is still alive after the 60 GC sweeps.

## Cause

`TdsProjectionTypeFactory` is shared by the whole process, and its weak cache keeps returning a type for as long as that type is alive. Another test running at the same time can reuse a type from the tracked assembly together with a newly emitted one, for example a join carrier whose member is a derived table's projection. The newer collectible assembly then references the tracked one for as long as the newer type stays among the retained types. That outlasts any number of GC retries. This is correct product behavior; the test just wasn't isolated from the tests running beside it.

It only shows in CI because the TdsServer test assembly takes 15–20s there instead of about 1.6s locally. This test and its sibling churn test hold two of roughly four xunit slots, so the other ~250 tests run spread across the whole churn instead of finishing alongside it.

## Change

- Mark the test `[Fact(DisableParallelization = true)]`, with a comment explaining which shared state forces it.
- Remove the sentence in the wait-loop comment that assumed parallel tests; it no longer applies.

## Verification

- I couldn't reproduce the CI failure locally: about 30 runs stayed green, including runs under CPU burners, with `DOTNET_PROCESSOR_COUNT=2/4`, and with `--max-threads 2–4`.
- I confirmed the mechanism with a temporary deterministic test, not committed. It adds a join late in the churn that reuses a derived-table type from the tracked assembly. It failed every time; the same test without that late join passed.
- All TdsServer tests pass on net10.0 and net11.0 (508 passed, 2 skipped). The TRX shows no other test overlapping this one on either TFM.
- `dotnet run ./eng/update-all.cs` produced no changes.
