### PR TITLE
Use 2 test shards and balance them by measured cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,16 +170,19 @@ jobs:
             "tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj"
           )
 
-          # Remaining expensive suites. They are assigned round-robin in declaration order
-          # (1st -> shard 1, 2nd -> shard 2, ...), so the list is ordered from slowest to fastest
-          # to spread them across shards.
+          # Remaining expensive suites, ordered from slowest to fastest. They are dealt out before
+          # everything else, so this order is what keeps the shards balanced: see the assignment
+          # loop below. The durations come from the .trx files of a full-rebuild run, taking the
+          # slowest of the Linux and Windows legs for each project.
           $HeavyProjects = @(
+            "tests/Meziantou.Framework.SnapshotTesting.PackageTests/Meziantou.Framework.SnapshotTesting.PackageTests.csproj"
             "tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj"
+            "tests/Meziantou.Framework.Roslyn.PackageTests/Meziantou.Framework.Roslyn.PackageTests.csproj"
             "tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests.csproj"
-            "tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj"
             "tests/Meziantou.Framework.Yaml.Tests/Meziantou.Framework.Yaml.Tests.csproj"
-            "tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj"
-            "tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj"
+            "tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj"
+            "tests/Meziantou.Framework.Roslyn.Tests/Meziantou.Framework.Roslyn.Tests.Roslyn5_6.csproj"
+            "tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj"
           )
 
           $MaxShards = 2
@@ -222,9 +225,16 @@ jobs:
             $shardCount = [int][Math]::Min($MaxShards, [Math]::Max(1, [Math]::Ceiling($rest.Count / $ProjectsPerShard)))
             $shards = @(1..$shardCount | ForEach-Object { ,[System.Collections.Generic.List[string]]::new() })
 
+            # Deal the heavy projects out in boustrophedon order: the first pass walks the shards
+            # forwards, the next one backwards, so shard 1 gets ranks 1 and 4 while shard 2 gets
+            # ranks 2 and 3. Plain round-robin pairs rank 1 with rank 3 and rank 2 with rank 4,
+            # which is lopsided whenever the costs drop off sharply, as they do here.
             $heavy = @($HeavyProjects | Where-Object { $rest -contains $_ })
             for ($i = 0; $i -lt $heavy.Count; $i++) {
-              $shards[$i % $shardCount].Add($heavy[$i])
+              $position = $i % $shardCount
+              $isReversePass = [Math]::Floor($i / $shardCount) % 2 -eq 1
+              $index = $(if ($isReversePass) { $shardCount - 1 - $position } else { $position })
+              $shards[$index].Add($heavy[$i])
             }
 
             # Split the remaining projects into contiguous blocks of equal size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
             "tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj"
           )
 
-          $MaxShards = 3
+          $MaxShards = 2
           $ProjectsPerShard = 15
 
           # Fail explicitly when a configured project is renamed or removed instead of silently


### PR DESCRIPTION
Two changes to the `compute_test_matrix` step in `.github/workflows/ci.yml`.

## 1. Cap the matrix at 2 shards instead of 3

`$MaxShards` goes from `3` to `2`. It bounds how many `shard-N` groups the step creates for the test projects that are neither in `$IsolatedProjects` nor in `$DnsProjects`. Dropping one shard group removes 12 `build_and_test` jobs from a full run: 4 runners × 2 configurations, plus the extra invariant-globalization leg that only Release carries.

`$ProjectsPerShard = 15` is unchanged. It only controls how quickly shards are *added* up to the cap (`min($MaxShards, ceil($rest.Count / $ProjectsPerShard))`), so shards exceed 15 projects on large runs — that is what capping the count means, and it was already true at 3 shards.

## 2. Balance the shards by cost instead of by project count

The shards were not taking the same time. shard-2 was slower on **all 12 legs**, by roughly 1.5×:

| leg | shard-1 | shard-2 |
|---|---|---|
| windows Release | 13 min | 17 min |
| windows Debug | 13 min | 19 min |
| ubuntu Release | 8 min | 12 min |
| macos Release | 8 min | 19 min |

Per-project times extracted from the `.trx` files of a full-rebuild run show 11.8 min of test work in shard-1 against 24.4 min in shard-2 on the Linux leg.

The cause was `$HeavyProjects`, the only thing steering the split. It had drifted — the two most expensive projects in the set were missing from it, and half its entries were no longer expensive:

```
    7.72 min  SnapshotTesting.PackageTests      not listed
    4.22 min  StronglyTypedId.Tests             listed
    3.66 min  Roslyn.PackageTests               not listed
    2.85 min  EmbeddedConstantsGenerator.Tests  listed
    2.22 min  Yaml.Tests                        listed
    1.66 min  QRCode.Tests                      not listed
    1.14 min  Roslyn.Tests.Roslyn5_6            not listed
    1.13 min  CommandLineTests                  listed
    0.75 min  DependencyScanning.Tests          listed
    0.64 min  ResxSourceGenerator.Tests         listed
```

So: rebuild the list from those measurements (the eight projects above one minute), and deal them out in **boustrophedon order** rather than round-robin. Round-robin pairs rank 1 with rank 3 and rank 2 with rank 4, which is lopsided when costs drop off as sharply as they do here; walking the shards forwards then backwards pairs rank 1 with rank 4 instead.

The contiguous block split of the remaining projects is **unchanged**. I tried interleaving those too and it was measurably worse on both platforms — the block split happens to counteract the imbalance the heavy projects leave behind.

## Result

Replaying the step over all 135 test projects and scoring the output with the measured durations:

| | shard-1 | shard-2 | gap | gap before |
|---|---|---|---|---|
| Linux | 18.9 min | 17.6 min | **1.3 min** | 10.5 min |
| Windows | 24.0 min | 21.8 min | **2.2 min** | 13.2 min |

The matrix comes out as the 4 isolated groups, the `Dns` group, and `shard-1`/`shard-2` with 64 and 63 projects.

## Notes for reviewers

- **This evens out runner usage but does not shorten the run.** `SnapshotTesting` is the slowest job in 9 of the 12 legs and sets the 34-minute ceiling on its own (windows Release). Balancing the shards moves shard-2 from 19 → ~15 min and leaves the overall run at 34 min. It also doesn't reduce billed minutes — same total work, redistributed. Making CI actually faster means attacking `Meziantou.Framework.SnapshotTesting.Tests`, which is a separate piece of work.
- Durations are the **slower** of the Linux and Windows legs per project, because the two disagree sharply. `DependencyScanning.Tests` measures 0.09 min on Linux but 0.75 min on Windows, since most of its tests skip there — taking Linux alone would have dropped it for the wrong reason.
- The weights are a snapshot and will drift again, exactly as the old list did. Making this self-maintaining (a scheduled workflow that reads the `.trx` artifacts of the last full `main` run and opens a PR updating a weights file, like the existing `update-*.yml` workflows) is the obvious follow-up if the drift becomes annoying.
- The measurements come from run [34676033699](https://github.com/meziantou/Meziantou.Framework/actions/runs/34676033699), this branch's own CI, which was a full rebuild because `ci.yml` is a full-rebuild trigger.
- Verified by replaying the real PowerShell step under `pwsh` with all 135 projects as the affected set, then scoring its JSON output against the measured weights. `dotnet run ./eng/update-all.cs` reports no generated-file changes. No build or test run — the change touches only a workflow file.