### PR TITLE
Cache JSONPath match()/search() regexes for patterns read from the document

### DIFF
--- a/src/Meziantou.Framework.JsonPath/Internals/Ast/FunctionCallExpression.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/Ast/FunctionCallExpression.cs
@@ -5,16 +5,25 @@ namespace Meziantou.Framework.Json.Internals;
 internal sealed class FunctionCallExpression : LogicalExpression
 {
     /// <summary>
-    /// Cached <see cref="Regex"/> for a <c>match()</c>/<c>search()</c> call whose pattern is a literal, which is
-    /// the overwhelmingly common case. A miss stores <see cref="RegexCacheEntry.Unusable"/> so an invalid pattern
-    /// is not re-translated per node either.
+    /// The last pattern a <c>match()</c>/<c>search()</c> call compiled, with its result. A literal pattern never
+    /// changes, and a pattern read from the document is usually one value shared by every node the filter
+    /// visits (<c>$.pattern</c>), so a single entry avoids recompiling per node in both cases. An invalid pattern
+    /// is cached as <see cref="RegexCacheEntry.Unusable"/> so it is not re-translated per node either.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// A pattern read from the document may be attacker-controlled, which is why this is one entry rather than
+    /// a growing map. Nodes whose patterns alternate replace the entry each time, which costs what an uncached
+    /// compilation costs.
+    /// </para>
+    /// <para>
     /// A parsed <see cref="JsonPath"/> is documented as thread-safe and reusable. Publishing this field races
-    /// benignly: <see cref="RegexCacheEntry"/> is immutable, reference assignment is atomic, and the worst case
-    /// is that two threads each build an equivalent entry and one wins.
+    /// benignly: <see cref="RegexCacheSlot"/> is immutable, so a reader never pairs one pattern with another's
+    /// regex, reference assignment is atomic, and the worst case is that concurrent evaluations using different
+    /// patterns keep replacing each other's entry.
+    /// </para>
     /// </remarks>
-    private RegexCacheEntry? _regexCache;
+    private RegexCacheSlot? _regexCache;
 
     public FunctionCallExpression(string name, FunctionArgument[] arguments, FunctionExpressionType resultType)
     {
@@ -31,21 +40,25 @@ internal sealed class FunctionCallExpression : LogicalExpression
 
     public FunctionExpressionType ResultType { get; }
 
-    /// <summary>Gets the cached regex for this call, building it with <paramref name="factory"/> on first use.</summary>
-    /// <param name="factory">Builds the entry from the literal pattern.</param>
-    /// <returns>The cached entry.</returns>
-    public RegexCacheEntry GetOrCreateRegex(Func<string, RegexCacheEntry> factory)
+    /// <summary>Gets the compiled regex for <paramref name="pattern"/>, building it with <paramref name="factory"/> unless it is the cached one.</summary>
+    /// <param name="pattern">The I-Regexp pattern, which is the cache key.</param>
+    /// <param name="anchored">
+    /// Passed to <paramref name="factory"/>. It is not part of the key: it depends only on whether this call is
+    /// <c>match()</c> or <c>search()</c>, so it never varies for a given call.
+    /// </param>
+    /// <param name="factory">Builds the entry from the pattern.</param>
+    /// <returns>The entry for <paramref name="pattern"/>.</returns>
+    public RegexCacheEntry GetOrCreateRegex(string pattern, bool anchored, Func<string, bool, RegexCacheEntry> factory)
     {
         var cached = _regexCache;
-        if (cached is not null)
+        if (cached is not null && string.Equals(cached.Pattern, pattern, StringComparison.Ordinal))
         {
-            return cached;
+            return cached.Entry;
         }
 
-        var pattern = (string)Arguments[1].Value!;
-        cached = factory(pattern);
-        _regexCache = cached;
-        return cached;
+        var entry = factory(pattern, anchored);
+        _regexCache = new RegexCacheSlot(pattern, entry);
+        return entry;
     }
 
     /// <summary>An immutable compiled-pattern result: either a usable <see cref="Regex"/> or a known failure.</summary>
@@ -57,5 +70,13 @@ internal sealed class FunctionCallExpression : LogicalExpression
         public RegexCacheEntry(Regex? regex) => Regex = regex;
 
         public Regex? Regex { get; }
+    }
+
+    /// <summary>A pattern paired with its entry, published as one reference so the two can never be torn apart.</summary>
+    private sealed class RegexCacheSlot(string pattern, RegexCacheEntry entry)
+    {
+        public string Pattern { get; } = pattern;
+
+        public RegexCacheEntry Entry { get; } = entry;
     }
 }

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
@@ -1141,11 +1141,9 @@ internal static class JsonPathEvaluator
     /// <returns><see langword="true"/> when the pattern matches; otherwise, <see langword="false"/>.</returns>
     private static bool IsRegexMatch(FunctionCallExpression func, string input, string iRegexp, bool anchored)
     {
-        // The pattern is a literal in almost every real query, so translate and compile it once per AST node
-        // rather than once per node visited. A computed pattern falls back to the per-call path.
-        var regex = func.Arguments[1].Kind is FunctionArgumentKind.Literal && func.Arguments[1].Value is string
-            ? func.GetOrCreateRegex(p => CreateRegex(p, anchored)).Regex
-            : CreateRegex(iRegexp, anchored).Regex;
+        // Translating and compiling a NonBacktracking regex costs far more than matching one, so reuse the
+        // last pattern this call compiled rather than rebuilding it for every node the filter visits.
+        var regex = func.GetOrCreateRegex(iRegexp, anchored, CreateRegex).Regex;
 
         if (regex is null)
         {

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Meziantou.Framework.Json;
+using Meziantou.Framework.Json.Internals;
 
 namespace Meziantou.Framework.JsonPathTests;
 
@@ -461,9 +462,10 @@ public sealed class JsonPathEvaluateTests
     }
 
     [Fact]
-    public void Evaluate_Function_Match_NonLiteralPattern_IsNotCached()
+    public void Evaluate_Function_Match_NonLiteralPattern_IsEvaluatedPerNode()
     {
-        // The pattern comes from the document, so it differs per node and must bypass the per-AST cache.
+        // The pattern comes from the document and differs per node, so the cached regex of one node must not be
+        // used for the next.
         var doc = JsonNode.Parse("""[{"s": "foo", "p": "f.o"}, {"s": "bar", "p": "z.z"}, {"s": "baz", "p": "b.z"}]""");
         var path = JsonPath.Parse("$[?match(@.s, @.p)]");
 
@@ -472,6 +474,82 @@ public sealed class JsonPathEvaluateTests
         Assert.Equal(2, result.Count);
         Assert.Equal("foo", result[0].Value!.AsObject()["s"]!.GetValue<string>());
         Assert.Equal("baz", result[1].Value!.AsObject()["s"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Evaluate_Function_Match_NonLiteralPattern_AlternatingAcrossNodes()
+    {
+        // The cache keeps one pattern, so the nodes below alternate between hits and replacements, including
+        // replacing a valid pattern with an invalid one and back.
+        var doc = JsonNode.Parse("""
+            [
+              {"id": 0, "s": "foo", "p": "f.o"},
+              {"id": 1, "s": "foo", "p": "f.o"},
+              {"id": 2, "s": "bar", "p": "f.o"},
+              {"id": 3, "s": "bar", "p": "b.r"},
+              {"id": 4, "s": "foo", "p": "("},
+              {"id": 5, "s": "foo", "p": "f.o"},
+              {"id": 6, "s": "foo", "p": "b.r"},
+              {"id": 7, "s": "bar", "p": "b.r"},
+              {"id": 8, "s": "(", "p": "("}
+            ]
+            """);
+        var path = JsonPath.Parse("$[?match(@.s, @.p)]");
+        int[] expected = [0, 1, 3, 5, 7];
+
+        var ids = path.Evaluate(doc).Select(match => match.Value!["id"]!.GetValue<int>()).ToArray();
+
+        Assert.Equal(expected, ids);
+    }
+
+    [Fact]
+    public void Evaluate_Function_Match_DocumentPattern_IsStableAcrossDocumentsAndThreads()
+    {
+        // The pattern is shared by every node of a document but differs between documents, so an entry cached
+        // while evaluating one document must not answer for the other, even when both are evaluated at once.
+        var items = string.Join(", ", Enumerable.Range(0, 50).Select(i => i % 2 is 0 ? "\"abc\"" : "\"xyz\""));
+        var abc = JsonNode.Parse($$"""{"pattern": "a.c", "items": [{{items}}]}""");
+        var xyz = JsonNode.Parse($$"""{"pattern": "x.z", "items": [{{items}}]}""");
+        var path = JsonPath.Parse("$.items[?match(@, $.pattern)]");
+
+        var results = new JsonPathResult[64];
+        results[0] = path.Evaluate(abc);
+        results[1] = path.Evaluate(xyz);
+        Parallel.For(2, results.Length, i => results[i] = path.Evaluate(i % 2 is 0 ? abc : xyz));
+
+        for (var i = 0; i < results.Length; i++)
+        {
+            var expected = i % 2 is 0 ? "abc" : "xyz";
+            Assert.Equal(25, results[i].Count);
+            Assert.All(results[i], match => Assert.Equal(expected, match.Value!.GetValue<string>()));
+        }
+    }
+
+    [Fact]
+    public void Evaluate_Function_Match_RegexCache_ReusesTheEntryForAnEqualPattern()
+    {
+        // A pattern read from the document is usually a new string instance for every node, so the cache must
+        // compare patterns by value to ever hit.
+        var func = new FunctionCallExpression("match", [], FunctionExpressionType.LogicalType);
+        var pattern = "a.c";
+        var equalPattern = new string(pattern.AsSpan());
+        var built = new List<string>();
+        string[] expectedBuilt = ["a.c", "x.z"];
+
+        var first = func.GetOrCreateRegex(pattern, anchored: true, Factory);
+        var second = func.GetOrCreateRegex(equalPattern, anchored: true, Factory);
+        var other = func.GetOrCreateRegex("x.z", anchored: true, Factory);
+
+        Assert.NotSame(pattern, equalPattern);
+        Assert.Same(first, second);
+        Assert.NotSame(first, other);
+        Assert.Equal(expectedBuilt, built);
+
+        FunctionCallExpression.RegexCacheEntry Factory(string p, bool _)
+        {
+            built.Add(p);
+            return new FunctionCallExpression.RegexCacheEntry(regex: null);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
`match()` and `search()` cached the compiled regex only when the pattern was a string literal. When the pattern came from the document, for example `$[?match(@.s, $.pattern)]` or `$[?match(@.s, @.p)]`, the evaluator translated the I-Regexp and built a new `NonBacktracking` regex for every node the filter visited. That construction is expensive, especially for `\p{..}` category escapes, which expand to large alternations. So a filter over a large array whose pattern came from one document value rebuilt the same automaton thousands of times.

## Change

- `FunctionCallExpression` now has a single-entry cache keyed by the pattern value (ordinal comparison). Literal and document patterns share it; a literal never changes, so it always hits.
- The pattern and its compiled result are published together as one immutable object with a plain reference write, the same benign race the literal cache already relied on. Concurrent `Evaluate` calls may replace each other's entry, but a reader can never pair one pattern with another pattern's regex.
- Invalid patterns are still cached as `RegexCacheEntry.Unusable`, so they yield `false` and never throw out of `Evaluate`.
- The cache holds at most one entry per `match()`/`search()` call in the path, so a document, possibly attacker-controlled, cannot grow it.
- `IsRegexMatch` passes the static `CreateRegex` method group instead of a capturing lambda, which drops a per-node allocation.

## Measurements

40 patterns of the form `[\p{L}\p{Nd}]+\P{Lu}{0,k}`, Release, macOS arm64. Each one costs about 90 ms to translate and compile.

| Scenario | Before | After |
|---|---|---|
| `$[?match(@.s, @.p)]`, 19 nodes per document | 69.6 s (0.6 patterns/s) | 4.0 s (9.9 patterns/s) |
| Same documents, literal pattern (already cached) | 3.8 s | 3.5 s |
| `$.items[?match(@, $.pattern)]`, 4 documents × 1000 items | 502 s | 0.48 s |

## Tests

- Renamed `Evaluate_Function_Match_NonLiteralPattern_IsNotCached` to `Evaluate_Function_Match_NonLiteralPattern_IsEvaluatedPerNode`, since document patterns are now cached. Its body is unchanged: per-node patterns still give per-node results.
- `Evaluate_Function_Match_NonLiteralPattern_AlternatingAcrossNodes`: the pattern alternates across nodes, including switching to an invalid pattern and back, and every node gets the right answer.
- `Evaluate_Function_Match_DocumentPattern_IsStableAcrossDocumentsAndThreads`: one parsed path, two documents with different `$.pattern` values, evaluated one after the other and then in parallel.
- `Evaluate_Function_Match_RegexCache_ReusesTheEntryForAnEqualPattern`: unit-tests the internal cache through the existing `InternalsVisibleTo`. Two distinct string instances with equal text hit the same entry. This matters because the navigator returns a new string for every node.

To check the tests aren't vacuous, I broke the cache on purpose. A cache that ignores the key fails all four tests; one that compares strings by reference fails only the last one.

## Reviewer notes

- Nodes whose patterns alternate, or concurrent evaluations using different pattern values, keep replacing the single entry. Each switch costs one compile, the same as before this change: no regression, but no gain there. A small bounded cache would cover that case if it turns out to matter.
- A parsed `JsonPath` now keeps the last document-supplied pattern string and its compiled regex alive, one per `match()`/`search()` call in the path. Literal patterns were already retained this way.
- Verified locally: Debug and `-c Release /p:IsOfficialBuild=true` builds with `/p:TreatWarningsAsErrors=true` (0 warnings), 908 tests passing on each of net10.0 and net11.0, and `dotnet run ./eng/update-all.cs` produced no changes.
