### PR TITLE
Skip the snapshot stack walk when the test framework already knows the names

### DIFF
--- a/benchmarks/SnapshotTestingBenchmarks/SnapshotCallerContextBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/SnapshotCallerContextBenchmark.cs
@@ -26,22 +26,29 @@ public class SnapshotCallerContextBenchmark
         File.WriteAllText(_sourceFilePath, "");
     }
 
+    private static readonly SnapshotTestContext TestContext = new() { ClassName = nameof(SnapshotCallerContextBenchmark), MethodName = nameof(Create) };
+
+    /// <summary>No test framework context: the name has to come from the call stack.</summary>
+    [Benchmark(Baseline = true)]
+    public string Create() => Recurse(StackDepth, testContext: null);
+
+    /// <summary>The test framework exposes the names, so the call stack is never walked.</summary>
     [Benchmark]
-    public string Create() => Recurse(StackDepth);
+    public string CreateWithTestContext() => Recurse(StackDepth, TestContext);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private string Recurse(int depth)
+    private string Recurse(int depth, SnapshotTestContext? testContext)
     {
         if (depth > 0)
-            return Recurse(depth - 1);
+            return Recurse(depth - 1, testContext);
 
-        return CreateCallerContext();
+        return CreateCallerContext(testContext);
     }
 
     [SnapshotAssertion]
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-    private string CreateCallerContext()
+    private string CreateCallerContext(SnapshotTestContext? testContext)
     {
-        return SnapshotCallerContext.Create(_sourceFilePath, lineNumber: 1, memberName: nameof(CreateCallerContext), testContext: null).MethodName;
+        return SnapshotCallerContext.Create(_sourceFilePath, lineNumber: 1, memberName: nameof(CreateCallerContext), testContext).MethodName;
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -6,9 +6,9 @@ using System.Text.RegularExpressions;
 namespace Meziantou.Framework.SnapshotTesting;
 
 /// <summary>
-/// Describes the call site of an assertion. The names of the test class and of the test method are read from
-/// the call stack, which is the most expensive part of an assertion, so the walk only runs when something
-/// asks for them: a naming or path strategy that uses neither never pays for it.
+/// Describes the call site of an assertion. The names of the test class and of the test method come from the
+/// test framework when it exposes them, and from the call stack otherwise. The walk is the most expensive
+/// part of an assertion, so it only runs when something asks for a name the test framework did not provide.
 /// </summary>
 internal sealed partial class SnapshotCallerContext
 {
@@ -67,38 +67,26 @@ internal sealed partial class SnapshotCallerContext
     public string? MemberName { get; }
 
     /// <summary>
-    /// Name of the test method the assertion belongs to. Reading it walks the call stack the first time.
+    /// Name of the test method the assertion belongs to. The test framework is asked first: its view is free,
+    /// and it is the only one that survives an await in a helper method, which drops the test method from
+    /// the call stack. The stack is walked only when the framework exposes nothing (Xunit v2, MSTest, or no
+    /// test framework at all), the first time the name is read.
     /// </summary>
     public string MethodName
     {
         get
         {
-            // The call stack only contains the test method as long as the assertion runs synchronously below
-            // it. A helper method that awaited before asserting runs on a continuation where the test method
-            // is gone, and the innermost frames then describe the helper. The test framework still knows
-            // which test is running, so its own view wins whenever the stack could not produce one.
-            var stackWalk = ResolveStackWalk();
-            if (stackWalk.TestMethodResolved && stackWalk.MethodName is not null)
-                return stackWalk.MethodName;
+            if (_testContext?.MethodName is { } methodName)
+                return methodName;
 
-            return _testContext?.MethodName ?? stackWalk.MethodName ?? MemberName ?? "Snapshot";
+            return ResolveStackWalk().MethodName ?? MemberName ?? "Snapshot";
         }
     }
 
     /// <summary>
-    /// Simple name of the type declaring the test method. Reading it walks the call stack the first time.
+    /// Simple name of the type declaring the test method. Same sources and precedence as <see cref="MethodName" />.
     /// </summary>
-    public string? ClassName
-    {
-        get
-        {
-            var stackWalk = ResolveStackWalk();
-            if (stackWalk.TestMethodResolved)
-                return stackWalk.ClassName;
-
-            return _testContext?.ClassName ?? stackWalk.ClassName;
-        }
-    }
+    public string? ClassName => _testContext?.ClassName ?? ResolveStackWalk().ClassName;
 
     /// <summary>Indicates whether the call stack was actually walked. Used by the tests.</summary>
     internal bool StackWalkPerformed => _stackWalk is not null && !ReferenceEquals(_stackWalk, StackWalkResult.Unavailable);
@@ -124,7 +112,6 @@ internal sealed partial class SnapshotCallerContext
         var stackAnalysisStartIndex = GetStackAnalysisStartIndex(stackTrace);
         string? discoveredMethodName = null;
         string? discoveredClassName = null;
-        var testMethodResolved = false;
 
         for (var i = stackAnalysisStartIndex; i < stackTrace.FrameCount; i++)
         {
@@ -139,7 +126,6 @@ internal sealed partial class SnapshotCallerContext
             {
                 discoveredMethodName = stackFrameMethod.NormalizedMethodName;
                 discoveredClassName = stackFrameMethod.NormalizedTypeName;
-                testMethodResolved = true;
                 break;
             }
 
@@ -162,7 +148,7 @@ internal sealed partial class SnapshotCallerContext
             }
         }
 
-        return new StackWalkResult(discoveredMethodName, discoveredClassName, testMethodResolved, sourceFilePath);
+        return new StackWalkResult(discoveredMethodName, discoveredClassName, sourceFilePath);
     }
 
     private static int GetStackAnalysisStartIndex(StackTrace stackTrace)
@@ -296,9 +282,9 @@ internal sealed partial class SnapshotCallerContext
 
     private sealed record StackFrameMethod(bool IsSnapshotAssertion, bool IsTestMethod, string NormalizedMethodName, string? NormalizedTypeName);
 
-    private sealed record StackWalkResult(string? MethodName, string? ClassName, bool TestMethodResolved, string? SourceFilePath)
+    private sealed record StackWalkResult(string? MethodName, string? ClassName, string? SourceFilePath)
     {
         /// <summary>Result of a walk that cannot run because the frames of the assertion are gone.</summary>
-        public static StackWalkResult Unavailable { get; } = new(MethodName: null, ClassName: null, TestMethodResolved: false, SourceFilePath: null);
+        public static StackWalkResult Unavailable { get; } = new(MethodName: null, ClassName: null, SourceFilePath: null);
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotPathContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotPathContext.cs
@@ -63,9 +63,10 @@ public sealed record SnapshotPathContext
     /// Simple name of the type declaring the test, or <see langword="null" /> when it is unknown.
     /// </summary>
     /// <remarks>
-    /// Unless the value was provided explicitly, reading this walks the call stack the first time, which is
-    /// the most expensive part of an assertion. A strategy that reads neither this nor <see cref="MethodName" />
-    /// never pays for that walk.
+    /// Unless the value was provided explicitly, it comes from <see cref="TestContext" /> when the test
+    /// framework exposes it, and from the call stack otherwise. The walk is the most expensive part of an
+    /// assertion and runs the first time a name the test framework did not provide is read; a strategy that
+    /// reads neither this nor <see cref="MethodName" /> never pays for it.
     /// </remarks>
     public string? ClassName
     {
@@ -77,9 +78,10 @@ public sealed record SnapshotPathContext
     /// Name of the test method the snapshot belongs to.
     /// </summary>
     /// <remarks>
-    /// Unless the value was provided explicitly, reading this walks the call stack the first time, which is
-    /// the most expensive part of an assertion. Use <see cref="MemberName" /> when the name the compiler
-    /// captured at the call site is enough.
+    /// Unless the value was provided explicitly, it comes from <see cref="TestContext" /> when the test
+    /// framework exposes it, and from the call stack otherwise. The walk is the most expensive part of an
+    /// assertion and runs the first time a name the test framework did not provide is read. Use
+    /// <see cref="MemberName" /> when the name the compiler captured at the call site is enough.
     /// </remarks>
     public string MethodName
     {
@@ -89,8 +91,8 @@ public sealed record SnapshotPathContext
 
     /// <summary>
     /// Member name captured by the compiler at the call site, or <see langword="null" /> when the assertion
-    /// did not provide one. Unlike <see cref="MethodName" />, it never walks the call stack, but it describes
-    /// the method that called the assertion rather than the test method.
+    /// did not provide one. Unlike <see cref="MethodName" />, it never needs the test framework nor the call
+    /// stack, but it describes the method that called the assertion rather than the test method.
     /// </summary>
     public string? MemberName { get; init; }
 

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotTestContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotTestContext.cs
@@ -9,15 +9,16 @@ public sealed record SnapshotTestContext(string? TestName = null, IReadOnlyDicti
     private static Func<SnapshotTestContext?>? s_nunitGetContext;
 
     /// <summary>
-    /// Simple name of the class declaring the running test, when the test framework exposes it. It is used
-    /// when the call stack does not contain the test method, which happens when the assertion runs in a
-    /// helper method that awaited before calling <see cref="Snapshot.Validate(object?, SnapshotType?, SnapshotSettings?, string?, int, string?)" />.
+    /// Simple name of the class the running test belongs to, when the test framework exposes it. When set, it
+    /// is used as <see cref="SnapshotPathContext.ClassName" /> without walking the call stack; the stack is
+    /// only consulted when it is <see langword="null" />.
     /// </summary>
     public string? ClassName { get; init; }
 
     /// <summary>
     /// Name of the running test method, when the test framework exposes it. Unlike <see cref="TestName" />,
-    /// it never contains the test arguments.
+    /// it never contains the test arguments. When set, it is used as <see cref="SnapshotPathContext.MethodName" />
+    /// without walking the call stack; the stack is only consulted when it is <see langword="null" />.
     /// </summary>
     public string? MethodName { get; init; }
 

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -82,9 +82,10 @@ You can choose how snapshot names are generated using `SnapshotSettings.Snapshot
 
 ## Calling `Snapshot.Validate` from a helper method
 
-Wrapping `Snapshot.Validate` in a helper method is supported. The test method is resolved by walking the
-stack until a method carrying a test attribute (`[Fact]`, `[Theory]`, `[Test]`, `[TestMethod]`) is found, so
-the helper frames are skipped and the snapshot is still named after the test, not after the helper.
+Wrapping `Snapshot.Validate` in a helper method is supported. The snapshot is still named after the test,
+not after the helper: the test method is read from the test framework context (Xunit v3, TUnit, and NUnit)
+and, under a framework that exposes no context (Xunit v2, MSTest), by walking the stack until a method
+carrying a test attribute (`[Fact]`, `[Theory]`, `[Test]`, `[TestMethod]`) is found.
 
 The snapshot directory, however, comes from `[CallerFilePath]`, which points at the file declaring the
 helper. Forward the caller information so the snapshots are created next to the test file:
@@ -115,10 +116,9 @@ public sealed class OpenApiTests
 
 No custom `SnapshotNamingStrategy` or `SnapshotPathStrategy` is needed for this scenario.
 
-This also works when the helper is `async` and awaits before asserting. The test method is then no longer on
-the call stack, so the test name and class name are read from the test framework context instead (Xunit v3,
-TUnit, and NUnit). Under a test framework that exposes no context (Xunit v2, MSTest), await inside the helper
-*after* the call to `Snapshot.Validate` rather than before it, so the test method is still on the stack.
+This also works when the helper is `async` and awaits before asserting, as long as the test framework exposes
+a context. Under a test framework that exposes no context (Xunit v2, MSTest), the test method must still be on
+the call stack, so await inside the helper *after* the call to `Snapshot.Validate` rather than before it.
 
 If the same test calls the helper several times, set `Snapshot.TestContext` to give each call a distinct name
 (see [Test context](#test-context)).
@@ -157,9 +157,10 @@ Snapshot naming uses test context when available:
 
 - `Snapshot.TestContext` (`AsyncLocal<SnapshotTestContext?>`) can be set explicitly.
 - Xunit v3, TUnit, and NUnit display names are auto-detected to improve generated file names.
-- The test class and method names are auto-detected from the same frameworks. They are used when the call
-  stack does not contain the test method, which happens when the assertion runs in a helper method that
-  awaited before asserting.
+- The test class and method names are auto-detected from the same frameworks and are used as-is. The call
+  stack is only walked for a name the context does not provide: under Xunit v2, MSTest, or no test framework,
+  or when `Snapshot.TestContext` is set to a context that carries no `ClassName` or `MethodName`.
+- A test declared in a base class is named after the class it ran in, as reported by the test framework.
 
 ## Customization
 
@@ -171,10 +172,10 @@ Use `SnapshotSettings` to customize behavior:
 - `SnapshotPathStrategy` for full path generation
 
 A custom `SnapshotNamingStrategy` or `SnapshotPathStrategy` receives a `SnapshotPathContext`. Its `ClassName`
-and `MethodName` are read from the call stack, which is the most expensive part of an assertion, so they are
-only resolved when a strategy reads them: a strategy that uses neither never pays for that walk. Use
-`MemberName` when the name of the method that called the assertion - captured by the compiler, always
-available - is enough.
+and `MethodName` come from the test framework context when it exposes them, and from the call stack otherwise.
+The walk is the most expensive part of an assertion and only runs when a strategy reads a name the context did
+not provide: a strategy that uses neither name never pays for it. Use `MemberName` when the name of the method
+that called the assertion - captured by the compiler, always available - is enough.
 
 You can also set the default strategy using the `SNAPSHOTTESTING_STRATEGY` environment variable.
 The value is case-insensitive and must match one of the `SnapshotUpdateStrategy` static property names (for example: `DISALLOW`, `MergeTool`, `overwritewithoutfailure`).

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -407,7 +407,7 @@ public sealed partial class SnapshotTests
     }
 
     [Fact]
-    public void Validate_WalksTheStack_WhenTheStrategyReadsTheTestNames()
+    public void Validate_DoesNotWalkTheStack_WhenTheTestFrameworkProvidesTheNames()
     {
         using var directory = TemporaryDirectory.Create();
         SnapshotPathContext? capturedContext = null;
@@ -418,20 +418,98 @@ public sealed partial class SnapshotTests
             SnapshotPathStrategy = context =>
             {
                 capturedContext = context;
-                return directory / (context.MethodName + ".verified.txt");
+                return directory / (context.ClassName + "_" + context.MethodName + ".verified.txt");
             },
         };
 
         Snapshot.Validate("sample", settings);
 
+        // Xunit v3 exposes both names, so the strategy read them without paying for the walk.
         Assert.NotNull(capturedContext);
-        Assert.True(capturedContext.StackWalkPerformed);
-        Assert.Equal(nameof(Validate_WalksTheStack_WhenTheStrategyReadsTheTestNames), capturedContext.MethodName);
+        Assert.False(capturedContext.StackWalkPerformed);
+        Assert.Equal(nameof(Validate_DoesNotWalkTheStack_WhenTheTestFrameworkProvidesTheNames), capturedContext.MethodName);
         Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
 
         var files = Directory.GetFiles(directory.FullPath);
         Assert.Single(files);
-        Assert.Equal(nameof(Validate_WalksTheStack_WhenTheStrategyReadsTheTestNames) + ".verified.txt", Path.GetFileName(files[0]));
+        Assert.Equal(nameof(SnapshotTests) + "_" + nameof(Validate_DoesNotWalkTheStack_WhenTheTestFrameworkProvidesTheNames) + ".verified.txt", Path.GetFileName(files[0]));
+    }
+
+    [Fact]
+    public void Validate_WalksTheStack_WhenTheTestContextDoesNotProvideTheNames()
+    {
+        using var directory = TemporaryDirectory.Create();
+        SnapshotPathContext? capturedContext = null;
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context =>
+            {
+                capturedContext = context;
+                return directory / (context.ClassName + "_" + context.MethodName + ".verified.txt");
+            },
+        };
+
+        // An explicit context replaces the one detected from the test framework. This one carries no names,
+        // so the call stack is the only remaining source.
+        using (new SnapshotTestContextScope(new SnapshotTestContext(TestName: "custom")))
+        {
+            Snapshot.Validate("sample", settings);
+        }
+
+        Assert.NotNull(capturedContext);
+        Assert.True(capturedContext.StackWalkPerformed);
+        Assert.Equal(nameof(Validate_WalksTheStack_WhenTheTestContextDoesNotProvideTheNames), capturedContext.MethodName);
+        Assert.Equal(nameof(SnapshotTests), capturedContext.ClassName);
+
+        var files = Directory.GetFiles(directory.FullPath);
+        Assert.Single(files);
+        Assert.Equal(nameof(SnapshotTests) + "_" + nameof(Validate_WalksTheStack_WhenTheTestContextDoesNotProvideTheNames) + ".verified.txt", Path.GetFileName(files[0]));
+    }
+
+    [Fact]
+    public void Validate_UsesTheNamesOfAnExplicitTestContext_OverTheCallStack()
+    {
+        using var directory = TemporaryDirectory.Create();
+        SnapshotPathContext? capturedContext = null;
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            SnapshotPathStrategy = context =>
+            {
+                capturedContext = context;
+                return directory / (context.ClassName + "_" + context.MethodName + ".verified.txt");
+            },
+        };
+
+        using (new SnapshotTestContextScope(new SnapshotTestContext { ClassName = "CustomClass", MethodName = "CustomMethod" }))
+        {
+            Snapshot.Validate("sample", settings);
+        }
+
+        Assert.NotNull(capturedContext);
+        Assert.False(capturedContext.StackWalkPerformed);
+        Assert.Equal("CustomClass", capturedContext.ClassName);
+        Assert.Equal("CustomMethod", capturedContext.MethodName);
+
+        var files = Directory.GetFiles(directory.FullPath);
+        Assert.Single(files);
+        Assert.Equal("CustomClass_CustomMethod.verified.txt", Path.GetFileName(files[0]));
+    }
+
+    private sealed class SnapshotTestContextScope : IDisposable
+    {
+        private readonly SnapshotTestContext? _previous;
+
+        public SnapshotTestContextScope(SnapshotTestContext? context)
+        {
+            _previous = Snapshot.TestContext.Value;
+            Snapshot.TestContext.Value = context;
+        }
+
+        public void Dispose() => Snapshot.TestContext.Value = _previous;
     }
 
     private static class SnapshotHelpers
@@ -2244,4 +2322,42 @@ public sealed partial class SnapshotTests
             ? "snapshot_" + context.Index.ToString(CultureInfo.InvariantCulture) + ".verified.txt"
             : "snapshot.verified.txt");
     }
+
+    /// <summary>
+    /// A test declared in a base class runs once per derived class. The test framework reports the class the
+    /// test ran in, whereas the call stack could only report the declaring class, so each derived class gets
+    /// its own snapshot name.
+    /// </summary>
+    public abstract class InheritedSnapshotTestsBase
+    {
+        [Fact]
+        public void Validate_NamesTheSnapshotAfterTheRunningClass_WhenTheTestIsInherited()
+        {
+            using var directory = TemporaryDirectory.Create();
+            SnapshotPathContext? capturedContext = null;
+            var settings = new SnapshotSettings()
+            {
+                AutoDetectContinuousEnvironment = false,
+                SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+                SnapshotPathStrategy = context =>
+                {
+                    capturedContext = context;
+                    return directory / (SnapshotSettings.Default.SnapshotPathStrategy(context).Name);
+                },
+            };
+
+            Snapshot.Validate("sample", settings);
+
+            Assert.NotNull(capturedContext);
+            Assert.False(capturedContext.StackWalkPerformed);
+            Assert.Equal(GetType().Name, capturedContext.ClassName);
+            Assert.Equal(nameof(Validate_NamesTheSnapshotAfterTheRunningClass_WhenTheTestIsInherited), capturedContext.MethodName);
+
+            var files = Directory.GetFiles(directory.FullPath);
+            Assert.Single(files);
+            Assert.Equal(GetType().Name + "_" + nameof(Validate_NamesTheSnapshotAfterTheRunningClass_WhenTheTestIsInherited) + ".verified.txt", Path.GetFileName(files[0]));
+        }
+    }
+
+    public sealed class InheritedSnapshotTests : InheritedSnapshotTestsBase;
 }


### PR DESCRIPTION
## What

`SnapshotCallerContext` deferred the call-stack walk to the first read of `ClassName` or `MethodName` (#3097), but the getters still walked the stack *before* consulting the test framework context. Under xunit v3, NUnit and TUnit the context already carries both names, so the default `ClassName_TestName` naming strategy paid the full walk on every assertion for nothing.

The getters now return the test context value when it is set, and only walk the stack as a fallback:

- xunit v2, MSTest, or no test framework at all
- an explicit `Snapshot.TestContext` that carries no `ClassName` / `MethodName`
- a missing caller file path still forces the PDB walk in the constructor, unchanged

## Behavior changes

Both are documented in the readme and pinned by tests:

- **Inherited tests** are now named after the class the test ran in, as reported by the framework. The stack could only see the declaring class, so several derived classes used to share one snapshot file.
- **Explicit names** set on `Snapshot.TestContext` now win over the stack. Previously the stack overrode them whenever the test method was on it.

## Measurements

`SnapshotCallerContextBenchmark`, net10.0, Release, short job:

| Case | Depth 1 | Depth 20 |
|---|---|---|
| No test context (walk) | 3.91 µs, 5.9 KB | 5.62 µs, 10.4 KB |
| Test context provides names | 1.18 µs, 56 B | 1.60 µs, 56 B |

The remaining cost is source file path resolution, unrelated to the walk.

## Tests

The test that asserted a walk under xunit v3 is replaced by four: names read without a walk when the framework provides them, a walk when an explicit context has no names, explicit names beating the stack, and an inherited test named after the running class (nested abstract base + sealed derived class, since MA0048 rejects extra top-level types in the file).

Library, test and benchmark projects build with `TreatWarningsAsErrors=true`; the SnapshotTesting test project passes on net10.0 and net11.0 (448 tests). `dotnet run ./eng/update-all.cs` ran clean. No public API change.
