### PR TITLE
Fix YAML scanner spec-compliance edge cases

### DIFF
--- a/src/Meziantou.Framework.Yaml/Events/NodeEvent.cs
+++ b/src/Meziantou.Framework.Yaml/Events/NodeEvent.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Framework.Yaml.Events;
 public abstract partial class NodeEvent : ParsingEvent
 {
     /// <summary>Matches <c>ns-anchor-name</c>: one or more printable characters other than whitespace and flow indicators.</summary>
-    [GeneratedRegex(@"^[^\x00-\x20\x7F-\x9F,\[\]{}\uFEFF]+$", RegexOptions.None, matchTimeoutMilliseconds: -1)]
+    [GeneratedRegex(@"^[^\x00-\x20\x7F-\x84\x86-\x9F,\[\]{}\uFEFF]+$", RegexOptions.None, matchTimeoutMilliseconds: -1)]
     internal static partial Regex AnchorValidator { get; }
 
     /// <summary>Gets the anchor.</summary>

--- a/src/Meziantou.Framework.Yaml/Scanner.cs
+++ b/src/Meziantou.Framework.Yaml/Scanner.cs
@@ -11,6 +11,9 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     private const int MaxVersionNumberLength = 9;
 
     private readonly Stack<int> _indents = new Stack<int>();
+
+    // Tracks, for each indentation level, whether a block mapping has an explicit key ('?') waiting for its value.
+    private readonly Stack<bool> _explicitKeyPendings = new Stack<bool>();
     private readonly InsertionQueue<Token> _tokens = new InsertionQueue<Token>();
     private readonly Stack<SimpleKey> _simpleKeys = new Stack<SimpleKey>();
 
@@ -24,6 +27,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     private bool _streamStartProduced;
     private bool _streamEndProduced;
     private int _indent = -1;
+    private bool _explicitKeyPending;
     private bool _simpleKeyAllowed;
 
     private int _index;
@@ -32,6 +36,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     private int _column;
     private char _previousCharacter;
     private int _firstTabColumn = -1;
+    private bool _nonBlankOnLine;
     private bool _adjacentValueAllowed;
 
     /// <summary>Gets the current position inside the input stream.</summary>
@@ -307,6 +312,11 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             return;
         }
 
+        // In the block context, the indentation of a node that starts a line must be made of spaces.
+
+        if (_flowLevel == 0 && !_nonBlankOnLine && _firstTabColumn >= 0 && _firstTabColumn <= _indent)
+            throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "A tab cannot be used for indentation.");
+
         // Is it the flow sequence start indicator?
 
         if (_analyzer.Check('['))
@@ -504,8 +514,15 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
         if (!char.IsLowSurrogate(character))
             _characterIndex++;
 
-        if (_previousCharacter is '\t' && _firstTabColumn < 0)
-            _firstTabColumn = _column;
+        if (character is '\t')
+        {
+            if (_firstTabColumn < 0)
+                _firstTabColumn = _column;
+        }
+        else if (character is not ' ')
+        {
+            _nonBlankOnLine = true;
+        }
         ++_index;
         ++_column;
         _analyzer.Skip(1);
@@ -514,6 +531,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     private void SkipLine()
     {
         _firstTabColumn = -1;
+        _nonBlankOnLine = false;
         if (_analyzer.IsCrLf())
         {
             _index += 2;
@@ -546,6 +564,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             {
                 Skip();
                 _column = 0;
+                _nonBlankOnLine = false;
             }
 
             // Eat whitespaces.
@@ -641,6 +660,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             // Pop the indentation level.
 
             _indent = _indents.Pop();
+            _explicitKeyPending = _explicitKeyPendings.Pop();
         }
     }
 
@@ -973,6 +993,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             // Add the BLOCK-MAPPING-START token if needed.
 
             RollIndent(_column, -1, false, CurrentPosition);
+            _explicitKeyPending = true;
         }
 
         // Reset any potential simple keys on the current flow level.
@@ -1009,6 +1030,10 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             // In the block context, we may need to add the BLOCK-MAPPING-START token.
 
             RollIndent(simpleKey.Mark.Column, simpleKey.TokenNumber, false, simpleKey.Mark);
+            if (_flowLevel == 0)
+            {
+                _explicitKeyPending = false;
+            }
 
             // Remove the simple key.
 
@@ -1036,11 +1061,17 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
                 // Add the BLOCK-MAPPING-START token if needed.
 
                 RollIndent(_column, -1, false, CurrentPosition);
+
+                // A value that follows an explicit key may be a compact sequence or mapping. The value of an empty
+                // implicit key (": value") must start on the next line when it is a block collection.
+
+                _simpleKeyAllowed = _explicitKeyPending;
+                _explicitKeyPending = false;
             }
-
-            // Simple keys after ':' are allowed in the block context.
-
-            _simpleKeyAllowed = _flowLevel == 0;
+            else
+            {
+                _simpleKeyAllowed = false;
+            }
         }
 
         // Consume the token.
@@ -1077,6 +1108,8 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
 
             _indents.Push(_indent);
+            _explicitKeyPendings.Push(_explicitKeyPending);
+            _explicitKeyPending = false;
 
             _indent = column;
 
@@ -1137,12 +1170,14 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
 
         // Check if length of the anchor is greater than 0 and it is followed by
-        // a whitespace character or one of the indicators:
+        // a whitespace character or one of the indicators that end a flow node:
 
-        //      '?', ':', ',', '[', ']', '{', '}', '%', '@', '`'.
+        //      ',', ']', '}'.
+
+        // Node content cannot follow an anchor without a separation, so '[' and '{' are not allowed.
 
 
-        if (value.Length == 0 || !(_analyzer.IsBlankOrBreakOrZero() || _analyzer.Check("?:,[]{}%@`")))
+        if (value.Length == 0 || !(_analyzer.IsBlankOrBreakOrZero() || _analyzer.Check(",]}")))
         {
             throw new SyntaxErrorException(start, CurrentPosition, "While scanning an anchor or alias, did not find expected alphabetic or numeric character.");
         }
@@ -1185,7 +1220,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
         string handle;
         string suffix;
 
-        if (_analyzer.IsBlankOrBreakOrZero(1))
+        if (_analyzer.IsBlankOrBreakOrZero(1) || (_flowLevel > 0 && _analyzer.Check(",]}", 1)))
         {
             Skip();
             return new Tag(string.Empty, "!", start, CurrentPosition);
@@ -1258,7 +1293,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
         // Check the character which ends the tag.
 
-        if (!_analyzer.IsBlankOrBreakOrZero() && !(_flowLevel > 0 && _analyzer.Check(",[]{}")))
+        if (!_analyzer.IsBlankOrBreakOrZero() && !(_flowLevel > 0 && _analyzer.Check(",]}")))
         {
             throw new SyntaxErrorException(start, CurrentPosition, "While scanning a tag, did not find expected whitespace or line break.");
         }
@@ -1271,6 +1306,13 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     /// <summary>Produce the SCALAR(...,literal) or SCALAR(...,folded) tokens.</summary>
     private void FetchBlockScalar(bool isLiteral)
     {
+        // A block scalar that starts a line must be more indented than its parent collection.
+
+        if (_column <= _indent)
+        {
+            throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "A block scalar must be more indented than its parent collection.");
+        }
+
         // Remove any potential simple keys.
 
         RemoveSimpleKey();
@@ -1293,7 +1335,9 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
         int chomping = 0;
         int increment = 0;
-        int currentIndent = 0;
+
+        // -1 means the indentation is not determined yet: a root block scalar can have its content at column 0.
+        int currentIndent = -1;
         bool leadingBlank = false;
 
         // Eat the indicator '|' or '>'.
@@ -1483,6 +1527,10 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     {
         int maxIndent = 0;
 
+        // Only a line made of indentation spaces ends with an implicit line break at the end of the input. A content
+        // line that reaches the end of the input already added its own break.
+        bool atLineStart = _column == 0;
+
         end = CurrentPosition;
 
         // Eat the intendation spaces and line breaks.
@@ -1491,7 +1539,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
         {
             // Eat the intendation spaces.
 
-            while ((currentIndent == 0 || _column < currentIndent) && _analyzer.IsSpace())
+            while ((currentIndent < 0 || _column < currentIndent) && _analyzer.IsSpace())
             {
                 Skip();
             }
@@ -1503,7 +1551,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
             // Check for a tab character messing the intendation.
 
-            if (_column < (currentIndent == 0 ? Math.Max(_indent + 1, 1) : currentIndent) && _analyzer.IsTab())
+            if (_column < (currentIndent < 0 ? _indent + 1 : currentIndent) && _analyzer.IsTab())
             {
                 throw new SyntaxErrorException(start, CurrentPosition, "While scanning a block scalar, find a tab character where an intendation space is expected.");
             }
@@ -1518,18 +1566,22 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             // Consume the line break.
 
             breaks.Append(ReadLine());
+            atLineStart = true;
 
             end = CurrentPosition;
         }
 
-        if (_analyzer.EndOfInput && _column > 0 && _line > start.Line)
+        if (atLineStart && _analyzer.EndOfInput && _column > 0)
             breaks.Append('\n');
 
         // Determine the indentation level if needed.
 
-        if (currentIndent == 0)
+        if (currentIndent < 0)
         {
-            if (!_analyzer.IsZero() && _column < maxIndent)
+            // Leading empty lines cannot be more indented than the first content line. A line that is not more
+            // indented than the parent collection is not content: the block scalar is empty.
+
+            if (!_analyzer.IsZero() && _column < maxIndent && _column > _indent)
                 throw new SyntaxErrorException(start, CurrentPosition, "Leading empty lines are more indented than block scalar content.");
 
             currentIndent = Math.Max(maxIndent, Math.Max(_indent + 1, 0));
@@ -1733,7 +1785,14 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
             // Check if we are at the end of the scalar.
 
             if (_analyzer.Check(isSingleQuoted ? '\'' : '"'))
+            {
+                // The closing quote can directly follow an escaped line break.
+
+                if (hasLeadingBlanks)
+                    CheckQuotedScalarContinuationIndentation(start);
+
                 break;
+            }
 
             // Consume blank characters.
 
@@ -1764,13 +1823,16 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
                     }
                     else
                     {
+                        if (_firstTabColumn >= 0 && _firstTabColumn <= _indent)
+                            throw new SyntaxErrorException(start, CurrentPosition, "A tab cannot be used for indentation.");
+
                         _scanScalarTrailingBreaks.Append(ReadLine());
                     }
                 }
             }
 
-            if (hasLeadingBlanks && (_column <= _indent || (_firstTabColumn >= 0 && _firstTabColumn <= _indent)))
-                throw new SyntaxErrorException(start, CurrentPosition, "Quoted scalar continuation is not sufficiently indented.");
+            if (hasLeadingBlanks)
+                CheckQuotedScalarContinuationIndentation(start);
 
             // Join the whitespaces or fold line breaks.
 
@@ -1809,6 +1871,12 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
         var end = CurrentPosition;
         return new Scalar(_scanScalarValue.ToString(), isSingleQuoted ? ScalarStyle.SingleQuoted : ScalarStyle.DoubleQuoted, start, end);
+    }
+
+    private void CheckQuotedScalarContinuationIndentation(Mark start)
+    {
+        if (_column <= _indent || (_firstTabColumn >= 0 && _firstTabColumn <= _indent))
+            throw new SyntaxErrorException(start, CurrentPosition, "Quoted scalar continuation is not sufficiently indented.");
     }
 
     /// <summary>Produce the SCALAR(...,plain) token.</summary>
@@ -1925,6 +1993,7 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
             // Consume blank characters.
 
+            bool hasTabIndentedEmptyLine = false;
             while (_analyzer.IsBlank() || _analyzer.IsBreak())
             {
                 if (_analyzer.IsBlank())
@@ -1952,15 +2021,28 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
                     }
                     else
                     {
+                        hasTabIndentedEmptyLine |= _firstTabColumn >= 0 && _firstTabColumn <= _indent;
                         _scanScalarTrailingBreaks.Append(ReadLine());
                     }
                 }
             }
 
+            // An empty line inside the scalar cannot be indented with a tab. The empty lines only belong to the
+            // scalar when it continues on a following line.
+
+            if (hasTabIndentedEmptyLine && !_analyzer.IsZero() && !_analyzer.Check('#') && !IsDocumentIndicator() && (_flowLevel > 0 || _column >= currentIndent))
+                throw new SyntaxErrorException(start, CurrentPosition, "A tab cannot be used for indentation.");
+
             // Check intendation level.
 
-            if (!_analyzer.IsZero() && _firstTabColumn >= 0 && _firstTabColumn <= _indent)
+            if (!_analyzer.IsZero() && !_analyzer.Check('#') && _firstTabColumn >= 0 && _firstTabColumn <= _indent)
                 throw new SyntaxErrorException(start, CurrentPosition, "A tab cannot be used for indentation.");
+
+            // A comment line may start at any column, but the continuation of a flow scalar must be more indented
+            // than the enclosing block collection.
+
+            if (_flowLevel > 0 && hasLeadingBlanks && _column <= _indent && !_analyzer.IsZero() && !_analyzer.Check('#'))
+                throw new SyntaxErrorException(start, CurrentPosition, "Flow content is not sufficiently indented.");
 
             if (_flowLevel == 0 && _column < currentIndent)
             {
@@ -2129,12 +2211,12 @@ public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
 
         // The set of characters that may appear in URI is as follows:
 
-        //      '0'-'9', 'A'-'Z', 'a'-'z', '_', '-', ';', '/', '?', ':', '@', '&',
+        //      '0'-'9', 'A'-'Z', 'a'-'z', '_', '-', '#', ';', '/', '?', ':', '@', '&',
         //      '=', '+', '$', ',', '.', '!', '~', '*', '\'', '(', ')', '[', ']',
         //      '%'.
 
 
-        while (_analyzer.IsAlpha() || _analyzer.Check(";/?:@&=+$.~*'()%") || (allowFlowIndicators && _analyzer.Check(",![]")))
+        while (_analyzer.IsAlpha() || _analyzer.Check("#;/?:@&=+$.~*'()%") || (allowFlowIndicators && _analyzer.Check(",![]")))
         {
             // Check if it is a URI-escape sequence.
 

--- a/tests/Meziantou.Framework.Yaml.Tests/ParserTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/ParserTests.cs
@@ -135,6 +135,59 @@ public class ParserTests : ParserTestHelper
         }
     }
 
+    [Theory]
+    [InlineData("|\na\n  b\n", "+STR\n+DOC\n=VAL |a\\n  b\\n\n-DOC\n-STR")]
+    [InlineData(">\na\n  b\nc\n", "+STR\n+DOC\n=VAL >a\\n  b\\nc\\n\n-DOC\n-STR")]
+    [InlineData("--- |\n- >\n x\n", "+STR\n+DOC ---\n=VAL |- >\\n x\\n\n-DOC\n-STR")]
+    [InlineData("|\nx\n  ", "+STR\n+DOC\n=VAL |x\\n  \\n\n-DOC\n-STR")]
+    [InlineData("|\n\ta\n", "+STR\n+DOC\n=VAL |\\ta\\n\n-DOC\n-STR")]
+    [InlineData("a: |+\n  abc", "+STR\n+DOC\n+MAP\n=VAL :a\n=VAL |abc\\n\n-MAP\n-DOC\n-STR")]
+    [InlineData(">+\nabc", "+STR\n+DOC\n=VAL >abc\\n\n-DOC\n-STR")]
+    [InlineData("strip: >-\n \nclip: x", "+STR\n+DOC\n+MAP\n=VAL :strip\n=VAL >\n=VAL :clip\n=VAL :x\n-MAP\n-DOC\n-STR")]
+    [InlineData("? a\n: - b", "+STR\n+DOC\n+MAP\n=VAL :a\n+SEQ\n=VAL :b\n-SEQ\n-MAP\n-DOC\n-STR")]
+    [InlineData("? - ? a\n    : b\n: - c", "+STR\n+DOC\n+MAP\n+SEQ\n+MAP\n=VAL :a\n=VAL :b\n-MAP\n-SEQ\n+SEQ\n=VAL :c\n-SEQ\n-MAP\n-DOC\n-STR")]
+    [InlineData("- x\n\t#c", "+STR\n+DOC\n+SEQ\n=VAL :x\n-SEQ\n-DOC\n-STR")]
+    [InlineData("k: v\n\t# c\n", "+STR\n+DOC\n+MAP\n=VAL :k\n=VAL :v\n-MAP\n-DOC\n-STR")]
+    [InlineData("!#a b", "+STR\n+DOC\n=VAL <!#a> :b\n-DOC\n-STR")]
+    [InlineData("%TAG !e! tag:x#\n--- !e!a b", "+STR\n+DOC ---\n=VAL <tag:x#a> :b\n-DOC\n-STR")]
+    [InlineData("[!]", "+STR\n+DOC\n+SEQ []\n=VAL <!> :\n-SEQ\n-DOC\n-STR")]
+    [InlineData("- &a\u0085 b\n- *a\u0085", "+STR\n+DOC\n+SEQ\n=VAL &a\u0085 :b\n=ALI *a\u0085\n-SEQ\n-DOC\n-STR")]
+    public void SpecificationEdgeCases_ProduceExpectedEvents(string yaml, string expected)
+    {
+        using var reader = new StringReader(yaml);
+        Assert.Equal(expected, ReadConformanceEvents(Parser.CreateParser(reader)));
+        using var bufferedReader = new StringReader(yaml);
+        Assert.Equal(expected, ReadConformanceEvents(new Parser<LookAheadBuffer>(new LookAheadBuffer(bufferedReader, 12))));
+    }
+
+    [Theory]
+    [InlineData(": - b")]
+    [InlineData(": a: b")]
+    [InlineData("- : - b")]
+    [InlineData("? a\n: b\n: - c")]
+    [InlineData("k:\n>\n text")]
+    [InlineData("k:\n|\n text")]
+    [InlineData("-\n>")]
+    [InlineData("a: &b\n>")]
+    [InlineData("k:\n\ta")]
+    [InlineData("k:\n\t\"a\"")]
+    [InlineData("a: &b\n\ta")]
+    [InlineData("k: \"a\n\t\n b\"")]
+    [InlineData("k: a\n\t\n b")]
+    [InlineData("k: \"\\\n\"")]
+    [InlineData("- [a\nb]")]
+    [InlineData("- { multi\nline: value}")]
+    [InlineData("&a[b]")]
+    [InlineData("[&a[b]]")]
+    [InlineData("[!t{a: b}]")]
+    public void SpecificationEdgeCases_ThrowYamlException(string yaml)
+    {
+        using var reader = new StringReader(yaml);
+        Assert.ThrowsAny<YamlException>(() => ReadConformanceEvents(Parser.CreateParser(reader)));
+        using var bufferedReader = new StringReader(yaml);
+        Assert.ThrowsAny<YamlException>(() => ReadConformanceEvents(new Parser<LookAheadBuffer>(new LookAheadBuffer(bufferedReader, 12))));
+    }
+
     private static void AssertConformance(IParser parser, string expectedEvents, bool invalid)
     {
         if (invalid)


### PR DESCRIPTION
The YAML parser passed all 402 vendored yaml-test-suite cases, but differential testing against the [YAML 1.2 reference parser](https://github.com/yaml/yaml-reference-parser), with the npm `yaml` package as a second opinion, found edge cases the suite does not cover. The run used about 300k generated and mutated inputs.

## Wrong values from valid YAML
- **Block scalars with content at column 0** (e.g. a document that is just `|` followed by text): `ScanBlockScalarBreaks` used indentation `0` to mean "not detected yet". It kept re-detecting on every line, so indented lines lost their leading spaces, a trailing whitespace-only line was dropped, and a tab at column 0 was rejected. The sentinel is now `-1`.
- **`|+` / `>+` at end of input with no final line break** returned `abc\n\n` instead of `abc\n`.
- **An empty block scalar followed by whitespace-only lines** (`strip: >-\n \nclip: x`) threw "Leading empty lines are more indented than block scalar content".

## Valid YAML that was rejected
- A tab-indented comment line after a plain scalar (`k: v\n\t# c`).
- `#` in tag shorthands (`!#a`), and a bare `!` tag inside a flow collection (`[!]`).
- U+0085 in anchor names: the scanner accepted it, but the event validator threw an `ArgumentException` instead of a `YamlException`.

## Invalid YAML that was accepted
- A compact sequence or mapping after an empty implicit key: `: - b`, `: a: b`. Explicit keys (`? a\n: - b`) are still allowed; the scanner now tracks a pending explicit key per indentation level.
- A block scalar that is not indented past its parent collection: `k:\n|\n text`, `-\n>`.
- Tabs used as indentation before a value (`k:\n\ta`), and tab-only empty lines inside multi-line scalars (`k: "a\n\t\n b"`).
- Flow scalar continuations at insufficient indentation (`- [a\nb]`), and a closing quote at column 0 right after an escaped line break.
- An anchor or tag directly followed by `[` or `{` (`&a[b]`).

## Tests
Two new theories in `ParserTests.cs` (35 cases) run both the string and buffered parser paths. 33 cases fail on `main`. The other two are regression guards for valid compact values after explicit keys.

- The YAML test project passes on net10.0 and net11.0 (4,284 tests).
- The Release build with `IsOfficialBuild=true` is clean.
- `eng/update-all.cs` produced no changes.
- CRLF, lone CR and BOM-prefixed variants of about 340k inputs produce the same events as the LF originals.

## Deliberately not changed
- **`|2` at the document root:** the grammar puts the content at column 1 (relative to n = -1). The library, libyaml and the npm `yaml` package use column 2.
- **Malformed `%TAG` lines**, `%YAML 1` and `%YAML 2.0` stay errors. The grammar alone would accept them as reserved directives, but the spec prose rejects them.
- **Remaining disagreements** with the oracles are oracle quirks: lone `\r`, BOMs, duplicate keys, NBSP/U+2028 treated as whitespace, and the reference receiver's folding after escaped line breaks.
