### PR TITLE
Make the XML parser spec compliant: report every well-formedness error and recover from them

### DIFF
--- a/ref/Meziantou.Framework.Language.Xml.cs
+++ b/ref/Meziantou.Framework.Language.Xml.cs
@@ -60,6 +60,7 @@ namespace Meziantou.Framework.Language.Xml
     {
         public static string GetText(Meziantou.Framework.Language.Xml.SyntaxKind kind) => throw null;
         public static bool IsTrivia(Meziantou.Framework.Language.Xml.SyntaxKind kind) => throw null;
+        public static bool IsWhitespace(char value) => throw null;
         public static bool IsNameStartCharacter(System.Text.Rune value) => throw null;
         public static bool IsNameCharacter(System.Text.Rune value) => throw null;
     }
@@ -106,7 +107,8 @@ namespace Meziantou.Framework.Language.Xml
         BadToken = 37,
         EndOfFileToken = 38,
         WhitespaceTrivia = 39,
-        EndOfLineTrivia = 40
+        EndOfLineTrivia = 40,
+        SkippedTextTrivia = 41
     }
 
     public sealed class XmlAttributeSyntax : Meziantou.Framework.Language.Xml.XmlSyntaxNode
@@ -451,6 +453,7 @@ namespace Meziantou.Framework.Language.Xml
     {
         public Meziantou.Framework.Language.SyntaxToken TextToken { get => throw null; }
         public string Text { get => throw null; }
+        public string Value { get => throw null; }
         public Meziantou.Framework.Language.Xml.XmlTextSyntax WithText(string text) => throw null;
         public Meziantou.Framework.Language.Xml.XmlTextSyntax Update(Meziantou.Framework.Language.SyntaxToken textToken) => throw null;
         public Meziantou.Framework.Language.Xml.XmlTextSyntax WithTextToken(Meziantou.Framework.Language.SyntaxToken textToken) => throw null;

--- a/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/CharacterData.cs
+++ b/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/CharacterData.cs
@@ -1,0 +1,257 @@
+using System.Buffers;
+using System.Text;
+
+namespace Meziantou.Framework.Language.Xml.Syntax.InternalSyntax;
+
+/// <summary>Reads character data the way an XML processor does.</summary>
+/// <remarks>
+/// A character reference and one of the five predefined entities are replaced by what they stand for, and line
+/// breaks are normalized to a line feed (XML 1.0 §2.11). An attribute value is normalized further, every whitespace
+/// character becoming a space (§3.3.3). Any other entity is left as it was written, because resolving it would mean
+/// reading the DTD.
+/// </remarks>
+internal static class CharacterData
+{
+    private static readonly SearchValues<char> TextSpecialCharacters = SearchValues.Create("&\r]<");
+    private static readonly SearchValues<char> AttributeSpecialCharacters = SearchValues.Create("&\r\n\t<");
+
+    private static readonly SearchValues<char> InvalidCharacters = SearchValues.Create(CreateInvalidCharacters());
+
+    /// <summary>Decodes the character data <paramref name="text"/> holds, without reporting anything.</summary>
+    public static string Decode(string text, bool isAttribute) => Read(text, 0, text.Length, isAttribute, reporter: null);
+
+    /// <summary>Decodes <paramref name="text"/> from <paramref name="start"/> to <paramref name="end"/>, reporting what is wrong with it.</summary>
+    public static string Read(string text, int start, int end, bool isAttribute, ICharacterDataReporter? reporter)
+    {
+        var span = text.AsSpan(start, end - start);
+        var firstSpecial = span.IndexOfAny(isAttribute ? AttributeSpecialCharacters : TextSpecialCharacters);
+        if (firstSpecial < 0)
+            return text.Substring(start, end - start);
+
+        var builder = new StringBuilder(end - start);
+        builder.Append(span[..firstSpecial]);
+
+        var index = start + firstSpecial;
+        while (index < end)
+        {
+            var current = text[index];
+            switch (current)
+            {
+                case '&':
+                    index = ReadReference(text, index, end, builder, reporter);
+                    continue;
+
+                case '\r':
+                    builder.Append(isAttribute ? ' ' : '\n');
+                    index += index + 1 < end && text[index + 1] == '\n' ? 2 : 1;
+                    continue;
+
+                case '\n' or '\t' when isAttribute:
+                    builder.Append(' ');
+                    break;
+
+                case '<' when isAttribute:
+                    reporter?.Report(index, 1, XmlDiagnosticDescriptors.LessThanInAttributeValue);
+                    builder.Append(current);
+                    break;
+
+                case ']' when !isAttribute && index + 2 < end && text[index + 1] == ']' && text[index + 2] == '>':
+                    reporter?.Report(index, 3, XmlDiagnosticDescriptors.CDataEndInText);
+                    builder.Append("]]>");
+                    index += 3;
+                    continue;
+
+                default:
+                    builder.Append(current);
+                    break;
+            }
+
+            index++;
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Determines whether <paramref name="value"/> matches the <c>Char</c> production of XML 1.0.</summary>
+    public static bool IsXmlCharacter(int value) => value switch
+    {
+        0x9 or 0xA or 0xD => true,
+        >= 0x20 and <= 0xD7FF => true,
+        >= 0xE000 and <= 0xFFFD => true,
+        >= 0x10000 and <= 0x10FFFF => true,
+        _ => false,
+    };
+
+    /// <summary>Returns the index of the first UTF-16 unit that is not part of an XML character, or -1.</summary>
+    /// <remarks>A surrogate is only invalid when it is not half of a pair, which the caller confirms.</remarks>
+    public static int IndexOfPossiblyInvalidCharacter(ReadOnlySpan<char> text) => text.IndexOfAny(InvalidCharacters);
+
+    /// <summary>Reads the reference starting at the ampersand at <paramref name="index"/>, and returns where reading resumes.</summary>
+    private static int ReadReference(string text, int index, int end, StringBuilder builder, ICharacterDataReporter? reporter)
+    {
+        if (index + 1 < end && text[index + 1] == '#')
+            return ReadCharacterReference(text, index, end, builder, reporter);
+
+        var nameEnd = index + 1;
+        if (nameEnd < end && TryReadScalar(text, nameEnd, end, out var first, out var firstLength) && SyntaxFacts.IsNameStartCharacter(first))
+        {
+            nameEnd += firstLength;
+            while (nameEnd < end && TryReadScalar(text, nameEnd, end, out var scalar, out var length) && SyntaxFacts.IsNameCharacter(scalar))
+            {
+                nameEnd += length;
+            }
+        }
+
+        if (nameEnd == index + 1 || nameEnd >= end || text[nameEnd] != ';')
+        {
+            // Not a reference at all, so the ampersand stands for itself and what follows it is read as usual.
+            reporter?.Report(index, 1, XmlDiagnosticDescriptors.UnescapedAmpersand);
+            builder.Append('&');
+
+            return index + 1;
+        }
+
+        var name = text[(index + 1)..nameEnd];
+        var replacement = name switch
+        {
+            "lt" => "<",
+            "gt" => ">",
+            "amp" => "&",
+            "apos" => "'",
+            "quot" => "\"",
+            _ => null,
+        };
+
+        if (replacement is null)
+        {
+            if (reporter is not null && !reporter.IsEntityDeclared(name))
+            {
+                reporter.Report(index, nameEnd + 1 - index, XmlDiagnosticDescriptors.UndeclaredEntity, name);
+            }
+
+            builder.Append(text, index, nameEnd + 1 - index);
+        }
+        else
+        {
+            builder.Append(replacement);
+        }
+
+        return nameEnd + 1;
+    }
+
+    private static int ReadCharacterReference(string text, int index, int end, StringBuilder builder, ICharacterDataReporter? reporter)
+    {
+        var position = index + 2;
+        var isHexadecimal = position < end && text[position] == 'x';
+        if (isHexadecimal)
+        {
+            position++;
+        }
+
+        var digitsStart = position;
+        var value = 0;
+        var overflow = false;
+        while (position < end && TryGetDigit(text[position], isHexadecimal, out var digit))
+        {
+            value = (value * (isHexadecimal ? 16 : 10)) + digit;
+            if (value > 0x10FFFF)
+            {
+                // Clamping keeps the arithmetic from overflowing; the value is out of range whatever the rest says.
+                overflow = true;
+                value = 0x110000;
+            }
+
+            position++;
+        }
+
+        if (position == digitsStart || position >= end || text[position] != ';')
+        {
+            var length = Math.Min(position + 1, end) - index;
+            reporter?.Report(index, length, XmlDiagnosticDescriptors.MalformedCharacterReference, text.Substring(index, length));
+            builder.Append('&');
+
+            return index + 1;
+        }
+
+        position++;
+        if (overflow || !IsXmlCharacter(value))
+        {
+            reporter?.Report(index, position - index, XmlDiagnosticDescriptors.InvalidCharacterReference, text[index..position]);
+            builder.Append(text, index, position - index);
+        }
+        else
+        {
+            builder.Append(char.ConvertFromUtf32(value));
+        }
+
+        return position;
+    }
+
+    private static bool TryGetDigit(char value, bool isHexadecimal, out int digit)
+    {
+        digit = value switch
+        {
+            >= '0' and <= '9' => value - '0',
+            >= 'a' and <= 'f' when isHexadecimal => value - 'a' + 10,
+            >= 'A' and <= 'F' when isHexadecimal => value - 'A' + 10,
+            _ => -1,
+        };
+
+        return digit >= 0;
+    }
+
+    /// <summary>Reads the scalar value at <paramref name="position"/>, and how many UTF-16 units it took.</summary>
+    /// <remarks>A lone surrogate is not a scalar value at all, so it can be no part of a name.</remarks>
+    public static bool TryReadScalar(string text, int position, int end, out Rune scalar, out int length)
+    {
+        if (position >= end)
+        {
+            scalar = default;
+            length = 0;
+
+            return false;
+        }
+
+        var first = text[position];
+        if (!char.IsSurrogate(first))
+        {
+            scalar = new Rune(first);
+            length = 1;
+
+            return true;
+        }
+
+        if (position + 1 < end && Rune.TryCreate(first, text[position + 1], out scalar))
+        {
+            length = 2;
+
+            return true;
+        }
+
+        scalar = default;
+        length = 0;
+
+        return false;
+    }
+
+    private static string CreateInvalidCharacters()
+    {
+        var builder = new StringBuilder();
+        for (var value = 0; value < 0x20; value++)
+        {
+            if (value is not (0x9 or 0xA or 0xD))
+            {
+                builder.Append((char)value);
+            }
+        }
+
+        for (var value = 0xD800; value <= 0xDFFF; value++)
+        {
+            builder.Append((char)value);
+        }
+
+        builder.Append('\uFFFE').Append('\uFFFF');
+
+        return builder.ToString();
+    }
+}

--- a/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/ICharacterDataReporter.cs
+++ b/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/ICharacterDataReporter.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.Language.Xml.Syntax.InternalSyntax;
+
+/// <summary>Receives what is wrong with a run of character data, and says which entities the document declares.</summary>
+internal interface ICharacterDataReporter
+{
+    bool IsEntityDeclared(string name);
+
+    void Report(int start, int length, DiagnosticDescriptor descriptor, params object?[] arguments);
+}

--- a/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/LanguageParser.cs
+++ b/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/LanguageParser.cs
@@ -1,17 +1,34 @@
 using System.Runtime.InteropServices;
-using System.Text;
 using Meziantou.Framework.Language.InternalSyntax;
+using static Meziantou.Framework.Language.Xml.Syntax.InternalSyntax.XmlDiagnosticDescriptors;
 using GreenToken = Meziantou.Framework.Language.InternalSyntax.SyntaxToken;
 
 namespace Meziantou.Framework.Language.Xml.Syntax.InternalSyntax;
 
 /// <summary>Reads a document into green nodes, reporting what is wrong with it rather than throwing.</summary>
 /// <remarks>
+/// <para>
 /// Whitespace is trivia only inside a tag. Between tags it is character data, which XML says is significant, so it
 /// becomes an <see cref="XmlTextSyntax"/> of its own.
+/// </para>
+/// <para>
+/// The checks are those of a non-validating processor: the well-formedness constraints of XML 1.0 and of Namespaces
+/// in XML 1.0. The DTD is read only far enough to know where it ends and which general entities it declares.
+/// </para>
+/// <para>
+/// Recovery aims to keep the shape the author meant. A tag missing its <c>&gt;</c> still opens its element, text a
+/// tag cannot use becomes skipped-text trivia inside that tag, and an end tag that matches an element further up
+/// closes the elements left open in between.
+/// </para>
 /// </remarks>
-internal sealed class LanguageParser
+internal sealed class LanguageParser : ICharacterDataReporter
 {
+    private const string XmlNamespaceUri = "http://www.w3.org/XML/1998/namespace";
+    private const string XmlnsNamespaceUri = "http://www.w3.org/2000/xmlns/";
+
+    private static readonly TagDiagnostics ElementTagDiagnostics = new(UnexpectedTextInStartTag, MissingAttributeValue, UnquotedAttributeValue, UnterminatedAttributeValue, MissingWhitespaceBeforeAttribute);
+    private static readonly TagDiagnostics DeclarationDiagnostics = new(UnexpectedTextInDeclaration, DeclarationMissingAttributeValue, DeclarationUnquotedAttributeValue, DeclarationUnterminatedAttributeValue, DeclarationMissingWhitespaceBeforeAttribute);
+
     private readonly SourceText _source;
     private readonly string _text;
     private readonly List<Diagnostic> _diagnostics = [];
@@ -19,41 +36,50 @@ internal sealed class LanguageParser
     private readonly Stack<ElementBuilder> _elementStack = new();
     private int _position;
 
+    private bool _hasRootElement;
+    private bool _hasDocumentType;
+    private bool _hasMisplacedContent;
+    private HashSet<string>? _declaredEntities;
+    private bool _mayDeclareEntitiesElsewhere;
+
     public LanguageParser(SourceText source)
     {
         _source = source;
         _text = source.Text;
     }
 
+    /// <summary>Gets everything wrong with the document, in the order it appears in the text.</summary>
     public IReadOnlyList<Diagnostic> Diagnostics => _diagnostics;
 
     public XmlDocumentSyntax ParseDocument()
     {
+        ReportInvalidCharacters();
+
         while (!IsAtEnd)
         {
             if (Current != '<')
             {
-                AddNode(ParseText());
+                ParseText();
             }
             else if (Match("<!--"))
             {
-                AddNode(ParseComment());
+                ParseComment();
             }
             else if (Match("<![CDATA["))
             {
-                AddNode(ParseCData());
+                ParseCData();
             }
-            else if (MatchInsensitive("<?xml"))
+            else if (IsAtXmlDeclaration())
             {
-                AddNode(ParseDeclaration());
+                ParseDeclaration();
             }
             else if (Match("<?"))
             {
-                AddNode(ParseProcessingInstruction());
+                ParseProcessingInstruction();
             }
             else if (MatchInsensitive("<!DOCTYPE"))
             {
-                AddNode(ParseDocumentType());
+                ParseDocumentType();
             }
             else if (Match("</"))
             {
@@ -61,7 +87,7 @@ internal sealed class LanguageParser
             }
             else
             {
-                ParseElementOrSkippedText();
+                ParseStartTagOrSkippedText();
             }
         }
 
@@ -69,10 +95,20 @@ internal sealed class LanguageParser
         // an end tag so the text it covers is still accounted for.
         while (_elementStack.Count > 0)
         {
-            var unclosed = _elementStack.Pop();
-            AddDiagnostic(unclosed.Start, _text.Length - unclosed.Start, "XML0001", $"Missing end tag for '{unclosed.Name}'.");
-            AddNode(new XmlElementSyntax(unclosed.StartTag, SyntaxFactory.List(CollectionsMarshal.AsSpan(unclosed.Content)), endTag: null));
+            CloseUnclosedElement();
         }
+
+        // A document whose top level already holds something misplaced has been reported for that; saying the root
+        // element is missing as well would only repeat it.
+        if (!_hasRootElement && !_hasMisplacedContent)
+        {
+            AddDiagnostic(_text.Length, 0, MissingRootElement);
+        }
+
+        // The checks run in several passes, so the order they found things in is not the order of the text.
+        var sorted = _diagnostics.OrderBy(diagnostic => diagnostic.Location.SourceSpan.Start).ToArray();
+        _diagnostics.Clear();
+        _diagnostics.AddRange(sorted);
 
         return new XmlDocumentSyntax(SyntaxFactory.List(CollectionsMarshal.AsSpan(_documentNodes)), SyntaxFactory.Token(SyntaxKind.EndOfFileToken));
     }
@@ -80,125 +116,348 @@ internal sealed class LanguageParser
     private bool IsAtEnd => _position >= _text.Length;
     private char Current => _position < _text.Length ? _text[_position] : '\0';
 
-    private XmlTextSyntax ParseText()
-    {
-        var start = _position;
-        while (!IsAtEnd && Current != '<')
-        {
-            _position++;
-        }
+    bool ICharacterDataReporter.IsEntityDeclared(string name) => _mayDeclareEntitiesElsewhere || (_declaredEntities?.Contains(name) ?? false);
 
-        return new XmlTextSyntax(SyntaxFactory.Token(leading: null, SyntaxKind.TextToken, _text[start.._position]));
+    void ICharacterDataReporter.Report(int start, int length, DiagnosticDescriptor descriptor, params object?[] arguments) => AddDiagnostic(start, length, descriptor, arguments);
+
+    /// <summary>Reports every run of UTF-16 units that is not an XML character, wherever it stands.</summary>
+    private void ReportInvalidCharacters()
+    {
+        var index = 0;
+        while (index < _text.Length)
+        {
+            var offset = CharacterData.IndexOfPossiblyInvalidCharacter(_text.AsSpan(index));
+            if (offset < 0)
+                return;
+
+            index += offset;
+            if (!IsInvalidUnit(index))
+            {
+                // Half of a well-formed surrogate pair, which is a character outside the basic plane.
+                index += 2;
+                continue;
+            }
+
+            var start = index;
+            do
+            {
+                index++;
+            }
+            while (index < _text.Length && IsInvalidUnit(index));
+
+            AddDiagnostic(start, index - start, InvalidCharacter, ((int)_text[start]).ToString("X4", CultureInfo.InvariantCulture));
+        }
     }
 
-    private XmlCommentSyntax ParseComment() => ParseDelimited(
-        SyntaxKind.XmlCommentStartToken, SyntaxKind.CommentToken, SyntaxKind.XmlCommentEndToken,
-        "XML0008", "Unterminated XML comment.",
-        static (start, text, end) => new XmlCommentSyntax(start, text, end));
+    private bool IsInvalidUnit(int index)
+    {
+        var value = _text[index];
+        if (char.IsHighSurrogate(value))
+            return index + 1 >= _text.Length || !char.IsLowSurrogate(_text[index + 1]);
 
-    private XmlCDataSectionSyntax ParseCData() => ParseDelimited(
-        SyntaxKind.CDataStartToken, SyntaxKind.CDataToken, SyntaxKind.CDataEndToken,
-        "XML0009", "Unterminated CDATA section.",
-        static (start, text, end) => new XmlCDataSectionSyntax(start, text, end));
+        if (char.IsLowSurrogate(value))
+            return index == 0 || !char.IsHighSurrogate(_text[index - 1]);
 
-    /// <summary>Reads a construct written as an opening delimiter, free text, and a closing delimiter.</summary>
-    private TNode ParseDelimited<TNode>(SyntaxKind startKind, SyntaxKind textKind, SyntaxKind endKind, string id, string message, Func<GreenNode, GreenNode, GreenNode, TNode> create)
+        return !CharacterData.IsXmlCharacter(value);
+    }
+
+    private void ParseText()
     {
         var start = _position;
-        var startText = SyntaxFacts.GetText(startKind);
-        var endText = SyntaxFacts.GetText(endKind);
-        _position += startText.Length;
+        var length = _text.AsSpan(_position).IndexOf('<');
+        _position = length < 0 ? _text.Length : _position + length;
 
-        var textStart = _position;
-        var end = _text.IndexOf(endText, _position, StringComparison.Ordinal);
+        // Outside the root element any text but whitespace is an error of its own, so what it holds is not examined.
+        var value = CharacterData.Read(_text, start, _position, isAttribute: false, _elementStack.Count > 0 ? this : null);
+
+        AddNode(new XmlTextSyntax(SyntaxFactory.TokenWithValue(leading: null, SyntaxKind.TextToken, _text[start.._position], value)), start);
+    }
+
+    private void ParseComment()
+    {
+        var start = _position;
+        var (textStart, textEnd, terminated) = ReadDelimited("<!--", "-->", UnterminatedComment);
+        var endToken = terminated ? SyntaxFactory.Token(SyntaxKind.XmlCommentEndToken) : SyntaxFactory.MissingToken(SyntaxKind.XmlCommentEndToken);
+
+        var doubleHyphen = _text.IndexOf("--", textStart, textEnd - textStart, StringComparison.Ordinal);
+        if (doubleHyphen >= 0)
+        {
+            AddDiagnostic(doubleHyphen, 2, DoubleHyphenInComment);
+        }
+        else if (terminated && textEnd > textStart && _text[textEnd - 1] == '-')
+        {
+            AddDiagnostic(textEnd - 1, 4, HyphenBeforeCommentEnd);
+        }
+
+        AddNode(new XmlCommentSyntax(SyntaxFactory.Token(SyntaxKind.XmlCommentStartToken), SyntaxFactory.Token(leading: null, SyntaxKind.CommentToken, _text[textStart..textEnd]), endToken), start);
+    }
+
+    private void ParseCData()
+    {
+        var start = _position;
+        var (textStart, textEnd, terminated) = ReadDelimited("<![CDATA[", "]]>", UnterminatedCData);
+        var endToken = terminated ? SyntaxFactory.Token(SyntaxKind.CDataEndToken) : SyntaxFactory.MissingToken(SyntaxKind.CDataEndToken);
+
+        AddNode(new XmlCDataSectionSyntax(SyntaxFactory.Token(SyntaxKind.CDataStartToken), SyntaxFactory.Token(leading: null, SyntaxKind.CDataToken, _text[textStart..textEnd]), endToken), start);
+    }
+
+    /// <summary>Reads past a construct written as an opening delimiter, free text, and a closing delimiter.</summary>
+    private (int TextStart, int TextEnd, bool Terminated) ReadDelimited(string startText, string endText, DiagnosticDescriptor unterminated)
+    {
+        var start = _position;
+        var textStart = _position + startText.Length;
+        var end = _text.IndexOf(endText, textStart, StringComparison.Ordinal);
         if (end < 0)
         {
             _position = _text.Length;
-            AddDiagnostic(start, _position - start, id, message);
+            AddDiagnostic(start, _position - start, unterminated);
 
-            return create(SyntaxFactory.Token(startKind), SyntaxFactory.Token(leading: null, textKind, _text[textStart.._position]), SyntaxFactory.MissingToken(endKind));
+            return (textStart, _position, false);
         }
 
         _position = end + endText.Length;
 
-        return create(SyntaxFactory.Token(startKind), SyntaxFactory.Token(leading: null, textKind, _text[textStart..end]), SyntaxFactory.Token(endKind));
+        return (textStart, end, true);
     }
 
-    private XmlNodeSyntax ParseDeclaration()
+    /// <summary>Determines whether the reading position is an XML declaration rather than a processing instruction.</summary>
+    /// <remarks>
+    /// Only a target of exactly <c>xml</c> is one. <c>&lt;?xml-stylesheet</c> is an ordinary processing instruction, and
+    /// taking it for a declaration would lose the rest of the document.
+    /// </remarks>
+    private bool IsAtXmlDeclaration()
+    {
+        if (!MatchInsensitive("<?xml"))
+            return false;
+
+        var next = _position + "<?xml".Length;
+
+        return next >= _text.Length || SyntaxFacts.IsWhitespace(_text[next]) || _text[next] == '?';
+    }
+
+    private void ParseDeclaration()
     {
         var start = _position;
         _position += "<?xml".Length;
-        var startToken = SyntaxFactory.Token(leading: null, SyntaxKind.LessThanQuestionXmlToken, _text[start.._position]);
+        var startText = _text[start.._position];
+        var startToken = SyntaxFactory.Token(leading: null, SyntaxKind.LessThanQuestionXmlToken, startText);
+
+        if (!string.Equals(startText, "<?xml", StringComparison.Ordinal))
+        {
+            AddDiagnostic(start, startText.Length, DeclarationCase, startText);
+        }
+
+        // A byte order mark decoded into the text is not content, so a declaration right after one is still first.
+        if (start != 0 && !(start == 1 && _text[0] == '\uFEFF'))
+        {
+            AddDiagnostic(start, startText.Length, MisplacedDeclaration);
+        }
 
         var attributes = new List<GreenNode?>();
+        var infos = new List<AttributeInfo>();
+        GreenToken endToken;
         while (true)
         {
-            var trivia = LexTagTrivia();
+            var tagEnd = _position;
+            var trivia = LexTagTrivia(isDeclaration: true, "xml", out var followsSkippedText);
             if (Match("?>"))
             {
                 _position += 2;
-
-                return new XmlDeclarationSyntax(startToken, SyntaxFactory.List(CollectionsMarshal.AsSpan(attributes)), SyntaxFactory.Token(trivia, SyntaxKind.QuestionGreaterThanToken));
+                endToken = SyntaxFactory.Token(trivia, SyntaxKind.QuestionGreaterThanToken);
+                break;
             }
 
-            if (!IsAtNameStart())
+            if (IsAtEnd || Current == '<')
             {
-                // Nothing here can be read as a pseudo-attribute, so the whole declaration is kept as skipped text.
-                _position = _text.Length;
-                AddDiagnostic(start, _position - start, "XML0007", "Unterminated XML declaration.");
-
-                return SkippedText(start, _position);
+                endToken = WithLeading(SyntaxFactory.MissingToken(SyntaxKind.QuestionGreaterThanToken), trivia);
+                AddDiagnostic(start, tagEnd - start, UnterminatedDeclaration);
+                break;
             }
 
-            attributes.Add(ParseAttribute(trivia));
+            attributes.Add(ParseAttribute(trivia, DeclarationDiagnostics, followsSkippedText, out var info));
+            infos.Add(info);
+        }
+
+        ValidateDeclaration(start, infos);
+        AddNode(new XmlDeclarationSyntax(startToken, SyntaxFactory.List(CollectionsMarshal.AsSpan(attributes)), endToken), start);
+    }
+
+    /// <summary>Checks the pseudo-attributes: a version, then optionally an encoding, then optionally standalone.</summary>
+    private void ValidateDeclaration(int start, List<AttributeInfo> attributes)
+    {
+        if (attributes.Count == 0 || !string.Equals(attributes[0].Name, "version", StringComparison.Ordinal))
+        {
+            AddDiagnostic(start, "<?xml".Length, MissingVersion);
+        }
+
+        var stage = 0;
+        foreach (var attribute in attributes)
+        {
+            var order = attribute.Name switch
+            {
+                "version" => 1,
+                "encoding" => 2,
+                "standalone" => 3,
+                _ => 0,
+            };
+
+            if (order <= stage)
+            {
+                AddDiagnostic(attribute.NameStart, attribute.Name.Length, UnexpectedDeclarationAttribute, attribute.Name);
+                continue;
+            }
+
+            stage = order;
+            if (!attribute.HasValue)
+                continue;
+
+            // Pseudo-attribute values are literal: a reference in one is not resolved, so the raw text is what counts.
+            var value = attribute.RawValue;
+            switch (order)
+            {
+                case 1 when !IsVersionNumber(value):
+                    AddDiagnostic(attribute.ValueStart, value.Length, InvalidVersion, value);
+                    break;
+
+                case 2 when !IsEncodingName(value):
+                    AddDiagnostic(attribute.ValueStart, value.Length, InvalidEncoding, value);
+                    break;
+
+                case 3 when value is not ("yes" or "no"):
+                    AddDiagnostic(attribute.ValueStart, value.Length, InvalidStandalone, value);
+                    break;
+            }
+        }
+
+        static bool IsVersionNumber(string value)
+            => value.Length > 2 && value.StartsWith("1.", StringComparison.Ordinal) && !value.AsSpan(2).ContainsAnyExceptInRange('0', '9');
+
+        static bool IsEncodingName(string value)
+        {
+            if (value.Length == 0 || !char.IsAsciiLetter(value[0]))
+                return false;
+
+            foreach (var character in value.AsSpan(1))
+            {
+                if (!char.IsAsciiLetterOrDigit(character) && character is not ('.' or '_' or '-'))
+                    return false;
+            }
+
+            return true;
         }
     }
 
-    private XmlNodeSyntax ParseProcessingInstruction()
+    private void ParseProcessingInstruction()
     {
         var start = _position;
         _position += 2;
         var end = _text.IndexOf("?>", _position, StringComparison.Ordinal);
-        if (end < 0)
-        {
-            _position = _text.Length;
-            AddDiagnostic(start, _position - start, "XML0012", "Unterminated processing instruction.");
-
-            return SkippedText(start, _position);
-        }
+        var terminated = end >= 0;
+        var limit = terminated ? end : _text.Length;
 
         var startToken = SyntaxFactory.Token(SyntaxKind.LessThanQuestionToken);
-        var trivia = LexTagTrivia(limit: end);
+        var nameTrivia = LexWhitespaceTrivia(limit);
         var nameStart = _position;
-        SkipNameCharacters(end);
+        if (IsAtNameStart())
+        {
+            SkipNameCharacters(limit);
+        }
 
-        var nameToken = _position > nameStart
-            ? SyntaxFactory.Token(trivia, SyntaxKind.IdentifierToken, _text[nameStart.._position])
-            : WithLeading(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken), trivia);
+        var target = _text[nameStart.._position];
+        var nameToken = target.Length > 0
+            ? SyntaxFactory.Token(nameTrivia, SyntaxKind.IdentifierToken, target)
+            : WithLeading(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken), nameTrivia);
 
-        // Everything up to the closing delimiter is the data, kept exactly as written so the text comes back whole.
-        var dataToken = SyntaxFactory.Token(leading: null, SyntaxKind.ProcessingInstructionDataToken, _text[_position..end]);
-        _position = end + 2;
+        if (target.Length == 0 || nameTrivia is not null)
+        {
+            AddDiagnostic(start, Math.Max(2, nameStart - start), MissingProcessingInstructionTarget);
+        }
 
-        return new XmlProcessingInstructionSyntax(startToken, nameToken, dataToken, SyntaxFactory.Token(SyntaxKind.QuestionGreaterThanToken));
+        if (string.Equals(target, "xml", StringComparison.OrdinalIgnoreCase))
+        {
+            AddDiagnostic(nameStart, target.Length, ReservedProcessingInstructionTarget, target);
+        }
+        else if (target.Contains(':', StringComparison.Ordinal))
+        {
+            AddDiagnostic(nameStart, target.Length, ColonInProcessingInstructionTarget);
+        }
+
+        // The data is everything up to the closing delimiter, except the whitespace separating it from the target.
+        var dataTrivia = LexWhitespaceTrivia(limit);
+        var dataStart = _position;
+        if (target.Length > 0 && dataTrivia is null && dataStart < limit)
+        {
+            AddDiagnostic(nameStart, target.Length, MissingWhitespaceAfterTarget);
+        }
+
+        var dataToken = dataStart < limit
+            ? SyntaxFactory.Token(dataTrivia, SyntaxKind.ProcessingInstructionDataToken, _text[dataStart..limit])
+            : WithLeading(SyntaxFactory.MissingToken(SyntaxKind.ProcessingInstructionDataToken), dataTrivia);
+
+        GreenToken endToken;
+        if (terminated)
+        {
+            _position = end + 2;
+            endToken = SyntaxFactory.Token(SyntaxKind.QuestionGreaterThanToken);
+        }
+        else
+        {
+            _position = _text.Length;
+            endToken = SyntaxFactory.MissingToken(SyntaxKind.QuestionGreaterThanToken);
+            AddDiagnostic(start, _position - start, UnterminatedProcessingInstruction);
+        }
+
+        AddNode(new XmlProcessingInstructionSyntax(startToken, nameToken, dataToken, endToken), start);
     }
 
-    private XmlDocumentTypeSyntax ParseDocumentType()
+    private void ParseDocumentType()
     {
         var start = _position;
         _position += "<!DOCTYPE".Length;
-        var startToken = SyntaxFactory.Token(leading: null, SyntaxKind.DocumentTypeStartToken, _text[start.._position]);
+        var startText = _text[start.._position];
+        var startToken = SyntaxFactory.Token(leading: null, SyntaxKind.DocumentTypeStartToken, startText);
 
-        var trivia = LexTagTrivia();
+        if (!string.Equals(startText, "<!DOCTYPE", StringComparison.Ordinal))
+        {
+            AddDiagnostic(start, startText.Length, DocumentTypeCase, startText);
+        }
+
+        if (_elementStack.Count > 0)
+        {
+            AddDiagnostic(start, startText.Length, DocumentTypeInsideElement);
+        }
+        else if (_hasRootElement)
+        {
+            AddDiagnostic(start, startText.Length, DocumentTypeAfterRootElement);
+        }
+        else if (_hasDocumentType)
+        {
+            AddDiagnostic(start, startText.Length, DuplicateDocumentType);
+        }
+
+        _hasDocumentType = true;
+        _declaredEntities ??= new(StringComparer.Ordinal);
+
+        var trivia = LexWhitespaceTrivia();
         var nameStart = _position;
         SkipNameCharacters();
 
-        var nameToken = _position > nameStart
-            ? SyntaxFactory.Token(trivia, SyntaxKind.IdentifierToken, _text[nameStart.._position])
+        var name = _text[nameStart.._position];
+        var nameToken = name.Length > 0
+            ? SyntaxFactory.Token(trivia, SyntaxKind.IdentifierToken, name)
             : WithLeading(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken), trivia);
 
-        // The internal subset may hold both quoted text and nested brackets, and a '>' inside either does not end
-        // the declaration.
+        if (name.Length == 0)
+        {
+            AddDiagnostic(start, startText.Length, MissingDocumentTypeName);
+        }
+        else if (trivia is null)
+        {
+            AddDiagnostic(start, startText.Length, MissingWhitespaceInDocumentType);
+        }
+
+        // The internal subset may hold quoted text, nested brackets, comments and processing instructions, and a '>'
+        // inside any of them does not end the declaration -- nor does a quote inside a comment start a literal.
         var contentStart = _position;
         var depth = 0;
         var quote = '\0';
@@ -212,6 +471,46 @@ internal sealed class LanguageParser
                 {
                     quote = '\0';
                 }
+
+                _position++;
+                continue;
+            }
+
+            if (depth > 0 && current == '<')
+            {
+                if (Match("<!--"))
+                {
+                    SkipPast("-->", "<!--".Length);
+                    continue;
+                }
+
+                if (Match("<?"))
+                {
+                    SkipPast("?>", "<?".Length);
+                    continue;
+                }
+
+                if (Match("<!ENTITY") && _position + "<!ENTITY".Length < _text.Length && SyntaxFacts.IsWhitespace(_text[_position + "<!ENTITY".Length]))
+                {
+                    _position += "<!ENTITY".Length;
+                    _ = LexWhitespaceTrivia();
+
+                    // A parameter entity, written with a '%', is not one a document's content can refer to.
+                    var entityNameStart = _position;
+                    if (IsAtNameStart())
+                    {
+                        SkipNameCharacters();
+                        _declaredEntities.Add(_text[entityNameStart.._position]);
+                    }
+
+                    continue;
+                }
+            }
+
+            if (depth > 0 && current == '%' && CharacterData.TryReadScalar(_text, _position + 1, _text.Length, out var scalar, out _) && SyntaxFacts.IsNameStartCharacter(scalar))
+            {
+                // A parameter entity reference can pull in declarations from anywhere.
+                _mayDeclareEntitiesElsewhere = true;
             }
             else if (current is '\'' or '"')
             {
@@ -225,13 +524,25 @@ internal sealed class LanguageParser
             {
                 depth = Math.Max(0, depth - 1);
             }
-            else if (current == '>' && depth == 0)
+            else if (depth == 0 && current == '>')
             {
                 terminated = true;
                 break;
             }
+            else if (depth == 0 && current == '<')
+            {
+                // Outside the internal subset a '<' can only be the next tag, so the declaration was never closed.
+                break;
+            }
 
             _position++;
+        }
+
+        var content = _text.AsSpan(contentStart, _position - contentStart).TrimStart(" \t\r\n");
+        if (content.StartsWith("SYSTEM", StringComparison.Ordinal) || content.StartsWith("PUBLIC", StringComparison.Ordinal))
+        {
+            // Declarations in the external subset cannot be seen without reading it.
+            _mayDeclareEntitiesElsewhere = true;
         }
 
         var contentToken = SyntaxFactory.Token(leading: null, SyntaxKind.DocumentTypeContentToken, _text[contentStart.._position]);
@@ -243,11 +554,17 @@ internal sealed class LanguageParser
         }
         else
         {
-            AddDiagnostic(start, _position - start, "XML0011", "Unterminated document type declaration.");
+            AddDiagnostic(start, _position - start, UnterminatedDocumentType);
             greaterThanToken = SyntaxFactory.MissingToken(SyntaxKind.GreaterThanToken);
         }
 
-        return new XmlDocumentTypeSyntax(startToken, nameToken, contentToken, greaterThanToken);
+        AddNode(new XmlDocumentTypeSyntax(startToken, nameToken, contentToken, greaterThanToken), start);
+    }
+
+    private void SkipPast(string terminator, int openingLength)
+    {
+        var end = _text.IndexOf(terminator, _position + openingLength, StringComparison.Ordinal);
+        _position = end < 0 ? _text.Length : end + terminator.Length;
     }
 
     private void ParseEndTag()
@@ -256,7 +573,7 @@ internal sealed class LanguageParser
         _position += 2;
         var lessThanSlashToken = SyntaxFactory.Token(SyntaxKind.LessThanSlashToken);
 
-        var trivia = LexTagTrivia();
+        var trivia = LexWhitespaceTrivia();
         var nameStart = _position;
         SkipNameCharacters();
 
@@ -265,23 +582,33 @@ internal sealed class LanguageParser
             ? SyntaxFactory.Token(trivia, SyntaxKind.IdentifierToken, name)
             : WithLeading(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken), trivia);
 
-        // Whatever a malformed tag puts between the name and the '>' is kept rather than dropped.
-        var skippedTrivia = LexTagTrivia();
+        // What is wrong with the tag itself is reported only when the tag goes on to close an element. One that does
+        // not is skipped as a whole, and saying so covers it.
+        PendingDiagnostic? problem = trivia is not null && name.Length > 0 ? new(start + 2, nameStart - start - 2, WhitespaceBeforeEndTagName, []) : null;
+
+        // Whatever a malformed tag puts between the name and the '>' is kept rather than dropped, but it stops at a
+        // '<', which can only be the next tag.
+        var skippedTrivia = LexWhitespaceTrivia();
         var skippedStart = _position;
-        while (!IsAtEnd && Current != '>')
+        while (!IsAtEnd && Current is not ('>' or '<'))
         {
             _position++;
         }
 
-        GreenNode? skippedTokens = _position > skippedStart
-            ? SyntaxFactory.Token(skippedTrivia, SyntaxKind.BadToken, _text[skippedStart.._position]).AsSkippedText()
-            : null;
+        GreenNode? skippedTokens = null;
+        if (_position > skippedStart)
+        {
+            var skipped = _text[skippedStart.._position];
+            skippedTokens = SyntaxFactory.Token(skippedTrivia, SyntaxKind.BadToken, skipped).AsSkippedText();
+            problem ??= new(skippedStart, skipped.Length, UnexpectedTextInEndTag, [skipped, name]);
+        }
 
         // Trivia the skipped tokens did not claim belongs to the '>', missing or not, so no character is lost.
         var greaterThanTrivia = skippedTokens is null ? skippedTrivia : null;
         GreenToken greaterThanToken;
-        if (IsAtEnd)
+        if (IsAtEnd || Current == '<')
         {
+            problem ??= new(start, _position - start, UnterminatedEndTag, [name]);
             greaterThanToken = WithLeading(SyntaxFactory.MissingToken(SyntaxKind.GreaterThanToken), greaterThanTrivia);
         }
         else
@@ -290,35 +617,85 @@ internal sealed class LanguageParser
             greaterThanToken = SyntaxFactory.Token(greaterThanTrivia, SyntaxKind.GreaterThanToken);
         }
 
-        if (_elementStack.Count == 0)
+        var depth = name.Length > 0 ? FindOpenElement(name) : -1;
+        if (depth < 0)
         {
-            AddDiagnostic(start, _position - start, "XML0002", $"Unexpected end tag '{name}'.");
-            AddNode(SkippedText(start, _position));
+            if (name.Length == 0)
+            {
+                AddDiagnostic(start, _position - start, MissingEndTagName);
+            }
+            else if (_elementStack.Count == 0)
+            {
+                AddDiagnostic(start, _position - start, UnexpectedEndTag, name);
+            }
+            else
+            {
+                AddDiagnostic(start, _position - start, MismatchedEndTag, name, _elementStack.Peek().Name);
+            }
+
+            AddNode(SkippedText(start, _position), start);
 
             return;
         }
 
-        var top = _elementStack.Peek();
-        if (!string.Equals(top.Name, name, StringComparison.Ordinal))
+        if (problem is { } pending)
         {
-            AddDiagnostic(start, _position - start, "XML0002", $"Mismatched end tag '{name}'.");
-            AddNode(SkippedText(start, _position));
-
-            return;
+            AddDiagnostic(pending.Start, pending.Length, pending.Descriptor, pending.Arguments);
         }
 
-        _ = _elementStack.Pop();
+        // The end tag belongs to an element further up, so the ones opened since were never closed.
+        for (var i = 0; i < depth; i++)
+        {
+            CloseUnclosedElement();
+        }
+
+        var element = _elementStack.Pop();
         var endTag = new XmlElementEndTagSyntax(lessThanSlashToken, nameToken, skippedTokens, greaterThanToken);
-        AddNode(new XmlElementSyntax(top.StartTag, SyntaxFactory.List(CollectionsMarshal.AsSpan(top.Content)), endTag));
+        AddNode(new XmlElementSyntax(element.StartTag, SyntaxFactory.List(CollectionsMarshal.AsSpan(element.Content)), endTag), element.Start);
     }
 
-    private void ParseElementOrSkippedText()
+    /// <summary>Returns how many open elements stand above the innermost one called <paramref name="name"/>, or -1.</summary>
+    private int FindOpenElement(string name)
+    {
+        var depth = 0;
+        foreach (var element in _elementStack)
+        {
+            if (string.Equals(element.Name, name, StringComparison.Ordinal))
+                return depth;
+
+            depth++;
+        }
+
+        return -1;
+    }
+
+    private void CloseUnclosedElement()
+    {
+        var unclosed = _elementStack.Pop();
+        AddDiagnostic(unclosed.Start, unclosed.StartTag.FullWidth, MissingEndTag, unclosed.Name);
+        AddNode(new XmlElementSyntax(unclosed.StartTag, SyntaxFactory.List(CollectionsMarshal.AsSpan(unclosed.Content)), endTag: null), unclosed.Start);
+    }
+
+    private void ParseStartTagOrSkippedText()
     {
         var start = _position;
         _position++;
         if (!IsAtNameStart())
         {
-            AddNode(ParseSkippedText(start, "Invalid start tag."));
+            // Not a tag. The text runs to a '>', but not past a '<', which is the next tag rather than part of this one.
+            while (!IsAtEnd && Current is not ('>' or '<'))
+            {
+                _position++;
+            }
+
+            if (!IsAtEnd && Current == '>')
+            {
+                _position++;
+            }
+
+            var isLoneLessThan = start + 1 >= _text.Length || SyntaxFacts.IsWhitespace(_text[start + 1]);
+            AddDiagnostic(start, _position - start, isLoneLessThan ? UnescapedLessThan : InvalidStartTag);
+            AddNode(SkippedText(start, _position), start);
 
             return;
         }
@@ -330,53 +707,70 @@ internal sealed class LanguageParser
         var name = _text[nameStart.._position];
         var nameToken = SyntaxFactory.Token(leading: null, SyntaxKind.IdentifierToken, name);
         var attributes = new List<GreenNode?>();
+        var infos = new List<AttributeInfo>();
 
         while (true)
         {
-            var trivia = LexTagTrivia();
+            var tagEnd = _position;
+            var trivia = LexTagTrivia(isDeclaration: false, name, out var followsSkippedText);
             if (Match("/>"))
             {
                 _position += 2;
-                AddNode(new XmlEmptyElementSyntax(lessThanToken, nameToken, SyntaxFactory.List(CollectionsMarshal.AsSpan(attributes)), SyntaxFactory.Token(trivia, SyntaxKind.SlashGreaterThanToken)));
+                _ = ValidateElement(nameStart, name, infos);
+                AddNode(new XmlEmptyElementSyntax(lessThanToken, nameToken, SyntaxFactory.List(CollectionsMarshal.AsSpan(attributes)), SyntaxFactory.Token(trivia, SyntaxKind.SlashGreaterThanToken)), start);
 
                 return;
             }
 
-            if (Match(">"))
+            if (IsAtEnd || Current is '>' or '<')
             {
-                _position++;
-                var startTag = new XmlElementStartTagSyntax(lessThanToken, nameToken, SyntaxFactory.List(CollectionsMarshal.AsSpan(attributes)), SyntaxFactory.Token(trivia, SyntaxKind.GreaterThanToken));
-                _elementStack.Push(new ElementBuilder(start, name, startTag));
+                GreenToken greaterThanToken;
+                if (Current == '>' && !IsAtEnd)
+                {
+                    _position++;
+                    greaterThanToken = SyntaxFactory.Token(trivia, SyntaxKind.GreaterThanToken);
+                }
+                else
+                {
+                    // The tag was never closed, but it still opens its element: what follows is most likely its content.
+                    AddDiagnostic(start, tagEnd - start, UnterminatedStartTag, name);
+                    greaterThanToken = WithLeading(SyntaxFactory.MissingToken(SyntaxKind.GreaterThanToken), trivia);
+                }
+
+                var scope = ValidateElement(nameStart, name, infos);
+                var startTag = new XmlElementStartTagSyntax(lessThanToken, nameToken, SyntaxFactory.List(CollectionsMarshal.AsSpan(attributes)), greaterThanToken);
+                _elementStack.Push(new ElementBuilder(start, name, startTag, scope));
 
                 return;
             }
 
-            if (!IsAtNameStart())
-            {
-                // The tag cannot be read any further, so the whole of it is kept as skipped text -- which is what the
-                // attributes read so far become part of again.
-                _position = start;
-                AddNode(ParseSkippedText(start, "Invalid attribute in start tag."));
-
-                return;
-            }
-
-            attributes.Add(ParseAttribute(trivia));
+            attributes.Add(ParseAttribute(trivia, ElementTagDiagnostics, followsSkippedText, out var info));
+            infos.Add(info);
         }
     }
 
-    private XmlAttributeSyntax ParseAttribute(GreenNode? leadingTrivia)
+    private XmlAttributeSyntax ParseAttribute(GreenNode? leadingTrivia, TagDiagnostics diagnostics, bool followsSkippedText, out AttributeInfo info)
     {
         var nameStart = _position;
         SkipNameCharacters();
 
-        var nameToken = SyntaxFactory.Token(leadingTrivia, SyntaxKind.IdentifierToken, _text[nameStart.._position]);
+        var name = _text[nameStart.._position];
+        var nameToken = SyntaxFactory.Token(leadingTrivia, SyntaxKind.IdentifierToken, name);
 
-        var equalsTrivia = LexTagTrivia();
-        if (Current != '=')
+        // Skipped text right in front of the name has been reported already, and is the more useful thing to say.
+        if (!followsSkippedText && nameStart > 0 && !SyntaxFacts.IsWhitespace(_text[nameStart - 1]))
+        {
+            AddDiagnostic(nameStart, name.Length, diagnostics.MissingWhitespace, name);
+        }
+
+        var nameEnd = _position;
+        var equalsTrivia = LexWhitespaceTrivia();
+        if (IsAtEnd || Current != '=')
         {
             // An attribute with no value at all. Rewinding leaves the whitespace for whatever comes next to claim.
-            _position = nameStart + nameToken.Text.Length;
+            _position = nameEnd;
+            AddDiagnostic(nameStart, name.Length, diagnostics.MissingValue, name);
+            info = new AttributeInfo(nameStart, name, nameEnd, RawValue: "", Value: "", HasValue: false);
 
             return new XmlAttributeSyntax(
                 nameToken,
@@ -388,71 +782,252 @@ internal sealed class LanguageParser
 
         _position++;
         var equalsToken = SyntaxFactory.Token(equalsTrivia, SyntaxKind.EqualsToken);
-        var valueTrivia = LexTagTrivia();
+        var equalsEnd = _position;
+        var valueTrivia = LexWhitespaceTrivia();
 
-        if (Current is '"' or '\'')
+        if (!IsAtEnd && Current is '"' or '\'')
         {
             var quote = Current;
             var quoteKind = quote == '"' ? SyntaxKind.DoubleQuoteToken : SyntaxKind.SingleQuoteToken;
             _position++;
             var valueStart = _position;
-            while (!IsAtEnd && Current != quote)
+
+            // A value runs to its closing quote. One that meets what looks like the next tag first was most likely
+            // never closed, and stopping there keeps the rest of the document out of it.
+            while (!IsAtEnd && Current != quote && !IsAtMarkupStart())
             {
                 _position++;
             }
 
-            var valueToken = SyntaxFactory.Token(leading: null, SyntaxKind.AttributeValueToken, _text[valueStart.._position]);
+            var raw = _text[valueStart.._position];
+            var value = CharacterData.Read(_text, valueStart, _position, isAttribute: true, this);
+            var valueToken = SyntaxFactory.TokenWithValue(leading: null, SyntaxKind.AttributeValueToken, raw, value);
             GreenToken endQuoteToken;
-            if (Current == quote)
+            if (!IsAtEnd && Current == quote)
             {
                 _position++;
                 endQuoteToken = SyntaxFactory.Token(quoteKind);
             }
             else
             {
+                AddDiagnostic(valueStart - 1, raw.Length + 1, diagnostics.UnterminatedValue, name);
                 endQuoteToken = SyntaxFactory.MissingToken(quoteKind);
             }
+
+            info = new AttributeInfo(nameStart, name, valueStart, raw, value, HasValue: true);
 
             return new XmlAttributeSyntax(nameToken, equalsToken, SyntaxFactory.Token(valueTrivia, quoteKind), valueToken, endQuoteToken);
         }
 
         var unquotedStart = _position;
-        while (!IsAtEnd && !char.IsWhiteSpace(Current) && !Match("/>") && Current != '>')
+        while (!IsAtEnd && !SyntaxFacts.IsWhitespace(Current) && Current is not ('>' or '<') && !Match("/>") && !Match("?>"))
         {
             _position++;
         }
+
+        if (_position == unquotedStart)
+        {
+            // Nothing that could be a value. Rewinding leaves the whitespace for whatever comes next to claim.
+            _position = equalsEnd;
+            AddDiagnostic(nameStart, name.Length, diagnostics.MissingValue, name);
+            info = new AttributeInfo(nameStart, name, equalsEnd, RawValue: "", Value: "", HasValue: false);
+
+            return new XmlAttributeSyntax(
+                nameToken,
+                equalsToken,
+                SyntaxFactory.MissingToken(SyntaxKind.DoubleQuoteToken),
+                SyntaxFactory.MissingToken(SyntaxKind.AttributeValueToken),
+                SyntaxFactory.MissingToken(SyntaxKind.DoubleQuoteToken));
+        }
+
+        var unquoted = _text[unquotedStart.._position];
+        AddDiagnostic(unquotedStart, unquoted.Length, diagnostics.UnquotedValue, name);
+        var unquotedValue = CharacterData.Read(_text, unquotedStart, _position, isAttribute: true, this);
+        info = new AttributeInfo(nameStart, name, unquotedStart, unquoted, unquotedValue, HasValue: true);
 
         return new XmlAttributeSyntax(
             nameToken,
             equalsToken,
             WithLeading(SyntaxFactory.MissingToken(SyntaxKind.DoubleQuoteToken), valueTrivia),
-            SyntaxFactory.Token(leading: null, SyntaxKind.AttributeValueToken, _text[unquotedStart.._position]),
+            SyntaxFactory.TokenWithValue(leading: null, SyntaxKind.AttributeValueToken, unquoted, unquotedValue),
             SyntaxFactory.MissingToken(SyntaxKind.DoubleQuoteToken));
     }
 
-    private XmlSkippedTextSyntax ParseSkippedText(int start, string message)
+    /// <summary>
+    /// Checks the constraints a start tag can break once all of it is read: unique attributes, and the Namespaces in
+    /// XML rules for its names and declarations.
+    /// </summary>
+    /// <returns>The namespaces in scope for the element's content.</returns>
+    private NamespaceScope? ValidateElement(int nameStart, string name, List<AttributeInfo> attributes)
     {
-        _position = start;
-        while (!IsAtEnd && Current != '>')
+        var parentScope = _elementStack.Count > 0 ? _elementStack.Peek().Scope : null;
+        Dictionary<string, string>? bindings = null;
+
+        // Most tags have a handful of attributes, where comparing each pair costs less than hashing them.
+        var seenNames = attributes.Count > 8 ? new HashSet<string>(StringComparer.Ordinal) : null;
+        for (var i = 0; i < attributes.Count; i++)
         {
-            _position++;
+            var attribute = attributes[i];
+            if (seenNames is null ? IsNameUsedBefore(attributes, i) : !seenNames.Add(attribute.Name))
+            {
+                AddDiagnostic(attribute.NameStart, attribute.Name.Length, DuplicateAttribute, attribute.Name);
+            }
+
+            if (!ValidateQualifiedNameSyntax(attribute.NameStart, attribute.Name) || !TryGetNamespaceDeclarationPrefix(attribute.Name, out var prefix) || !attribute.HasValue)
+                continue;
+
+            var namespaceUri = attribute.Value;
+            if (string.Equals(prefix, "xmlns", StringComparison.Ordinal))
+            {
+                AddDiagnostic(attribute.NameStart, attribute.Name.Length, XmlnsPrefixDeclaration);
+                continue;
+            }
+
+            if (string.Equals(prefix, "xml", StringComparison.Ordinal))
+            {
+                if (!string.Equals(namespaceUri, XmlNamespaceUri, StringComparison.Ordinal))
+                {
+                    AddDiagnostic(attribute.NameStart, attribute.Name.Length, XmlPrefixBinding);
+                }
+
+                continue;
+            }
+
+            if (namespaceUri is XmlNamespaceUri or XmlnsNamespaceUri)
+            {
+                AddDiagnostic(attribute.NameStart, attribute.Name.Length, ReservedNamespace, namespaceUri, attribute.Name);
+            }
+            else if (prefix.Length > 0 && namespaceUri.Length == 0)
+            {
+                AddDiagnostic(attribute.NameStart, attribute.Name.Length, EmptyPrefixedNamespace, prefix);
+            }
+
+            bindings ??= new(StringComparer.Ordinal);
+            bindings[prefix] = namespaceUri;
         }
 
-        if (!IsAtEnd)
+        var scope = bindings is null ? parentScope : new NamespaceScope(parentScope, bindings);
+
+        if (ValidateQualifiedNameSyntax(nameStart, name) && TryGetPrefix(name, out var elementPrefix))
         {
-            _position++;
+            if (string.Equals(elementPrefix, "xmlns", StringComparison.Ordinal))
+            {
+                AddDiagnostic(nameStart, name.Length, XmlnsElementPrefix);
+            }
+            else if (ResolvePrefix(scope, elementPrefix) is null)
+            {
+                AddDiagnostic(nameStart, elementPrefix.Length, UndeclaredPrefix, elementPrefix);
+            }
         }
 
-        AddDiagnostic(start, _position - start, "XML0010", message);
+        // Two attributes can share a namespace and a local name under different prefixes.
+        Dictionary<(string NamespaceUri, string LocalName), string>? qualified = null;
+        foreach (var attribute in attributes)
+        {
+            if (TryGetNamespaceDeclarationPrefix(attribute.Name, out _) || !IsQualifiedName(attribute.Name) || !TryGetPrefix(attribute.Name, out var attributePrefix))
+                continue;
 
-        return SkippedText(start, _position);
+            var namespaceUri = ResolvePrefix(scope, attributePrefix);
+            if (namespaceUri is null)
+            {
+                AddDiagnostic(attribute.NameStart, attributePrefix.Length, UndeclaredPrefix, attributePrefix);
+                continue;
+            }
+
+            // An attribute repeated under the same prefix has been reported as a duplicate already.
+            var expandedName = (namespaceUri, attribute.Name[(attributePrefix.Length + 1)..]);
+            qualified ??= [];
+            if (!qualified.TryAdd(expandedName, attribute.Name) && !string.Equals(qualified[expandedName], attribute.Name, StringComparison.Ordinal))
+            {
+                AddDiagnostic(attribute.NameStart, attribute.Name.Length, DuplicateExpandedAttribute, qualified[expandedName], attribute.Name);
+            }
+        }
+
+        return scope;
+
+        static bool IsNameUsedBefore(List<AttributeInfo> attributes, int index)
+        {
+            for (var i = 0; i < index; i++)
+            {
+                if (string.Equals(attributes[i].Name, attributes[index].Name, StringComparison.Ordinal))
+                    return true;
+            }
+
+            return false;
+        }
     }
+
+    /// <summary>Reports a name that is not a <c>QName</c>: at most one colon, with a name on each side of it.</summary>
+    private bool ValidateQualifiedNameSyntax(int start, string name)
+    {
+        if (IsQualifiedName(name))
+            return true;
+
+        AddDiagnostic(start, name.Length, InvalidQualifiedName, name);
+
+        return false;
+    }
+
+    private static bool IsQualifiedName(string name)
+    {
+        var colon = name.IndexOf(':', StringComparison.Ordinal);
+        if (colon < 0)
+            return true;
+
+        if (colon == 0 || colon == name.Length - 1 || name.AsSpan(colon + 1).Contains(':'))
+            return false;
+
+        return CharacterData.TryReadScalar(name, colon + 1, name.Length, out var scalar, out _) && SyntaxFacts.IsNameStartCharacter(scalar);
+    }
+
+    private static bool TryGetPrefix(string name, out string prefix)
+    {
+        var colon = name.IndexOf(':', StringComparison.Ordinal);
+        prefix = colon > 0 ? name[..colon] : "";
+
+        return colon > 0;
+    }
+
+    private static bool TryGetNamespaceDeclarationPrefix(string name, out string prefix)
+    {
+        if (string.Equals(name, "xmlns", StringComparison.Ordinal))
+        {
+            prefix = "";
+
+            return true;
+        }
+
+        if (name.StartsWith("xmlns:", StringComparison.Ordinal))
+        {
+            prefix = name["xmlns:".Length..];
+
+            return true;
+        }
+
+        prefix = "";
+
+        return false;
+    }
+
+    private static string? ResolvePrefix(NamespaceScope? scope, string prefix)
+        => string.Equals(prefix, "xml", StringComparison.Ordinal) ? XmlNamespaceUri : scope?.Resolve(prefix);
 
     private XmlSkippedTextSyntax SkippedText(int start, int end)
         => new(SyntaxFactory.BadToken(leading: null, _text[start..end]));
 
     /// <summary>Determines whether an XML name begins at the reading position.</summary>
-    private bool IsAtNameStart() => TryReadScalar(_position, out var scalar, out _) && SyntaxFacts.IsNameStartCharacter(scalar);
+    private bool IsAtNameStart() => CharacterData.TryReadScalar(_text, _position, _text.Length, out var scalar, out _) && SyntaxFacts.IsNameStartCharacter(scalar);
+
+    /// <summary>Determines whether the reading position is a '&lt;' that starts a tag, a comment, or the like.</summary>
+    private bool IsAtMarkupStart()
+    {
+        if (Current != '<' || _position + 1 >= _text.Length)
+            return false;
+
+        var next = _text[_position + 1];
+
+        return next is '/' or '!' or '?' || (CharacterData.TryReadScalar(_text, _position + 1, _text.Length, out var scalar, out _) && SyntaxFacts.IsNameStartCharacter(scalar));
+    }
 
     /// <summary>Advances past the name characters at the reading position.</summary>
     /// <remarks>
@@ -463,58 +1038,80 @@ internal sealed class LanguageParser
     private void SkipNameCharacters(int limit = int.MaxValue)
     {
         var end = Math.Min(limit, _text.Length);
-        while (_position < end && TryReadScalar(_position, out var scalar, out var length) && _position + length <= end && SyntaxFacts.IsNameCharacter(scalar))
+        while (_position < end && CharacterData.TryReadScalar(_text, _position, end, out var scalar, out var length) && SyntaxFacts.IsNameCharacter(scalar))
         {
             _position += length;
         }
     }
 
-    /// <summary>Reads the scalar value at <paramref name="position"/>, and how many UTF-16 units it took.</summary>
-    /// <remarks>A lone surrogate is not a scalar value at all, so it can be no part of a name.</remarks>
-    private bool TryReadScalar(int position, out Rune scalar, out int length)
+    /// <summary>Claims the trivia at the reading position inside a tag: whitespace, and any text the tag cannot use.</summary>
+    /// <remarks>
+    /// Text is skipped up to whatever the tag can use again: whitespace, a name, the end of the tag, or a '&lt;',
+    /// which starts the next tag. Keeping it as trivia keeps the element and everything else in its tag.
+    /// </remarks>
+    private GreenNode? LexTagTrivia(bool isDeclaration, string tagName, out bool endsWithSkippedText)
     {
-        if (position >= _text.Length)
+        GreenNode? single = null;
+        List<GreenNode?>? pieces = null;
+        endsWithSkippedText = false;
+        while (true)
         {
-            scalar = default;
-            length = 0;
+            if (LexWhitespace(ref single, ref pieces, _text.Length))
+            {
+                endsWithSkippedText = false;
+            }
 
-            return false;
+            if (IsAtEnd || IsAtTagContinuation(isDeclaration))
+                break;
+
+            var skippedStart = _position;
+            do
+            {
+                _position++;
+            }
+            while (!IsAtEnd && !SyntaxFacts.IsWhitespace(Current) && !IsAtTagContinuation(isDeclaration));
+
+            var skipped = _text[skippedStart.._position];
+            if (isDeclaration)
+            {
+                AddDiagnostic(skippedStart, skipped.Length, UnexpectedTextInDeclaration, skipped);
+            }
+            else
+            {
+                AddDiagnostic(skippedStart, skipped.Length, UnexpectedTextInStartTag, skipped, tagName);
+            }
+
+            Append(ref single, ref pieces, SyntaxFactory.Trivia(SyntaxKind.SkippedTextTrivia, skipped).AsSkippedText());
+            endsWithSkippedText = true;
         }
 
-        var first = _text[position];
-        if (!char.IsSurrogate(first))
-        {
-            scalar = new Rune(first);
-            length = 1;
+        return pieces is null ? single : SyntaxFactory.List(CollectionsMarshal.AsSpan(pieces));
+    }
 
+    private bool IsAtTagContinuation(bool isDeclaration)
+    {
+        if (Current == '<' || IsAtNameStart())
             return true;
-        }
 
-        if (position + 1 < _text.Length && Rune.TryCreate(first, _text[position + 1], out scalar))
-        {
-            length = 2;
-
-            return true;
-        }
-
-        scalar = default;
-        length = 0;
-
-        return false;
+        return isDeclaration ? Match("?>") : Current == '>' || Match("/>");
     }
 
     /// <summary>Claims the whitespace at the reading position, which inside a tag is trivia.</summary>
-    private GreenNode? LexTagTrivia(int limit = int.MaxValue)
+    private GreenNode? LexWhitespaceTrivia(int limit = int.MaxValue)
     {
-        var end = Math.Min(limit, _text.Length);
-        if (_position >= end || !char.IsWhiteSpace(Current))
-            return null;
-
-        List<GreenNode?>? trivia = null;
         GreenNode? single = null;
-        while (_position < end && char.IsWhiteSpace(_text[_position]))
+        List<GreenNode?>? pieces = null;
+        _ = LexWhitespace(ref single, ref pieces, Math.Min(limit, _text.Length));
+
+        return pieces is null ? single : SyntaxFactory.List(CollectionsMarshal.AsSpan(pieces));
+    }
+
+    private bool LexWhitespace(ref GreenNode? single, ref List<GreenNode?>? pieces, int end)
+    {
+        var start = _position;
+        while (_position < end && SyntaxFacts.IsWhitespace(_text[_position]))
         {
-            var start = _position;
+            var pieceStart = _position;
             SyntaxKind kind;
             if (_text[_position] is '\r' or '\n')
             {
@@ -529,45 +1126,98 @@ internal sealed class LanguageParser
             else
             {
                 kind = SyntaxKind.WhitespaceTrivia;
-                while (_position < end && char.IsWhiteSpace(_text[_position]) && _text[_position] is not ('\r' or '\n'))
+                while (_position < end && _text[_position] is ' ' or '\t')
                 {
                     _position++;
                 }
             }
 
-            var item = SyntaxFactory.Trivia(kind, _text[start.._position]);
-            if (single is null && trivia is null)
-            {
-                single = item;
-            }
-            else
-            {
-                trivia ??= [single];
-                trivia.Add(item);
-            }
+            Append(ref single, ref pieces, SyntaxFactory.Trivia(kind, _text[pieceStart.._position]));
         }
 
-        return trivia is null ? single : SyntaxFactory.List(CollectionsMarshal.AsSpan(trivia));
+        return _position > start;
+    }
+
+    private static void Append(ref GreenNode? single, ref List<GreenNode?>? pieces, GreenNode item)
+    {
+        if (single is null && pieces is null)
+        {
+            single = item;
+        }
+        else
+        {
+            pieces ??= [single];
+            pieces.Add(item);
+        }
     }
 
     /// <summary>Puts trivia in front of a token that was built without any, such as a missing one.</summary>
     private static GreenToken WithLeading(GreenToken token, GreenNode? leading)
         => leading is null ? token : new GreenToken(token.RawKind, token.Text, leading, trailingTrivia: null, isMissing: token.IsMissing);
 
-    private void AddNode(GreenNode node)
+    private void AddNode(GreenNode node, int start)
     {
-        if (_elementStack.Count == 0)
-        {
-            _documentNodes.Add(node);
-        }
-        else
+        if (_elementStack.Count > 0)
         {
             _elementStack.Peek().Content.Add(node);
+
+            return;
+        }
+
+        _documentNodes.Add(node);
+        switch ((SyntaxKind)node.RawKind)
+        {
+            case SyntaxKind.XmlElement or SyntaxKind.XmlEmptyElement:
+                if (_hasRootElement)
+                {
+                    var isEmpty = node.RawKind == (int)SyntaxKind.XmlEmptyElement;
+                    var startTag = isEmpty ? node : node.GetSlot(0)!;
+                    var name = ((GreenToken)startTag.GetSlot(1)!).Text;
+                    AddDiagnostic(start, startTag.FullWidth, MultipleRootElements, name);
+                }
+
+                _hasRootElement = true;
+                break;
+
+            case SyntaxKind.XmlText:
+                ReportTextOutsideRootElement(start, start + node.FullWidth);
+                break;
+
+            case SyntaxKind.XmlCDataSection:
+                AddDiagnostic(start, node.FullWidth, CDataOutsideRootElement);
+                _hasMisplacedContent = true;
+                break;
+
+            case SyntaxKind.XmlSkippedText:
+                _hasMisplacedContent = true;
+                break;
         }
     }
 
-    private void AddDiagnostic(int start, int length, string id, string message)
-        => _diagnostics.Add(new Diagnostic(id, message, DiagnosticSeverity.Error, new Location(new TextSpan(start, length), _source)));
+    /// <summary>Reports what a run of text between top-level nodes holds besides whitespace, which is all it may hold.</summary>
+    private void ReportTextOutsideRootElement(int start, int end)
+    {
+        var first = start;
+        while (first < end && (SyntaxFacts.IsWhitespace(_text[first]) || (first == 0 && _text[first] == '\uFEFF')))
+        {
+            first++;
+        }
+
+        if (first == end)
+            return;
+
+        var last = end;
+        while (SyntaxFacts.IsWhitespace(_text[last - 1]))
+        {
+            last--;
+        }
+
+        AddDiagnostic(first, last - first, TextOutsideRootElement);
+        _hasMisplacedContent = true;
+    }
+
+    private void AddDiagnostic(int start, int length, DiagnosticDescriptor descriptor, params object?[] arguments)
+        => _diagnostics.Add(Diagnostic.Create(descriptor, new Location(new TextSpan(start, length), _source), arguments));
 
     private bool Match(string token)
     {
@@ -585,11 +1235,41 @@ internal sealed class LanguageParser
         return string.Compare(_text, _position, token, 0, token.Length, StringComparison.OrdinalIgnoreCase) == 0;
     }
 
-    private sealed class ElementBuilder(int start, string name, GreenNode startTag)
+    private readonly record struct AttributeInfo(int NameStart, string Name, int ValueStart, string RawValue, string Value, bool HasValue);
+
+    private readonly record struct PendingDiagnostic(int Start, int Length, DiagnosticDescriptor Descriptor, object?[] Arguments);
+
+    private sealed record TagDiagnostics(
+        DiagnosticDescriptor UnexpectedText,
+        DiagnosticDescriptor MissingValue,
+        DiagnosticDescriptor UnquotedValue,
+        DiagnosticDescriptor UnterminatedValue,
+        DiagnosticDescriptor MissingWhitespace);
+
+    /// <summary>The prefixes an element declares, chained to the ones it inherits.</summary>
+    private sealed class NamespaceScope(NamespaceScope? parent, Dictionary<string, string> bindings)
+    {
+        public NamespaceScope? Parent { get; } = parent;
+        public Dictionary<string, string> Bindings { get; } = bindings;
+
+        public string? Resolve(string prefix)
+        {
+            for (var scope = this; scope is not null; scope = scope.Parent)
+            {
+                if (scope.Bindings.TryGetValue(prefix, out var namespaceUri))
+                    return namespaceUri;
+            }
+
+            return null;
+        }
+    }
+
+    private sealed class ElementBuilder(int start, string name, GreenNode startTag, NamespaceScope? scope)
     {
         public int Start { get; } = start;
         public string Name { get; } = name;
         public GreenNode StartTag { get; } = startTag;
+        public NamespaceScope? Scope { get; } = scope;
         public List<GreenNode?> Content { get; } = [];
     }
 }

--- a/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/XmlDiagnosticDescriptors.cs
+++ b/src/Meziantou.Framework.Language.Xml/Syntax/InternalSyntax/XmlDiagnosticDescriptors.cs
@@ -1,0 +1,90 @@
+namespace Meziantou.Framework.Language.Xml.Syntax.InternalSyntax;
+
+/// <summary>Everything the parser can report, grouped by id.</summary>
+/// <remarks>
+/// An id names a family of related problems, so a tool can filter on it without depending on the wording; each
+/// descriptor within a family says precisely what went wrong.
+/// </remarks>
+internal static class XmlDiagnosticDescriptors
+{
+    public static readonly DiagnosticDescriptor MissingEndTag = Error("XML0001", "Missing end tag", "Missing end tag for '{0}'.");
+
+    public static readonly DiagnosticDescriptor UnexpectedEndTag = Error("XML0002", "Unexpected end tag", "Unexpected end tag '{0}'.");
+    public static readonly DiagnosticDescriptor MismatchedEndTag = Error("XML0002", "Mismatched end tag", "End tag '{0}' does not match the start tag '{1}'.");
+    public static readonly DiagnosticDescriptor MissingEndTagName = Error("XML0002", "Missing end tag name", "Expected an element name in the end tag.");
+    public static readonly DiagnosticDescriptor WhitespaceBeforeEndTagName = Error("XML0002", "Whitespace before end tag name", "An end tag cannot have whitespace between '</' and the element name.");
+    public static readonly DiagnosticDescriptor UnexpectedTextInEndTag = Error("XML0002", "Unexpected text in end tag", "Unexpected '{0}' in the end tag of '{1}'.");
+    public static readonly DiagnosticDescriptor UnterminatedEndTag = Error("XML0002", "Unterminated end tag", "The end tag of '{0}' is missing its closing '>'.");
+
+    public static readonly DiagnosticDescriptor InvalidCharacter = Error("XML0003", "Invalid character", "Character U+{0} is not allowed in XML.");
+
+    public static readonly DiagnosticDescriptor MalformedCharacterReference = Error("XML0004", "Malformed character reference", "'{0}' is not a well-formed character reference.");
+    public static readonly DiagnosticDescriptor InvalidCharacterReference = Error("XML0004", "Invalid character reference", "'{0}' does not refer to a character XML allows.");
+    public static readonly DiagnosticDescriptor UnescapedAmpersand = Error("XML0004", "Unescaped ampersand", "The '&' character must be escaped as '&amp;' when it does not start a reference.");
+    public static readonly DiagnosticDescriptor UndeclaredEntity = Error("XML0004", "Undeclared entity", "Reference to undeclared entity '{0}'.");
+
+    public static readonly DiagnosticDescriptor LessThanInAttributeValue = Error("XML0005", "Unescaped '<' in attribute value", "The '<' character must be escaped as '&lt;' in an attribute value.");
+    public static readonly DiagnosticDescriptor CDataEndInText = Error("XML0005", "']]>' in character data", "']]>' is not allowed in character data; escape the '>' as '&gt;'.");
+
+    public static readonly DiagnosticDescriptor DuplicateAttribute = Error("XML0006", "Duplicate attribute", "Duplicate attribute '{0}'.");
+    public static readonly DiagnosticDescriptor DuplicateExpandedAttribute = Error("XML0006", "Duplicate attribute", "Attributes '{0}' and '{1}' have the same namespace and local name.");
+
+    public static readonly DiagnosticDescriptor UnterminatedDeclaration = Error("XML0007", "Unterminated XML declaration", "Unterminated XML declaration.");
+    public static readonly DiagnosticDescriptor UnterminatedComment = Error("XML0008", "Unterminated comment", "Unterminated XML comment.");
+    public static readonly DiagnosticDescriptor UnterminatedCData = Error("XML0009", "Unterminated CDATA section", "Unterminated CDATA section.");
+
+    public static readonly DiagnosticDescriptor InvalidStartTag = Error("XML0010", "Invalid start tag", "Invalid start tag.");
+    public static readonly DiagnosticDescriptor UnescapedLessThan = Error("XML0010", "Unescaped '<'", "The '<' character must be escaped as '&lt;' in character data.");
+    public static readonly DiagnosticDescriptor UnexpectedTextInStartTag = Error("XML0010", "Unexpected text in start tag", "Unexpected '{0}' in the start tag of '{1}'.");
+    public static readonly DiagnosticDescriptor UnterminatedStartTag = Error("XML0010", "Unterminated start tag", "The start tag of '{0}' is missing its closing '>'.");
+    public static readonly DiagnosticDescriptor MissingAttributeValue = Error("XML0010", "Missing attribute value", "Attribute '{0}' is missing its value.");
+    public static readonly DiagnosticDescriptor UnquotedAttributeValue = Error("XML0010", "Unquoted attribute value", "The value of attribute '{0}' must be quoted.");
+    public static readonly DiagnosticDescriptor UnterminatedAttributeValue = Error("XML0010", "Unterminated attribute value", "The value of attribute '{0}' is missing its closing quote.");
+    public static readonly DiagnosticDescriptor MissingWhitespaceBeforeAttribute = Error("XML0010", "Missing whitespace before attribute", "Attribute '{0}' must be separated from what precedes it by whitespace.");
+
+    public static readonly DiagnosticDescriptor UnterminatedDocumentType = Error("XML0011", "Unterminated document type declaration", "Unterminated document type declaration.");
+    public static readonly DiagnosticDescriptor UnterminatedProcessingInstruction = Error("XML0012", "Unterminated processing instruction", "Unterminated processing instruction.");
+
+    public static readonly DiagnosticDescriptor MisplacedDeclaration = Error("XML0013", "Misplaced XML declaration", "The XML declaration is only allowed at the very start of the document.");
+    public static readonly DiagnosticDescriptor DeclarationCase = Error("XML0013", "Invalid XML declaration", "The XML declaration must be written '<?xml', not '{0}'.");
+    public static readonly DiagnosticDescriptor MissingVersion = Error("XML0013", "Missing XML version", "The XML declaration must start with a version.");
+    public static readonly DiagnosticDescriptor InvalidVersion = Error("XML0013", "Invalid XML version", "'{0}' is not a valid XML version.");
+    public static readonly DiagnosticDescriptor InvalidEncoding = Error("XML0013", "Invalid encoding name", "'{0}' is not a valid encoding name.");
+    public static readonly DiagnosticDescriptor InvalidStandalone = Error("XML0013", "Invalid standalone value", "The standalone value must be 'yes' or 'no', not '{0}'.");
+    public static readonly DiagnosticDescriptor UnexpectedDeclarationAttribute = Error("XML0013", "Unexpected XML declaration attribute", "'{0}' is not allowed here; the XML declaration takes version, encoding and standalone, once each and in that order.");
+    public static readonly DiagnosticDescriptor UnexpectedTextInDeclaration = Error("XML0013", "Unexpected text in XML declaration", "Unexpected '{0}' in the XML declaration.");
+    public static readonly DiagnosticDescriptor DeclarationMissingAttributeValue = Error("XML0013", "Missing attribute value", "Attribute '{0}' is missing its value.");
+    public static readonly DiagnosticDescriptor DeclarationUnquotedAttributeValue = Error("XML0013", "Unquoted attribute value", "The value of attribute '{0}' must be quoted.");
+    public static readonly DiagnosticDescriptor DeclarationUnterminatedAttributeValue = Error("XML0013", "Unterminated attribute value", "The value of attribute '{0}' is missing its closing quote.");
+    public static readonly DiagnosticDescriptor DeclarationMissingWhitespaceBeforeAttribute = Error("XML0013", "Missing whitespace before attribute", "Attribute '{0}' must be separated from what precedes it by whitespace.");
+
+    public static readonly DiagnosticDescriptor MissingRootElement = Error("XML0014", "Missing root element", "The document has no root element.");
+    public static readonly DiagnosticDescriptor MultipleRootElements = Error("XML0014", "Multiple root elements", "A document can have only one root element; '{0}' is a second one.");
+    public static readonly DiagnosticDescriptor TextOutsideRootElement = Error("XML0014", "Text outside the root element", "Text is not allowed outside the root element.");
+    public static readonly DiagnosticDescriptor CDataOutsideRootElement = Error("XML0014", "CDATA section outside the root element", "A CDATA section is not allowed outside the root element.");
+    public static readonly DiagnosticDescriptor DocumentTypeAfterRootElement = Error("XML0014", "Misplaced document type declaration", "The document type declaration must come before the root element.");
+    public static readonly DiagnosticDescriptor DuplicateDocumentType = Error("XML0014", "Duplicate document type declaration", "A document can have only one document type declaration.");
+    public static readonly DiagnosticDescriptor DocumentTypeInsideElement = Error("XML0014", "Misplaced document type declaration", "A document type declaration is not allowed inside an element.");
+
+    public static readonly DiagnosticDescriptor DoubleHyphenInComment = Error("XML0015", "'--' in comment", "'--' is not allowed inside a comment.");
+    public static readonly DiagnosticDescriptor HyphenBeforeCommentEnd = Error("XML0015", "Comment ending with '--->'", "A comment cannot end with '--->'.");
+
+    public static readonly DiagnosticDescriptor MissingProcessingInstructionTarget = Error("XML0016", "Missing processing instruction target", "A processing instruction must start with a target name.");
+    public static readonly DiagnosticDescriptor ReservedProcessingInstructionTarget = Error("XML0016", "Reserved processing instruction target", "The processing instruction target '{0}' is reserved.");
+    public static readonly DiagnosticDescriptor MissingWhitespaceAfterTarget = Error("XML0016", "Missing whitespace after target", "The target of a processing instruction must be followed by whitespace.");
+
+    public static readonly DiagnosticDescriptor UndeclaredPrefix = Error("XML0017", "Undeclared namespace prefix", "The namespace prefix '{0}' is not declared.");
+    public static readonly DiagnosticDescriptor InvalidQualifiedName = Error("XML0017", "Invalid qualified name", "'{0}' is not a valid qualified name.");
+    public static readonly DiagnosticDescriptor EmptyPrefixedNamespace = Error("XML0017", "Empty namespace for a prefix", "The prefix '{0}' cannot be bound to an empty namespace.");
+    public static readonly DiagnosticDescriptor XmlPrefixBinding = Error("XML0017", "Invalid 'xml' prefix binding", "The 'xml' prefix can only be bound to 'http://www.w3.org/XML/1998/namespace'.");
+    public static readonly DiagnosticDescriptor XmlnsPrefixDeclaration = Error("XML0017", "Invalid 'xmlns' prefix declaration", "The 'xmlns' prefix cannot be declared.");
+    public static readonly DiagnosticDescriptor ReservedNamespace = Error("XML0017", "Reserved namespace", "The namespace '{0}' cannot be bound to '{1}'.");
+    public static readonly DiagnosticDescriptor ColonInProcessingInstructionTarget = Error("XML0017", "Colon in processing instruction target", "A processing instruction target cannot contain a colon.");
+    public static readonly DiagnosticDescriptor XmlnsElementPrefix = Error("XML0017", "Invalid element prefix", "An element name cannot use the 'xmlns' prefix.");
+
+    public static readonly DiagnosticDescriptor DocumentTypeCase = Error("XML0018", "Invalid document type declaration", "The document type declaration must be written '<!DOCTYPE', not '{0}'.");
+    public static readonly DiagnosticDescriptor MissingDocumentTypeName = Error("XML0018", "Missing document type name", "The document type declaration must name the root element.");
+    public static readonly DiagnosticDescriptor MissingWhitespaceInDocumentType = Error("XML0018", "Missing whitespace in document type declaration", "'<!DOCTYPE' must be followed by whitespace.");
+
+    private static DiagnosticDescriptor Error(string id, string title, string messageFormat) => new(id, title, messageFormat, DiagnosticSeverity.Error);
+}

--- a/src/Meziantou.Framework.Language.Xml/SyntaxFactory.cs
+++ b/src/Meziantou.Framework.Language.Xml/SyntaxFactory.cs
@@ -1,4 +1,3 @@
-using System.Security;
 using Meziantou.Framework.Language.InternalSyntax;
 using Green = Meziantou.Framework.Language.Xml.Syntax.InternalSyntax;
 
@@ -174,11 +173,15 @@ public static class SyntaxFactory
         => (XmlAttributeSyntax)new Green.XmlAttributeSyntax(Required(nameToken), Required(equalsToken), Required(startQuoteToken), Required(valueToken), Required(endQuoteToken)).CreateRed();
 
     /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <paramref name="text"/> is written exactly as given, so a reference it holds stays a reference; the node's
+    /// <see cref="XmlTextSyntax.Value"/> is what that text reads as.
+    /// </remarks>
     public static XmlTextSyntax XmlText(string text)
     {
         ArgumentNullException.ThrowIfNull(text);
 
-        return XmlText(Token(SyntaxKind.TextToken, text));
+        return XmlText(TextToken(text));
     }
 
     public static XmlTextSyntax XmlText(SyntaxToken textToken) => (XmlTextSyntax)new Green.XmlTextSyntax(Required(textToken)).CreateRed();
@@ -284,15 +287,50 @@ public static class SyntaxFactory
         return value.Length == name.Length || char.IsWhiteSpace(value[name.Length]);
     }
 
-    internal static SyntaxToken ProcessingInstructionData(string? data)
-        => data is null ? MissingToken(SyntaxKind.ProcessingInstructionDataToken) : Token(SyntaxKind.ProcessingInstructionDataToken, " " + data);
+    /// <summary>Creates a character data token whose value is what <paramref name="text"/> reads as.</summary>
+    internal static SyntaxToken TextToken(string text)
+        => new(parent: null, Green.SyntaxFactory.TokenWithValue(leading: null, SyntaxKind.TextToken, text, Green.CharacterData.Decode(text, isAttribute: false)), position: 0, index: 0);
 
+    /// <summary>Creates the data of a processing instruction, separated from its target by a space.</summary>
+    /// <remarks>An instruction carrying no data is written without one, which is also how the parser reads it back.</remarks>
+    internal static SyntaxToken ProcessingInstructionData(string? data)
+        => string.IsNullOrEmpty(data) ? MissingToken(SyntaxKind.ProcessingInstructionDataToken) : Token(SyntaxKind.ProcessingInstructionDataToken, data).WithLeadingTrivia(Space);
+
+    /// <summary>Escapes what an attribute value cannot hold literally.</summary>
+    /// <remarks>
+    /// Besides the markup characters and the quote in use, a tab, a line feed and a carriage return are written as
+    /// character references: written literally, XML reads each of them back as a space.
+    /// </remarks>
     private static string EscapeAttributeValue(string value, char quote)
     {
-        var escaped = SecurityElement.Escape(value) ?? "";
+        StringBuilder? builder = null;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var replacement = value[i] switch
+            {
+                '&' => "&amp;",
+                '<' => "&lt;",
+                '>' => "&gt;",
+                '"' when quote == '"' => "&quot;",
+                '\'' when quote == '\'' => "&apos;",
+                '\t' => "&#x9;",
+                '\n' => "&#xA;",
+                '\r' => "&#xD;",
+                _ => null,
+            };
 
-        // SecurityElement escapes both quote characters. Only the one the attribute is written with has to be.
-        return quote == '\'' ? escaped.Replace("&quot;", "\"", StringComparison.Ordinal) : escaped.Replace("&apos;", "'", StringComparison.Ordinal);
+            if (replacement is null)
+            {
+                builder?.Append(value[i]);
+            }
+            else
+            {
+                builder ??= new StringBuilder(value.Length + 16).Append(value, 0, i);
+                builder.Append(replacement);
+            }
+        }
+
+        return builder?.ToString() ?? value;
     }
 
     private static XmlAttributeSyntax SpaceBefore(XmlAttributeSyntax attribute)

--- a/src/Meziantou.Framework.Language.Xml/SyntaxFacts.cs
+++ b/src/Meziantou.Framework.Language.Xml/SyntaxFacts.cs
@@ -7,8 +7,9 @@ public static class SyntaxFacts
 {
     /// <summary>Returns the text a kind is always spelled with, or an empty string when its text varies.</summary>
     /// <remarks>
-    /// This is the canonical spelling. A document may write <c>&lt;?xml</c> and <c>&lt;!DOCTYPE</c> in any case, and
-    /// the token then carries what the document said; a token built from a kind alone gets the spelling here.
+    /// This is the canonical spelling, and the only one XML allows. The parser still reads <c>&lt;?XML</c> or
+    /// <c>&lt;!doctype</c> as the construct they were meant to be, reporting the spelling, and the token then carries
+    /// what the document said; a token built from a kind alone gets the spelling here.
     /// </remarks>
     public static string GetText(SyntaxKind kind) => kind switch
     {
@@ -30,8 +31,15 @@ public static class SyntaxFacts
         _ => "",
     };
 
-    /// <summary>Determines whether <paramref name="kind"/> is whitespace or a line break.</summary>
-    public static bool IsTrivia(SyntaxKind kind) => kind is SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia;
+    /// <summary>Determines whether <paramref name="kind"/> is whitespace, a line break, or text skipped inside a tag.</summary>
+    public static bool IsTrivia(SyntaxKind kind) => kind is SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia or SyntaxKind.SkippedTextTrivia;
+
+    /// <summary>Determines whether <paramref name="value"/> is whitespace as XML defines it.</summary>
+    /// <remarks>
+    /// This is the <c>S</c> production: a space, a tab, a carriage return, or a line feed. It is much narrower than
+    /// <see cref="char.IsWhiteSpace(char)"/>, which also accepts characters such as a no-break space.
+    /// </remarks>
+    public static bool IsWhitespace(char value) => value is ' ' or '\t' or '\r' or '\n';
 
     /// <summary>Determines whether <paramref name="value"/> may begin an XML name.</summary>
     /// <remarks>

--- a/src/Meziantou.Framework.Language.Xml/SyntaxKind.cs
+++ b/src/Meziantou.Framework.Language.Xml/SyntaxKind.cs
@@ -62,4 +62,7 @@ public enum SyntaxKind
     // Trivia
     WhitespaceTrivia,
     EndOfLineTrivia,
+
+    /// <summary>Text inside a tag that the parser could not read, kept so the document still reproduces its source.</summary>
+    SkippedTextTrivia,
 }

--- a/src/Meziantou.Framework.Language.Xml/XmlAttributeSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlAttributeSyntax.cs
@@ -19,7 +19,11 @@ public sealed class XmlAttributeSyntax : XmlSyntaxNode
     /// <summary>Gets the name of the attribute.</summary>
     public string Name => NameToken.Text;
 
-    /// <summary>Gets the value of the attribute, with any escape the source used resolved.</summary>
+    /// <summary>Gets the value of the attribute as an XML processor reads it.</summary>
+    /// <remarks>
+    /// Character references and the predefined entities are resolved, and each tab and line break becomes a space
+    /// (XML 1.0 §3.3.3). A reference to any other entity is left as written.
+    /// </remarks>
     public string Value => ValueToken.ValueText;
 
     /// <summary>Returns this attribute renamed.</summary>

--- a/src/Meziantou.Framework.Language.Xml/XmlProcessingInstructionSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlProcessingInstructionSyntax.cs
@@ -18,7 +18,7 @@ public sealed class XmlProcessingInstructionSyntax : XmlNodeSyntax
     /// <summary>Gets the target the instruction names.</summary>
     public string Target => NameToken.Text;
 
-    /// <summary>Gets what follows the target, or <see langword="null"/> when the instruction carries nothing.</summary>
+    /// <summary>Gets what follows the target and the whitespace after it, or <see langword="null"/> when the instruction carries nothing.</summary>
     public string? Data => DataToken.IsMissing ? null : DataToken.Text;
 
     /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>

--- a/src/Meziantou.Framework.Language.Xml/XmlSyntaxNavigator.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSyntaxNavigator.cs
@@ -273,7 +273,7 @@ internal sealed class XmlSyntaxNavigator : XPathNavigator
             localName: string.Empty,
             prefix: string.Empty,
             namespaceUri: string.Empty,
-            value: text.Text,
+            value: text.Value,
             underlyingObject: text);
     }
 
@@ -284,7 +284,7 @@ internal sealed class XmlSyntaxNavigator : XPathNavigator
             localName: string.Empty,
             prefix: string.Empty,
             namespaceUri: string.Empty,
-            value: comment.Text,
+            value: NormalizeLineBreaks(comment.Text),
             underlyingObject: comment);
     }
 
@@ -295,7 +295,7 @@ internal sealed class XmlSyntaxNavigator : XPathNavigator
             localName: string.Empty,
             prefix: string.Empty,
             namespaceUri: string.Empty,
-            value: cdataSection.Text,
+            value: NormalizeLineBreaks(cdataSection.Text),
             underlyingObject: cdataSection);
     }
 
@@ -306,7 +306,7 @@ internal sealed class XmlSyntaxNavigator : XPathNavigator
             localName: processingInstruction.Target,
             prefix: string.Empty,
             namespaceUri: string.Empty,
-            value: processingInstruction.Data ?? string.Empty,
+            value: NormalizeLineBreaks(processingInstruction.Data ?? string.Empty),
             underlyingObject: processingInstruction);
     }
 
@@ -349,6 +349,10 @@ internal sealed class XmlSyntaxNavigator : XPathNavigator
             value: skippedText.Text,
             underlyingObject: skippedText);
     }
+
+    /// <summary>Normalizes line breaks the way an XML processor does before anything else reads the text.</summary>
+    private static string NormalizeLineBreaks(string text)
+        => text.Contains('\r', StringComparison.Ordinal) ? text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n') : text;
 
     private static string GetValue(NavigatorNode node)
     {

--- a/src/Meziantou.Framework.Language.Xml/XmlSyntaxTree.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlSyntaxTree.cs
@@ -30,7 +30,7 @@ public sealed class XmlSyntaxTree : SyntaxTree
     /// <summary>Gets the document this tree holds.</summary>
     public new XmlDocumentSyntax GetRoot() => _root;
 
-    /// <summary>Gets everything wrong with the document, in the order the parser found it.</summary>
+    /// <summary>Gets everything wrong with the document, in the order it appears in the text.</summary>
     public override IReadOnlyList<Diagnostic> GetDiagnostics() => _diagnostics;
 
     /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>

--- a/src/Meziantou.Framework.Language.Xml/XmlTextSyntax.cs
+++ b/src/Meziantou.Framework.Language.Xml/XmlTextSyntax.cs
@@ -15,12 +15,15 @@ public sealed class XmlTextSyntax : XmlNodeSyntax
     /// <summary>Gets the character data, exactly as it was written.</summary>
     public string Text => TextToken.Text;
 
+    /// <summary>Gets the character data as XML reads it: references resolved and line breaks normalized.</summary>
+    public string Value => TextToken.ValueText;
+
     /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
     public XmlTextSyntax WithText(string text)
     {
         ArgumentNullException.ThrowIfNull(text);
 
-        return string.Equals(text, Text, StringComparison.Ordinal) ? this : WithTextToken(SyntaxFactory.Token(SyntaxKind.TextToken, text).WithTriviaFrom(TextToken));
+        return string.Equals(text, Text, StringComparison.Ordinal) ? this : WithTextToken(SyntaxFactory.TextToken(text).WithTriviaFrom(TextToken));
     }
 
     /// <summary>Returns this node with the given parts, or itself when nothing changed.</summary>

--- a/src/Meziantou.Framework.Language.Xml/readme.md
+++ b/src/Meziantou.Framework.Language.Xml/readme.md
@@ -131,8 +131,13 @@ var found = edited.GetAnnotatedNodes(marker).Single();
 
 ## Diagnostics
 
-Nothing is thrown for bad input; it is reported instead, with a location you can turn into line and character
-positions.
+Nothing is thrown for bad input; it is reported instead, in the order it appears in the text, with a location you
+can turn into line and character positions.
+
+The checks are those of a non-validating XML processor: every well-formedness constraint of XML 1.0 (Fifth Edition)
+and of Namespaces in XML 1.0. A document System.Xml can read produces no diagnostic, with two deliberate exceptions
+where the specifications are stricter than it is — an encoding name that is not an `EncName`, and an element name
+with the `xmlns` prefix — and one where they are more permissive: any `1.x` version is accepted.
 
 ```csharp
 foreach (var diagnostic in XmlSyntaxTree.ParseText("<root>\n  <item>\n</root>").GetDiagnostics())
@@ -145,13 +150,39 @@ foreach (var diagnostic in XmlSyntaxTree.ParseText("<root>\n  <item>\n</root>").
 | Id | Reported for |
 | --- | --- |
 | `XML0001` | An element with no end tag |
-| `XML0002` | An unexpected or mismatched end tag |
+| `XML0002` | An unexpected, mismatched, or malformed end tag |
+| `XML0003` | A character XML does not allow, such as U+0001, U+FFFE, or a lone surrogate |
+| `XML0004` | A malformed or invalid character reference, an `&` that starts no reference, or an undeclared entity |
+| `XML0005` | A `<` in an attribute value, or `]]>` in character data |
+| `XML0006` | A duplicate attribute, including two that differ only by a prefix bound to the same namespace |
 | `XML0007` | An unterminated XML declaration |
 | `XML0008` | An unterminated comment |
 | `XML0009` | An unterminated CDATA section |
-| `XML0010` | An invalid start tag or attribute |
+| `XML0010` | An invalid start tag or attribute: text a tag cannot use, a missing `>`, a missing or unquoted value, or attributes not separated by whitespace |
 | `XML0011` | An unterminated document type declaration |
 | `XML0012` | An unterminated processing instruction |
+| `XML0013` | An invalid or misplaced XML declaration |
+| `XML0014` | A document that does not have exactly one root element, or holds text, a CDATA section, or a document type declaration where it cannot |
+| `XML0015` | A comment containing `--` |
+| `XML0016` | A processing instruction with no target, the reserved target `xml`, or no whitespace after its target |
+| `XML0017` | A namespace error: an undeclared prefix, a name that is not a qualified name, or a reserved prefix misused |
+| `XML0018` | A malformed document type declaration |
+
+An entity reference counts as declared when the internal subset declares it, or when the document has an external
+subset or a parameter entity reference, which could declare it where the parser cannot see.
+
+### Recovery
+
+The parser keeps the shape the author most likely meant, so one mistake produces one diagnostic rather than a cascade:
+
+- An end tag that matches an element further up closes the elements left open in between, each reported as missing its
+  end tag. One that matches no open element is kept as `XmlSkippedTextSyntax`.
+- A start tag missing its `>` still opens its element, with a missing `GreaterThanToken`.
+- Text a tag cannot use — `<a @ b="1">` — is kept as `SkippedTextTrivia` on the next token, and the element and the rest
+  of its attributes are read as usual.
+- An attribute value that meets what looks like the next tag before its closing quote stops there.
+- A `<` that starts no markup, as in `a < b`, is skipped on its own rather than swallowing the text up to the next `>`.
+- An unterminated XML declaration, document type declaration, or end tag stops at the next `<`.
 
 ## Walking a tree
 
@@ -222,6 +253,12 @@ edit expressed as text can change how everything after it reads.
 Nodes are shared between the trees an edit produces, so holding several versions of a document costs little more
 than holding one.
 
-This is a parser, not a validator. It reads the shape of a document without resolving entities or applying a schema.
+This is a parser, not a validator. It reads the shape of a document without applying a DTD or a schema.
+
+The syntax keeps text exactly as written, references included; `XmlAttributeSyntax.Value` and `XmlTextSyntax.Value`
+are what an XML processor reads it as. Character references and the five predefined entities are resolved, line
+breaks are normalized to `\n`, and an attribute value turns each tab and line break into a space. Other entities are
+left as written, since resolving one means reading the DTD. `WithValue` escapes a tab or a line break as a character
+reference, so the value it sets is the value read back.
 Names do follow XML's own `NameStartChar` and `NameChar` productions, so a name may hold a combining mark, a middle
 dot, or a character from outside the basic plane, and a Unicode letter XML leaves out — `ª`, say — does not start one.

--- a/tests/Meziantou.Framework.Language.Xml.Tests/XmlSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Language.Xml.Tests/XmlSyntaxTreeTests.cs
@@ -92,7 +92,6 @@ public sealed class XmlSyntaxTreeTests
 
     [Theory]
     [InlineData("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>\n<root />")]
-    [InlineData("<?xml version=\"1.0\" standalone=\"yes\" encoding=\"UTF-8\" ?>\n<root />")]
     [InlineData("<?xml version=\"1.0\"\n encoding=\"UTF-8\"\n standalone=\"yes\" ?>\n<root />")]
     public void Parse_Save_RoundTripsXmlDeclarationVariants(string text)
     {
@@ -100,6 +99,20 @@ public sealed class XmlSyntaxTreeTests
 
         Assert.Empty(tree.GetDiagnostics());
         Assert.Equal(text, tree.GetRoot().ToFullString());
+    }
+
+    /// <summary>The declaration fixes the order of its pseudo-attributes, but one written out of order still round-trips.</summary>
+    [Fact]
+    public void Parse_Save_RoundTripsAnXmlDeclarationWrittenOutOfOrder()
+    {
+        const string Text = "<?xml version=\"1.0\" standalone=\"yes\" encoding=\"UTF-8\" ?>\n<root />";
+        var tree = XmlSyntaxTree.ParseText(Text);
+
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal("XML0013", diagnostic.Id);
+        AssertSpan(Text.IndexOf("encoding", StringComparison.Ordinal), "encoding".Length, diagnostic.Location.SourceSpan);
+        Assert.Equal("UTF-8", Assert.IsType<XmlDeclarationSyntax>(tree.GetRoot().Nodes[0]).Encoding);
+        Assert.Equal(Text, tree.GetRoot().ToFullString());
     }
 
     [Fact]
@@ -517,9 +530,10 @@ public sealed class XmlSyntaxTreeTests
 
         Assert.All(tree.GetDiagnostics(), diagnostic => Assert.Same(tree.GetText(), diagnostic.Location.SourceText));
 
-        // The mismatched end tag on the third line, then the unclosed <item> indented on the second.
-        Assert.Equal(new LinePosition(2, 0), tree.GetDiagnostics()[0].Location.GetLineSpan().Start);
-        Assert.Equal(new LinePosition(1, 2), tree.GetDiagnostics()[1].Location.GetLineSpan().Start);
+        // The end tag on the third line closes <root>, which leaves the <item> indented on the second unclosed.
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal(new LinePosition(1, 2), diagnostic.Location.GetLineSpan().Start);
+        Assert.Equal(new LinePosition(1, 8), diagnostic.Location.GetLineSpan().End);
     }
 
     [Theory]
@@ -651,7 +665,7 @@ public sealed class XmlSyntaxTreeTests
     }
 
     [Fact]
-    public void Positions_UnclosedElementCoversTheRecoveredText()
+    public void Positions_UnclosedElementEndsWhereItsParentIsClosed()
     {
         const string Text = "<root><a></root>";
         var tree = XmlSyntaxTree.ParseText(Text);
@@ -660,10 +674,11 @@ public sealed class XmlSyntaxTreeTests
         AssertSpan(0, 16, root.FullSpan);
 
         var inner = Assert.IsType<XmlElementSyntax>(root.Content[0]);
-        AssertSpan(6, 10, inner.FullSpan);
+        AssertSpan(6, 3, inner.FullSpan);
+        Assert.Null(inner.EndTag);
 
-        var skipped = Assert.IsType<XmlSkippedTextSyntax>(inner.Content[0]);
-        AssertSpan(9, 7, skipped.FullSpan);
+        AssertSpan(9, 7, Assert.IsType<XmlElementEndTagSyntax>(root.EndTag).FullSpan);
+        AssertSpan(6, 3, Assert.Single(tree.GetDiagnostics()).Location.SourceSpan);
     }
 
     [Fact]
@@ -1056,5 +1071,529 @@ public sealed class XmlSyntaxTreeTests
         var updated = tree.GetRoot().InsertNodesAfter(root.Content[0], [added]);
 
         Assert.Equal("<r><a/><b/></r>", updated.ToFullString());
+    }
+
+    /// <summary>Documents XML 1.0 and Namespaces in XML 1.0 call well-formed, each checked against System.Xml too.</summary>
+    public static TheoryData<string> WellFormedDocuments => new()
+    {
+        "<a/>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!-- c -->\n<?pi?>\n<!DOCTYPE a>\n<a/>\n<!-- trailing -->\n<?end data?>\n",
+        "<?xml version='1.0'?><a/>",
+        "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?><a/>",
+        "<?xmlfoo bar?><a/>",
+        "<!DOCTYPE a [<!-- don't -->]><a/>",
+        "<!DOCTYPE a [<?pi it's [data]?>]><a/>",
+        "<!DOCTYPE a [<!ENTITY e \"x'>\">]><a>&e;</a>",
+        "<!DOCTYPE a SYSTEM \"a.dtd\"><a/>",
+        "<a b=\"it's\" c='say \"hi\"' d='&#60;&#x3C;&lt;'/>",
+        "<a>&lt;&gt;&amp;&apos;&quot;&#65;&#x41;&#x10000;&#xFFFD;</a>",
+        "<a></a >",
+        "<a\n/>",
+        "<a b = \"1\"\t\r\n c='2'/>",
+        "<a>]]</a>",
+        "<a>]></a>",
+        "<a>x > y</a>",
+        "<a><![CDATA[<&]]]]><![CDATA[>]]></a>",
+        "<!----><a><!--a-b--></a>",
+        "<p:a xmlns:p=\"urn:x\" p:b=\"1\"><p:c/></p:a>",
+        "<a xml:lang=\"en\" xmlns=\"urn:x\"><b xmlns=\"\"/></a>",
+        "<a xmlns:p=\"urn:x\" xmlns:q=\"urn:y\" p:b=\"1\" q:b=\"2\"/>",
+        "<a>\u00A0\U0001F600</a>",
+        "<a\u00B7b/>",
+        "<root>\r\n  <child>text</child>\r\n</root>",
+        "<a>&#x9;&#xA;&#xD;</a>",
+    };
+
+    [Theory]
+    [MemberData(nameof(WellFormedDocuments))]
+    public void WellFormedDocumentsHaveNoDiagnostics(string text)
+    {
+        Assert.Null(ReadWithXmlReader(text));
+
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        Assert.Empty(tree.GetDiagnostics());
+        Assert.Equal(text, tree.GetRoot().ToFullString());
+    }
+
+    /// <summary>Documents that break a well-formedness constraint, with the diagnostic each must report.</summary>
+    public static TheoryData<string, string> MalformedDocuments => new()
+    {
+        // Structure
+        { "", "XML0014" },
+        { "   ", "XML0014" },
+        { "<!-- only a comment -->", "XML0014" },
+        { "<a/><b/>", "XML0014" },
+        { "<a/>text", "XML0014" },
+        { "text<a/>", "XML0014" },
+        { "&amp;<a/>", "XML0014" },
+        { "<![CDATA[x]]><a/>", "XML0014" },
+        { "<a/><!DOCTYPE a>", "XML0014" },
+        { "<!DOCTYPE a><!DOCTYPE a><a/>", "XML0014" },
+        { "<a><!DOCTYPE a></a>", "XML0014" },
+
+        // XML declaration
+        { " <?xml version=\"1.0\"?><a/>", "XML0013" },
+        { "<a/><?xml version=\"1.0\"?>", "XML0013" },
+        { "<a><?xml version=\"1.0\"?></a>", "XML0013" },
+        { "<?XML version=\"1.0\"?><a/>", "XML0013" },
+        { "<?xml?><a/>", "XML0013" },
+        { "<?xml encoding=\"UTF-8\"?><a/>", "XML0013" },
+        { "<?xml version=\"2.0\"?><a/>", "XML0013" },
+        { "<?xml version=\"1.0\" standalone=\"maybe\"?><a/>", "XML0013" },
+        { "<?xml version=\"1.0\" standalone=\"yes\" encoding=\"UTF-8\"?><a/>", "XML0013" },
+        { "<?xml version=\"1.0\" foo=\"bar\"?><a/>", "XML0013" },
+        { "<?xml version=\"1.0\"encoding=\"UTF-8\"?><a/>", "XML0013" },
+        { "<?xml version=\"1.0\" version=\"1.0\"?><a/>", "XML0013" },
+        { "<?xml version=\"1.0\"", "XML0007" },
+
+        // Processing instructions
+        { "<a><? pi?></a>", "XML0016" },
+        { "<a><?pi!data?></a>", "XML0016" },
+        { "<a><?XmL data?></a>", "XML0013" },
+        { "<a><?xml!?></a>", "XML0016" },
+        { "<a><?pi data", "XML0012" },
+
+        // Comments
+        { "<a><!-- a -- b --></a>", "XML0015" },
+        { "<a><!-- a ---></a>", "XML0015" },
+
+        // Document type declaration
+        { "<!doctype a><a/>", "XML0018" },
+        { "<!DOCTYPEa><a/>", "XML0018" },
+        { "<!DOCTYPE><a/>", "XML0018" },
+        { "<!DOCTYPE a", "XML0011" },
+
+        // Start tags and attributes
+        { "<a b/>", "XML0010" },
+        { "<a b=c/>", "XML0010" },
+        { "<a b=/>", "XML0010" },
+        { "<a b=\"1\"c=\"2\"/>", "XML0010" },
+        { "<a @/>", "XML0010" },
+        { "<a\u00A0b=\"1\"/>", "XML0010" },
+        { "<a b=\"1\" / >", "XML0010" },
+        { "<a b=\"1\"", "XML0010" },
+        { "<a>x < y</a>", "XML0010" },
+        { "<a b=\"1\" b=\"2\"/>", "XML0006" },
+        { "<a xmlns:p=\"urn:x\" xmlns:q=\"urn:x\" p:b=\"1\" q:b=\"2\"/>", "XML0006" },
+        { "<a b=\"<\"/>", "XML0005" },
+
+        // End tags
+        { "<a></b>", "XML0002" },
+        { "<a></ a>", "XML0002" },
+        { "<a></a b>", "XML0002" },
+        { "<a></>", "XML0002" },
+        { "<a>", "XML0001" },
+
+        // Character data and references
+        { "<a>]]></a>", "XML0005" },
+        { "<a>&</a>", "XML0004" },
+        { "<a>& b</a>", "XML0004" },
+        { "<a>&amp</a>", "XML0004" },
+        { "<a>&unknown;</a>", "XML0004" },
+        { "<!DOCTYPE a [<!ENTITY e \"x\">]><a>&f;</a>", "XML0004" },
+        { "<a>&#;</a>", "XML0004" },
+        { "<a>&#x;</a>", "XML0004" },
+        { "<a>&#12a;</a>", "XML0004" },
+        { "<a>&#0;</a>", "XML0004" },
+        { "<a>&#xD800;</a>", "XML0004" },
+        { "<a>&#xFFFE;</a>", "XML0004" },
+        { "<a>&#x110000;</a>", "XML0004" },
+        { "<a>&#99999999999;</a>", "XML0004" },
+        { "<a b=\"&\"/>", "XML0004" },
+        { "<a b=\"&x;\"/>", "XML0004" },
+
+        // Characters XML does not allow at all
+        { "<a>\u0001</a>", "XML0003" },
+        { "<a b=\"\u001F\"/>", "XML0003" },
+        { "<a><!--\u0008--></a>", "XML0003" },
+        { "<a><![CDATA[\uFFFF]]></a>", "XML0003" },
+        { "<a>\uFFFE</a>", "XML0003" },
+
+        // Namespaces
+        { "<p:a/>", "XML0017" },
+        { "<a p:b=\"1\"/>", "XML0017" },
+        { "<a><b xmlns:p=\"urn:x\"/><p:c/></a>", "XML0017" },
+        { "<a xmlns:p=\"\"/>", "XML0017" },
+        { "<a:b:c xmlns:a=\"urn:x\"/>", "XML0017" },
+        { "<a xmlns:xml=\"urn:x\"/>", "XML0017" },
+        { "<a xmlns:xmlns=\"urn:x\"/>", "XML0017" },
+        { "<a><?p:i data?></a>", "XML0017" },
+    };
+
+    [Theory]
+    [MemberData(nameof(MalformedDocuments))]
+    public void MalformedDocumentsReportTheirDiagnostic(string text, string expectedId)
+    {
+        Assert.NotNull(ReadWithXmlReader(text));
+
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Id == expectedId);
+        Assert.Equal(text, tree.GetRoot().ToFullString());
+    }
+
+    /// <summary>Documents the specifications call malformed, but that System.Xml accepts anyway.</summary>
+    public static TheoryData<string, string> MalformedDocumentsSystemXmlAccepts => new()
+    {
+        // EncName must start with a letter; a reader over a string never looks at the encoding.
+        { "<?xml version=\"1.0\" encoding=\"8bit\"?><a/>", "XML0013" },
+
+        // Namespaces in XML 1.0: element names must not have the prefix xmlns.
+        { "<xmlns:a/>", "XML0017" },
+    };
+
+    [Theory]
+    [MemberData(nameof(MalformedDocumentsSystemXmlAccepts))]
+    public void MalformedDocumentsSystemXmlAcceptsReportTheirDiagnostic(string text, string expectedId)
+    {
+        Assert.Null(ReadWithXmlReader(text));
+
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Id == expectedId);
+        Assert.Equal(text, tree.GetRoot().ToFullString());
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedDocuments))]
+    public void MalformedDocumentsReproduceEveryPrefixAndEverySingleCharacterDeletion(string text, string expectedId)
+    {
+        _ = expectedId;
+        ParseText_ReproducesEveryPrefixAndEverySingleCharacterDeletion(text);
+    }
+
+    /// <summary>A lone surrogate is not a character at all, so it is built here rather than passed as test data.</summary>
+    [Fact]
+    public void ALoneSurrogateInContentIsAnInvalidCharacter()
+    {
+        var text = "<a>" + (char)0xDC00 + "</a>";
+        var tree = XmlSyntaxTree.ParseText(text);
+
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal("XML0003", diagnostic.Id);
+        AssertSpan(3, 1, diagnostic.Location.SourceSpan);
+    }
+
+    [Fact]
+    public void AnXmlStylesheetProcessingInstructionIsNotAnXmlDeclaration()
+    {
+        var tree = XmlSyntaxTree.ParseText("<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>\n<root/>");
+
+        Assert.Empty(tree.GetDiagnostics());
+        var processingInstruction = Assert.IsType<XmlProcessingInstructionSyntax>(tree.GetRoot().Nodes[0]);
+        Assert.Equal("xml-stylesheet", processingInstruction.Target);
+        Assert.Equal("type=\"text/xsl\" href=\"style.xsl\"", processingInstruction.Data);
+        Assert.IsType<XmlEmptyElementSyntax>(tree.GetRoot().Nodes[2]);
+    }
+
+    [Fact]
+    public void AnApostropheInACommentOfTheInternalSubsetDoesNotSwallowTheDocument()
+    {
+        var tree = XmlSyntaxTree.ParseText("<!DOCTYPE root [\n<!-- don't -->\n<!ENTITY e \"x\">\n]>\n<root>&e;</root>");
+
+        Assert.Empty(tree.GetDiagnostics());
+        var documentType = Assert.IsType<XmlDocumentTypeSyntax>(tree.GetRoot().Nodes[0]);
+        Assert.False(documentType.GreaterThanToken.IsMissing);
+        Assert.Equal("root", Assert.IsType<XmlElementSyntax>(tree.GetRoot().Nodes[2]).Name);
+    }
+
+    [Fact]
+    public void AttributeValue_ResolvesReferencesAndNormalizesWhitespace()
+    {
+        const string Text = "<a b=\"&lt;&amp;&gt;&quot;&apos;&#65;&#x42;&#x1F600;\" c=\"x&#10;y&#x9;z&#13;\" d=\"line1\r\n\tline2\rline3\" e=\"&custom;\"/>";
+        var tree = XmlSyntaxTree.ParseText("<!DOCTYPE a [<!ENTITY custom \"v\">]>" + Text);
+        var element = Assert.IsType<XmlEmptyElementSyntax>(tree.GetRoot().Nodes[1]);
+
+        Assert.Empty(tree.GetDiagnostics());
+        Assert.Equal("<&>\"'AB\U0001F600", element.GetAttribute("b")?.Value);
+        Assert.Equal("x\ny\tz\r", element.GetAttribute("c")?.Value);
+        Assert.Equal("line1  line2 line3", element.GetAttribute("d")?.Value);
+
+        // Only the predefined entities and character references can be resolved without reading the DTD.
+        Assert.Equal("&custom;", element.GetAttribute("e")?.Value);
+
+        var expected = System.Xml.Linq.XDocument.Parse("<!DOCTYPE a [<!ENTITY custom \"v\">]>" + Text).Root!;
+        Assert.Equal(expected.Attribute("b")?.Value, element.GetAttribute("b")?.Value);
+        Assert.Equal(expected.Attribute("c")?.Value, element.GetAttribute("c")?.Value);
+        Assert.Equal(expected.Attribute("d")?.Value, element.GetAttribute("d")?.Value);
+    }
+
+    [Fact]
+    public void AttributeValue_SelectedThroughXPathIsResolved()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root><item name=\"a &amp; b\" /></root>");
+
+        Assert.Single(tree.GetRoot().SelectNodes("//item[@name='a & b']"));
+    }
+
+    [Theory]
+    [InlineData("a\nb")]
+    [InlineData("tab\there")]
+    [InlineData("cr\rlf\r\n")]
+    [InlineData("<\"'&>")]
+    [InlineData("  leading and trailing  ")]
+    public void AttributeValue_WithValueSurvivesAReparse(string value)
+    {
+        var tree = XmlSyntaxTree.ParseText("<a b='x' c=\"y\"/>");
+
+        var updated = tree.GetRoot()
+            .ReplaceNode("//@b", node => ((XmlAttributeSyntax)node).WithValue(value))
+            .ReplaceNode("//@c", node => ((XmlAttributeSyntax)node).WithValue(value));
+
+        Assert.Equal(value, Assert.IsType<XmlAttributeSyntax>(updated.SelectSingleSyntaxNode("//@b")).Value);
+
+        var reparsed = XmlSyntaxTree.ParseText(updated.ToFullString());
+        var reparsedElement = Assert.IsType<XmlEmptyElementSyntax>(reparsed.GetRoot().Nodes[0]);
+
+        Assert.Empty(reparsed.GetDiagnostics());
+        Assert.Equal(value, reparsedElement.GetAttribute("b")?.Value);
+        Assert.Equal(value, reparsedElement.GetAttribute("c")?.Value);
+        Assert.Equal(value, System.Xml.Linq.XElement.Parse(updated.ToFullString()).Attribute("b")?.Value);
+    }
+
+    [Fact]
+    public void TextValue_ResolvesReferencesAndNormalizesLineBreaks()
+    {
+        const string Text = "<a>x &lt; y&#x20;&#13;\r\n&amp;&#x10000;\rz</a>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+        var element = Assert.IsType<XmlElementSyntax>(tree.GetRoot().Nodes[0]);
+        var text = Assert.IsType<XmlTextSyntax>(Assert.Single(element.Content));
+
+        Assert.Equal("x &lt; y&#x20;&#13;\r\n&amp;&#x10000;\rz", text.Text);
+        Assert.Equal("x < y \r\n&\U00010000\nz", text.Value);
+        Assert.Equal(System.Xml.Linq.XElement.Parse(Text).Value, text.Value);
+        Assert.Equal(text.Value, tree.GetRoot().CreateNavigator().SelectSingleNode("/a")?.Value);
+    }
+
+    [Fact]
+    public void ProcessingInstructionData_ExcludesTheWhitespaceAfterTheTarget()
+    {
+        var tree = XmlSyntaxTree.ParseText("<?target  some data ?><?empty?><?blank   ?><a/>");
+
+        Assert.Empty(tree.GetDiagnostics());
+        Assert.Equal("some data ", Assert.IsType<XmlProcessingInstructionSyntax>(tree.GetRoot().Nodes[0]).Data);
+        Assert.Null(Assert.IsType<XmlProcessingInstructionSyntax>(tree.GetRoot().Nodes[1]).Data);
+        Assert.Null(Assert.IsType<XmlProcessingInstructionSyntax>(tree.GetRoot().Nodes[2]).Data);
+        Assert.Equal("some data ", tree.GetRoot().CreateNavigator().SelectSingleNode("/processing-instruction('target')")?.Value);
+
+        var created = SyntaxFactory.XmlProcessingInstruction("target", "data");
+        Assert.Equal("<?target data?>", created.ToFullString());
+        Assert.Equal("data", created.Data);
+        Assert.Same(created, created.WithData("data"));
+    }
+
+    [Fact]
+    public void Diagnostics_AreSortedByPosition()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root>\n  <item>\n    <a b=c/>\n");
+
+        var positions = tree.GetDiagnostics().Select(diagnostic => diagnostic.Location.SourceSpan.Start).ToList();
+
+        Assert.Equal(positions.Order().ToList(), positions);
+        Assert.HasCount(3, positions);
+    }
+
+    [Fact]
+    public void Recovery_AnEndTagMatchingAnAncestorClosesTheElementsLeftOpen()
+    {
+        const string Text = "<root>\n  <a>\n    <b>\n</root>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        Assert.NotNull(root.EndTag);
+        var a = Assert.IsType<XmlElementSyntax>(root.Content[1]);
+        Assert.Null(a.EndTag);
+        var b = Assert.IsType<XmlElementSyntax>(a.Content[1]);
+        Assert.Null(b.EndTag);
+
+        Assert.Equal(["XML0001", "XML0001"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        Assert.Equal("Missing end tag for 'a'.", tree.GetDiagnostics()[0].Message);
+        AssertSpan(Text.IndexOf("<a>", StringComparison.Ordinal), 3, tree.GetDiagnostics()[0].Location.SourceSpan);
+        AssertSpan(Text.IndexOf("<b>", StringComparison.Ordinal), 3, tree.GetDiagnostics()[1].Location.SourceSpan);
+    }
+
+    [Fact]
+    public void Recovery_AnEndTagMatchingNoOpenElementIsSkipped()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root><a>text</b></a></root>");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        var a = Assert.IsType<XmlElementSyntax>(Assert.Single(root.Content));
+        Assert.NotNull(a.EndTag);
+        Assert.IsType<XmlSkippedTextSyntax>(a.Content[1]);
+        Assert.Equal("XML0002", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_AStartTagMissingItsGreaterThanStillOpensTheElement()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root>\n  <a b=\"1\"\n  <c/>\n  </a>\n</root>");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        Assert.NotNull(root.EndTag);
+        var a = Assert.IsType<XmlElementSyntax>(root.Content[1]);
+        Assert.True(a.StartTag.GreaterThanToken.IsMissing);
+        Assert.Equal("1", a.GetAttribute("b")?.Value);
+        Assert.NotNull(a.EndTag);
+        Assert.IsType<XmlEmptyElementSyntax>(a.Content[0]);
+        Assert.Equal("XML0010", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_UnexpectedCharactersInAStartTagAreSkippedAndTheElementKept()
+    {
+        const string Text = "<root><a @ b=\"1\" #>text</a></root>";
+        var tree = XmlSyntaxTree.ParseText(Text);
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        var a = Assert.IsType<XmlElementSyntax>(Assert.Single(root.Content));
+        Assert.Equal("1", a.GetAttribute("b")?.Value);
+        Assert.Equal("text", Assert.IsType<XmlTextSyntax>(Assert.Single(a.Content)).Text);
+        Assert.NotNull(a.EndTag);
+        Assert.True(a.StartTag.ContainsSkippedText);
+        Assert.Equal(["XML0010", "XML0010"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        AssertSpan(Text.IndexOf('@', StringComparison.Ordinal), 1, tree.GetDiagnostics()[0].Location.SourceSpan);
+    }
+
+    [Fact]
+    public void Recovery_AnUnterminatedAttributeValueStopsAtTheNextTag()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root>\n  <a b=\"1>\n  <c/>\n</root>");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        Assert.NotNull(root.EndTag);
+        var a = Assert.IsType<XmlElementSyntax>(root.Content[1]);
+        Assert.True(a.Attributes[0].EndQuoteToken.IsMissing);
+        Assert.IsType<XmlEmptyElementSyntax>(a.Content[0]);
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Id == "XML0010" && diagnostic.Message.Contains("quote", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Recovery_ALessThanInAnAttributeValueThatIsNotATagIsKept()
+    {
+        var tree = XmlSyntaxTree.ParseText("<a Condition=\"'$(X)' < '2'\"/>");
+
+        var element = Assert.IsType<XmlEmptyElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        Assert.Equal("'$(X)' < '2'", element.GetAttribute("Condition")?.Value);
+        Assert.Equal("XML0005", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_ALessThanInTextDoesNotSwallowTheEndTag()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root>a < b</root>");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        Assert.NotNull(root.EndTag);
+        Assert.Equal("XML0010", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_AnUnterminatedDeclarationKeepsTheRestOfTheDocument()
+    {
+        var tree = XmlSyntaxTree.ParseText("<?xml version=\"1.0\"\n<root/>");
+
+        var declaration = Assert.IsType<XmlDeclarationSyntax>(tree.GetRoot().Nodes[0]);
+        Assert.True(declaration.EndDeclarationToken.IsMissing);
+        Assert.Equal("1.0", declaration.Version);
+        Assert.IsType<XmlEmptyElementSyntax>(tree.GetRoot().Nodes[^1]);
+        Assert.Equal("XML0007", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_AnInvalidDeclarationAttributeKeepsTheRestOfTheDocument()
+    {
+        var tree = XmlSyntaxTree.ParseText("<?xml version=\"1.0\" ! ?>\n<root/>");
+
+        var declaration = Assert.IsType<XmlDeclarationSyntax>(tree.GetRoot().Nodes[0]);
+        Assert.False(declaration.EndDeclarationToken.IsMissing);
+        Assert.IsType<XmlEmptyElementSyntax>(tree.GetRoot().Nodes[^1]);
+        Assert.Single(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void Recovery_AnUnterminatedDocumentTypeKeepsTheRootElement()
+    {
+        var tree = XmlSyntaxTree.ParseText("<!DOCTYPE root\n<root/>");
+
+        var documentType = Assert.IsType<XmlDocumentTypeSyntax>(tree.GetRoot().Nodes[0]);
+        Assert.True(documentType.GreaterThanToken.IsMissing);
+        Assert.IsType<XmlEmptyElementSyntax>(tree.GetRoot().Nodes[^1]);
+        Assert.Equal("XML0011", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_AnUnterminatedProcessingInstructionIsStillOne()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root><?pi data");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        var processingInstruction = Assert.IsType<XmlProcessingInstructionSyntax>(Assert.Single(root.Content));
+        Assert.Equal("pi", processingInstruction.Target);
+        Assert.True(processingInstruction.EndProcessingInstructionToken.IsMissing);
+        Assert.Equal(["XML0001", "XML0012"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+    }
+
+    [Fact]
+    public void Recovery_AMalformedEndTagStillClosesItsElement()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root><a></a b=\"1\"><c/></root>");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        var a = Assert.IsType<XmlElementSyntax>(root.Content[0]);
+        Assert.NotNull(a.EndTag);
+        Assert.IsType<XmlEmptyElementSyntax>(root.Content[1]);
+        Assert.Equal("XML0002", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_AnEndTagMissingItsGreaterThanDoesNotSwallowTheNextTag()
+    {
+        var tree = XmlSyntaxTree.ParseText("<root><a></a\n<b/></root>");
+
+        var root = Assert.IsType<XmlElementSyntax>(Assert.Single(tree.GetRoot().Nodes));
+        Assert.True(Assert.IsType<XmlElementSyntax>(root.Content[0]).EndTag?.GreaterThanToken.IsMissing);
+        Assert.IsType<XmlEmptyElementSyntax>(root.Content[1]);
+        Assert.Equal("XML0002", Assert.Single(tree.GetDiagnostics()).Id);
+    }
+
+    [Fact]
+    public void Recovery_TheRootElementIsNotReportedMissingWhenMarkupWasSkipped()
+    {
+        Assert.Equal(["XML0002"], XmlSyntaxTree.ParseText("</a>").GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        Assert.Equal(["XML0014"], XmlSyntaxTree.ParseText("<?xml version=\"1.0\"?>\n").GetDiagnostics().Select(diagnostic => diagnostic.Id));
+    }
+
+    public static TheoryData<string> AdditionalRecoverySamples => new()
+    {
+        "<?xml-stylesheet href='a'?><a/>", "<!DOCTYPE a [<!-- ' -->]><a/>", "<a b=\"1\" c='2' @ d>x</a>", "<a b=\"<c/>",
+        "<a b=\"x<y\"/>", "<a <b/></a>", "<root>a < b</root>", "<?xml version=\"1.0\" ! ?><a/>", "<!DOCTYPE a\n<a/>",
+        "<a></a\n<b/>", "<a>&#x;&#;&amp&unknown;]]></a>", "<a xmlns:p=''><p:b p:c='1'/></a>", "<?XML version='1.0'?><a/>",
+        "<!doctype a><a/>", "<a><? x?></a>", "<a><!-- -- --></a>", "<a b='1'/ ><c/ >", "<a\u00A0b='1'/>", "<a></ a >",
+    };
+
+    [Theory]
+    [MemberData(nameof(AdditionalRecoverySamples))]
+    public void AdditionalRecoverySamplesReproduceEveryPrefixAndEverySingleCharacterDeletion(string text)
+    {
+        ParseText_ReproducesEveryPrefixAndEverySingleCharacterDeletion(text);
+        ParseText_ReproducesItsSourceExactly(text);
+    }
+
+    private static Exception? ReadWithXmlReader(string text)
+    {
+        return Record.Exception(() =>
+        {
+            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse, XmlResolver = null };
+            using var reader = XmlReader.Create(new StringReader(text), settings);
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    _ = reader.MoveToFirstAttribute();
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
`Meziantou.Framework.Language.Xml` accepted many malformed documents without a diagnostic, misread some valid ones, and recovered poorly from common mistakes. This PR makes the parser check every well-formedness constraint of XML 1.0 (Fifth Edition) and Namespaces in XML 1.0, like a non-validating processor.

## Bugs fixed

- **`<?xml-stylesheet …?>` was parsed as an XML declaration.** It was reported as unterminated and everything after it became skipped text.
- **An apostrophe in a comment of the DTD internal subset swallowed the document.** `<!DOCTYPE a [<!-- don't -->]>` was read as an unclosed quote.
- **`XmlAttributeSyntax.Value` did not decode references or normalize whitespace,** though its doc said it did. XPath predicates on values such as `@name='a & b'` did not match.
- **`WithValue("a\nb")` did not survive a reparse.** A literal line break in an attribute reads back as a space, so it is now escaped as `&#xA;` (same for tab and CR).
- **`XmlProcessingInstructionSyntax.Data` included the whitespace after the target.**
- **A no-break space and other non-XML whitespace were accepted as separators inside tags.**

## New diagnostics

Previously unreported errors now produce `XML0003`–`XML0006` and `XML0013`–`XML0018`, documented in the readme:

- invalid characters; malformed, invalid, or undeclared references (entities declared in the internal subset are honoured)
- `<` in attribute values; `]]>` in text; `--` in comments
- duplicate attributes, including the same expanded name under two prefixes
- missing, unquoted, or unterminated attribute values; no whitespace between attributes
- XML declaration: wrong case, misplaced, bad version/encoding/standalone, wrong order
- document structure: no root, several roots, text/CDATA outside the root, misplaced or duplicate DOCTYPE
- processing instructions: missing target, reserved `xml` target, colon in target, no whitespace after target
- namespaces: undeclared prefixes, invalid QNames, reserved `xml`/`xmlns` misuse, empty prefixed namespace

Diagnostics are now sorted by position.

## Recovery

- An end tag that matches an element further up closes the elements left open in between. Previously `<root><a></root>` left both open and turned `</root>` into skipped text.
- A start tag missing its `>` still opens its element (missing `GreaterThanToken`).
- Text a tag cannot use (`<a @ b="1">`) becomes `SkippedTextTrivia` inside the tag; the element and its other attributes are kept.
- An attribute value that meets what looks like the next tag before its closing quote stops there.
- `a < b` in content, an unterminated declaration, DOCTYPE, or end tag no longer swallow text up to the next `>`.
- An unterminated processing instruction is an `XmlProcessingInstructionSyntax` with a missing end token rather than skipped text.

## Public API (additions only, `ref/` regenerated)

- `XmlTextSyntax.Value`: character data with references resolved and line breaks normalized
- `SyntaxKind.SkippedTextTrivia`
- `SyntaxFacts.IsWhitespace(char)`

## Things for reviewers

- **Behaviour changes:** documents that parsed without diagnostics before may now report them (e.g. `""`, `<a/><b/>`). The missing-end-tag diagnostic now spans only the start tag instead of running to the end of the file.
- **Existing tests updated:** two recovery-shape tests now expect the ancestor-close tree. `Parse_Save_RoundTripsXmlDeclarationVariants` claimed `standalone` before `encoding` is valid. The `XMLDecl` production fixes that order and System.Xml rejects it, so that case moved to its own test that expects `XML0013`.
- **`SyntaxFacts.IsWhitespace` may not need to be public:** only the parser uses it. Happy to make it internal.
- **Where System.Xml and the spec disagree, the parser follows the spec:** encoding names that are not an `EncName`, `<xmlns:a/>`, versions other than `1.0`, and `&#x10100000;`. Those cases live in a separate `MalformedDocumentsSystemXmlAccepts` theory.
- **Not changed:** the XPath view still exposes `xmlns` attributes and the declaration, and does not merge adjacent text/CDATA nodes, because editing through XPath relies on that.

## Testing

- **Well-formed and malformed theories:** every sample is cross-checked with `XmlReader`, so the expected outcome is not just this parser's opinion.
- **Recovery tests:** each asserts both the tree shape and the diagnostics.
- **Round-trip tests:** every prefix and every single-character deletion of the samples still reproduces the source.
- **Fuzzing (not committed):** a scratch program compared this parser with `XmlReader` on about 750k mutated documents. There were no crashes, round-trip failures, or out-of-range spans, and the only disagreements are the spec divergences above and DTD-internal syntax, which the parser does not validate by design.
- **Local runs:** `Meziantou.Framework.Language.Xml.Tests` (379 tests), `DependencyScanning.Tests` (118), and `Language.Tool.Tests` (50) pass on net10.0 and net11.0. The Release `IsOfficialBuild` build is clean, and `eng/update-all.cs` made no changes.
