### PR TITLE
Replace the unsafe expressions that have a safe equivalent

### DIFF
--- a/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash128.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash128.cs
@@ -32,13 +32,12 @@ public sealed partial class BloomFilterXXHash128 : BloomFilter
             return;
         }
 
-        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         if (AdvSimd.Arm64.IsSupported)
         {
             while (index <= values.Length - Vector128<ulong>.Count)
             {
-                var current = unsafe(Vector128.LoadUnsafe(ref valuesReference, (nuint)index));
+                var current = Vector128.Create(values[index..]);
                 Multiply64To128(current ^ Vector128.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;
@@ -62,7 +61,7 @@ public sealed partial class BloomFilterXXHash128 : BloomFilter
         {
             while (index <= values.Length - Vector256<ulong>.Count)
             {
-                var current = unsafe(Vector256.LoadUnsafe(ref valuesReference, (nuint)index));
+                var current = Vector256.Create(values[index..]);
                 Multiply64To128(current ^ Vector256.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;

--- a/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash32.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash32.cs
@@ -29,7 +29,6 @@ public sealed partial class BloomFilterXXHash32 : BloomFilter
             return;
         }
 
-        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var hash = new Vector<uint>(Prime5 + sizeof(uint));
         var prime2 = new Vector<uint>(Prime2);
@@ -37,7 +36,7 @@ public sealed partial class BloomFilterXXHash32 : BloomFilter
         var prime4 = new Vector<uint>(Prime4);
         while (index <= values.Length - Vector<uint>.Count)
         {
-            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
+            var current = Vector.Create(values[index..]);
             var hashes = hash + (current * prime3);
             hashes = RotateLeft(hashes, 17) * prime4;
             hashes ^= hashes >> 15;

--- a/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash64.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterXXHash64.cs
@@ -30,7 +30,6 @@ public sealed partial class BloomFilterXXHash64 : BloomFilter
             return;
         }
 
-        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var prime1 = new Vector<ulong>(Prime1);
         var prime2 = new Vector<ulong>(Prime2);
@@ -39,7 +38,7 @@ public sealed partial class BloomFilterXXHash64 : BloomFilter
         var hash = new Vector<ulong>(Prime5 + sizeof(ulong));
         while (index <= values.Length - Vector<ulong>.Count)
         {
-            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
+            var current = Vector.Create(values[index..]);
             var round = RotateLeft(current * prime2, 31) * prime1;
             var hashes = RotateLeft(hash ^ round, 27) * prime1 + prime4;
             hashes ^= hashes >> 33;

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash128.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash128.cs
@@ -47,13 +47,12 @@ public sealed partial class CountingBloomFilterXXHash128 : CountingBloomFilter
             return;
         }
 
-        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         if (AdvSimd.Arm64.IsSupported)
         {
             while (index <= values.Length - Vector128<ulong>.Count)
             {
-                var current = unsafe(Vector128.LoadUnsafe(ref valuesReference, (nuint)index));
+                var current = Vector128.Create(values[index..]);
                 Multiply64To128(current ^ Vector128.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;
@@ -77,7 +76,7 @@ public sealed partial class CountingBloomFilterXXHash128 : CountingBloomFilter
         {
             while (index <= values.Length - Vector256<ulong>.Count)
             {
-                var current = unsafe(Vector256.LoadUnsafe(ref valuesReference, (nuint)index));
+                var current = Vector256.Create(values[index..]);
                 Multiply64To128(current ^ Vector256.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
                 high += low << 1;
                 low ^= high >> 3;

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash32.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash32.cs
@@ -44,7 +44,6 @@ public sealed partial class CountingBloomFilterXXHash32 : CountingBloomFilter
             return;
         }
 
-        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var hash = new Vector<uint>(Prime5 + sizeof(uint));
         var prime2 = new Vector<uint>(Prime2);
@@ -52,7 +51,7 @@ public sealed partial class CountingBloomFilterXXHash32 : CountingBloomFilter
         var prime4 = new Vector<uint>(Prime4);
         while (index <= values.Length - Vector<uint>.Count)
         {
-            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
+            var current = Vector.Create(values[index..]);
             var hashes = hash + (current * prime3);
             hashes = RotateLeft(hashes, 17) * prime4;
             hashes ^= hashes >> 15;

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash64.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash64.cs
@@ -45,7 +45,6 @@ public sealed partial class CountingBloomFilterXXHash64 : CountingBloomFilter
             return;
         }
 
-        ref var valuesReference = ref unsafe(MemoryMarshal.GetReference(values));
         var index = 0;
         var prime1 = new Vector<ulong>(Prime1);
         var prime2 = new Vector<ulong>(Prime2);
@@ -54,7 +53,7 @@ public sealed partial class CountingBloomFilterXXHash64 : CountingBloomFilter
         var hash = new Vector<ulong>(Prime5 + sizeof(ulong));
         while (index <= values.Length - Vector<ulong>.Count)
         {
-            var current = unsafe(Vector.LoadUnsafe(ref valuesReference, (nuint)index));
+            var current = Vector.Create(values[index..]);
             var round = RotateLeft(current * prime2, 31) * prime1;
             var hashes = RotateLeft(hash ^ round, 27) * prime1 + prime4;
             hashes ^= hashes >> 33;

--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.BloomFilters;
 
@@ -54,6 +55,10 @@ internal sealed class SegmentedBitStorage
         return count;
     }
 
+    // The masked index is in range by construction, so the reference is taken without a bounds check:
+    // replacing this with segment[(int)(wordIndex & SegmentMask)] measured ~5% slower on
+    // LargeBloomFilterBenchmark.MayContain, and the JIT cannot elide the check because the last segment is
+    // shorter than SegmentMask + 1.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Set(long bitIndex)
     {
@@ -61,7 +66,8 @@ internal sealed class SegmentedBitStorage
 
         var wordIndex = bitIndex >> 6;
         var segment = _segments[(int)(wordIndex >> SegmentShift)];
-        ref var wordRef = ref segment[(int)(wordIndex & SegmentMask)];
+        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
+        ref var wordRef = ref unsafe(Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask)));
         Interlocked.Or(ref wordRef, 1UL << (int)bitIndex);
     }
 
@@ -72,7 +78,8 @@ internal sealed class SegmentedBitStorage
 
         var wordIndex = bitIndex >> 6;
         var segment = _segments[(int)(wordIndex >> SegmentShift)];
-        ref var wordRef = ref segment[(int)(wordIndex & SegmentMask)];
+        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
+        ref var wordRef = ref unsafe(Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask)));
         return (Volatile.Read(ref wordRef) & (1UL << (int)bitIndex)) != 0;
     }
 

--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.BloomFilters;
 
@@ -62,8 +61,7 @@ internal sealed class SegmentedBitStorage
 
         var wordIndex = bitIndex >> 6;
         var segment = _segments[(int)(wordIndex >> SegmentShift)];
-        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
-        ref var wordRef = ref unsafe(Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask)));
+        ref var wordRef = ref segment[(int)(wordIndex & SegmentMask)];
         Interlocked.Or(ref wordRef, 1UL << (int)bitIndex);
     }
 
@@ -74,8 +72,7 @@ internal sealed class SegmentedBitStorage
 
         var wordIndex = bitIndex >> 6;
         var segment = _segments[(int)(wordIndex >> SegmentShift)];
-        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
-        ref var wordRef = ref unsafe(Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask)));
+        ref var wordRef = ref segment[(int)(wordIndex & SegmentMask)];
         return (Volatile.Read(ref wordRef) & (1UL << (int)bitIndex)) != 0;
     }
 

--- a/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.BloomFilters;
 
@@ -65,13 +66,16 @@ internal sealed class SegmentedCounterStorage
         return Volatile.Read(ref GetCounterReference(counterIndex));
     }
 
+    // The masked index is in range by construction, so the reference is taken without a bounds check.
+    // See the note in SegmentedBitStorage: the safe indexer measured slower on the probe path.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private ref int GetCounterReference(long counterIndex)
     {
         ValidateCounterIndex(counterIndex);
 
         var segment = _segments[(int)(counterIndex >> SegmentShift)];
-        return ref segment[(int)(counterIndex & SegmentMask)];
+        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
+        return ref unsafe(Unsafe.Add(ref baseRef, (nint)(counterIndex & SegmentMask)));
     }
 
     [Conditional("DEBUG")]

--- a/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.BloomFilters;
 
@@ -72,8 +71,7 @@ internal sealed class SegmentedCounterStorage
         ValidateCounterIndex(counterIndex);
 
         var segment = _segments[(int)(counterIndex >> SegmentShift)];
-        ref var baseRef = ref unsafe(MemoryMarshal.GetArrayDataReference(segment));
-        return ref unsafe(Unsafe.Add(ref baseRef, (nint)(counterIndex & SegmentMask)));
+        return ref segment[(int)(counterIndex & SegmentMask)];
     }
 
     [Conditional("DEBUG")]

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/SecurityProvidersSnapshot.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/SecurityProvidersSnapshot.cs
@@ -117,7 +117,7 @@ public sealed class SecurityProvidersSnapshot
     }
 
     // The projected properties hand back an owned BSTR, so it must be released once it has been copied to a managed string.
-    private static unsafe string? GetString(Func<BSTR> getter)
+    private static string? GetString(Func<BSTR> getter)
     {
         var value = default(BSTR);
         try

--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -125,7 +125,7 @@ namespace Meziantou.Framework
             internal const int MAX_PATH = 260;
 
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-            internal unsafe struct WIN32_FIND_DATA
+            internal struct WIN32_FIND_DATA
             {
                 internal uint dwFileAttributes;
                 internal FILE_TIME ftCreationTime;

--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -213,7 +213,7 @@ public static partial class SensitiveData
 /// </code>
 /// </example>
 [TypeConverter(typeof(SensitiveDataTypeConverter))]
-public sealed unsafe class SensitiveData<T> : IDisposable
+public sealed class SensitiveData<T> : IDisposable
     where T : unmanaged
 {
     [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed through the local returned by Interlocked.Exchange in Dispose")]

--- a/src/Meziantou.Framework.SnapshotTesting/Images/SsimAccumulator.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/SsimAccumulator.cs
@@ -74,9 +74,6 @@ internal struct SsimAccumulator
         double sumActualSquared0 = 0, sumActualSquared1 = 0, sumActualSquared2 = 0;
         double sumCross0 = 0, sumCross1 = 0, sumCross2 = 0;
 
-        // The caller slices both spans to the same length, and every vector load below stays within pixelCount.
-        ref var expectedRef = ref unsafe(MemoryMarshal.GetReference(expectedPixels));
-        ref var actualRef = ref unsafe(MemoryMarshal.GetReference(actualPixels));
         var i = 0;
 
         // Vector512 path (AVX-512): 16 pixels per iteration
@@ -91,8 +88,8 @@ internal struct SsimAccumulator
 
             for (; i <= pixelCount - Vector512<uint>.Count; i += Vector512<uint>.Count)
             {
-                var expectedPixel = unsafe(Vector512.LoadUnsafe(ref expectedRef, (nuint)i));
-                var actualPixel = unsafe(Vector512.LoadUnsafe(ref actualRef, (nuint)i));
+                var expectedPixel = Vector512.Create(expectedPixels[i..]);
+                var actualPixel = Vector512.Create(actualPixels[i..]);
                 var expected0 = Vector512.ConvertToSingle((expectedPixel & mask).AsInt32());
                 var expected1 = Vector512.ConvertToSingle((Vector512.ShiftRightLogical(expectedPixel, 8) & mask).AsInt32());
                 var expected2 = Vector512.ConvertToSingle((Vector512.ShiftRightLogical(expectedPixel, 16) & mask).AsInt32());
@@ -125,8 +122,8 @@ internal struct SsimAccumulator
 
             for (; i <= pixelCount - Vector256<uint>.Count; i += Vector256<uint>.Count)
             {
-                var expectedPixel = unsafe(Vector256.LoadUnsafe(ref expectedRef, (nuint)i));
-                var actualPixel = unsafe(Vector256.LoadUnsafe(ref actualRef, (nuint)i));
+                var expectedPixel = Vector256.Create(expectedPixels[i..]);
+                var actualPixel = Vector256.Create(actualPixels[i..]);
                 var expected0 = Vector256.ConvertToSingle((expectedPixel & mask).AsInt32());
                 var expected1 = Vector256.ConvertToSingle((Vector256.ShiftRightLogical(expectedPixel, 8) & mask).AsInt32());
                 var expected2 = Vector256.ConvertToSingle((Vector256.ShiftRightLogical(expectedPixel, 16) & mask).AsInt32());
@@ -159,8 +156,8 @@ internal struct SsimAccumulator
 
             for (; i <= pixelCount - Vector128<uint>.Count; i += Vector128<uint>.Count)
             {
-                var expectedPixel = unsafe(Vector128.LoadUnsafe(ref expectedRef, (nuint)i));
-                var actualPixel = unsafe(Vector128.LoadUnsafe(ref actualRef, (nuint)i));
+                var expectedPixel = Vector128.Create(expectedPixels[i..]);
+                var actualPixel = Vector128.Create(actualPixels[i..]);
                 var expected0 = Vector128.ConvertToSingle((expectedPixel & mask).AsInt32());
                 var expected1 = Vector128.ConvertToSingle((Vector128.ShiftRightLogical(expectedPixel, 8) & mask).AsInt32());
                 var expected2 = Vector128.ConvertToSingle((Vector128.ShiftRightLogical(expectedPixel, 16) & mask).AsInt32());

--- a/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
+++ b/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
@@ -143,7 +143,7 @@ public static class LsaPrivateData
         ArgumentOutOfRangeException.ThrowIfGreaterThan(key.Length, MaxLengthInChars, nameof(key));
     }
 
-    private static unsafe LsaCloseSafeHandle GetLsaPolicy(in LSA_OBJECT_ATTRIBUTES objectAttributes, uint desiredAccess)
+    private static LsaCloseSafeHandle GetLsaPolicy(in LSA_OBJECT_ATTRIBUTES objectAttributes, uint desiredAccess)
     {
         // A null SystemName means the local system
         var ntsResult = PInvoke.LsaOpenPolicy(SystemName: null, in objectAttributes, desiredAccess, out var lsaPolicyHandle);


### PR DESCRIPTION
## Why

[#3110](https://github.com/meziantou/Meziantou.Framework/pull/3110) made the whole repository compile under the updated memory safety rules by wrapping every annotated BCL call in an `unsafe(...)` expression. Several of those calls have a safe counterpart in the net11.0 BCL, so the wrapper was only preserving an old spelling rather than expressing a real requirement.

This removes 22 `unsafe(...)` expressions (77 → 55 in `src`, 12 of the remainder being in the generated `BloomFilter.g.cs`) and 4 `unsafe` modifiers.

## What changed

**Vector loads → `Vector*.Create(ReadOnlySpan<T>)` (22 sites)**

`Vector.Create(ReadOnlySpan<T>)` and the `Vector128/256/512` equivalents are *not* annotated unsafe, so `MemoryMarshal.GetReference` followed by `Vector*.LoadUnsafe(ref, (nuint)i)` becomes `Create(span[i..])`. Applied to `SsimAccumulator` (all three widths) and to the six `XXHash` bloom filters. The loops already guarantee `index <= Length - Count`, which is exactly the precondition `Create` checks.

**Vestigial `unsafe` modifiers (4)** — the rules report these as CS9377:

- the `WIN32_FIND_DATA` struct: fixed-size buffers no longer need an unsafe context
- `LsaPrivateData.GetLsaPolicy` and `SecurityProvidersSnapshot.GetString`, neither of which mentions a pointer
- the **public** `SensitiveData<T>` class: all the pointer work lives in the nested `NativeMemorySafeHandle`, which keeps its own modifier

## Measured, then reverted: the segmented bloom filter storage

`SegmentedBitStorage` and `SegmentedCounterStorage` combine `MemoryMarshal.GetArrayDataReference` with `Unsafe.Add` to reach a word whose index is already masked into the segment. A plain `ref segment[i]` is the safe equivalent, but it measured slower, so the unsafe references stay (with the measurement recorded in a comment).

`LargeBloomFilterBenchmark.MayContain_NewItems`, the tightest case (StdDev 0.02–0.5 µs):

| Variant | Mean |
|---|---|
| `main` (unsafe), run 1 | 20.98 µs |
| `main` (unsafe), run 2 | 21.16 µs |
| Vector changes kept, `SegmentedBitStorage` reverted | 21.17 µs |
| Both changes, run 1 | 21.84 µs |
| Both changes, run 2 | 22.47 µs |

The isolation run lands on the `main` numbers, which attributes the ~5% to the added bounds check rather than to the vector loads. The JIT cannot elide that check because the last segment is shorter than `SegmentMask + 1`, so there is no safe spelling without the cost.

The vector rewrites are unaffected: `AddRange` measured 218.3 vs 225.9 µs (XXHash32), 247.0 vs 249.4 µs (XXHash64) and 155.9 vs 165.0 µs (XXHash128) — all within noise. `MayContain_ExistingItems` (103.5–118.7 µs across runs) and `Add` (129.8–139.4 µs) were too noisy on this machine to read anything into.

Apple M5 Pro, .NET 10.0.11 arm64, BenchmarkDotNet 0.15.8.

## What else was deliberately left

| Site | Reason |
|---|---|
| `MemoryMarshal.AsBytes` on char spans (Htpasswd, HttpBasic) | No char overload of `CryptographicOperations.FixedTimeEquals` / `ZeroMemory`. Hand-rolling either would trade a BCL crypto primitive for a JIT-elidable loop. |
| `MemoryMarshal.Cast` (SkiaSharp, ImageSharp, bloom filter `int→uint`) | Reinterpretation has no safe equivalent. In `ImageSharpSnapshotComparer.ExactEquals` the byte view could become an element-wise `SequenceEqual`, but `Rgba32` is not bitwise-equatable, so it would lose the vectorized memcmp. |
| `GC.AllocateUninitializedArray` (PooledMemoryStream, AppendOnlyCollectionSegment) | Deliberate; the safe form zeroes. |
| `Unsafe.As` / `CreateSpan` in the FixedStringBuilder generator | The documented `IFixedString.GetUnsafeFullSpan` escape hatch — an interface member cannot be `[UnscopedRef]`. |
| P/Invoke `unsafe` methods (Win32.Jobs, AccessToken, CredentialManager, ProjectedFileSystem, ChangeJournal, …) | Pointers in the signatures. These projects reference CsWin32 and are carved out of the rules anyway. |

## Notes for the reviewer

`global.json` still pins Meziantou.NET.Sdk 1.0.166, where `updated-memory-safety-rules` is not enabled — a plain build cannot tell a required `unsafe(...)` from a decorative one. Each removal here was checked by temporarily appending the feature to `$(Features)` in `Directory.Build.targets` and rebuilding the project on net11.0; that probe is not part of this PR (`Directory.Build.targets` is untouched).

`ref/` is unchanged: no public signature was `unsafe` to begin with, since PublicApiGenerator only emits the modifier for pointer-typed signatures.

## Verification

- Debug and `Release -p:IsOfficialBuild=true` builds of all six touched projects with `TreatWarningsAsErrors=true`: 0 warnings, 0 errors
- Tests: BloomFilters 1020 ✓, SnapshotTesting 442 ✓, SensitiveData 86 ✓, FullPath 238 ✓ (76 Windows-only skips), ContextSnapshot 20 ✓, Win32.Lsa 26 skipped (Windows-only)
- `dotnet run ./eng/update-all.cs` exits 0 (no files changed)