### PR TITLE
Zero decoded HTTP Basic credentials before releasing their buffers

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationHandler.cs
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationHandler.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Microsoft.AspNetCore.Authentication;
@@ -46,7 +48,7 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         if (headerValue.Parameter.Length > Options.MaxCredentialLength)
             return CredentialsTooLongResult;
 
-        var decodeResult = DecodeCredentials(headerValue.Parameter, out var credentials);
+        var decodeResult = DecodeCredentials(headerValue.Parameter, ArrayPool<byte>.Shared, ArrayPool<char>.Shared, out var credentials);
         if (decodeResult is not CredentialsDecodeResult.Success)
         {
             return decodeResult is CredentialsDecodeResult.InvalidBase64 ? InvalidBase64CredentialsResult : InvalidCredentialsEncodingResult;
@@ -86,41 +88,44 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         return value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
     }
 
-    private static CredentialsDecodeResult DecodeCredentials(string encodedCredentials, out string credentials)
+    // The buffers hold the plaintext credentials, so they are zeroed on every path before being released.
+    // The whole span is cleared rather than the written prefix because a failed decode does not report
+    // how much it wrote. The pools are parameters so tests can observe what is returned to them.
+    internal static CredentialsDecodeResult DecodeCredentials(string encodedCredentials, ArrayPool<byte> bytePool, ArrayPool<char> charPool, out string credentials)
     {
         byte[]? rentedBuffer = null;
+        var maxDecodedLength = GetMaximumDecodedLength(encodedCredentials.Length);
+        var credentialBytes = maxDecodedLength <= StackallocThreshold ? stackalloc byte[maxDecodedLength] : (rentedBuffer = bytePool.Rent(maxDecodedLength)).AsSpan(0, maxDecodedLength);
 
         try
         {
-            var maxDecodedLength = GetMaximumDecodedLength(encodedCredentials.Length);
-            var credentialBytes = maxDecodedLength <= StackallocThreshold ? stackalloc byte[maxDecodedLength] : (rentedBuffer = ArrayPool<byte>.Shared.Rent(maxDecodedLength));
-
             if (!Convert.TryFromBase64String(encodedCredentials, credentialBytes, out var bytesWritten))
             {
                 credentials = "";
                 return CredentialsDecodeResult.InvalidBase64;
             }
 
-            return TranscodeUtf8(credentialBytes[..bytesWritten], out credentials);
+            return TranscodeUtf8(credentialBytes[..bytesWritten], charPool, out credentials);
         }
         finally
         {
+            CryptographicOperations.ZeroMemory(credentialBytes);
             if (rentedBuffer is not null)
             {
-                ArrayPool<byte>.Shared.Return(rentedBuffer);
+                bytePool.Return(rentedBuffer);
             }
         }
     }
 
-    private static CredentialsDecodeResult TranscodeUtf8(ReadOnlySpan<byte> credentialBytes, out string credentials)
+    private static CredentialsDecodeResult TranscodeUtf8(ReadOnlySpan<byte> credentialBytes, ArrayPool<char> charPool, out string credentials)
     {
         char[]? rentedBuffer = null;
 
+        // A UTF-8 sequence never produces more UTF-16 code units than it has bytes.
+        var credentialChars = credentialBytes.Length <= StackallocThreshold ? stackalloc char[credentialBytes.Length] : (rentedBuffer = charPool.Rent(credentialBytes.Length)).AsSpan(0, credentialBytes.Length);
+
         try
         {
-            // A UTF-8 sequence never produces more UTF-16 code units than it has bytes.
-            var credentialChars = credentialBytes.Length <= StackallocThreshold ? stackalloc char[credentialBytes.Length] : (rentedBuffer = ArrayPool<char>.Shared.Rent(credentialBytes.Length));
-
             // replaceInvalidSequences: false keeps malformed input from silently collapsing onto U+FFFD,
             // which would make unrelated byte sequences decode to the same credentials.
             if (Utf8.ToUtf16(credentialBytes, credentialChars, out _, out var charsWritten, replaceInvalidSequences: false) is not OperationStatus.Done)
@@ -134,9 +139,10 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         }
         finally
         {
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(credentialChars));
             if (rentedBuffer is not null)
             {
-                ArrayPool<char>.Shared.Return(rentedBuffer);
+                charPool.Return(rentedBuffer);
             }
         }
     }
@@ -146,7 +152,7 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         return (int)((encodedLength + 3L) / 4L * 3L);
     }
 
-    private enum CredentialsDecodeResult
+    internal enum CredentialsDecodeResult
     {
         Success,
         InvalidBase64,

--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/Meziantou.AspNetCore.Authentication.HttpBasic.csproj
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/Meziantou.AspNetCore.Authentication.HttpBasic.csproj
@@ -12,4 +12,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.AspNetCore.Authentication.HttpBasic.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -1,6 +1,8 @@
+using System.Buffers;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -432,6 +434,53 @@ public sealed class HttpBasicAuthenticationTests
         });
     }
 
+    [Fact]
+    public void DecodeCredentials_ClearsPooledBuffers_WhenDecodingSucceeds()
+    {
+        var plaintext = new string('u', 300) + ":synthetic-pool-secret";
+        var encodedCredentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(plaintext));
+        var bytePool = new RecordingArrayPool<byte>();
+        var charPool = new RecordingArrayPool<char>();
+
+        var result = HttpBasicAuthenticationHandler.DecodeCredentials(encodedCredentials, bytePool, charPool, out var credentials);
+
+        Assert.Equal(HttpBasicAuthenticationHandler.CredentialsDecodeResult.Success, result);
+        Assert.Equal(plaintext, credentials);
+        bytePool.AssertAllArraysReturnedCleared();
+        charPool.AssertAllArraysReturnedCleared();
+    }
+
+    [Fact]
+    public void DecodeCredentials_ClearsPooledBuffers_WhenBase64IsMalformedAfterADecodedPrefix()
+    {
+        var encodedCredentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(new string('u', 300) + ":synthetic-pool-secret")) + "*AAA";
+        var bytePool = new RecordingArrayPool<byte>();
+        var charPool = new RecordingArrayPool<char>();
+
+        var result = HttpBasicAuthenticationHandler.DecodeCredentials(encodedCredentials, bytePool, charPool, out var credentials);
+
+        Assert.Equal(HttpBasicAuthenticationHandler.CredentialsDecodeResult.InvalidBase64, result);
+        Assert.Equal("", credentials);
+        bytePool.AssertAllArraysReturnedCleared();
+        Assert.Empty(charPool.Rented);
+    }
+
+    [Fact]
+    public void DecodeCredentials_ClearsPooledBuffers_WhenUtf8IsInvalid()
+    {
+        byte[] plaintext = [.. Encoding.UTF8.GetBytes(new string('u', 300) + ":synthetic-pool-secret"), 0xFF];
+        var encodedCredentials = Convert.ToBase64String(plaintext);
+        var bytePool = new RecordingArrayPool<byte>();
+        var charPool = new RecordingArrayPool<char>();
+
+        var result = HttpBasicAuthenticationHandler.DecodeCredentials(encodedCredentials, bytePool, charPool, out var credentials);
+
+        Assert.Equal(HttpBasicAuthenticationHandler.CredentialsDecodeResult.InvalidEncoding, result);
+        Assert.Equal("", credentials);
+        bytePool.AssertAllArraysReturnedCleared();
+        charPool.AssertAllArraysReturnedCleared();
+    }
+
     private static IdentityUser CreateIdentityUser(string id, string username, string password)
     {
         var user = new IdentityUser
@@ -464,6 +513,42 @@ public sealed class HttpBasicAuthenticationTests
 
         var identity = new ClaimsIdentity(claims, authenticationType: HttpBasicAuthenticationDefaults.AuthenticationScheme);
         return new ClaimsPrincipal(identity);
+    }
+
+    // Hands out fresh zeroed arrays, so anything non-default left in a returned array was written by the caller.
+    private sealed class RecordingArrayPool<T> : ArrayPool<T>
+    {
+        public List<T[]> Rented { get; } = [];
+
+        public List<T[]> Returned { get; } = [];
+
+        public override T[] Rent(int minimumLength)
+        {
+            var array = new T[minimumLength];
+            Rented.Add(array);
+            return array;
+        }
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            if (clearArray)
+            {
+                Array.Clear(array);
+            }
+
+            Returned.Add(array);
+        }
+
+        public void AssertAllArraysReturnedCleared()
+        {
+            Assert.NotEmpty(Rented);
+            Assert.HasCount(Rented.Count, Returned);
+            Assert.All(Returned, (array, index) =>
+            {
+                Assert.Same(Rented[index], array);
+                Assert.All(array, item => Assert.Equal(default, item));
+            });
+        }
     }
 
     private sealed class FakeBearerAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>


### PR DESCRIPTION
## Problem

`HttpBasicAuthenticationHandler` decodes credentials longer than the stackalloc threshold into arrays rented from `ArrayPool<byte>.Shared` and `ArrayPool<char>.Shared`. Both arrays went back to the pool without being cleared, and `ArrayPool<T>.Return` does not clear by default. The next component in the process to rent a buffer of the same size could read the plaintext username and password. Rejected inputs (malformed Base64, invalid UTF-8) left partially decoded material behind too.

## Change

- Both buffers, pooled or stack-allocated, are zeroed with `CryptographicOperations.ZeroMemory` in `finally` before release, on success and on both failure paths.
- The whole span is cleared rather than the decoded prefix, because a failed decode does not report how much it wrote.
- Pooled arrays are now used only up to the requested length, so clearing that range covers everything that could hold credential data. `clearArray: true` would clear a larger array a second time and would not reach the stack buffers.
- `DecodeCredentials` takes the two pools as parameters (production passes `ArrayPool<T>.Shared`). It and its result enum are now `internal`, with `InternalsVisibleTo` for the test project. The public API is unchanged.

This cannot erase the immutable strings passed to the credential validator or the copy in the request header.

## Tests

Three new tests use a recording pool that hands out fresh arrays, so they do not depend on the shared pool returning the same array. They cover successful decoding, malformed Base64 after a decoded prefix, and invalid UTF-8. Each checks that every rented array is returned and contains only zeros.

With the zeroing removed, all three fail. That includes the malformed-Base64 case, which confirms the decoder writes a partial result before rejecting the input.

All 84 tests pass on net10.0 and net11.0. The Release build with `IsOfficialBuild=true` is clean, and `eng/update-all.cs` produced no changes.
