### PR TITLE
Run tests on pull requests only and publish packages from a dedicated workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
-name: publish
+# Validates pull requests. Pushes to main only pack and publish the packages (publish.yml), as the
+# code was already validated by its pull request.
+name: ci
 on:
   workflow_dispatch:
     inputs:
@@ -7,22 +9,18 @@ on:
         type: boolean
         default: false
         required: false
-  push:
-    branches:
-      - 'main'
   pull_request:
     branches:
       - '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   NuGetDirectory: ${{ github.workspace}}/nuget
-  NuGetSource: "https://api.nuget.org/v3/index.json"
 
 defaults:
   run:
@@ -75,8 +73,7 @@ jobs:
         with:
           input-project: eng/packages.proj
           output-project: eng/packages.delta.proj
-          base-commit: ${{ case(github.event_name == 'push', github.event.before, '') }}
-          run-generate: ${{ case(github.event_name == 'pull_request' || github.event_name == 'push', 'true', 'false') }}
+          run-generate: ${{ case(github.event_name == 'pull_request', 'true', 'false') }}
           full-rebuild-triggers: |
             .github/workflows/ci.yml
             eng/**/*.proj
@@ -132,7 +129,7 @@ jobs:
         run: dotnet run ./eng/validate-nuget.cs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_VALIDATION_IS_DELTA: ${{ case((github.event_name == 'pull_request' || github.event_name == 'push') && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
+          NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'pull_request' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
 
   run_analyzers:
     runs-on: ubuntu-26.04
@@ -155,8 +152,7 @@ jobs:
           # They compile everywhere, and this is the only job that reports the IDExxxx
           # diagnostics for them.
           properties: SkipUnsupportedPlatforms=false
-          base-commit: ${{ case(github.event_name == 'push', github.event.before, '') }}
-          run-generate: ${{ case(github.event_name == 'pull_request' || github.event_name == 'push', 'true', 'false') }}
+          run-generate: ${{ case(github.event_name == 'pull_request', 'true', 'false') }}
           full-rebuild-triggers: |
             .github/workflows/ci.yml
             eng/**/*.proj
@@ -201,15 +197,10 @@ jobs:
 
       - name: Compute base commit
         id: base-commit
-        env:
-          BEFORE_COMMIT: ${{ github.event.before }}
         run: |
           if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
             # Let DeltaBuild compute the merge-base with the pull request base branch
             $baseCommit = ""
-          }
-          elseif ($env:GITHUB_EVENT_NAME -eq "push") {
-            $baseCommit = $env:BEFORE_COMMIT
           }
           else {
             # There is no base to compare with (workflow_dispatch), so use the empty tree:
@@ -549,113 +540,10 @@ jobs:
             test-result.coverage
             test-result.cobertura.xml
 
-  deploy:
-    # build_and_test is skipped when no test project is affected, which must not prevent the deployment
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
-    runs-on: ubuntu-26.04
-    needs: [ build_eng_scripts, validate_generated_files, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf ]
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - parallel:
-          - name: Setup .NET
-            uses: ./.github/actions/setup-dotnet
-          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-            with:
-              name: nuget
-              path: ${{ env.NuGetDirectory }}
-      - name: NuGet login (OIDC → temp API key)
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
-        id: login
-        with:
-          user: meziantou
-
-      - run: |
-          Write-Host "Current ref: $env:GITHUB_REF"
-          Write-Host "Searching nupkg in folder: ${{ env.NuGetDirectory }}"
-          $files = Get-ChildItem "${{ env.NuGetDirectory }}/*" -Include *.nupkg
-          if ($env:GITHUB_REF -eq 'refs/heads/main')
-          {
-            $apiKey = $env:NUGETAPIKEY
-            $source = "${{ env.NuGetSource }}"
-          }
-          else
-          {
-            $apiKey = $env:FEEDZ_APIKEY
-            $source = "https://f.feedz.io/meziantou/meziantou-framework/nuget/index.json"
-          }
-
-          if ($files.Count -eq 0) {
-            Write-Host "No NuGet package found to push."
-          }
-          else {
-            $maxAttempts = 3
-            $baseDelaySeconds = 2
-            $results = $files | ForEach-Object -Parallel {
-              $packagePath = $_.FullName
-              $apiKey = $using:apiKey
-              $source = $using:source
-              $maxAttempts = $using:maxAttempts
-              $baseDelaySeconds = $using:baseDelaySeconds
-
-              for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-                Write-Host "Pushing NuGet package: $packagePath (attempt $attempt/$maxAttempts)"
-                & dotnet nuget push "$packagePath" --api-key "$apiKey" --source "$source" --force-english-output --skip-duplicate
-                $exitCode = $LASTEXITCODE
-
-                if ($exitCode -eq 0) {
-                  return [pscustomobject]@{
-                    PackagePath = $packagePath
-                    Succeeded = $true
-                    Attempts = $attempt
-                  }
-                }
-
-                if ($attempt -lt $maxAttempts) {
-                  $delaySeconds = [int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1))
-                  Write-Host "Retrying NuGet push for $packagePath in $delaySeconds second(s)."
-                  Start-Sleep -Seconds $delaySeconds
-                }
-              }
-
-              return [pscustomobject]@{
-                PackagePath = $packagePath
-                Succeeded = $false
-                Attempts = $maxAttempts
-              }
-            } -ThrottleLimit 8
-
-            $pushResults = @(
-              $results
-              | Where-Object { $_.PSObject.Properties.Name -contains "Succeeded" }
-            )
-            $failedPackages = @($pushResults | Where-Object { -not $_.Succeeded })
-            $succeededPackages = @($pushResults | Where-Object { $_.Succeeded })
-            foreach ($item in $succeededPackages) {
-              Write-Host "Successfully pushed NuGet package: $($item.PackagePath) (attempts: $($item.Attempts))"
-            }
-
-            if ($failedPackages.Count -gt 0) {
-              foreach ($item in $failedPackages) {
-                Write-Host "::error::Failed to push NuGet package after retries: $($item.PackagePath)"
-              }
-
-              Write-Host "::error::Failed to push NuGet packages after retries: $($failedPackages.PackagePath -join ', ')"
-              throw "Failed to push NuGet packages after retries: $($failedPackages.PackagePath -join ', ')"
-            }
-          }
-        name: Publish NuGet packages
-        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-        env:
-          NUGETAPIKEY: ${{steps.login.outputs.NUGET_API_KEY}}
-          FEEDZ_APIKEY: ${{ secrets.FEEDZ_APIKEY }}
-
   final_status_check:
     runs-on: ubuntu-slim
     if: always()
-    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
+    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf, merge_coverage ]
     steps:
       - name: Check previous jobs status
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# Validates pull requests. Pushes to main only pack and publish the packages (publish.yml), as the
-# code was already validated by its pull request.
+# Validates pull requests: generated files, analyzers, tests and trimming. The NuGet packages are
+# built by publish.yml, which runs on pull requests too and publishes them on main.
 name: ci
 on:
   workflow_dispatch:
@@ -20,7 +20,6 @@ concurrency:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  NuGetDirectory: ${{ github.workspace}}/nuget
 
 defaults:
   run:
@@ -51,85 +50,6 @@ jobs:
         uses: ./.github/actions/setup-dotnet
       - name: Validate generated files and test project TFMs
         run: dotnet run ./eng/update-all.cs
-
-  create_nuget:
-    runs-on: ubuntu-26.04
-    timeout-minutes: 20
-    outputs:
-      has-project: ${{ steps.package-project.outputs.has-project }}
-    env:
-      # Analyzers run in the run_analyzers job
-      RunAnalyzers: false
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      - run: git config --global protocol.file.allow always
-      - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
-      - name: Generate delta build file
-        id: package-project
-        uses: ./.github/actions/deltabuild
-        with:
-          input-project: eng/packages.proj
-          output-project: eng/packages.delta.proj
-          run-generate: ${{ case(github.event_name == 'pull_request', 'true', 'false') }}
-          full-rebuild-triggers: |
-            .github/workflows/ci.yml
-            eng/**/*.proj
-
-      - run: dotnet restore ${{ steps.package-project.outputs.project }} -p:Configuration=Release /p:IsOfficialBuild=true /bl:restore.binlog
-        if: steps.package-project.outputs.has-project == 'true'
-      - run: dotnet build src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj --configuration Release /p:IsOfficialBuild=true /bl:build.publicapi.binlog
-        if: steps.package-project.outputs.has-project == 'true'
-      - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release --no-restore /p:IsOfficialBuild=true /p:PublicApiGeneratorVerifyNoChangeOnBuild=true /bl:build.binlog
-        if: steps.package-project.outputs.has-project == 'true'
-
-      - name: Prepare NuGet artifact directory
-        run: |
-          New-Item -ItemType Directory -Path "${{ env.NuGetDirectory }}" -Force | Out-Null
-          Set-Content -Path "${{ env.NuGetDirectory }}/artifact-placeholder.txt" -Value "placeholder"
-      - run: dotnet pack ${{ steps.package-project.outputs.project }} --configuration Release --no-build /p:IsOfficialBuild=true --output ${{ env.NuGetDirectory }} /p:RepositoryBranch="${{github.ref}}" "/p:PromptFolder=${{runner.temp}}/prompt" /bl:pack.binlog
-        if: steps.package-project.outputs.has-project == 'true'
-
-      - name: Skip packaging
-        if: steps.package-project.outputs.has-project != 'true'
-        run: Write-Host "No package project was impacted. Skipping build and pack."
-      - parallel:
-          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-            if: always()
-            with:
-              name: nuget
-              if-no-files-found: error
-              retention-days: 3
-              path: ${{ env.NuGetDirectory }}/**/*
-          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-            if: always()
-            with:
-              name: binlog
-              if-no-files-found: ${{ case(steps.package-project.outputs.has-project == 'true', 'error', 'warn') }}
-              retention-days: 3
-              path: '**/*.binlog'
-
-  validate_nuget:
-    runs-on: ubuntu-26.04
-    needs: [ create_nuget ]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - parallel:
-          - name: Setup .NET
-            uses: ./.github/actions/setup-dotnet
-          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-            if: needs.create_nuget.outputs.has-project == 'true'
-            with:
-              name: nuget
-              path: ${{ env.NuGetDirectory }}
-      - name: Validate NuGet packages
-        if: needs.create_nuget.outputs.has-project == 'true'
-        run: dotnet run ./eng/validate-nuget.cs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'pull_request' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
 
   run_analyzers:
     runs-on: ubuntu-26.04
@@ -543,7 +463,7 @@ jobs:
   final_status_check:
     runs-on: ubuntu-slim
     if: always()
-    needs: [ build_eng_scripts, validate_generated_files, create_nuget, validate_nuget, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf, merge_coverage ]
+    needs: [ build_eng_scripts, validate_generated_files, run_analyzers, compute_test_matrix, build_and_test, test_trimming, test_trimming_wpf, merge_coverage ]
     steps:
       - name: Check previous jobs status
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,19 @@
+# Builds and validates the NuGet packages on pull requests, and publishes them on main.
 name: publish
 on:
   workflow_dispatch:
   push:
     branches:
       - 'main'
+  pull_request:
+    branches:
+      - '*'
 
-# No concurrency group: each run only packs the packages changed since the previous push, so a
-# cancelled or replaced run would never publish its packages.
+concurrency:
+  # A run on main gets a group of its own: it only packs the packages changed since the previous
+  # push, so a cancelled or replaced run would never publish them.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -25,7 +32,7 @@ jobs:
     outputs:
       has-project: ${{ steps.package-project.outputs.has-project }}
     env:
-      # Analyzers already ran on the pull request
+      # Analyzers run in the run_analyzers job of ci.yml
       RunAnalyzers: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -41,7 +48,7 @@ jobs:
           output-project: eng/packages.delta.proj
           base-commit: ${{ case(github.event_name == 'push', github.event.before, '') }}
           # A manual run packs every package, so it can recover from a partial publish
-          run-generate: ${{ case(github.event_name == 'push', 'true', 'false') }}
+          run-generate: ${{ case(github.event_name == 'pull_request' || github.event_name == 'push', 'true', 'false') }}
           full-rebuild-triggers: |
             .github/workflows/publish.yml
             eng/**/*.proj
@@ -57,7 +64,7 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path $env:NuGetDirectory -Force | Out-Null
           Set-Content -Path (Join-Path $env:NuGetDirectory "artifact-placeholder.txt") -Value "placeholder"
-      - run: dotnet pack ${{ steps.package-project.outputs.project }} --configuration Release --no-build /p:IsOfficialBuild=true --output ${{ env.NuGetDirectory }} /p:RepositoryBranch="${{github.ref}}" "/p:PromptFolder=${{runner.temp}}/prompt" /bl:pack.binlog
+      - run: dotnet pack ${{ steps.package-project.outputs.project }} --configuration Release --no-build /p:IsOfficialBuild=true --output $env:NuGetDirectory /p:RepositoryBranch="$env:GITHUB_REF" "/p:PromptFolder=$env:RUNNER_TEMP/prompt" /bl:pack.binlog
         if: steps.package-project.outputs.has-project == 'true'
 
       - name: Skip packaging
@@ -97,11 +104,12 @@ jobs:
         run: dotnet run ./eng/validate-nuget.cs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'push' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
+          NUGET_VALIDATION_IS_DELTA: ${{ case((github.event_name == 'pull_request' || github.event_name == 'push') && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
 
   deploy:
-    # A manual run from another branch must not publish to nuget.org
-    if: github.ref == 'refs/heads/main' && needs.create_nuget.outputs.has-project == 'true'
+    # Pull requests only build and validate the packages. A manual run from another branch must not
+    # publish to nuget.org either.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && needs.create_nuget.outputs.has-project == 'true'
     runs-on: ubuntu-26.04
     needs: [ create_nuget, validate_nuget ]
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,193 @@
+name: publish
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+# No concurrency group: each run only packs the packages changed since the previous push, so a
+# cancelled or replaced run would never publish its packages.
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  NuGetDirectory: ${{ github.workspace}}/nuget
+  NuGetSource: "https://api.nuget.org/v3/index.json"
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  create_nuget:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 20
+    outputs:
+      has-project: ${{ steps.package-project.outputs.has-project }}
+    env:
+      # Analyzers already ran on the pull request
+      RunAnalyzers: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - run: git config --global protocol.file.allow always
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+      - name: Generate delta build file
+        id: package-project
+        uses: ./.github/actions/deltabuild
+        with:
+          input-project: eng/packages.proj
+          output-project: eng/packages.delta.proj
+          base-commit: ${{ case(github.event_name == 'push', github.event.before, '') }}
+          # A manual run packs every package, so it can recover from a partial publish
+          run-generate: ${{ case(github.event_name == 'push', 'true', 'false') }}
+          full-rebuild-triggers: |
+            .github/workflows/publish.yml
+            eng/**/*.proj
+
+      - run: dotnet restore ${{ steps.package-project.outputs.project }} -p:Configuration=Release /p:IsOfficialBuild=true /bl:restore.binlog
+        if: steps.package-project.outputs.has-project == 'true'
+      - run: dotnet build src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj --configuration Release /p:IsOfficialBuild=true /bl:build.publicapi.binlog
+        if: steps.package-project.outputs.has-project == 'true'
+      - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release --no-restore /p:IsOfficialBuild=true /p:PublicApiGeneratorVerifyNoChangeOnBuild=true /bl:build.binlog
+        if: steps.package-project.outputs.has-project == 'true'
+
+      - name: Prepare NuGet artifact directory
+        run: |
+          New-Item -ItemType Directory -Path "${{ env.NuGetDirectory }}" -Force | Out-Null
+          Set-Content -Path "${{ env.NuGetDirectory }}/artifact-placeholder.txt" -Value "placeholder"
+      - run: dotnet pack ${{ steps.package-project.outputs.project }} --configuration Release --no-build /p:IsOfficialBuild=true --output ${{ env.NuGetDirectory }} /p:RepositoryBranch="${{github.ref}}" "/p:PromptFolder=${{runner.temp}}/prompt" /bl:pack.binlog
+        if: steps.package-project.outputs.has-project == 'true'
+
+      - name: Skip packaging
+        if: steps.package-project.outputs.has-project != 'true'
+        run: Write-Host "No package project was impacted. Skipping build and pack."
+      - parallel:
+          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            if: always()
+            with:
+              name: nuget
+              if-no-files-found: error
+              retention-days: 3
+              path: ${{ env.NuGetDirectory }}/**/*
+          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            if: always()
+            with:
+              name: binlog
+              if-no-files-found: ${{ case(steps.package-project.outputs.has-project == 'true', 'error', 'warn') }}
+              retention-days: 3
+              path: '**/*.binlog'
+
+  validate_nuget:
+    runs-on: ubuntu-26.04
+    needs: [ create_nuget ]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - parallel:
+          - name: Setup .NET
+            uses: ./.github/actions/setup-dotnet
+          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+            if: needs.create_nuget.outputs.has-project == 'true'
+            with:
+              name: nuget
+              path: ${{ env.NuGetDirectory }}
+      - name: Validate NuGet packages
+        if: needs.create_nuget.outputs.has-project == 'true'
+        run: dotnet run ./eng/validate-nuget.cs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'push' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
+
+  deploy:
+    # A manual run from another branch must not publish to nuget.org
+    if: github.ref == 'refs/heads/main' && needs.create_nuget.outputs.has-project == 'true'
+    runs-on: ubuntu-26.04
+    needs: [ create_nuget, validate_nuget ]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - parallel:
+          - name: Setup .NET
+            uses: ./.github/actions/setup-dotnet
+          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+            with:
+              name: nuget
+              path: ${{ env.NuGetDirectory }}
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: login
+        with:
+          user: meziantou
+
+      - name: Publish NuGet packages
+        env:
+          NUGETAPIKEY: ${{steps.login.outputs.NUGET_API_KEY}}
+        run: |
+          Write-Host "Searching nupkg in folder: ${{ env.NuGetDirectory }}"
+          $files = Get-ChildItem "${{ env.NuGetDirectory }}/*" -Include *.nupkg
+          $apiKey = $env:NUGETAPIKEY
+          $source = "${{ env.NuGetSource }}"
+
+          if ($files.Count -eq 0) {
+            Write-Host "No NuGet package found to push."
+          }
+          else {
+            $maxAttempts = 3
+            $baseDelaySeconds = 2
+            $results = $files | ForEach-Object -Parallel {
+              $packagePath = $_.FullName
+              $apiKey = $using:apiKey
+              $source = $using:source
+              $maxAttempts = $using:maxAttempts
+              $baseDelaySeconds = $using:baseDelaySeconds
+
+              for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+                Write-Host "Pushing NuGet package: $packagePath (attempt $attempt/$maxAttempts)"
+                & dotnet nuget push "$packagePath" --api-key "$apiKey" --source "$source" --force-english-output --skip-duplicate
+                $exitCode = $LASTEXITCODE
+
+                if ($exitCode -eq 0) {
+                  return [pscustomobject]@{
+                    PackagePath = $packagePath
+                    Succeeded = $true
+                    Attempts = $attempt
+                  }
+                }
+
+                if ($attempt -lt $maxAttempts) {
+                  $delaySeconds = [int]($baseDelaySeconds * [math]::Pow(2, $attempt - 1))
+                  Write-Host "Retrying NuGet push for $packagePath in $delaySeconds second(s)."
+                  Start-Sleep -Seconds $delaySeconds
+                }
+              }
+
+              return [pscustomobject]@{
+                PackagePath = $packagePath
+                Succeeded = $false
+                Attempts = $maxAttempts
+              }
+            } -ThrottleLimit 8
+
+            $pushResults = @(
+              $results
+              | Where-Object { $_.PSObject.Properties.Name -contains "Succeeded" }
+            )
+            $failedPackages = @($pushResults | Where-Object { -not $_.Succeeded })
+            $succeededPackages = @($pushResults | Where-Object { $_.Succeeded })
+            foreach ($item in $succeededPackages) {
+              Write-Host "Successfully pushed NuGet package: $($item.PackagePath) (attempts: $($item.Attempts))"
+            }
+
+            if ($failedPackages.Count -gt 0) {
+              foreach ($item in $failedPackages) {
+                Write-Host "::error::Failed to push NuGet package after retries: $($item.PackagePath)"
+              }
+
+              Write-Host "::error::Failed to push NuGet packages after retries: $($failedPackages.PackagePath -join ', ')"
+              throw "Failed to push NuGet packages after retries: $($failedPackages.PackagePath -join ', ')"
+            }
+          }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - run: git config --global protocol.file.allow always
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
       - name: Generate delta build file

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Prepare NuGet artifact directory
         run: |
-          New-Item -ItemType Directory -Path "${{ env.NuGetDirectory }}" -Force | Out-Null
-          Set-Content -Path "${{ env.NuGetDirectory }}/artifact-placeholder.txt" -Value "placeholder"
+          New-Item -ItemType Directory -Path $env:NuGetDirectory -Force | Out-Null
+          Set-Content -Path (Join-Path $env:NuGetDirectory "artifact-placeholder.txt") -Value "placeholder"
       - run: dotnet pack ${{ steps.package-project.outputs.project }} --configuration Release --no-build /p:IsOfficialBuild=true --output ${{ env.NuGetDirectory }} /p:RepositoryBranch="${{github.ref}}" "/p:PromptFolder=${{runner.temp}}/prompt" /bl:pack.binlog
         if: steps.package-project.outputs.has-project == 'true'
 
@@ -127,10 +127,10 @@ jobs:
         env:
           NUGETAPIKEY: ${{steps.login.outputs.NUGET_API_KEY}}
         run: |
-          Write-Host "Searching nupkg in folder: ${{ env.NuGetDirectory }}"
-          $files = Get-ChildItem "${{ env.NuGetDirectory }}/*" -Include *.nupkg
+          Write-Host "Searching nupkg in folder: $env:NuGetDirectory"
+          $files = Get-ChildItem (Join-Path $env:NuGetDirectory "*") -Include *.nupkg
           $apiKey = $env:NUGETAPIKEY
-          $source = "${{ env.NuGetSource }}"
+          $source = $env:NuGetSource
 
           if ($files.Count -eq 0) {
             Write-Host "No NuGet package found to push."

--- a/.github/workflows/retry-ci.yml
+++ b/.github/workflows/retry-ci.yml
@@ -2,6 +2,7 @@ name: retry-ci
 on:
   workflow_run:
     workflows:
+      - ci
       - publish
     types:
       - completed


### PR DESCRIPTION
Pushes to main re-ran the whole test matrix (4 OSes × Debug/Release/invariant × shards) on code its pull request had already validated. This PR splits CI in two, by concern rather than by trigger.

## Changes

**`publish.yml`: new, the package pipeline**
- Runs on pull requests, on push to main, and manually.
- `create_nuget` (delta pack) → `validate_nuget` → `deploy`. Pull requests stop after validation: `deploy` only runs on a push to main, so a manual run from another branch can't publish either.
- Concurrency: a run on main gets a group of its own (`run_id`), because it packs only the packages changed since `github.event.before` and a cancelled or superseded run would never publish them. Pull request runs still cancel their predecessors.
- `workflow_dispatch` repacks every package and pushes with `--skip-duplicate`, to recover from a partial publish.
- feedz.io is gone: pull requests no longer push preview packages anywhere.

**`ci.yml`: pull request validation only**
- Renamed the workflow from `publish` to `ci`, removed the `push` trigger, and removed the `create_nuget`, `validate_nuget` and `deploy` jobs. It now covers eng scripts, generated files, analyzers, the test matrix and trimming.
- A manual run is still a full, non-delta run, with optional code coverage.
- `final_status_check` keeps its name, so the required branch-protection check still matches.

**`retry-ci.yml`**: watches both `ci` and `publish`.

## Before merging

- [ ] Add a nuget.org trusted-publishing policy for workflow file `publish.yml`. `NuGet/login` (OIDC) is tied to the workflow file name, so without it the first publish on main fails to log in. Remove the `ci.yml` policy after the first successful publish.
- [ ] Delete the now-unused `FEEDZ_APIKEY` repository secret.
- [ ] Consider making `create_nuget` and `validate_nuget` required checks: they now live in `publish.yml`, so `final_status_check` in `ci.yml` no longer covers them.

## Notes for reviewers

- The first `publish` run on main after merging repacks every package, because `publish.yml` is a full-rebuild trigger and the file is new. Pushes use `--skip-duplicate`, so that run is only slower.
- The publish path itself is first exercised by the merge, since `publish.yml` can't be dispatched before it exists on main. This PR's own runs exercise both workflows on the pull request side.
- Checked locally: both files parse as YAML, the deploy script passes the PowerShell parser, and `dotnet run ./eng/update-all.cs` reports no changes. actionlint doesn't support the `parallel:`/`case()` syntax these workflows use.
