### PR TITLE
Compile under the updated memory safety rules enabled by Meziantou.NET.Sdk 1.0.171

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationHandler.cs
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationHandler.cs
@@ -139,7 +139,7 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(credentialChars));
+            CryptographicOperations.ZeroMemory(unsafe(MemoryMarshal.AsBytes(credentialChars)));
             if (rentedBuffer is not null)
             {
                 charPool.Return(rentedBuffer);

--- a/src/Meziantou.Framework.Assertions/Assert.Equal.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equal.cs
@@ -193,8 +193,10 @@ public partial class Assert
             return false;
 
         var byteCount = expected.Length * elementSize;
-        var expectedBytes = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(expected)), byteCount);
-        var actualBytes = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(actual)), byteCount);
+        // Both spans have the same length, checked by every caller, and BitwiseEquatable<T> only admits primitive
+        // types, which have no padding, so the byte views cover exactly the memory of the elements.
+        var expectedBytes = unsafe(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(expected)), byteCount));
+        var actualBytes = unsafe(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(actual)), byteCount));
 
         return expectedBytes.SequenceEqual(actualBytes);
     }

--- a/src/Meziantou.Framework.Assertions/Assert.Equality.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equality.cs
@@ -87,7 +87,7 @@ public partial class Assert
         var sameType = typeof(TExpected) == typeof(TActual);
         if (sameType)
         {
-            if (EqualityComparer<TExpected>.Default.Equals(expected, Unsafe.As<TActual, TExpected>(ref actual)))
+            if (EqualityComparer<TExpected>.Default.Equals(expected, unsafe(Unsafe.As<TActual, TExpected>(ref actual))))
                 return true;
 
             if (typeof(TExpected).IsValueType)

--- a/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
@@ -1234,8 +1234,7 @@ internal class AssertionFormatter
     {
         if (typeof(T) == typeof(char))
         {
-            ref var firstChar = ref System.Runtime.CompilerServices.Unsafe.As<T, char>(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(value));
-            var chars = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(ref firstChar, value.Length);
+            var chars = unsafe(System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(ref System.Runtime.CompilerServices.Unsafe.As<T, char>(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(value)), value.Length));
             return FormatStringValue(chars, highlightedIndex);
         }
 

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.g.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.g.cs
@@ -101,7 +101,7 @@ partial class BloomFilterXXHash128 : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash128 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -109,7 +109,7 @@ partial class BloomFilterXXHash128 : IBloomFilter
     private static Hash128 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -145,7 +145,7 @@ partial class BloomFilterXXHash64 : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash64 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -153,7 +153,7 @@ partial class BloomFilterXXHash64 : IBloomFilter
     private static Hash64 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -189,7 +189,7 @@ partial class BloomFilterXXHash32 : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash32 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -197,7 +197,7 @@ partial class BloomFilterXXHash32 : IBloomFilter
     private static Hash32 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -233,7 +233,7 @@ partial class BloomFilterXXHash3 : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash64 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -241,7 +241,7 @@ partial class BloomFilterXXHash3 : IBloomFilter
     private static Hash64 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -275,7 +275,7 @@ partial class BloomFilterCrc64 : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash64 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -283,7 +283,7 @@ partial class BloomFilterCrc64 : IBloomFilter
     private static Hash64 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -317,7 +317,7 @@ partial class BloomFilterCrc32 : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash32 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -325,7 +325,7 @@ partial class BloomFilterCrc32 : IBloomFilter
     private static Hash32 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -359,7 +359,7 @@ partial class CountingBloomFilterXXHash128 : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash128 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -367,7 +367,7 @@ partial class CountingBloomFilterXXHash128 : ICountingBloomFilter
     private static Hash128 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -423,7 +423,7 @@ partial class CountingBloomFilterXXHash64 : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash64 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -431,7 +431,7 @@ partial class CountingBloomFilterXXHash64 : ICountingBloomFilter
     private static Hash64 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -487,7 +487,7 @@ partial class CountingBloomFilterXXHash32 : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash32 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -495,7 +495,7 @@ partial class CountingBloomFilterXXHash32 : ICountingBloomFilter
     private static Hash32 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -551,7 +551,7 @@ partial class CountingBloomFilterXXHash3 : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash64 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -559,7 +559,7 @@ partial class CountingBloomFilterXXHash3 : ICountingBloomFilter
     private static Hash64 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -611,7 +611,7 @@ partial class CountingBloomFilterCrc64 : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash64 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -619,7 +619,7 @@ partial class CountingBloomFilterCrc64 : ICountingBloomFilter
     private static Hash64 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -671,7 +671,7 @@ partial class CountingBloomFilterCrc32 : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash32 Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -679,7 +679,7 @@ partial class CountingBloomFilterCrc32 : ICountingBloomFilter
     private static Hash32 Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.tt
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.tt
@@ -77,7 +77,7 @@ partial class BloomFilter<#= algorithm.Name #> : IBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash<#= algorithm.HashSize #> Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -85,7 +85,7 @@ partial class BloomFilter<#= algorithm.Name #> : IBloomFilter
     private static Hash<#= algorithm.HashSize #> Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 
@@ -110,7 +110,7 @@ partial class CountingBloomFilter<#= algorithm.Name #> : ICountingBloomFilter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Hash<#= algorithm.HashSize #> Hash<T>(in T value) where T : unmanaged
     {
-        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        var bytes = unsafe(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1)));
         return Hash(bytes);
     }
 
@@ -118,7 +118,7 @@ partial class CountingBloomFilter<#= algorithm.Name #> : ICountingBloomFilter
     private static Hash<#= algorithm.HashSize #> Hash(string value)
     {
         var chars = value.AsSpan();
-        var bytes = MemoryMarshal.AsBytes(chars);
+        var bytes = unsafe(MemoryMarshal.AsBytes(chars));
         return Hash(bytes);
     }
 

--- a/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash128.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash128.cs
@@ -17,7 +17,7 @@ public sealed partial class BloomFilterXXHash128 : BloomFilter
 
     private void AddRangeCore(ReadOnlySpan<long> values)
     {
-        AddRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+        AddRangeCore(unsafe(MemoryMarshal.Cast<long, ulong>(values)));
     }
 
     private void AddRangeCore(ReadOnlySpan<ulong> values)
@@ -32,13 +32,13 @@ public sealed partial class BloomFilterXXHash128 : BloomFilter
             return;
         }
 
-        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         if (AdvSimd.Arm64.IsSupported)
         {
             while (index <= values.Length - Vector128<ulong>.Count)
             {
-                var current = Vector128.LoadUnsafe(ref valuesReference, (nuint)index);
+                var current = unsafe(Vector128.LoadUnsafe(ref valuesReference, (nuint)index));
                 Multiply64To128(current ^ Vector128.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;
@@ -62,7 +62,7 @@ public sealed partial class BloomFilterXXHash128 : BloomFilter
         {
             while (index <= values.Length - Vector256<ulong>.Count)
             {
-                var current = Vector256.LoadUnsafe(ref valuesReference, (nuint)index);
+                var current = unsafe(Vector256.LoadUnsafe(ref valuesReference, (nuint)index));
                 Multiply64To128(current ^ Vector256.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;

--- a/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash32.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash32.cs
@@ -14,7 +14,7 @@ public sealed partial class BloomFilterXXHash32 : BloomFilter
 
     private void AddRangeCore(ReadOnlySpan<int> values)
     {
-        AddRangeCore(MemoryMarshal.Cast<int, uint>(values));
+        AddRangeCore(unsafe(MemoryMarshal.Cast<int, uint>(values)));
     }
 
     private void AddRangeCore(ReadOnlySpan<uint> values)
@@ -29,7 +29,7 @@ public sealed partial class BloomFilterXXHash32 : BloomFilter
             return;
         }
 
-        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var hash = new Vector<uint>(Prime5 + sizeof(uint));
         var prime2 = new Vector<uint>(Prime2);
@@ -37,7 +37,7 @@ public sealed partial class BloomFilterXXHash32 : BloomFilter
         var prime4 = new Vector<uint>(Prime4);
         while (index <= values.Length - Vector<uint>.Count)
         {
-            var current = Vector.LoadUnsafe(ref valuesReference, (nuint)index);
+            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
             var hashes = hash + (current * prime3);
             hashes = RotateLeft(hashes, 17) * prime4;
             hashes ^= hashes >> 15;

--- a/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash64.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash64.cs
@@ -15,7 +15,7 @@ public sealed partial class BloomFilterXXHash64 : BloomFilter
 
     private void AddRangeCore(ReadOnlySpan<long> values)
     {
-        AddRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+        AddRangeCore(unsafe(MemoryMarshal.Cast<long, ulong>(values)));
     }
 
     private void AddRangeCore(ReadOnlySpan<ulong> values)
@@ -30,7 +30,7 @@ public sealed partial class BloomFilterXXHash64 : BloomFilter
             return;
         }
 
-        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var prime1 = new Vector<ulong>(Prime1);
         var prime2 = new Vector<ulong>(Prime2);
@@ -39,7 +39,7 @@ public sealed partial class BloomFilterXXHash64 : BloomFilter
         var hash = new Vector<ulong>(Prime5 + sizeof(ulong));
         while (index <= values.Length - Vector<ulong>.Count)
         {
-            var current = Vector.LoadUnsafe(ref valuesReference, (nuint)index);
+            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
             var round = RotateLeft(current * prime2, 31) * prime1;
             var hashes = RotateLeft(hash ^ round, 27) * prime1 + prime4;
             hashes ^= hashes >> 33;

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash128.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash128.cs
@@ -17,12 +17,12 @@ public sealed partial class CountingBloomFilterXXHash128 : CountingBloomFilter
 
     private void AddRangeCore(ReadOnlySpan<long> values)
     {
-        AddRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+        AddRangeCore(unsafe(MemoryMarshal.Cast<long, ulong>(values)));
     }
 
     private void RemoveRangeCore(ReadOnlySpan<long> values)
     {
-        RemoveRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+        RemoveRangeCore(unsafe(MemoryMarshal.Cast<long, ulong>(values)));
     }
 
     private void AddRangeCore(ReadOnlySpan<ulong> values)
@@ -47,13 +47,13 @@ public sealed partial class CountingBloomFilterXXHash128 : CountingBloomFilter
             return;
         }
 
-        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         if (AdvSimd.Arm64.IsSupported)
         {
             while (index <= values.Length - Vector128<ulong>.Count)
             {
-                var current = Vector128.LoadUnsafe(ref valuesReference, (nuint)index);
+                var current = unsafe(Vector128.LoadUnsafe(ref valuesReference, (nuint)index));
                 Multiply64To128(current ^ Vector128.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;
@@ -77,7 +77,7 @@ public sealed partial class CountingBloomFilterXXHash128 : CountingBloomFilter
         {
             while (index <= values.Length - Vector256<ulong>.Count)
             {
-                var current = Vector256.LoadUnsafe(ref valuesReference, (nuint)index);
+                var current = unsafe(Vector256.LoadUnsafe(ref valuesReference, (nuint)index));
                 Multiply64To128(current ^ Vector256.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash32.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash32.cs
@@ -14,12 +14,12 @@ public sealed partial class CountingBloomFilterXXHash32 : CountingBloomFilter
 
     private void AddRangeCore(ReadOnlySpan<int> values)
     {
-        AddRangeCore(MemoryMarshal.Cast<int, uint>(values));
+        AddRangeCore(unsafe(MemoryMarshal.Cast<int, uint>(values)));
     }
 
     private void RemoveRangeCore(ReadOnlySpan<int> values)
     {
-        RemoveRangeCore(MemoryMarshal.Cast<int, uint>(values));
+        RemoveRangeCore(unsafe(MemoryMarshal.Cast<int, uint>(values)));
     }
 
     private void AddRangeCore(ReadOnlySpan<uint> values)
@@ -44,7 +44,7 @@ public sealed partial class CountingBloomFilterXXHash32 : CountingBloomFilter
             return;
         }
 
-        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var hash = new Vector<uint>(Prime5 + sizeof(uint));
         var prime2 = new Vector<uint>(Prime2);
@@ -52,7 +52,7 @@ public sealed partial class CountingBloomFilterXXHash32 : CountingBloomFilter
         var prime4 = new Vector<uint>(Prime4);
         while (index <= values.Length - Vector<uint>.Count)
         {
-            var current = Vector.LoadUnsafe(ref valuesReference, (nuint)index);
+            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
             var hashes = hash + (current * prime3);
             hashes = RotateLeft(hashes, 17) * prime4;
             hashes ^= hashes >> 15;

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash64.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash64.cs
@@ -15,12 +15,12 @@ public sealed partial class CountingBloomFilterXXHash64 : CountingBloomFilter
 
     private void AddRangeCore(ReadOnlySpan<long> values)
     {
-        AddRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+        AddRangeCore(unsafe(MemoryMarshal.Cast<long, ulong>(values)));
     }
 
     private void RemoveRangeCore(ReadOnlySpan<long> values)
     {
-        RemoveRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+        RemoveRangeCore(unsafe(MemoryMarshal.Cast<long, ulong>(values)));
     }
 
     private void AddRangeCore(ReadOnlySpan<ulong> values)
@@ -45,7 +45,7 @@ public sealed partial class CountingBloomFilterXXHash64 : CountingBloomFilter
             return;
         }
 
-        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var prime1 = new Vector<ulong>(Prime1);
         var prime2 = new Vector<ulong>(Prime2);
@@ -54,7 +54,7 @@ public sealed partial class CountingBloomFilterXXHash64 : CountingBloomFilter
         var hash = new Vector<ulong>(Prime5 + sizeof(ulong));
         while (index <= values.Length - Vector<ulong>.Count)
         {
-            var current = Vector.LoadUnsafe(ref valuesReference, (nuint)index);
+            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
             var round = RotateLeft(current * prime2, 31) * prime1;
             var hashes = RotateLeft(hash ^ round, 27) * prime1 + prime4;
             hashes ^= hashes >> 33;

--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -62,8 +62,8 @@ internal sealed class SegmentedBitStorage
 
         var wordIndex = bitIndex >> 6;
         var segment = _segments[(int)(wordIndex >> SegmentShift)];
-        ref var baseRef = ref MemoryMarshal.GetArrayDataReference(segment);
-        ref var wordRef = ref Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask));
+        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
+        ref var wordRef = ref unsafe(Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask)));
         Interlocked.Or(ref wordRef, 1UL << (int)bitIndex);
     }
 
@@ -74,8 +74,8 @@ internal sealed class SegmentedBitStorage
 
         var wordIndex = bitIndex >> 6;
         var segment = _segments[(int)(wordIndex >> SegmentShift)];
-        ref var baseRef = ref MemoryMarshal.GetArrayDataReference(segment);
-        ref var wordRef = ref Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask));
+        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
+        ref var wordRef = ref unsafe(Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask)));
         return (Volatile.Read(ref wordRef) & (1UL << (int)bitIndex)) != 0;
     }
 

--- a/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
@@ -72,8 +72,8 @@ internal sealed class SegmentedCounterStorage
         ValidateCounterIndex(counterIndex);
 
         var segment = _segments[(int)(counterIndex >> SegmentShift)];
-        ref var baseRef = ref MemoryMarshal.GetArrayDataReference(segment);
-        return ref Unsafe.Add(ref baseRef, (nint)(counterIndex & SegmentMask));
+        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
+        return ref unsafe(Unsafe.Add(ref baseRef, (nint)(counterIndex & SegmentMask)));
     }
 
     [Conditional("DEBUG")]

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -20,6 +20,8 @@ internal static class Program
     private static readonly JsonSerializerOptions ListJsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        RespectNullableAnnotations = true,
+        RespectRequiredConstructorParameters = true,
         WriteIndented = true,
     };
 

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -93,7 +93,8 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
                     ContainingTypeDeclarations: GetContainingTypeDeclarations(targetTypeSymbol),
                     Length: length,
                     ImplementsIFixedStringGeneric: fixedStringInterface is not null,
-                    ImplementsIFixedStringNonGeneric: fixedStringNonGenericInterface is not null);
+                    ImplementsIFixedStringNonGeneric: fixedStringNonGenericInterface is not null,
+                    UsesUpdatedMemorySafetyRules: declaration.SyntaxTree.Options.Features.ContainsKey("updated-memory-safety-rules"));
             }
         }
 
@@ -471,8 +472,13 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
 
         // Unlike AsSpan, this one has to launder the ref: the explicit IFixedString.GetUnsafeFullSpan
         // implementation returns it, and an interface member cannot be [UnscopedRef]. That is the escape hatch
-        // IFixedString.GetUnsafeFullSpan is documented to be.
-        AppendLine("private Span<char> AsUnsafeFullSpan() => MemoryMarshal.CreateSpan(ref Unsafe.As<Storage, char>(ref Unsafe.AsRef(in _storage)), MaxLength);");
+        // IFixedString.GetUnsafeFullSpan is documented to be. Under the updated memory safety rules, the Unsafe and
+        // MemoryMarshal methods doing so require an unsafe context. The unsafe expression does not exist in older
+        // language versions, so it is only emitted when the compilation opted into the rules.
+        const string FullSpanExpression = "MemoryMarshal.CreateSpan(ref Unsafe.As<Storage, char>(ref Unsafe.AsRef(in _storage)), MaxLength)";
+        AppendLine(target.UsesUpdatedMemorySafetyRules
+            ? $"private Span<char> AsUnsafeFullSpan() => unsafe({FullSpanExpression});"
+            : $"private Span<char> AsUnsafeFullSpan() => {FullSpanExpression};");
         AppendLine();
         AppendLine("private Span<char> AsRemainingSpan() => AsUnsafeFullSpan().Slice(_length);");
         AppendLine();
@@ -625,5 +631,6 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         string ContainingTypeDeclarations,
         int Length,
         bool ImplementsIFixedStringGeneric,
-        bool ImplementsIFixedStringNonGeneric);
+        bool ImplementsIFixedStringNonGeneric,
+        bool UsesUpdatedMemorySafetyRules);
 }

--- a/src/Meziantou.Framework.Html/HtmlDocument.cs
+++ b/src/Meziantou.Framework.Html/HtmlDocument.cs
@@ -956,7 +956,7 @@ sealed class HtmlDocument : HtmlNode
                     {
                         element = current as HtmlElement;
                         var currentAttributeValue = currentAtt.Value;
-                        if (element is not null && currentAttributeValue is not null && !Options.EmptyNamespaces.Contains(currentAttributeValue, StringComparer.Ordinal))
+                        if (element is not null && currentAttributeValue is not null && !Options.EmptyNamespaces.Contains(currentAttributeValue))
                         {
                             element.NamespaceURI = currentAttributeValue;
                         }

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -267,7 +267,7 @@ public sealed class HtpasswdFile
     /// a length difference is still observable.
     /// </remarks>
     private static bool FixedTimeEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
-        => CryptographicOperations.FixedTimeEquals(MemoryMarshal.AsBytes(left), MemoryMarshal.AsBytes(right));
+        => CryptographicOperations.FixedTimeEquals(unsafe(MemoryMarshal.AsBytes(left)), unsafe(MemoryMarshal.AsBytes(right)));
 
     private static bool VerifyMd5Crypt(ReadOnlySpan<char> password, ReadOnlySpan<char> expectedHash, string prefix)
     {

--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/JsonElementConverter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/JsonElementConverter.cs
@@ -7,6 +7,8 @@ internal sealed class JsonElementConverter : HumanReadableConverter<JsonElement>
 {
     internal static readonly JsonSerializerOptions IndentedOptions = new()
     {
+        RespectNullableAnnotations = false,
+        RespectRequiredConstructorParameters = false,
         WriteIndented = true,
     };
 

--- a/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/JsonFormatter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/JsonFormatter.cs
@@ -9,12 +9,16 @@ public sealed class JsonFormatter : ValueFormatter
 {
     private static readonly JsonSerializerOptions NonIndentedOptions = new()
     {
+        RespectNullableAnnotations = false,
+        RespectRequiredConstructorParameters = false,
         WriteIndented = false,
         Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
     private static readonly JsonSerializerOptions IndentedOptions = new()
     {
+        RespectNullableAnnotations = false,
+        RespectRequiredConstructorParameters = false,
         WriteIndented = true,
         Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Serialization/JsonSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Serialization/JsonSnapshotSerializer.cs
@@ -7,6 +7,10 @@ public sealed class JsonSnapshotSerializer : SnapshotSerializer
 {
     private static readonly JsonSerializerOptions DefaultOptions = new()
     {
+        // A snapshot must show the actual value, including a null that the nullable annotations rule out, and must
+        // not depend on the RespectNullableAnnotations switch of the test application.
+        RespectNullableAnnotations = false,
+        RespectRequiredConstructorParameters = false,
         WriteIndented = true,
         Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };

--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/Program.cs
@@ -116,6 +116,8 @@ internal static partial class Program
             var jsonOptions = new JsonSerializerOptions
             {
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                RespectNullableAnnotations = true,
+                RespectRequiredConstructorParameters = true,
                 TypeInfoResolver = ResultContext.Default,
                 WriteIndented = true,
             };

--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -409,7 +409,8 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     {
         EnsureOpen();
         ThrowIfLongerThanAnArray();
-        var result = GC.AllocateUninitializedArray<byte>((int)_length);
+        // CopyAllTo overwrites every byte of the array.
+        var result = unsafe(GC.AllocateUninitializedArray<byte>((int)_length));
         CopyAllTo(result);
         return result;
     }

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSharpSnapshotComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSharpSnapshotComparer.cs
@@ -47,8 +47,9 @@ internal sealed class ImageSharpSnapshotComparer(ImageComparisonSettings? settin
         {
             for (var y = 0; y < expectedAccessor.Height && equal; y++)
             {
-                var expectedRow = MemoryMarshal.AsBytes(expectedAccessor.GetRowSpan(y));
-                var actualRow = MemoryMarshal.AsBytes(actualAccessor.GetRowSpan(y));
+                // Rgba32 is four bytes without padding, so its byte and uint views are exact.
+                var expectedRow = unsafe(MemoryMarshal.AsBytes(expectedAccessor.GetRowSpan(y)));
+                var actualRow = unsafe(MemoryMarshal.AsBytes(actualAccessor.GetRowSpan(y)));
                 if (!expectedRow.SequenceEqual(actualRow))
                     equal = false;
             }
@@ -68,8 +69,8 @@ internal sealed class ImageSharpSnapshotComparer(ImageComparisonSettings? settin
             for (var y = 0; y < expectedAccessor.Height; y++)
             {
                 accumulator.Add(
-                    MemoryMarshal.Cast<Rgba32, uint>(expectedAccessor.GetRowSpan(y)),
-                    MemoryMarshal.Cast<Rgba32, uint>(actualAccessor.GetRowSpan(y)));
+                    unsafe(MemoryMarshal.Cast<Rgba32, uint>(expectedAccessor.GetRowSpan(y))),
+                    unsafe(MemoryMarshal.Cast<Rgba32, uint>(actualAccessor.GetRowSpan(y))));
             }
         });
 

--- a/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/SkiaSharpSnapshotComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/SkiaSharpSnapshotComparer.cs
@@ -21,8 +21,8 @@ internal sealed class SkiaSharpSnapshotComparer(ImageComparisonSettings? setting
         if (expectedImage.Width != actualImage.Width || expectedImage.Height != actualImage.Height)
             return false;
 
-        var expectedPixels = MemoryMarshal.Cast<byte, uint>(expectedImage.GetPixelSpan());
-        var actualPixels = MemoryMarshal.Cast<byte, uint>(actualImage.GetPixelSpan());
+        var expectedPixels = unsafe(MemoryMarshal.Cast<byte, uint>(expectedImage.GetPixelSpan()));
+        var actualPixels = unsafe(MemoryMarshal.Cast<byte, uint>(actualImage.GetPixelSpan()));
 
         var threshold = settings?.SimilarityThreshold;
         if (threshold is null)

--- a/src/Meziantou.Framework.SnapshotTesting/Images/SsimAccumulator.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/SsimAccumulator.cs
@@ -74,8 +74,9 @@ internal struct SsimAccumulator
         double sumActualSquared0 = 0, sumActualSquared1 = 0, sumActualSquared2 = 0;
         double sumCross0 = 0, sumCross1 = 0, sumCross2 = 0;
 
-        ref var expectedRef = ref MemoryMarshal.GetReference(expectedPixels);
-        ref var actualRef = ref MemoryMarshal.GetReference(actualPixels);
+        // The caller slices both spans to the same length, and every vector load below stays within pixelCount.
+        ref var expectedRef = ref unsafe(MemoryMarshal.GetReference(expectedPixels));
+        ref var actualRef = ref unsafe(MemoryMarshal.GetReference(actualPixels));
         var i = 0;
 
         // Vector512 path (AVX-512): 16 pixels per iteration
@@ -90,8 +91,8 @@ internal struct SsimAccumulator
 
             for (; i <= pixelCount - Vector512<uint>.Count; i += Vector512<uint>.Count)
             {
-                var expectedPixel = Vector512.LoadUnsafe(ref expectedRef, (nuint)i);
-                var actualPixel = Vector512.LoadUnsafe(ref actualRef, (nuint)i);
+                var expectedPixel = unsafe(Vector512.LoadUnsafe(ref expectedRef, (nuint)i));
+                var actualPixel = unsafe(Vector512.LoadUnsafe(ref actualRef, (nuint)i));
                 var expected0 = Vector512.ConvertToSingle((expectedPixel & mask).AsInt32());
                 var expected1 = Vector512.ConvertToSingle((Vector512.ShiftRightLogical(expectedPixel, 8) & mask).AsInt32());
                 var expected2 = Vector512.ConvertToSingle((Vector512.ShiftRightLogical(expectedPixel, 16) & mask).AsInt32());
@@ -124,8 +125,8 @@ internal struct SsimAccumulator
 
             for (; i <= pixelCount - Vector256<uint>.Count; i += Vector256<uint>.Count)
             {
-                var expectedPixel = Vector256.LoadUnsafe(ref expectedRef, (nuint)i);
-                var actualPixel = Vector256.LoadUnsafe(ref actualRef, (nuint)i);
+                var expectedPixel = unsafe(Vector256.LoadUnsafe(ref expectedRef, (nuint)i));
+                var actualPixel = unsafe(Vector256.LoadUnsafe(ref actualRef, (nuint)i));
                 var expected0 = Vector256.ConvertToSingle((expectedPixel & mask).AsInt32());
                 var expected1 = Vector256.ConvertToSingle((Vector256.ShiftRightLogical(expectedPixel, 8) & mask).AsInt32());
                 var expected2 = Vector256.ConvertToSingle((Vector256.ShiftRightLogical(expectedPixel, 16) & mask).AsInt32());
@@ -158,8 +159,8 @@ internal struct SsimAccumulator
 
             for (; i <= pixelCount - Vector128<uint>.Count; i += Vector128<uint>.Count)
             {
-                var expectedPixel = Vector128.LoadUnsafe(ref expectedRef, (nuint)i);
-                var actualPixel = Vector128.LoadUnsafe(ref actualRef, (nuint)i);
+                var expectedPixel = unsafe(Vector128.LoadUnsafe(ref expectedRef, (nuint)i));
+                var actualPixel = unsafe(Vector128.LoadUnsafe(ref actualRef, (nuint)i));
                 var expected0 = Vector128.ConvertToSingle((expectedPixel & mask).AsInt32());
                 var expected1 = Vector128.ConvertToSingle((Vector128.ShiftRightLogical(expectedPixel, 8) & mask).AsInt32());
                 var expected2 = Vector128.ConvertToSingle((Vector128.ShiftRightLogical(expectedPixel, 16) & mask).AsInt32());

--- a/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.cs
+++ b/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.cs
@@ -123,7 +123,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
 
@@ -186,7 +186,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
         T2 result2;
@@ -207,7 +207,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask2, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result2);
+                result2 = default!;
             }
         }
 
@@ -270,7 +270,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
         T2 result2;
@@ -291,7 +291,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask2, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result2);
+                result2 = default!;
             }
         }
         T3 result3;
@@ -312,7 +312,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask3, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result3);
+                result3 = default!;
             }
         }
 
@@ -375,7 +375,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
         T2 result2;
@@ -396,7 +396,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask2, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result2);
+                result2 = default!;
             }
         }
         T3 result3;
@@ -417,7 +417,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask3, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result3);
+                result3 = default!;
             }
         }
         T4 result4;
@@ -438,7 +438,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask4, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result4);
+                result4 = default!;
             }
         }
 
@@ -501,7 +501,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
         T2 result2;
@@ -522,7 +522,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask2, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result2);
+                result2 = default!;
             }
         }
         T3 result3;
@@ -543,7 +543,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask3, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result3);
+                result3 = default!;
             }
         }
         T4 result4;
@@ -564,7 +564,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask4, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result4);
+                result4 = default!;
             }
         }
         T5 result5;
@@ -585,7 +585,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask5, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result5);
+                result5 = default!;
             }
         }
 
@@ -648,7 +648,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
         T2 result2;
@@ -669,7 +669,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask2, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result2);
+                result2 = default!;
             }
         }
         T3 result3;
@@ -690,7 +690,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask3, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result3);
+                result3 = default!;
             }
         }
         T4 result4;
@@ -711,7 +711,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask4, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result4);
+                result4 = default!;
             }
         }
         T5 result5;
@@ -732,7 +732,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask5, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result5);
+                result5 = default!;
             }
         }
         T6 result6;
@@ -753,7 +753,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask6, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result6);
+                result6 = default!;
             }
         }
 
@@ -816,7 +816,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask1, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result1);
+                result1 = default!;
             }
         }
         T2 result2;
@@ -837,7 +837,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask2, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result2);
+                result2 = default!;
             }
         }
         T3 result3;
@@ -858,7 +858,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask3, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result3);
+                result3 = default!;
             }
         }
         T4 result4;
@@ -879,7 +879,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask4, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result4);
+                result4 = default!;
             }
         }
         T5 result5;
@@ -900,7 +900,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask5, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result5);
+                result5 = default!;
             }
         }
         T6 result6;
@@ -921,7 +921,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask6, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result6);
+                result6 = default!;
             }
         }
         T7 result7;
@@ -942,7 +942,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask7, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result7);
+                result7 = default!;
             }
         }
 

--- a/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.tt
+++ b/src/Meziantou.Framework.Threading/Threading/Tasks/TaskExtensions.WhenAll.tt
@@ -106,7 +106,7 @@ public static partial class TaskExtensions
             else
             {
                 Observe(observedTask<#=j#>, ref observedExceptions, ref observedCancellation);
-                Unsafe.SkipInit(out result<#=j#>);
+                result<#=j#> = default!;
             }
         }
 <# } #>

--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework;
 
@@ -102,7 +101,7 @@ ref partial struct ValueStringBuilder
     /// </summary>
     public ref char GetPinnableReference()
     {
-        return ref MemoryMarshal.GetReference(_chars);
+        return ref _chars.GetPinnableReference();
     }
 
     /// <summary>

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/UnsafeAccessorRegistry.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/UnsafeAccessorRegistry.cs
@@ -21,11 +21,18 @@ internal sealed class UnsafeAccessorRegistry
     private readonly Dictionary<string, string> _namesByKey = new(StringComparer.Ordinal);
     private readonly List<string> _declarations = [];
     private readonly Dictionary<string, GenericAccessorClass> _genericClassesByKey = new(StringComparer.Ordinal);
+    private readonly string _externModifiers;
 
     public UnsafeAccessorRegistry(Compilation compilation, INamedTypeSymbol contextSymbol)
     {
         _compilation = compilation;
         _contextSymbol = contextSymbol;
+
+        // Under the updated memory safety rules, an 'extern' member must be marked 'safe' or 'unsafe' (CS9389). The
+        // stubs are safe: their signatures mirror the target members, and the runtime throws a MissingMemberException
+        // rather than binding a mismatched signature. The 'safe' keyword does not exist in older language versions,
+        // so it is only emitted when the compilation opted into the rules.
+        _externModifiers = UsesUpdatedMemorySafetyRules(compilation) ? " safe extern " : " extern ";
     }
 
     public bool HasAccessors => _declarations.Count != 0 || _genericClassesByKey.Count != 0;
@@ -70,7 +77,7 @@ internal sealed class UnsafeAccessorRegistry
             name = CreateName(context, field.MetadataName);
             var builder = new StringBuilder();
             AppendAttribute(builder, context, "Field", field.MetadataName);
-            builder.Append(context.Indent).Append(context.Modifiers).Append(" extern ref ")
+            builder.Append(context.Indent).Append(context.Modifiers).Append(_externModifiers).Append("ref ")
                 .Append(context.TypeName(field, static f => f.Type))
                 .Append(' ').Append(name).Append('(');
             AppendReceiverParameter(builder, context, field);
@@ -95,7 +102,7 @@ internal sealed class UnsafeAccessorRegistry
             var parameters = constructor.OriginalDefinition.Parameters;
             var builder = new StringBuilder();
             AppendAttribute(builder, context, "Constructor", name: null);
-            builder.Append(context.Indent).Append(context.Modifiers).Append(" extern ").Append(context.ReceiverTypeName)
+            builder.Append(context.Indent).Append(context.Modifiers).Append(_externModifiers).Append(context.ReceiverTypeName)
                 .Append(' ').Append(name).Append('(');
             for (var i = 0; i < parameters.Length; i++)
             {
@@ -156,7 +163,7 @@ internal sealed class UnsafeAccessorRegistry
         name = CreateName(context, method.MetadataName);
         var builder = new StringBuilder();
         AppendAttribute(builder, context, "Method", method.MetadataName);
-        builder.Append(context.Indent).Append(context.Modifiers).Append(" extern ").Append(returnType).Append(' ').Append(name).Append('(');
+        builder.Append(context.Indent).Append(context.Modifiers).Append(_externModifiers).Append(returnType).Append(' ').Append(name).Append('(');
         var hasReceiver = AppendReceiverParameter(builder, context, method);
         for (var i = 0; i < parameters.Length; i++)
         {
@@ -211,6 +218,19 @@ internal sealed class UnsafeAccessorRegistry
 
         var self = member.ContainingType.IsValueType ? "ref " + receiver : receiver;
         return additionalArguments is null ? self : self + ", " + additionalArguments;
+    }
+
+    private static bool UsesUpdatedMemorySafetyRules(Compilation compilation)
+    {
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            if (syntaxTree.Options.Features.ContainsKey("updated-memory-safety-rules"))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private string CreateName(AccessorContext context, string hint)

--- a/src/Meziantou.Framework/Collections/AppendOnlyCollectionSegment.cs
+++ b/src/Meziantou.Framework/Collections/AppendOnlyCollectionSegment.cs
@@ -7,7 +7,8 @@ internal sealed class AppendOnlyCollectionSegment<T>
 
     public AppendOnlyCollectionSegment(int capacity, int startIndex)
     {
-        Items = GC.AllocateUninitializedArray<T>(capacity);
+        // Only the first Count items are ever read, and they are written before Count is incremented.
+        Items = unsafe(GC.AllocateUninitializedArray<T>(capacity));
         StartIndex = startIndex;
     }
 

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
@@ -489,7 +489,12 @@ public sealed partial class WriterTests
             .ToList();
     }
 
-    private sealed record CustomPayload(int Value);
+    // Not a positional record: the System.Text.Json source generator reaches an init accessor through an extern
+    // [UnsafeAccessor] method, which does not compile under the updated memory safety rules (dotnet/runtime#133592).
+    private sealed record CustomPayload(int Value)
+    {
+        public int Value { get; } = Value;
+    }
 
     private sealed class UnserializableArgument;
 

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -20,6 +20,8 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
 
         testOutputHelper.WriteLine(JsonSerializer.Serialize(snapshot, new JsonSerializerOptions
         {
+            RespectNullableAnnotations = true,
+            RespectRequiredConstructorParameters = true,
             WriteIndented = true,
             Converters =
             {
@@ -153,7 +155,7 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public unsafe void CountProcessorsWalksVariableSizedEntries()
+    public void CountProcessorsWalksVariableSizedEntries()
     {
         var buffer = new List<byte>();
         AddProcessorEntry(buffer, LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage, groupMask: 0b1111);
@@ -165,12 +167,15 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
         AddProcessorEntry(buffer, LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, groupMask: 0b1100);
 
         var bytes = buffer.ToArray();
-        fixed (byte* ptr = bytes)
+        unsafe
         {
-            WindowsCpuInfoProvider.CountProcessors(ptr, (uint)bytes.Length, out var physicalProcessorCount, out var physicalCoreCount, out var logicalCoreCount);
-            Assert.Equal(1, physicalProcessorCount);
-            Assert.Equal(2, physicalCoreCount);
-            Assert.Equal(4, logicalCoreCount);
+            fixed (byte* ptr = bytes)
+            {
+                WindowsCpuInfoProvider.CountProcessors(ptr, (uint)bytes.Length, out var physicalProcessorCount, out var physicalCoreCount, out var logicalCoreCount);
+                Assert.Equal(1, physicalProcessorCount);
+                Assert.Equal(2, physicalCoreCount);
+                Assert.Equal(4, logicalCoreCount);
+            }
         }
 
         static void AddProcessorEntry(List<byte> buffer, LOGICAL_PROCESSOR_RELATIONSHIP relationship, nuint groupMask)
@@ -180,7 +185,7 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
             entry.Size = (uint)sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX);
             entry.Anonymous.Processor.GroupCount = 1;
             entry.Anonymous.Processor.GroupMask[0].Mask = groupMask;
-            buffer.AddRange(MemoryMarshal.AsBytes(new ReadOnlySpan<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(in entry)));
+            buffer.AddRange(unsafe(MemoryMarshal.AsBytes(new ReadOnlySpan<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(in entry))));
         }
 
         static void AddOpaqueEntry(List<byte> buffer, LOGICAL_PROCESSOR_RELATIONSHIP relationship, uint size)

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -452,18 +452,68 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.Equal("MFFSG0003", diagnostic.Id);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GeneratedCodeCompilesWithAndWithoutUpdatedMemorySafetyRules(bool updatedMemorySafetyRules)
+    {
+        const string Source = """
+            namespace Meziantou.Framework.FixedStringBuilder
+            {
+                public interface IFixedString
+                {
+                    global::System.Span<char> GetUnsafeFullSpan();
+                }
+
+                public interface IFixedString<T> : IFixedString where T : IFixedString<T>
+                {
+                    static abstract implicit operator T(string value);
+                }
+            }
+
+            [FixedStringBuilderAttribute(4)]
+            public partial struct FixedStringBuilder4
+            {
+            }
+            """;
+
+        var parseOptions = updatedMemorySafetyRules ? ParseOptions.WithFeatures([new("updated-memory-safety-rules", "true")]) : ParseOptions;
+
+        // The reference pack used by the other tests predates the annotations marking Unsafe and MemoryMarshal
+        // members as requiring an unsafe context. The assemblies of the running runtime have them from .NET 11.
+        var references = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static path => MetadataReference.CreateFromFile(path))
+            .ToArray();
+
+        var (runResult, compilation) = Generate(Source, parseOptions, references);
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        var diagnostics = string.Join('\n', emitResult.Diagnostics);
+        Assert.True(emitResult.Success, diagnostics);
+
+        var generatedCode = string.Join('\n', runResult.Results[0].GeneratedSources.Select(static source => source.SourceText.ToString()));
+        Assert.Equal(updatedMemorySafetyRules, generatedCode.Contains("AsUnsafeFullSpan() => unsafe(", StringComparison.Ordinal));
+    }
+
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "10.0.0", "ref/net10.0/");
         var references = netcoreRef.Select(static location => MetadataReference.CreateFromFile(location)).ToArray();
+        return Generate(source, ParseOptions, references);
+    }
+
+    private static (GeneratorDriverRunResult RunResult, Compilation Compilation) Generate(string source, CSharpParseOptions parseOptions, MetadataReference[] references)
+    {
         var compilation = CSharpCompilation.Create(
             "compilation",
-            [CSharpSyntaxTree.ParseText(source, ParseOptions)],
+            [CSharpSyntaxTree.ParseText(source, parseOptions)],
             references,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable, allowUnsafe: true));
 
         ISourceGenerator generator = new FixedStringBuilderSourceGenerator().AsSourceGenerator();
-        GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], parseOptions: ParseOptions);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], parseOptions: parseOptions);
         driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
 
         Assert.Empty(diagnostics);

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -375,7 +375,7 @@ public sealed class SensitiveDataTests
     public void SystemTestJsonDoesNotRevealValue_Field()
     {
         using var data = SensitiveData.Create("foo");
-        var text = JsonSerializer.Serialize(data, new JsonSerializerOptions { IncludeFields = true });
+        var text = JsonSerializer.Serialize(data, new JsonSerializerOptions { IncludeFields = true, RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true });
         Assert.DoesNotContain("foo", text, ignoreCase: true);
     }
 

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -402,7 +402,8 @@ public class ChangeJournalTests
 
     private static void WriteName(byte[] buffer, int offset, string name)
     {
-        MemoryMarshal.AsBytes(name.AsSpan()).CopyTo(buffer.AsSpan(offset));
+        var bytes = unsafe(MemoryMarshal.AsBytes(name.AsSpan()));
+        bytes.CopyTo(buffer.AsSpan(offset));
     }
 
     // The change journal aligns records on 8 byte boundaries.
@@ -410,16 +411,19 @@ public class ChangeJournalTests
 
     private static ChangeJournalEntry ParseRecord(byte[] buffer)
     {
-        var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-        try
+        unsafe
         {
-            var pointer = handle.AddrOfPinnedObject();
-            var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>(pointer);
-            return ChangeJournalEntries.GetBufferedEntry(pointer, header);
-        }
-        finally
-        {
-            handle.Free();
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
+            {
+                var pointer = handle.AddrOfPinnedObject();
+                var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>(pointer);
+                return ChangeJournalEntries.GetBufferedEntry(pointer, header);
+            }
+            finally
+            {
+                handle.Free();
+            }
         }
     }
 }

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -209,18 +209,21 @@ public sealed class CredentialManagerTests
     [InlineData("john", "")]
     [InlineData("CONTOSO\\john", "Pa$$w0rd")]
     [SupportedOSPlatform("windows6.0.6000")]
-    public unsafe void CredentialManager_AuthenticationBuffer_RoundTrips(string user, string password)
+    public void CredentialManager_AuthenticationBuffer_RoundTrips(string user, string password)
     {
-        CredentialManager.GetInputBuffer(user, password, out var buffer, out var size);
-        Assert.NotEqual(IntPtr.Zero, (IntPtr)buffer);
+        unsafe
+        {
+            CredentialManager.GetInputBuffer(user, password, out var buffer, out var size);
+            Assert.NotEqual(IntPtr.Zero, (IntPtr)buffer);
 
-        // GetCredentialsFromOutputBuffer zeroes and frees the buffer it is given.
-        Assert.True(CredentialManager.GetCredentialsFromOutputBuffer(buffer, size, out var actualUser, out var actualPassword, out var actualDomain));
+            // GetCredentialsFromOutputBuffer zeroes and frees the buffer it is given.
+            Assert.True(CredentialManager.GetCredentialsFromOutputBuffer(buffer, size, out var actualUser, out var actualPassword, out var actualDomain));
 
-        var (expectedDomain, expectedUser) = user.Split('\\') is [var d, var u] ? (d, u) : ("", user);
-        Assert.Equal(expectedUser, actualUser);
-        Assert.Equal(expectedDomain, actualDomain);
-        Assert.Equal(password, actualPassword);
+            var (expectedDomain, expectedUser) = user.Split('\\') is [var d, var u] ? (d, u) : ("", user);
+            Assert.Equal(expectedUser, actualUser);
+            Assert.Equal(expectedDomain, actualDomain);
+            Assert.Equal(password, actualPassword);
+        }
     }
 
     // 1024 bytes, the size this used to hard-code, is not enough for a long user name plus a password.
@@ -228,31 +231,37 @@ public sealed class CredentialManagerTests
     [InlineData(400, 200)]
     [InlineData(513, 256)]
     [SupportedOSPlatform("windows6.0.6000")]
-    public unsafe void CredentialManager_AuthenticationBuffer_RoundTripsLongCredentials(int userLength, int passwordLength)
+    public void CredentialManager_AuthenticationBuffer_RoundTripsLongCredentials(int userLength, int passwordLength)
     {
-        var user = new string('u', userLength);
-        var password = new string('p', passwordLength);
+        unsafe
+        {
+            var user = new string('u', userLength);
+            var password = new string('p', passwordLength);
 
-        CredentialManager.GetInputBuffer(user, password, out var buffer, out var size);
-        Assert.NotEqual(IntPtr.Zero, (IntPtr)buffer);
-        Assert.True(size > 1024, $"expected the packed buffer to exceed 1024 bytes, was {size}");
+            CredentialManager.GetInputBuffer(user, password, out var buffer, out var size);
+            Assert.NotEqual(IntPtr.Zero, (IntPtr)buffer);
+            Assert.True(size > 1024, $"expected the packed buffer to exceed 1024 bytes, was {size}");
 
-        Assert.True(CredentialManager.GetCredentialsFromOutputBuffer(buffer, size, out var actualUser, out var actualPassword, out _));
-        Assert.Equal(user, actualUser);
-        Assert.Equal(password, actualPassword);
+            Assert.True(CredentialManager.GetCredentialsFromOutputBuffer(buffer, size, out var actualUser, out var actualPassword, out _));
+            Assert.Equal(user, actualUser);
+            Assert.Equal(password, actualPassword);
+        }
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
     [SupportedOSPlatform("windows6.0.6000")]
-    public unsafe void CredentialManager_GetInputBuffer_NoUserName_PacksNothing()
+    public void CredentialManager_GetInputBuffer_NoUserName_PacksNothing()
     {
-        CredentialManager.GetInputBuffer(user: null, password: "Pa$$w0rd", out var buffer, out var size);
-        Assert.Equal(IntPtr.Zero, (IntPtr)buffer);
-        Assert.Equal(0u, size);
+        unsafe
+        {
+            CredentialManager.GetInputBuffer(user: null, password: "Pa$$w0rd", out var buffer, out var size);
+            Assert.Equal(IntPtr.Zero, (IntPtr)buffer);
+            Assert.Equal(0u, size);
 
-        CredentialManager.GetInputBuffer(user: "", password: "Pa$$w0rd", out buffer, out size);
-        Assert.Equal(IntPtr.Zero, (IntPtr)buffer);
-        Assert.Equal(0u, size);
+            CredentialManager.GetInputBuffer(user: "", password: "Pa$$w0rd", out buffer, out size);
+            Assert.Equal(IntPtr.Zero, (IntPtr)buffer);
+            Assert.Equal(0u, size);
+        }
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
@@ -405,24 +414,27 @@ public sealed class CredentialManagerTests
     }
 
     /// <summary>Stores a credential whose blob is arbitrary bytes, the way another application could.</summary>
-    private static unsafe void WriteRawCredential(string targetName, string userName, byte[] blob)
+    private static void WriteRawCredential(string targetName, string userName, byte[] blob)
     {
-        fixed (byte* blobPtr = blob)
-        fixed (char* targetNamePtr = targetName)
-        fixed (char* userNamePtr = userName)
+        unsafe
         {
-            var credential = new CREDENTIALW
+            fixed (byte* blobPtr = blob)
+            fixed (char* targetNamePtr = targetName)
+            fixed (char* userNamePtr = userName)
             {
-                Type = CRED_TYPE.CRED_TYPE_GENERIC,
-                Persist = CRED_PERSIST.CRED_PERSIST_SESSION,
-                TargetName = targetNamePtr,
-                UserName = userNamePtr,
-                CredentialBlob = blobPtr,
-                CredentialBlobSize = (uint)blob.Length,
-            };
+                var credential = new CREDENTIALW
+                {
+                    Type = CRED_TYPE.CRED_TYPE_GENERIC,
+                    Persist = CRED_PERSIST.CRED_PERSIST_SESSION,
+                    TargetName = targetNamePtr,
+                    UserName = userNamePtr,
+                    CredentialBlob = blobPtr,
+                    CredentialBlobSize = (uint)blob.Length,
+                };
 
-            if (!PInvoke.CredWrite(in credential, Flags: 0))
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                if (!PInvoke.CredWrite(in credential, Flags: 0))
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
         }
     }
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -1216,6 +1216,63 @@ public class YamlSerializerContextGeneratorDiagnosticTests
         Assert.Contains("\"Cat\"", result.GeneratedSource);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GeneratedUnsafeAccessorsCompileWithAndWithoutUpdatedMemorySafetyRules(bool updatedMemorySafetyRules)
+    {
+        // The generated code relies on the implicit usings of the SDK
+        const string Source = """
+            global using System;
+            global using System.Collections.Generic;
+            global using System.IO;
+            global using System.Linq;
+            global using System.Threading;
+            global using System.Threading.Tasks;
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public sealed class RestrictedConfig
+            {
+                [YamlConstructor]
+                private RestrictedConfig(int retries) => Retries = retries;
+
+                [YamlInclude]
+                private string _name = string.Empty;
+
+                public int Retries { get; }
+
+                public string GetName() => _name;
+            }
+
+            public sealed class GenericConfig<T>
+                where T : notnull
+            {
+                [YamlInclude]
+                private string _name = string.Empty;
+
+                public string GetName() => _name;
+            }
+
+            [YamlSerializable(typeof(RestrictedConfig))]
+            [YamlSerializable(typeof(GenericConfig<int>))]
+            internal partial class RestrictedContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        if (updatedMemorySafetyRules)
+        {
+            parseOptions = parseOptions.WithFeatures([new("updated-memory-safety-rules", "true")]);
+        }
+
+        var result = RunGenerator(Source, parseOptions);
+
+        Assert.DoesNotContain(result.Diagnostics, static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("private static" + (updatedMemorySafetyRules ? " safe" : "") + " extern ", result.GeneratedSource);
+        Assert.Contains("public static" + (updatedMemorySafetyRules ? " safe" : "") + " extern ", result.GeneratedSource);
+    }
+
     private static Diagnostic[] RunAnalyzer([StringSyntax("c#-test")] string source)
     {
         var compilation = CreateCompilation(source);
@@ -1234,9 +1291,11 @@ public class YamlSerializerContextGeneratorDiagnosticTests
     }
 
     private static (Compilation OutputCompilation, Diagnostic[] GeneratorDiagnostics, Diagnostic[] Diagnostics, string GeneratedSource) RunGenerator([StringSyntax("c#-test")]string source, params MetadataReference[] additionalReferences)
+        => RunGenerator(source, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview), additionalReferences);
+
+    private static (Compilation OutputCompilation, Diagnostic[] GeneratorDiagnostics, Diagnostic[] Diagnostics, string GeneratedSource) RunGenerator([StringSyntax("c#-test")] string source, CSharpParseOptions parseOptions, params MetadataReference[] additionalReferences)
     {
-        var compilation = CreateCompilation(source, additionalReferences);
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var compilation = CreateCompilation(source, additionalReferences, parseOptions);
 
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             generators: new[] { new YamlSerializerContextGenerator().AsSourceGenerator() },
@@ -1253,9 +1312,9 @@ public class YamlSerializerContextGeneratorDiagnosticTests
         return (outputCompilation, generatorDiagnostics.ToArray(), generatorDiagnostics.Concat(outputCompilation.GetDiagnostics()).ToArray(), generatedSource);
     }
 
-    private static CSharpCompilation CreateCompilation([StringSyntax("c#-test")] string source, MetadataReference[]? additionalReferences = null)
+    private static CSharpCompilation CreateCompilation([StringSyntax("c#-test")] string source, MetadataReference[]? additionalReferences = null, CSharpParseOptions? parseOptions = null)
     {
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        parseOptions ??= CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
 
         return CSharpCompilation.Create(

--- a/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
@@ -279,6 +279,8 @@ static async Task<(List<Data> entries, string fileUrl, string commit, DateTimeOf
     {
         AllowTrailingCommas = true,
         ReadCommentHandling = JsonCommentHandling.Skip,
+        RespectNullableAnnotations = true,
+        RespectRequiredConstructorParameters = true,
     };
 
     using var getCommitsRequest = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/repos/chromium/chromium/commits?path=net/http/transport_security_state_static.json&per_page=1");


### PR DESCRIPTION
Unblocks #3031 (Meziantou.NET.Sdk 1.0.166 → 1.0.171), where every CI job fails to compile ([example job](https://github.com/meziantou/Meziantou.Framework/actions/runs/34618933594/job/103328078751?pr=3031)).

## Why

1.0.171 enables the `updated-memory-safety-rules` compiler feature for every project with `LangVersion=preview`, except those referencing CsWin32, and brings Meziantou.Analyzer 3.0.234. Under the new rules `Unsafe.*`, `MemoryMarshal.*`, `Vector*.LoadUnsafe` and `GC.AllocateUninitializedArray` require an unsafe context (CS9362), members with pointers from legacy-rules assemblies too (CS9363), and `extern` members must be marked `safe` or `unsafe` (CS9389).

Unlike #3101, this adopts the rules instead of opting out, which is what the CsWin32 carve-out in 1.0.171 is for.

## What

**Memory safety**
- Wrap each unsafe call in an `unsafe(...)` expression. The unsafe context stays inside the member, so no public API becomes caller-unsafe, and the `ref/` files do not change. `AllowUnsafeBlocks` is already on by default in the SDK.
- Where the unsafe API bought nothing, drop it: `Unsafe.SkipInit` in the ValueTask `WhenAll` helpers becomes `default!` (the state machine field is already zeroed), and `ValueStringBuilder.GetPinnableReference` uses `Span<T>.GetPinnableReference`, which also avoids an out-of-bounds ref for an empty initial buffer.
- **Source generators** shipped to users: the YAML generator marks its `[UnsafeAccessor]` stubs `safe`, and the FixedStringBuilder generator wraps its ref laundering in `unsafe(...)`. Both only do so when the compilation opted into the rules, since neither syntax exists in older language versions. Each has a new test that compiles the generated code with and without the feature; both fail when the generator change is reverted.
- Tests calling pointer-typed CsWin32 members use explicit `unsafe` blocks instead of `unsafe` methods, which no longer create an unsafe context under the new rules.
- A ChromiumTracing test record avoids an `init` accessor: the System.Text.Json source generator reaches it through an `extern` accessor that does not compile under the rules (dotnet/runtime#133592).

**Analyzers**
- MA0224/MA0225: pin `RespectNullableAnnotations`/`RespectRequiredConstructorParameters` on `JsonSerializerOptions`. Tools and tests use `true`, the value the SDK already sets through AppContext switches. `JsonSnapshotSerializer` and the HumanReadableSerializer options use `false`, so a snapshot shows a null the annotations rule out rather than throwing, independently of the test app's switches.
- MA0227: `HtmlOptions.EmptyNamespaces` is an ordinal `HashSet`, so use its own lookup.

## Validation

On this branch, with `global.json` temporarily at 1.0.171:
- Every project builds with `-p:TreatWarningsAsErrors=true`, in Debug and in Release with `IsOfficialBuild=true` and `PublicApiGeneratorVerifyNoChangeOnBuild=true`, except the three protoc projects (OpenTelemetryCollector, its InMemory package and their tests), which cannot build on the macOS machine used for this.
- Tests pass for all 21 affected test projects (0 failures). The Win32 CredentialManager/ChangeJournal tests are skipped on macOS, so Windows CI covers them.

With the current 1.0.166, the same build succeeds, and `dotnet run ./eng/update-all.cs` produces no changes. #3031 should go green once Renovate rebases it on top of this.
