### PR TITLE
Fix brace leading dots and ToString round-trip in Globbing

### DIFF
--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -105,6 +105,7 @@ namespace Meziantou.Framework.Globbing;
 public sealed class Glob : IGlobEvaluatable
 {
     private readonly GlobMatchType _matchType;
+    private readonly GlobDialect _dialect;
     internal readonly Segment[] _segments;
     private readonly bool[] _matchLeadingDot;
     private readonly bool _pathSeparatorAware;
@@ -122,12 +123,13 @@ public sealed class Glob : IGlobEvaluatable
     bool IGlobEvaluatable.CanMatchDirectories => _matchType is GlobMatchType.Directory or GlobMatchType.Any;
     bool IGlobEvaluatable.TraverseDirectories => !_pathSeparatorAware || _segments.Length > 1 || ShouldRecurse(_segments[0]);
 
-    internal Glob(Segment[] segments, bool[] matchLeadingDot, bool pathSeparatorAware, GlobMode mode, GlobMatchType matchType)
+    internal Glob(Segment[] segments, bool[] matchLeadingDot, bool pathSeparatorAware, GlobMode mode, GlobMatchType matchType, GlobDialect dialect)
     {
         _segments = segments;
         _matchLeadingDot = matchLeadingDot;
         _pathSeparatorAware = pathSeparatorAware;
         _matchType = matchType;
+        _dialect = dialect;
         Mode = mode;
 
         _segmentAnchors = new SegmentAnchor?[segments.Length];
@@ -451,27 +453,62 @@ public sealed class Glob : IGlobEvaluatable
         }
     }
 
+    /// <summary>Returns a pattern that parses back, with the same dialect and options, into a glob that matches the same paths.</summary>
+    /// <returns>The pattern of this glob.</returns>
     public override string ToString()
     {
-        using var sb = new ValueStringBuilder();
+        var sb = new ValueStringBuilder(stackalloc char[128]);
         if (Mode is GlobMode.Exclude)
         {
             sb.Append('!');
         }
 
-        var first = true;
-        foreach (var segment in _segments)
+        var patternStart = sb.Length;
+        for (var i = 0; i < _segments.Length; i++)
         {
-            if (!first)
+            if (i > 0)
             {
                 sb.Append('/');
             }
 
-            sb.Append(segment.ToString());
-            first = false;
+            if (_segments[i] is LiteralSegment literal)
+            {
+                GlobPatternWriter.AppendPathSegmentLiteral(ref sb, literal.Value, _dialect);
+            }
+            else
+            {
+                _segments[i].AppendPattern(ref sb, _dialect);
+            }
+        }
+
+        // A DirectoryContentSegment is written as an empty segment, which already ends the pattern with a '/'
+        if (_matchType is GlobMatchType.Directory)
+        {
+            sb.Append('/');
+        }
+
+        if (_dialect is GlobDialect.Git && _segments[0] is not RecursiveMatchAllSegment && !ContainsSeparator(sb.AsSpan(patternStart), _segments[^1] is DirectoryContentSegment))
+        {
+            // gitignore matches an entry without a '/' at any depth, whereas this one is anchored to the root
+            sb.Insert(patternStart, "/");
+        }
+        else if (_dialect is GlobDialect.Standard or GlobDialect.Git && Mode is GlobMode.Include && sb.Length > patternStart && sb[patternStart] == '!')
+        {
+            // A leading '!' would negate the pattern
+            sb.Insert(patternStart, "\\");
         }
 
         return sb.ToString();
+
+        static bool ContainsSeparator(ReadOnlySpan<char> pattern, bool endsWithDirectorySeparator)
+        {
+            if (endsWithDirectorySeparator)
+            {
+                pattern = pattern[..^1];
+            }
+
+            return pattern.Contains('/');
+        }
     }
 
     internal static ReadOnlySpan<char> GetRelativeDirectory(ref FileSystemEntry entry)

--- a/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
@@ -315,7 +315,7 @@ internal static class GlobParser
             }
 
             errorMessage = null;
-            result = CreateGlob(segments, matchLeadingDot, exclude, settings.IgnoreCase, matchType, settings.MatchLeadingDot, settings.PathSeparatorAware);
+            result = CreateGlob(segments, matchLeadingDot, exclude, settings.IgnoreCase, matchType, settings.MatchLeadingDot, settings.PathSeparatorAware, dialect);
             return true;
         }
         finally
@@ -349,8 +349,12 @@ internal static class GlobParser
                 currentLiteral.Clear();
             }
 
-            segments.Add(CreateSegment(subSegments, ignoreCase, pathSeparatorAware));
-            matchLeadingDot.Add(currentSegmentMatchLeadingDot);
+            // A literal set that starts the segment decides whether a leading dot is written in the pattern, but only
+            // the alternative the path takes tells: '{.a,b}' matches '.a', and '{.a,}*' does not match '.b'. The
+            // segment checks it while matching, so the leading dot must not be rejected before.
+            var requiresLiteralLeadingDot = !currentSegmentMatchLeadingDot && CanStartWithLiteralDot(subSegments);
+            segments.Add(CreateSegment(subSegments, ignoreCase, pathSeparatorAware, restrictsLeadingDot: !currentSegmentMatchLeadingDot, requiresLiteralLeadingDot));
+            matchLeadingDot.Add(currentSegmentMatchLeadingDot || requiresLiteralLeadingDot);
             subSegments = null;
         }
         else if (currentLiteral.Length > 0)
@@ -359,6 +363,28 @@ internal static class GlobParser
             matchLeadingDot.Add(currentSegmentMatchLeadingDot);
             currentLiteral.Clear();
         }
+    }
+
+    /// <summary>Whether a literal set that starts the segment can match a leading dot with a '.' written in the pattern.</summary>
+    private static bool CanStartWithLiteralDot(List<Segment> parts)
+    {
+        foreach (var part in parts)
+        {
+            if (part is LiteralSegment literal)
+                return literal.Value[0] == '.';
+
+            if (part is not LiteralSetSegment literalSet)
+                return false;
+
+            if (Array.Exists(literalSet.Values, value => value is ['.', ..]))
+                return true;
+
+            // An empty alternative consumes nothing, so the next part may still provide the dot
+            if (!Array.Exists(literalSet.Values, value => value.Length == 0))
+                return false;
+        }
+
+        return false;
     }
 
     /// <param name="isAtPatternStart">Whether only separators precede the separator, which makes the pattern an absolute path.</param>
@@ -466,7 +492,7 @@ internal static class GlobParser
     // CanMatchLeadingDot checks Glob.IsMatchCore would otherwise run - that is why each one records 'true' in
     // matchLeadingDot. They are only sound when leading dots are allowed everywhere, so do not loosen this gate
     // without giving the rewritten segments a way to reject a segment that starts with a dot.
-    private static Glob CreateGlob(List<Segment> segments, List<bool> matchLeadingDot, bool exclude, bool ignoreCase, GlobMatchType matchType, bool canSkipLeadingDotChecks, bool pathSeparatorAware)
+    private static Glob CreateGlob(List<Segment> segments, List<bool> matchLeadingDot, bool exclude, bool ignoreCase, GlobMatchType matchType, bool canSkipLeadingDotChecks, bool pathSeparatorAware, GlobDialect dialect)
     {
         // Optimize segments
         if (canSkipLeadingDotChecks && segments.Count >= 3)
@@ -534,7 +560,7 @@ internal static class GlobParser
             }
         }
 
-        return new Glob([.. segments], [.. matchLeadingDot], pathSeparatorAware, exclude ? GlobMode.Exclude : GlobMode.Include, matchType);
+        return new Glob([.. segments], [.. matchLeadingDot], pathSeparatorAware, exclude ? GlobMode.Exclude : GlobMode.Include, matchType, dialect);
     }
 
     private static void AppendLiteral(ref ValueStringBuilder currentLiteral, ref bool currentSegmentMatchLeadingDot, List<Segment>? subSegments, char c, bool defaultMatchLeadingDot)
@@ -702,6 +728,7 @@ internal static class GlobParser
         }
 
         segment = CreateRangeSubsegment(ranges, classes, inverse, settings.IgnoreCase);
+        segment.BracketExpressionText = pattern[start..i].ToString();
         end = i;
         return BracketExpressionParseResult.Parsed;
     }
@@ -886,15 +913,18 @@ internal static class GlobParser
         };
     }
 
-    private static Segment CreateSegment(List<Segment> parts, bool ignoreCase, bool pathSeparatorAware)
+    /// <param name="restrictsLeadingDot">Whether a leading dot of the path segment must be written in the pattern instead of being matched by a wildcard or a bracket expression.</param>
+    /// <param name="requiresLiteralLeadingDot">Whether the segment itself must check that a leading dot is written in the pattern, as it depends on the alternative of a literal set.</param>
+    private static Segment CreateSegment(List<Segment> parts, bool ignoreCase, bool pathSeparatorAware, bool restrictsLeadingDot, bool requiresLiteralLeadingDot)
     {
         Debug.Assert(parts.Count > 0);
+        Debug.Assert(!requiresLiteralLeadingDot || parts[0] is LiteralSetSegment);
 
         // Concat Literal and single character sets (abc[d])
         for (var i = parts.Count - 2; i >= 0; i--)
         {
-            var s1 = GetString(parts[i], pathSeparatorAware);
-            var s2 = GetString(parts[i + 1], pathSeparatorAware);
+            var s1 = GetString(parts[i], pathSeparatorAware, restrictsLeadingDot);
+            var s2 = GetString(parts[i + 1], pathSeparatorAware, restrictsLeadingDot);
 
             if (s1 is null || s2 is null)
                 continue;
@@ -905,13 +935,15 @@ internal static class GlobParser
             parts.RemoveAt(i + 1);
 
             // A path segment never contains a separator, so '[/]' never matches, whereas a literal holding a
-            // separator would read past the end of the segment.
-            static string? GetString(Segment segment, bool pathSeparatorAware)
+            // separator would read past the end of the segment. A '[.]' must not become a literal either when the
+            // leading dot has to be written in the pattern: '{,.a}[.]a' does not match '.a', and the pattern that
+            // ToString writes for '[.]a' must not become '.a'.
+            static string? GetString(Segment segment, bool pathSeparatorAware, bool restrictsLeadingDot)
             {
                 return segment switch
                 {
                     LiteralSegment literal => literal.Value,
-                    CharacterSetSegment set when set.Set.Length == 1 && !(pathSeparatorAware && PathReader.IsPathSeparator(set.Set[0])) => set.Set,
+                    CharacterSetSegment set when set.Set.Length == 1 && !(pathSeparatorAware && PathReader.IsPathSeparator(set.Set[0])) && !(restrictsLeadingDot && set.Set[0] == '.') => set.Set,
                     _ => null,
                 };
             }
@@ -1018,7 +1050,7 @@ internal static class GlobParser
         if (parts.Count == 1 && parts[0] is not LiteralSetSegment)
             return parts[0];
 
-        return new RaggedSegment(parts.ToArray());
+        return new RaggedSegment(parts.ToArray(), requiresLiteralLeadingDot);
     }
 
     private enum BracketExpressionParseResult

--- a/src/Meziantou.Framework.Globbing/Internals/GlobPatternWriter.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobPatternWriter.cs
@@ -1,0 +1,79 @@
+namespace Meziantou.Framework.Globbing.Internals;
+
+/// <summary>Writes literal text into a pattern, escaping the characters that the dialect would read as syntax.</summary>
+internal static class GlobPatternWriter
+{
+    public static void AppendLiteral(ref ValueStringBuilder sb, ReadOnlySpan<char> value, GlobDialect dialect)
+    {
+        foreach (var c in value)
+        {
+            AppendLiteral(ref sb, c, dialect);
+        }
+    }
+
+    /// <summary>
+    ///     Writes a literal that makes a whole path segment. <see cref="GlobDialect.Standard"/> and
+    ///     <see cref="GlobDialect.MSBuild"/> read a '.' or '..' segment as a relative path, so its first dot is escaped.
+    /// </summary>
+    public static void AppendPathSegmentLiteral(ref ValueStringBuilder sb, string value, GlobDialect dialect)
+    {
+        if (value is "." or ".." && dialect is GlobDialect.Standard or GlobDialect.MSBuild)
+        {
+            AppendEscaped(ref sb, '.', dialect);
+            AppendLiteral(ref sb, value.AsSpan(1), dialect);
+            return;
+        }
+
+        AppendLiteral(ref sb, value, dialect);
+    }
+
+    /// <summary>Writes an alternative of a <see cref="GlobDialect.Standard"/> literal set, such as <c>{a,b}</c>.</summary>
+    public static void AppendLiteralSetValue(ref ValueStringBuilder sb, string value)
+    {
+        foreach (var c in value)
+        {
+            if (c is '\\' or ',' or '}')
+            {
+                sb.Append('\\');
+            }
+
+            sb.Append(c);
+        }
+    }
+
+    public static void AppendLiteral(ref ValueStringBuilder sb, char c, GlobDialect dialect)
+    {
+        var mustEscape = dialect switch
+        {
+            GlobDialect.MSBuild => c is '*' or '?' or '%',
+            GlobDialect.Standard => c is '\\' or '*' or '?' or '[' or '{',
+            _ => c is '\\' or '*' or '?' or '[',
+        };
+
+        if (mustEscape)
+        {
+            AppendEscaped(ref sb, c, dialect);
+        }
+        else
+        {
+            sb.Append(c);
+        }
+    }
+
+    private static void AppendEscaped(ref ValueStringBuilder sb, char c, GlobDialect dialect)
+    {
+        if (dialect is GlobDialect.MSBuild)
+        {
+            // Only ASCII characters are ever escaped, so two hexadecimal digits are enough
+            const string HexDigits = "0123456789ABCDEF";
+            sb.Append('%');
+            sb.Append(HexDigits[c >> 4]);
+            sb.Append(HexDigits[c & 0xF]);
+        }
+        else
+        {
+            sb.Append('\\');
+            sb.Append(c);
+        }
+    }
+}

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/ContainsSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/ContainsSegment.cs
@@ -27,8 +27,22 @@ internal sealed class ContainsSegment : Segment
         return false;
     }
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        return '*' + Value + '*';
+        sb.Append('*');
+
+        // MSBuild reads a file name made of "*.*" as every file, including the ones without an extension
+        if (dialect is GlobDialect.MSBuild && Value is ".")
+        {
+            sb.Append("%2E");
+        }
+        else
+        {
+            GlobPatternWriter.AppendLiteral(ref sb, Value, dialect);
+        }
+
+        sb.Append('*');
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/EndsWithSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/EndsWithSegment.cs
@@ -24,8 +24,11 @@ internal sealed class EndsWithSegment : Segment
         return false;
     }
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        return '*' + Value;
+        sb.Append('*');
+        GlobPatternWriter.AppendLiteral(ref sb, Value, dialect);
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/LastSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/LastSegment.cs
@@ -17,8 +17,18 @@ internal sealed class LastSegment : Segment
 
     public override bool IsRecursiveMatchAll => true;
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        return "**/" + _innerSegment.ToString();
+        sb.Append("**/");
+        if (_innerSegment is LiteralSegment literal)
+        {
+            GlobPatternWriter.AppendPathSegmentLiteral(ref sb, literal.Value, dialect);
+        }
+        else
+        {
+            _innerSegment.AppendPattern(ref sb, dialect);
+        }
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/LiteralSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/LiteralSegment.cs
@@ -28,8 +28,10 @@ internal sealed class LiteralSegment : Segment
         return false;
     }
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        return Value;
+        GlobPatternWriter.AppendLiteral(ref sb, Value, dialect);
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/LiteralSetSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/LiteralSetSegment.cs
@@ -20,9 +20,9 @@ internal sealed class LiteralSetSegment : Segment
     // a RaggedSegment, so a set is never matched through this method.
     public override bool IsMatch(ref PathReader pathReader) => throw new NotSupportedException();
 
-    public override string ToString()
+    // Only the Standard dialect supports literal sets, so the alternatives always use its escape syntax
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        using var sb = new ValueStringBuilder();
         sb.Append('{');
 
         var first = true;
@@ -33,11 +33,12 @@ internal sealed class LiteralSetSegment : Segment
                 sb.Append(',');
             }
 
-            sb.Append(value);
+            GlobPatternWriter.AppendLiteralSetValue(ref sb, value);
             first = false;
         }
 
         sb.Append('}');
-        return sb.ToString();
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllEndsWithSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllEndsWithSegment.cs
@@ -24,8 +24,11 @@ internal sealed class MatchAllEndsWithSegment : Segment
 
     public override bool IsRecursiveMatchAll => true;
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        return "**/*" + _suffix;
+        sb.Append("**/*");
+        GlobPatternWriter.AppendLiteral(ref sb, _suffix, dialect);
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/PathSuffixSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/PathSuffixSegment.cs
@@ -18,9 +18,8 @@ internal sealed class PathSuffixSegment : Segment
 
     public override bool IsRecursiveMatchAll => true;
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        using var sb = new ValueStringBuilder();
         sb.Append("**/");
 
         var first = true;
@@ -31,10 +30,10 @@ internal sealed class PathSuffixSegment : Segment
                 sb.Append('/');
             }
 
-            sb.Append(segment);
+            GlobPatternWriter.AppendPathSegmentLiteral(ref sb, segment, dialect);
             first = false;
         }
-
-        return sb.ToString();
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/RaggedSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/RaggedSegment.cs
@@ -8,10 +8,18 @@ internal sealed class RaggedSegment : Segment
     private readonly int _matchAllSubSegmentCount;
     private readonly int _firstMatchAllSubSegmentIndex;
     private readonly bool _hasLiteralSet;
+    private readonly bool _requiresLiteralLeadingDot;
 
-    public RaggedSegment(Segment[] segments)
+    /// <param name="segments">The subsegments to match in order.</param>
+    /// <param name="requiresLiteralLeadingDot">
+    ///     Whether a path segment starting with a dot only matches when that dot is written in the pattern, rather
+    ///     than matched by a wildcard. It is only needed when the segment starts with a literal set, as the
+    ///     alternative that the path takes decides whether the dot is written.
+    /// </param>
+    public RaggedSegment(Segment[] segments, bool requiresLiteralLeadingDot)
     {
         _segments = segments;
+        _requiresLiteralLeadingDot = requiresLiteralLeadingDot;
 
         _firstMatchAllSubSegmentIndex = -1;
         for (var i = 0; i < segments.Length; i++)
@@ -70,13 +78,19 @@ internal sealed class RaggedSegment : Segment
                 return MatchSingleStar(ref pathReader, patternSegments, _firstMatchAllSubSegmentIndex);
         }
 
-        return Match(ref pathReader, patternSegments);
+        var literalDotPending = _requiresLiteralLeadingDot && pathReader.CurrentSegmentLength > 0 && pathReader.CurrentText[0] == '.';
+        return Match(ref pathReader, patternSegments, literalDotPending);
 
-        static bool Match(ref PathReader pathReader, ReadOnlySpan<Segment> patternSegments)
+        // literalDotPending is true while the leading dot of the path segment has not been consumed yet: only a
+        // literal, or an alternative of a literal set, can consume it.
+        static bool Match(ref PathReader pathReader, ReadOnlySpan<Segment> patternSegments, bool literalDotPending)
         {
             for (var i = 0; i < patternSegments.Length; i++)
             {
                 var patternSegment = patternSegments[i];
+                if (literalDotPending && patternSegment is not (LiteralSegment or LiteralSetSegment))
+                    return false;
+
                 if (patternSegment is MatchAllSubSegment)
                 {
                     var remainingPatternSegments = patternSegments[(i + 1)..];
@@ -86,7 +100,7 @@ internal sealed class RaggedSegment : Segment
                     }
 
                     var copyReader = pathReader;
-                    if (Match(ref copyReader, remainingPatternSegments))
+                    if (Match(ref copyReader, remainingPatternSegments, literalDotPending: false))
                     {
                         pathReader = copyReader;
                         return true;
@@ -96,7 +110,7 @@ internal sealed class RaggedSegment : Segment
                     {
                         pathReader.ConsumeInSegment(1);
                         copyReader = pathReader;
-                        if (Match(ref copyReader, remainingPatternSegments))
+                        if (Match(ref copyReader, remainingPatternSegments, literalDotPending: false))
                         {
                             pathReader = copyReader;
                             return true;
@@ -114,7 +128,7 @@ internal sealed class RaggedSegment : Segment
                         if (!TryConsumeLiteral(ref copyReader, value, literalSet.Comparison))
                             continue;
 
-                        if (Match(ref copyReader, remainingPatternSegments))
+                        if (Match(ref copyReader, remainingPatternSegments, literalDotPending && value.Length == 0))
                         {
                             pathReader = copyReader;
                             return true;
@@ -127,6 +141,8 @@ internal sealed class RaggedSegment : Segment
                 {
                     if (!patternSegment.IsMatch(ref pathReader))
                         return false;
+
+                    literalDotPending = false;
                 }
             }
 
@@ -279,14 +295,13 @@ internal sealed class RaggedSegment : Segment
         }
     }
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        using var sb = new ValueStringBuilder();
         foreach (var item in _segments)
         {
-            sb.Append(item.ToString());
+            item.AppendPattern(ref sb, dialect);
         }
-
-        return sb.ToString();
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/Segment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/Segment.cs
@@ -17,4 +17,30 @@ internal abstract class Segment
     ///     the path is exhausted, so only a segment that says otherwise is given a chance to match nothing.
     /// </summary>
     public virtual bool CanMatchEmptyPath => false;
+
+    /// <summary>
+    ///     The text of the bracket expression the segment was parsed from, such as <c>[[:alpha:]-]</c>. A bracket
+    ///     expression is written back as is: its syntax depends on the dialect, and the parser does not keep the
+    ///     order of its items.
+    /// </summary>
+    public string? BracketExpressionText { get; set; }
+
+    /// <summary>
+    ///     Writes a pattern that <paramref name="dialect"/> parses back into an equivalent segment. The default
+    ///     implementation writes <see cref="ToString"/>, which is enough for a segment that holds no literal text. A
+    ///     segment that holds literal text must override this method, as the characters to escape depend on the
+    ///     dialect.
+    /// </summary>
+    public virtual void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
+    {
+        sb.Append(BracketExpressionText ?? ToString());
+    }
+
+    /// <summary>Returns the pattern that <paramref name="dialect"/> parses back into an equivalent segment.</summary>
+    public string ToString(GlobDialect dialect)
+    {
+        var sb = new ValueStringBuilder(stackalloc char[64]);
+        AppendPattern(ref sb, dialect);
+        return sb.ToString();
+    }
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/StartsWithSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/StartsWithSegment.cs
@@ -26,8 +26,11 @@ internal sealed class StartsWithSegment : Segment
         return false;
     }
 
-    public override string ToString()
+    public override void AppendPattern(ref ValueStringBuilder sb, GlobDialect dialect)
     {
-        return Value + '*';
+        GlobPatternWriter.AppendLiteral(ref sb, Value, dialect);
+        sb.Append('*');
     }
+
+    public override string ToString() => ToString(GlobDialect.Standard);
 }

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -199,6 +199,59 @@ public class GlobParserTests
     }
 
     [Theory]
+    [InlineData(GlobDialect.Standard, @"\*", "*", "a")]
+    [InlineData(GlobDialect.Standard, @"*\*", "a*", "ab")]
+    [InlineData(GlobDialect.Standard, @"**/a/\*", "x/a/*", "x/a/b")]
+    [InlineData(GlobDialect.Standard, "a[?]", "a?", "ab")]
+    [InlineData(GlobDialect.Standard, @"\[ab]", "[ab]", "a")]
+    [InlineData(GlobDialect.Standard, @"\{a,b\}", "{a,b}", "a")]
+    [InlineData(GlobDialect.Standard, @"{a\,,b}", "a,", "a", "b")]
+    [InlineData(GlobDialect.Standard, @"\!a", "!a", "a")]
+    [InlineData(GlobDialect.Standard, @"a\\b", @"a\b", "ab")]
+    [InlineData(GlobDialect.Standard, @"\.\.", "..")]
+    [InlineData(GlobDialect.Standard, @"**/\./a", "x/./a", "x/a")]
+    [InlineData(GlobDialect.Standard, "a/", "a/", "a")]
+    [InlineData(GlobDialect.Standard, "a/**/", "a/b/", "a/b")]
+    [InlineData(GlobDialect.Standard, "[a-bd]", "a", "d", "c")]
+    [InlineData(GlobDialect.Standard, "[!a-bd]", "c", "a", "d")]
+    [InlineData(GlobDialect.Git, "/a", "a", "b/a")]
+    [InlineData(GlobDialect.Git, "!/a/", "a/", "b/a/")]
+    [InlineData(GlobDialect.Git, @"\!a", "!a", "a")]
+    [InlineData(GlobDialect.Git, @"[\]a-]", "]", "-", "b")]
+    [InlineData(GlobDialect.Git, "[[:digit:]x]", "1", "x", "a")]
+    [InlineData(GlobDialect.MSBuild, "%2A.cs", "*.cs", "a.cs")]
+    [InlineData(GlobDialect.MSBuild, "%2541", "%41", "A")]
+    [InlineData(GlobDialect.MSBuild, "*%2E*", "a.b", "ab")]
+    [InlineData(GlobDialect.MSBuild, "a/%2E%2E/b", "a/../b", "b")]
+    [InlineData(GlobDialect.MSBuild, "/a/", "/a/", "a/")]
+    [InlineData(GlobDialect.Posix, @"a\*", "a*", "ab")]
+    [InlineData(GlobDialect.Posix, "[[:alpha:]-]", "a", "-", "1")]
+    [InlineData(GlobDialect.PosixPath, "//a/", "//a/", "/a/")]
+    public void ToStringParsesBackToAnEquivalentGlob(GlobDialect dialect, string pattern, params string[] paths)
+    {
+        var glob = Glob.Parse(pattern, dialect);
+        var text = glob.ToString();
+        Assert.True(glob.IsMatch(paths[0]));
+
+        Assert.True(Glob.TryParse(text, dialect, GlobOptions.None, out var roundTripped), $"'{text}' is not a valid pattern");
+        foreach (var path in paths)
+        {
+            Assert.Equal(glob.IsMatch(path), roundTripped.IsMatch(path));
+        }
+    }
+
+    [Fact]
+    public void ToStringDoesNotTurnABracketExpressionIntoALeadingDot()
+    {
+        // '[.]' does not match a leading dot by default, whereas the '.' of '.a' does
+        var glob = Glob.Parse("[.]a", GlobDialect.Standard);
+        var roundTripped = Glob.Parse(glob.ToString(), GlobDialect.Standard);
+
+        Assert.False(glob.IsMatch(".a"));
+        Assert.False(roundTripped.IsMatch(".a"));
+    }
+
+    [Theory]
     [InlineData("a/**/b")]
     [InlineData("a/**/b/c")]
     [InlineData("a/**/*")]

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -207,7 +207,6 @@ public class GlobParserTests
     [InlineData(GlobDialect.Standard, @"\{a,b\}", "{a,b}", "a")]
     [InlineData(GlobDialect.Standard, @"{a\,,b}", "a,", "a", "b")]
     [InlineData(GlobDialect.Standard, @"\!a", "!a", "a")]
-    [InlineData(GlobDialect.Standard, @"a\\b", @"a\b", "ab")]
     [InlineData(GlobDialect.Standard, @"\.\.", "..")]
     [InlineData(GlobDialect.Standard, @"**/\./a", "x/./a", "x/a")]
     [InlineData(GlobDialect.Standard, "a/", "a/", "a")]
@@ -238,6 +237,13 @@ public class GlobParserTests
         {
             Assert.Equal(glob.IsMatch(path), roundTripped.IsMatch(path));
         }
+    }
+
+    [Fact]
+    public void ToStringEscapesABackslash()
+    {
+        // '\' is a path separator on Windows, so no path can check this one by matching
+        Assert.Equal(@"a\\b", Glob.Parse(@"a\\b", GlobDialect.Standard).ToString());
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -35,6 +35,7 @@ public class GlobTests
     [InlineData("test/**/a*.txt", "test/a")]
     [InlineData("test/**/a*.txt", "test/a/b/c/d")]
     [InlineData("!test/**/a*.txt", "test/a/b/c/d")]
+    [InlineData("{.github,docs}/*.yml", ".github")]
     public void ShouldRecurse(string pattern, string folderPath)
     {
         var glob = Glob.Parse(pattern, GlobDialect.Standard);
@@ -250,6 +251,11 @@ public class GlobTests
     [InlineData("[.]", ".")]
     [InlineData("**/*.txt", ".hidden/test.txt")]
     [InlineData("**/*.txt", "src/.hidden/test.txt")]
+    [InlineData("{,a}*", ".hidden")]
+    [InlineData("{.a,}*", ".hidden")]
+    [InlineData("{a,b}?", ".a")]
+    [InlineData("{,a}[.]x", ".x")]
+    [InlineData("{,.a}[.]a", ".a")]
     public void DoesNotMatchLeadingDotByDefault(string pattern, string path)
     {
         var glob = Glob.Parse(pattern, GlobDialect.Standard);
@@ -274,6 +280,12 @@ public class GlobTests
     [InlineData(".*", ".hidden")]
     [InlineData("**/.hidden/*.txt", ".hidden/test.txt")]
     [InlineData("**/.hidden/*.txt", "src/.hidden/test.txt")]
+    [InlineData("{.a,b}", ".a")]
+    [InlineData("{.a,b}*", ".ab")]
+    [InlineData("**/{.editorconfig,.gitignore}", "src/.gitignore")]
+    [InlineData("{.github,docs}/*.yml", ".github/ci.yml")]
+    [InlineData("{,a}.x", ".x")]
+    [InlineData("{}{,a}{.x,y}", ".x")]
     public void MatchExplicitLeadingDot(string pattern, string path)
     {
         var glob = Glob.Parse(pattern, GlobDialect.Standard);
@@ -590,6 +602,7 @@ public class GlobTests
 
         AssertEnumerateFiles(directory, Glob.Parse("**/*.txt", GlobDialect.Standard), ["visible/f2.txt"]);
         AssertEnumerateFiles(directory, Glob.Parse("**/*.txt", GlobDialect.Standard, GlobOptions.MatchLeadingDot), [".hidden/f1.txt", "visible/f2.txt"]);
+        AssertEnumerateFiles(directory, Glob.Parse("{.hidden,visible}/*.txt", GlobDialect.Standard), [".hidden/f1.txt", "visible/f2.txt"]);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

A spec-compliance pass over `Glob` found two bugs. Each fix comes with tests that failed before it.

### 1. Standard dialect: a brace alternative can write the leading dot

Wildcards must not match the leading dot of a hidden name, but a dot written in the pattern may. The parser only counted a `.` typed at the very start of a segment, so a dot inside a `{…}` alternative was ignored:

- `**/{.editorconfig,.gitignore}` did not match `src/.gitignore`
- `{.hidden,visible}/*.txt` did not enumerate `.hidden/…`, and `IsPartialMatch` refused to recurse into `.hidden`
- `{,a}.x` did not match `.x`

Which alternative the path takes decides whether the dot is written, so `RaggedSegment` now checks it while matching. Until the leading dot is consumed, only a literal or a set alternative may consume it. Wildcards and bracket expressions still cannot: `{.a,}*`, `{,a}[.]x` and `{,.a}[.]a` do not match a hidden name. For the same reason, the parser no longer folds a `[.]` into a literal in a segment that restricts leading dots.

### 2. `Glob.ToString()` now round-trips in every dialect

An existing test claimed `ToString()` parses back into an equivalent pattern, but it only compared text. In practice:

| Dialect | Pattern | Old `ToString()` |
| --- | --- | --- |
| Standard | `\*` | `*` |
| Standard | `a/` | `a` (loses the directory restriction) |
| Standard | `[a-bd]` | `([d][a-b])` |
| Standard | `{a\,,b}` | `{a,,b}` |
| Git | `/a` | `a` (no longer anchored) |
| MSBuild | `%2A.cs` | `*.cs` |
| MSBuild | `*%2E*` | `*.*` (every file) |
| Posix | `[[:alpha:]-]` | `([-][[:alpha:]])` |

How it works now:

- `Glob` keeps its dialect.
- Literal-bearing segments implement `Segment.AppendPattern(ref ValueStringBuilder, GlobDialect)`, which escapes through the new `GlobPatternWriter`: `\` in most dialects, `%XX` in MSBuild.
- Bracket expressions keep their source text (`Segment.BracketExpressionText`), because the parser reorders their items and their syntax depends on the dialect.
- `Glob.ToString()` restores the structural parts: the directory `/`, a Git root anchor, an escaped leading `!`, and escaped `.`/`..` segments.

One case still cannot round-trip. A `GlobCollection.ParseGitIgnore` entry ending with `/` deliberately does not match the directory's content, while `Glob.Parse` of the same text does.

## Testing

- New rows in `GlobTests` (leading dot, enumeration, `ShouldRecurse`) and a new `ToStringParsesBackToAnEquivalentGlob` theory covering all dialects in `GlobParserTests`.
- Full Globbing test suite: 1650 passed (825 on net10.0, 825 on net11.0).
- Release builds with `IsOfficialBuild=true` succeed for the library and the tests; `ref/` is unchanged.
- Differential fuzzing (scratch programs, not committed):
  - A reference model of the Standard dialect, plus cross-checks between every `IsMatch` overload and `IsPartialMatch` soundness across all path-aware dialects: ~240M checks, no remaining mismatch.
  - Standard's leading-dot rule against macOS libc `fnmatch(FNM_PATHNAME|FNM_PERIOD)`, and `IgnoreCase` against `FNM_CASEFOLD`. Literals, sets and escapes agree. Ranges differ only where macOS folds range bounds, which the library documents differently on purpose.
  - `Parse(glob.ToString())` against the original on ~1.1M generated globs across all dialects and options.
- Not tested on Windows.
