### PR TITLE
Make the regex parser agree with V8, PCRE2, and glibc

### DIFF
--- a/ref/Meziantou.Framework.Language.Regex.cs
+++ b/ref/Meziantou.Framework.Language.Regex.cs
@@ -25,7 +25,9 @@ namespace Meziantou.Framework.Language.Regex
         ContiguousMatch = 5,
         WordBoundary = 6,
         NonWordBoundary = 7,
-        KeepOut = 8
+        KeepOut = 8,
+        StartOfWord = 9,
+        EndOfWord = 10
     }
 
     public sealed class RegexAnchorSyntax : Meziantou.Framework.Language.Regex.RegexAtomSyntax

--- a/src/Meziantou.Framework.Language.Regex/Internals/JavaScriptRegexParser.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/JavaScriptRegexParser.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using Meziantou.Framework.Language.InternalSyntax;
 using Meziantou.Framework.Language.Regex.Internals;
 using ScannedToken = Meziantou.Framework.Language.InternalSyntax.SyntaxToken;
@@ -7,7 +9,13 @@ namespace Meziantou.Framework.Language.Regex.Syntax.InternalSyntax;
 /// <summary>Parses an ECMAScript pattern, and the delimiters and flags of a literal when there are any.</summary>
 internal sealed class JavaScriptRegexParser : PerlStyleRegexParser
 {
+    /// <summary>
+    /// The punctuators the class set grammar lets a backslash escape inside a class, on top of the syntax characters.
+    /// </summary>
+    private const string ClassSetReservedPunctuators = "&-!#%,:;<=>@`~";
+
     private readonly JavaScriptLiteral? _literal;
+    private readonly Dictionary<string, List<(int Alternation, int Branch)[]>> _groupNames = new(StringComparer.Ordinal);
 
     public JavaScriptRegexParser(SourceText source, RegexParseOptions parseOptions, JavaScriptLiteral? literal)
         : base(source, parseOptions)
@@ -31,9 +39,301 @@ internal sealed class JavaScriptRegexParser : PerlStyleRegexParser
         if (!UsesStrictGrammar)
             return true;
 
-        // The strict grammar allows only these, plus "-" inside a character class.
+        // The strict grammar allows only these, plus "-" inside a character class, and under the "v" flag the
+        // punctuators the class set grammar reserves.
         return ch is '^' or '$' or '\\' or '.' or '*' or '+' or '?' or '(' or ')' or '[' or ']' or '{' or '}' or '|' or '/'
-            || (ch == '-' && IsInCharacterClass);
+            || (ch == '-' && IsInCharacterClass)
+            || (IsInCharacterClass && UsesUnicodeSetsMode && ClassSetReservedPunctuators.Contains(ch, StringComparison.Ordinal));
+    }
+
+    protected override bool HasBellAndEscapeEscapes => false;
+
+    protected override bool UsesJavaScriptDecimalEscapes => true;
+
+    protected override bool ReportsShorthandClassAsRangeStart => UsesStrictGrammar;
+
+    protected override bool NamedGroupsTakeNumbersInOrder => true;
+
+    protected override bool AllowsNumberedGroups => false;
+
+    /// <summary>A quantifier bound may be as large as it likes; the engine clamps it.</summary>
+    protected override long? MaxBoundValue => null;
+
+    protected override bool IsGroupNameStartAt(int position) =>
+        TryReadIdentifierCodePoint(position, out var codePoint, out _) && IsIdentifierStart(codePoint);
+
+    /// <summary>Reads a group name, which is an identifier that may spell any of its characters as <c>\u</c> escapes.</summary>
+    protected override string ReadGroupName()
+    {
+        var name = new StringBuilder();
+        while (TryReadIdentifierCodePoint(Scanner.Position, out var codePoint, out var length) &&
+            (name.Length == 0 ? IsIdentifierStart(codePoint) : IsIdentifierPart(codePoint)))
+        {
+            name.Append(char.ConvertFromUtf32(codePoint));
+            Scanner.Position += length;
+        }
+
+        return name.ToString();
+    }
+
+    /// <summary>Two groups may share a name only when they are in different alternatives, so at most one takes part.</summary>
+    protected override void CheckGroupNameDeclaration(string name, int number, TextSpan span)
+    {
+        var path = CurrentAlternativePath;
+        if (!_groupNames.TryGetValue(name, out var declared))
+        {
+            _groupNames[name] = [path];
+
+            return;
+        }
+
+        foreach (var other in declared)
+        {
+            if (MightBothParticipate(other, path))
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.DuplicateGroupName, $"The group name '{name}' is already used by a group that can take part in the same match.");
+                break;
+            }
+        }
+
+        declared.Add(path);
+    }
+
+    /// <summary>
+    /// Checks a <c>\p{…}</c> name against the tables of the specification, which JavaScript compares exactly.
+    /// </summary>
+    protected override void ValidatePropertyName(TextSpan span, string name, bool negated, bool braced)
+    {
+        var separator = name.IndexOf('=', StringComparison.Ordinal);
+        if (separator >= 0)
+        {
+            var property = name[..separator];
+            var value = name[(separator + 1)..];
+            var known = property switch
+            {
+                "General_Category" or "gc" => UnicodePropertyNames.JavaScriptGeneralCategoryValues.Contains(value),
+                "Script" or "sc" or "Script_Extensions" or "scx" => UnicodePropertyNames.JavaScriptScriptValues.Contains(value),
+                _ => false,
+            };
+
+            if (!known)
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"Unknown Unicode property '{name}'.");
+            }
+
+            return;
+        }
+
+        if (UnicodePropertyNames.JavaScriptGeneralCategoryValues.Contains(name) || UnicodePropertyNames.JavaScriptBinaryProperties.Contains(name))
+            return;
+
+        if (UnicodePropertyNames.JavaScriptStringProperties.Contains(name))
+        {
+            if (!UsesUnicodeSetsMode)
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"The property of strings '{name}' requires the 'v' flag.");
+            }
+            else if (negated)
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.NegatedClassContainsStrings, $"The property of strings '{name}' cannot be negated.");
+            }
+            else
+            {
+                LastSetMemberMayContainStrings = true;
+            }
+
+            return;
+        }
+
+        AddDiagnostic(span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"Unknown Unicode property '{name}'.");
+    }
+
+    /// <summary>
+    /// Parses the <c>(?ims-ims:…)</c> modifiers group, the only inline options JavaScript has. It always has a body,
+    /// takes only the three letters, and may not name a letter twice.
+    /// </summary>
+    protected override RegexAtomSyntax? TryParseDialectGroupHeader(ScannedToken openParenToken, int questionStart)
+    {
+        if (!char.IsAsciiLetter(Scanner.Current) && Scanner.Current != '-')
+            return null;
+
+        var questionToken = Scanner.Token(SyntaxKind.QuestionToken, questionStart);
+        var optionsStart = Scanner.Position;
+        var seen = new HashSet<char>();
+        var hasHyphen = false;
+        var letters = 0;
+        while (char.IsAsciiLetter(Scanner.Current) || Scanner.Current == '-')
+        {
+            var ch = Scanner.Current;
+            var span = new TextSpan(Scanner.Position, 1);
+            Scanner.Position++;
+
+            if (ch == '-')
+            {
+                if (hasHyphen)
+                {
+                    AddDiagnostic(span, RegexDiagnosticIds.InvalidModifiers, "A modifiers group may contain only one '-'.");
+                }
+
+                hasHyphen = true;
+                continue;
+            }
+
+            var option = ch switch
+            {
+                'i' => RegexPatternOptions.IgnoreCase,
+                'm' => RegexPatternOptions.Multiline,
+                's' => RegexPatternOptions.DotAll | RegexPatternOptions.Singleline,
+                _ => RegexPatternOptions.None,
+            };
+
+            if (option == RegexPatternOptions.None)
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.InvalidModifiers, $"'{ch}' is not a modifier; only 'i', 'm', and 's' are.");
+                continue;
+            }
+
+            if (!seen.Add(ch))
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.InvalidModifiers, $"The modifier '{ch}' is repeated.");
+            }
+
+            letters++;
+            Options = hasHyphen ? Options & ~option : Options | option;
+        }
+
+        var optionsToken = Scanner.Token(SyntaxKind.OptionsToken, optionsStart);
+        if (hasHyphen && letters == 0)
+        {
+            AddDiagnostic(optionsToken.Span, RegexDiagnosticIds.InvalidModifiers, "A modifiers group must add or remove at least one modifier.");
+        }
+
+        ScannedToken colonToken = default;
+        if (Scanner.Current == ':')
+        {
+            var colonStart = Scanner.Position;
+            Scanner.Position++;
+            colonToken = Scanner.Token(SyntaxKind.ColonToken, colonStart);
+        }
+        else
+        {
+            // JavaScript has no "(?i)" that applies to the rest of the pattern. The body is still read, so the
+            // parenthesis is matched and nothing after it is misread.
+            AddDiagnostic(
+                TextSpan.FromBounds(openParenToken.Span.Start, Scanner.Position),
+                RegexDiagnosticIds.InvalidGroupingConstruct,
+                "Invalid group: a modifiers group must be written '(?flags:…)'.");
+        }
+
+        var body = ParseAlternation(insideGroup: true);
+        var closeParenToken = ReadCloseParen(openParenToken);
+        var group = new RegexOptionsGroupSyntax(openParenToken, questionToken, optionsToken, colonToken, body, closeParenToken, Options, body.Options);
+        RestoreOptions();
+
+        return group;
+    }
+
+    /// <summary>
+    /// Reads the code point at <paramref name="position"/> the way an identifier does: a surrogate pair is one code point,
+    /// and <c>\uHHHH</c>, a pair of those, and <c>\u{…}</c> all spell one.
+    /// </summary>
+    private bool TryReadIdentifierCodePoint(int position, out int codePoint, out int length)
+    {
+        codePoint = 0;
+        length = 0;
+        if (position >= Text.Length)
+            return false;
+
+        var ch = Text[position];
+        if (ch != '\\')
+        {
+            length = char.IsHighSurrogate(ch) && position + 1 < Text.Length && char.IsLowSurrogate(Text[position + 1]) ? 2 : 1;
+            codePoint = length == 2 ? char.ConvertToUtf32(ch, Text[position + 1]) : ch;
+
+            return true;
+        }
+
+        if (position + 1 >= Text.Length || Text[position + 1] != 'u')
+            return false;
+
+        if (position + 2 < Text.Length && Text[position + 2] == '{')
+        {
+            var end = Text.IndexOf('}', position + 3, StringComparison.Ordinal);
+            if (end <= position + 3 || !int.TryParse(Text.AsSpan(position + 3, end - position - 3), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out codePoint) || codePoint > 0x10FFFF)
+                return false;
+
+            length = end + 1 - position;
+
+            return true;
+        }
+
+        if (!TryReadHex4(position + 2, out var unit))
+            return false;
+
+        codePoint = unit;
+        length = 6;
+        if (char.IsHighSurrogate((char)unit) && position + 12 <= Text.Length && Text[position + 6] == '\\' && Text[position + 7] == 'u' &&
+            TryReadHex4(position + 8, out var low) && char.IsLowSurrogate((char)low))
+        {
+            codePoint = char.ConvertToUtf32((char)unit, (char)low);
+            length = 12;
+        }
+
+        return true;
+    }
+
+    private bool TryReadHex4(int position, out int value)
+    {
+        value = 0;
+        if (position + 4 > Text.Length)
+            return false;
+
+        foreach (var ch in Text.AsSpan(position, 4))
+        {
+            if (!char.IsAsciiHexDigit(ch))
+                return false;
+        }
+
+        return int.TryParse(Text.AsSpan(position, 4), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+    }
+
+    /// <summary>Whether a code point may start an identifier: <c>$</c>, <c>_</c>, or anything with ID_Start.</summary>
+    private static bool IsIdentifierStart(int codePoint) =>
+        codePoint is '$' or '_' || IsIdStart(codePoint);
+
+    /// <summary>Whether a code point may continue an identifier: <c>$</c>, the two joiners, or anything with ID_Continue.</summary>
+    private static bool IsIdentifierPart(int codePoint) =>
+        codePoint is '$' or 0x200C or 0x200D || IsIdStart(codePoint) || IsIdContinueOnly(codePoint);
+
+    private static bool IsIdStart(int codePoint)
+    {
+        if (codePoint < 0x80)
+            return char.IsAsciiLetter((char)codePoint);
+
+        // Other_ID_Start, and the one letter Pattern_Syntax takes back.
+        if (codePoint is 0x1885 or 0x1886 or 0x2118 or 0x212E or 0x309B or 0x309C)
+            return true;
+
+        if (codePoint is 0x2E2F or (>= 0xD800 and <= 0xDFFF))
+            return false;
+
+        return CharUnicodeInfo.GetUnicodeCategory(codePoint) is
+            UnicodeCategory.UppercaseLetter or UnicodeCategory.LowercaseLetter or UnicodeCategory.TitlecaseLetter or
+            UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or UnicodeCategory.LetterNumber;
+    }
+
+    private static bool IsIdContinueOnly(int codePoint)
+    {
+        if (codePoint < 0x80)
+            return char.IsAsciiDigit((char)codePoint) || codePoint == '_';
+
+        // Other_ID_Continue.
+        if (codePoint is 0x00B7 or 0x0387 or (>= 0x1369 and <= 0x1371) or 0x19DA or 0x30FB or 0xFF65)
+            return true;
+
+        return CharUnicodeInfo.GetUnicodeCategory(codePoint) is
+            UnicodeCategory.NonSpacingMark or UnicodeCategory.SpacingCombiningMark or
+            UnicodeCategory.DecimalDigitNumber or UnicodeCategory.ConnectorPunctuation;
     }
 
     protected override bool AllowsMalformedNumericEscape => !UsesStrictGrammar;

--- a/src/Meziantou.Framework.Language.Regex/Internals/PcreRegexParser.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/PcreRegexParser.cs
@@ -1,43 +1,54 @@
+using System.Globalization;
+using System.Text;
 using Meziantou.Framework.Language.InternalSyntax;
 using Meziantou.Framework.Language.Regex.Internals;
-using ScannedToken = Meziantou.Framework.Language.InternalSyntax.SyntaxToken;
+using GreenToken = Meziantou.Framework.Language.InternalSyntax.SyntaxToken;
+using Red = Meziantou.Framework.Language.Regex;
 
 namespace Meziantou.Framework.Language.Regex.Syntax.InternalSyntax;
 
-/// <summary>Parses a pattern the way PCRE and Perl do.</summary>
+/// <summary>Parses a pattern the way PCRE2 does.</summary>
 /// <remarks>
+/// <para>
 /// Most of PCRE is the Perl grammar the shared parser already reads, narrowed or widened by dialect features. What is
-/// here is what PCRE has and the others do not: the <c>\g</c> reference family, subroutine calls, callouts, the extra
-/// shorthand classes, and the two numeric escapes with braces.
+/// here is what PCRE has and the others do not: the <c>\g</c> reference family, subroutine calls, callouts, backtracking
+/// verbs and alpha assertions, the extra shorthand classes, the braced numeric escapes, and PCRE's own conditions.
+/// </para>
+/// <para>
+/// A pattern is read the way PCRE2 reads it in UTF mode, which is the only mode in which a .NET string is a sequence of
+/// characters rather than of bytes.
+/// </para>
 /// </remarks>
 internal sealed class PcreRegexParser : PerlStyleRegexParser
 {
+    /// <summary>The longest group name PCRE2 accepts, in code units.</summary>
+    private const int MaxGroupNameLength = 128;
+
+    /// <summary>The longest a variable-length lookbehind branch may be.</summary>
+    private const int MaxLookbehindLength = 255;
+
+    private readonly Dictionary<string, int> _numbersByName = new(StringComparer.Ordinal);
+    private readonly Dictionary<int, string> _namesByNumber = [];
+    private readonly Dictionary<int, (RegexGroupSyntax Group, TextSpan Span)> _captureGroups = [];
+    private readonly List<(RegexAlternationSyntax Body, TextSpan Span, int BodyStart)> _lookbehinds = [];
+
     public PcreRegexParser(SourceText source, RegexParseOptions parseOptions)
         : base(source, parseOptions)
     {
     }
 
-    /// <summary><c>\R</c> and <c>\X</c> stand for a set of characters but may not appear inside a class.</summary>
+    /// <summary><c>\R</c>, <c>\X</c>, and <c>\C</c> stand for a set of characters but may not appear inside a class.</summary>
     /// <remarks>
     /// <c>\N</c> is "any character except a newline" on its own, but <c>\N{…}</c> names a code point. The brace is
     /// what tells them apart, so the shorthand has to decline when one follows.
     /// </remarks>
     protected override bool IsShorthandClassLetter(char letter) =>
         IsShorthandClassLetterInClass(letter) ||
-        letter is 'R' or 'X' ||
-        (letter == 'N' && Scanner.Peek(2) != '{');
+        letter is 'R' or 'X' or 'C' ||
+        (letter == 'N' && (Scanner.Peek(2) != '{' || IsWellFormedBoundAt(Scanner.Position + 2)));
 
     protected override bool IsShorthandClassLetterInClass(char letter) =>
         base.IsShorthandClassLetterInClass(letter) || letter is 'h' or 'H' or 'v' or 'V';
-
-    /// <summary><c>J</c> and <c>U</c> change matching rather than syntax, but they still have to be accepted.</summary>
-    protected override bool TryMapOptionLetter(char letter, out RegexPatternOptions option)
-    {
-        if (base.TryMapOptionLetter(letter, out option))
-            return true;
-
-        return letter is 'J' or 'U' or 'a' or 'u';
-    }
 
     protected override bool AllowsEmptyOptionGroup => true;
 
@@ -46,6 +57,159 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
     protected override bool AllowsAnyControlEscapeCharacter => true;
 
     protected override bool AllowsBracelessProperty => true;
+
+    protected override bool ReadsCodePoints => true;
+
+    protected override bool SupportsUnicodeEscape => false;
+
+    protected override bool NamedGroupsTakeNumbersInOrder => true;
+
+    protected override bool AllowsNumberedGroups => false;
+
+    protected override bool ReportsShorthandClassAsRangeStart => true;
+
+    protected override long? MaxBoundValue => 65535;
+
+    protected override bool AllowsSpacesInBounds => true;
+
+    protected override bool AllowsOmittedMinimumBound => true;
+
+    private protected override bool ConditionMayStartWithComment => true;
+
+    /// <summary>A name may not start with a digit, which is what tells <c>(?&amp;1)</c> apart from a name.</summary>
+    protected override bool IsGroupNameStartAt(int position) =>
+        NameCharacterLength(position) > 0 && !char.IsAsciiDigit(Scanner.CharAt(position));
+
+    /// <summary>A name is made of word characters, which in UTF mode include letters outside the Basic Multilingual Plane.</summary>
+    protected override string ReadGroupName()
+    {
+        var start = Scanner.Position;
+        while (NameCharacterLength(Scanner.Position) is var length && length > 0)
+        {
+            Scanner.Position += length;
+        }
+
+        return Text[start..Scanner.Position];
+    }
+
+    /// <summary>The number of code units of the word character at <paramref name="position"/>, or 0 when there is none.</summary>
+    private int NameCharacterLength(int position)
+    {
+        if (position >= Text.Length || !Rune.TryGetRuneAt(Text, position, out var rune))
+            return 0;
+
+        return rune.IsAscii
+            ? RegexCharacterTables.IsWordChar((char)rune.Value) ? 1 : 0
+            : Rune.GetUnicodeCategory(rune) is
+                UnicodeCategory.UppercaseLetter or UnicodeCategory.LowercaseLetter or UnicodeCategory.TitlecaseLetter or
+                UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or UnicodeCategory.NonSpacingMark or
+                UnicodeCategory.SpacingCombiningMark or UnicodeCategory.DecimalDigitNumber or UnicodeCategory.ConnectorPunctuation
+                ? rune.Utf16SequenceLength
+                : 0;
+    }
+
+    /// <summary>
+    /// A backslash before anything that is not an ASCII letter or digit stands for that character. Inside a class a few
+    /// letters that mean something elsewhere are ordinary too.
+    /// </summary>
+    protected override bool AllowsIdentityEscape(char ch) =>
+        !char.IsAsciiLetterOrDigit(ch) || (IsInCharacterClass && ch is '8' or '9' or 'g' or 'k');
+
+    /// <summary>An assertion, a callout, and most verbs match nothing, so there is nothing for a quantifier to repeat.</summary>
+    protected override bool IsQuantifiable(RegexTermSyntax term) => term switch
+    {
+        RegexAnchorSyntax => false,
+        RegexCalloutSyntax => false,
+        RegexBacktrackingVerbSyntax verb => verb.GetSlot(1) is GreenToken { Text: ['*', 'A', 'C', 'C', 'E', 'P', 'T', ..] },
+        RegexCharacterEscapeSyntax escape => escape.GetSlot(0) is not GreenToken { ValueText.Length: 0 },
+        RegexQuotedLiteralSyntax quoted => quoted.GetSlot(1) is not null,
+        _ => true,
+    };
+
+    protected override void CheckGroupNameDeclaration(string name, int number, TextSpan span)
+    {
+        if (name.Length > MaxGroupNameLength)
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.CaptureGroupNameInvalid, FormattableString.Invariant($"The group name is longer than {MaxGroupNameLength} characters."));
+        }
+
+        // A branch reset group gives the same number to a group in each branch, and those must agree on the name.
+        if (_namesByNumber.TryGetValue(number, out var existingName))
+        {
+            if (existingName != name)
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.DuplicateGroupName, $"Group {number.ToString(CultureInfo.InvariantCulture)} is already named '{existingName}'.");
+            }
+
+            return;
+        }
+
+        _namesByNumber[number] = name;
+        if (_numbersByName.TryAdd(name, number))
+            return;
+
+        if (!DuplicateNamesAllowed)
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.DuplicateGroupName, $"The group name '{name}' is already used; '(?J)' allows duplicate names.");
+        }
+    }
+
+    private protected override void OnCaptureGroupParsed(int number, RegexGroupSyntax group) => _captureGroups.TryAdd(number, (group, JustParsedSpan(group)));
+
+    /// <summary>
+    /// Reads the option letters PCRE has, including <c>^</c>, which turns off the options a pattern can set before the
+    /// letters after it are applied.
+    /// </summary>
+    private protected override ScannedToken ScanInlineOptions(int start)
+    {
+        var off = false;
+        if (Scanner.Current == '^')
+        {
+            Options &= ~(RegexPatternOptions.IgnoreCase | RegexPatternOptions.Multiline | RegexPatternOptions.ExplicitCapture | RegexPatternOptions.Singleline | RegexPatternOptions.IgnorePatternWhitespace);
+            Scanner.Position++;
+            if (Scanner.Current == '-')
+            {
+                AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.InvalidGroupingConstruct, "A '^' option setting cannot also turn options off.");
+                Scanner.Position++;
+            }
+        }
+
+        while (!Scanner.IsAtEnd)
+        {
+            var ch = Scanner.Current;
+            var option = RegexPatternOptions.None;
+            if (ch == '-')
+            {
+                if (off)
+                {
+                    AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.InvalidGroupingConstruct, "An option setting may contain only one '-'.");
+                }
+
+                off = true;
+            }
+            else if (ch == 'a' && Scanner.Peek() is 'D' or 'T' or 'P' or 'S')
+            {
+                // "aD", "aT", "aP", and "aS" restrict one class each to ASCII; the letter after "a" belongs to it.
+                Scanner.Position++;
+            }
+            else if (ch == 'J')
+            {
+                DuplicateNamesAllowed = !off;
+            }
+            else if (ch is 'U' or 'r' or 'a' || (char.IsAsciiLetterLower(ch) && TryMapOptionLetter(ch, out option)))
+            {
+                Options = off ? Options & ~option : Options | option;
+            }
+            else
+            {
+                break;
+            }
+
+            Scanner.Position++;
+        }
+
+        return Scanner.Position > start ? Scanner.Token(SyntaxKind.OptionsToken, start) : default;
+    }
 
     protected override RegexAtomSyntax? TryParseDialectGroupHeader(ScannedToken openParenToken, int questionStart)
     {
@@ -61,6 +225,12 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
         if (Scanner.Current == 'C')
             return ParseCallout(openParenToken, questionStart);
 
+        // "(?+" is the start of a relative subroutine call, and needs its digits.
+        if (Scanner.Current == '+')
+        {
+            AddDiagnostic(TextSpan.FromBounds(openParenToken.Span.Start, Scanner.Position + 1), RegexDiagnosticIds.InvalidGroupingConstruct, "A digit is expected after '(?+'.");
+        }
+
         return null;
     }
 
@@ -69,11 +239,388 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
         return Scanner.Peek() switch
         {
             'g' => ParseGReference(leadingTrivia),
-            'o' when Scanner.Peek(2) == '{' => ParseBracedNumericEscape(leadingTrivia, octal: true),
-            'x' when Scanner.Peek(2) == '{' => ParseBracedNumericEscape(leadingTrivia, octal: false, hexOnly: true),
-            'N' when Scanner.Peek(2) == '{' => ParseBracedNumericEscape(leadingTrivia, octal: false),
+            'k' when Scanner.Peek(2) == '{' => ParseBracedNamedBackreference(leadingTrivia),
+            '8' or '9' => ParseHighDigitBackreference(leadingTrivia),
             _ => null,
         };
+    }
+
+    /// <summary>A property name runs to the closing brace, spaces and all, because PCRE compares names loosely.</summary>
+    protected override void ReadPropertyName()
+    {
+        while (!Scanner.IsAtEnd && Scanner.Current != '}')
+        {
+            Scanner.Position++;
+        }
+    }
+
+    /// <summary>
+    /// Checks a property name the way PCRE2 looks it up: case, spaces, hyphens, and underscores are ignored, a leading
+    /// <c>^</c> negates, and <c>sc:</c>, <c>scx:</c>, and <c>bc:</c> select a script or a bidirectional class.
+    /// </summary>
+    protected override void ValidatePropertyName(TextSpan span, string name, bool negated, bool braced)
+    {
+        if (!braced)
+        {
+            if ((char)(name[0] | 0x20) is not ('c' or 'l' or 'm' or 'n' or 'p' or 's' or 'z'))
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"Unknown Unicode property '{name}'.");
+            }
+
+            return;
+        }
+
+        var normalized = string.Concat(name.Where(ch => ch is not (' ' or '-' or '_')).Select(char.ToLowerInvariant));
+        if (normalized is ['^', ..])
+        {
+            normalized = normalized[1..];
+        }
+
+        var separator = normalized.IndexOfAny([':', '=']);
+        var known = separator < 0
+            ? UnicodePropertyNames.PcreProperties.Contains(normalized) || UnicodePropertyNames.PcreScripts.Contains(normalized)
+            : normalized[..separator] switch
+            {
+                "sc" or "script" or "scx" or "scriptextensions" => UnicodePropertyNames.PcreScripts.Contains(normalized[(separator + 1)..]),
+                "bc" or "bidiclass" => UnicodePropertyNames.PcreBidiClasses.Contains(normalized[(separator + 1)..]),
+                _ => false,
+            };
+
+        if (!known)
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"Unknown Unicode property '{name}'.");
+        }
+    }
+
+    /// <summary>Parses <c>(*VERB)</c>, <c>(*VERB:NAME)</c>, a start-of-pattern option, or an alpha assertion.</summary>
+    private protected override RegexAtomSyntax ParseBacktrackingVerb(ScannedToken openParenToken)
+    {
+        var verbStart = Scanner.Position;
+        Scanner.Position++;
+        while (char.IsAsciiLetterOrDigit(Scanner.Current) || Scanner.Current == '_')
+        {
+            Scanner.Position++;
+        }
+
+        var name = Text[(verbStart + 1)..Scanner.Position];
+        if (Scanner.Current == ':' && name.Length > 0 && TryGetAlphaAssertionKind(name) is { } kind)
+            return ParseAlphaAssertion(openParenToken, verbStart, kind);
+
+        var hasArgument = false;
+        if (Scanner.Current == ':')
+        {
+            hasArgument = Scanner.Peek() != ')';
+            while (!Scanner.IsAtEnd && Scanner.Current != ')')
+            {
+                Scanner.Position++;
+            }
+        }
+        else if (Scanner.Current == '=' && name.StartsWith("LIMIT_", StringComparison.Ordinal))
+        {
+            Scanner.Position++;
+            var digitsStart = Scanner.Position;
+            while (char.IsAsciiDigit(Scanner.Current))
+            {
+                Scanner.Position++;
+            }
+
+            hasArgument = Scanner.Position > digitsStart && Scanner.Position - digitsStart <= 10 &&
+                long.Parse(Text.AsSpan(digitsStart, Scanner.Position - digitsStart), CultureInfo.InvariantCulture) <= uint.MaxValue;
+        }
+
+        var verbToken = Scanner.Token(SyntaxKind.VerbToken, verbStart);
+        var closeParenToken = ReadCloseParen(openParenToken);
+        RestoreOptions();
+
+        var verbSpan = TextSpan.FromBounds(openParenToken.Span.Start, Math.Max(openParenToken.Span.Start, Scanner.Position));
+        switch (name)
+        {
+            case "ACCEPT" or "FAIL" or "F" or "COMMIT" or "PRUNE" or "SKIP" or "THEN":
+                break;
+
+            case "MARK" or "":
+                if (!hasArgument)
+                {
+                    AddDiagnostic(verbSpan, RegexDiagnosticIds.InvalidBacktrackingVerb, "(*MARK) must have a name.");
+                }
+
+                break;
+
+            case var option when IsStartOfPatternOption(option):
+                var needsNumber = name.StartsWith("LIMIT_", StringComparison.Ordinal);
+                if (needsNumber != hasArgument || (!needsNumber && Scanner.CharAt(verbStart + 1 + name.Length) == ':'))
+                {
+                    AddDiagnostic(verbSpan, RegexDiagnosticIds.InvalidBacktrackingVerb, $"(*{name}) is malformed.");
+                }
+                else if (!IsAtStartOfPatternOptions(openParenToken.Span.Start))
+                {
+                    AddDiagnostic(verbSpan, RegexDiagnosticIds.InvalidBacktrackingVerb, $"(*{name}) is only allowed at the start of the pattern.");
+                }
+
+                break;
+
+            default:
+                AddDiagnostic(verbSpan, RegexDiagnosticIds.InvalidBacktrackingVerb, $"(*{name}) is not a recognized verb.");
+                break;
+        }
+
+        return new RegexBacktrackingVerbSyntax(openParenToken, verbToken, closeParenToken, Options);
+    }
+
+    /// <summary>Whether only start-of-pattern options such as <c>(*UTF)</c> stand before <paramref name="position"/>.</summary>
+    private bool IsAtStartOfPatternOptions(int position)
+    {
+        var index = 0;
+        while (index < position)
+        {
+            if (Text[index] != '(' || index + 1 >= Text.Length || Text[index + 1] != '*')
+                return false;
+
+            var close = Text.IndexOf(')', index, StringComparison.Ordinal);
+            if (close < 0 || close >= position)
+                return false;
+
+            // Only another option may come first; a verb such as "(*MARK:x)" ends the prefix.
+            var name = Text.AsSpan(index + 2, close - index - 2);
+            var equals = name.IndexOf('=');
+            if (!IsStartOfPatternOption((equals < 0 ? name : name[..equals]).ToString()))
+                return false;
+
+            index = close + 1;
+        }
+
+        return true;
+    }
+
+    private static bool IsStartOfPatternOption(string name) => name is
+        "UTF" or "UTF8" or "UCP" or "CR" or "LF" or "CRLF" or "ANYCRLF" or "ANY" or "NUL" or "BSR_ANYCRLF" or "BSR_UNICODE" or
+        "NOTEMPTY" or "NOTEMPTY_ATSTART" or "NO_AUTO_POSSESS" or "NO_DOTSTAR_ANCHOR" or "NO_JIT" or "NO_START_OPT" or
+        "CASELESS_RESTRICT" or "TURKISH_CASING" or "LIMIT_MATCH" or "LIMIT_DEPTH" or "LIMIT_HEAP" or "LIMIT_RECURSION";
+
+    private static SyntaxKind? TryGetAlphaAssertionKind(string name) => name switch
+    {
+        "pla" or "positive_lookahead" or "nla" or "negative_lookahead" or "plb" or "positive_lookbehind" or "nlb" or "negative_lookbehind" or
+        "napla" or "non_atomic_positive_lookahead" or "naplb" or "non_atomic_positive_lookbehind" => SyntaxKind.Lookaround,
+        "atomic" => SyntaxKind.AtomicGroup,
+        "sr" or "script_run" or "asr" or "atomic_script_run" => SyntaxKind.NonCapturingGroup,
+        _ => null,
+    };
+
+    /// <summary>Parses <c>(*pla:…)</c> and the other alpha assertions, which are groups spelled as verbs.</summary>
+    private RegexGroupSyntax ParseAlphaAssertion(ScannedToken openParenToken, int kindStart, SyntaxKind kind)
+    {
+        Scanner.Position++;
+        var groupKindToken = Scanner.Token(SyntaxKind.GroupKindToken, kindStart);
+        var name = groupKindToken.Text[1..^1];
+        var isLookbehind = name is "plb" or "positive_lookbehind" or "nlb" or "negative_lookbehind" or "naplb" or "non_atomic_positive_lookbehind";
+
+        LookaroundDepth += kind == SyntaxKind.Lookaround ? 1 : 0;
+        LookbehindDepth += isLookbehind ? 1 : 0;
+        var body = ParseAlternation(insideGroup: true);
+        LookaroundDepth -= kind == SyntaxKind.Lookaround ? 1 : 0;
+        LookbehindDepth -= isLookbehind ? 1 : 0;
+        var closeParenToken = ReadCloseParen(openParenToken);
+
+        if (isLookbehind)
+        {
+            OnLookbehindParsed(body, TextSpan.FromBounds(openParenToken.Span.Start, closeParenToken.End), groupKindToken.End);
+        }
+
+        RegexGroupSyntax group = kind switch
+        {
+            SyntaxKind.Lookaround => new RegexLookaroundSyntax(openParenToken, groupKindToken, body, closeParenToken, Options, body.Options),
+            SyntaxKind.AtomicGroup => new RegexAtomicGroupSyntax(openParenToken, groupKindToken, body, closeParenToken, Options, body.Options),
+            _ => new RegexNonCapturingGroupSyntax(openParenToken, groupKindToken, body, closeParenToken, Options, body.Options),
+        };
+
+        RestoreOptions();
+
+        return group;
+    }
+
+    /// <summary>A PCRE conditional names a group, a recursion, <c>DEFINE</c>, or a version, or it is an assertion.</summary>
+    private protected override RegexConditionalReferenceSyntax? ReadConditionalReference(int conditionStart)
+    {
+        var next = Scanner.CharAt(conditionStart + 1);
+        if (next is '?' or '*')
+        {
+            ReportNonAssertionCondition(conditionStart);
+
+            return null;
+        }
+
+        Scanner.Position++;
+        var openParenToken = Scanner.Token(SyntaxKind.OpenParenToken, conditionStart);
+
+        var nameStart = Scanner.Position;
+        while (!Scanner.IsAtEnd && Scanner.Current != ')')
+        {
+            Scanner.Position++;
+        }
+
+        var nameToken = Scanner.Token(SyntaxKind.NameToken, nameStart);
+        ValidateConditionName(nameToken);
+
+        ScannedToken closeToken;
+        if (Scanner.Current == ')')
+        {
+            var closeStart = Scanner.Position;
+            Scanner.Position++;
+            closeToken = Scanner.Token(SyntaxKind.CloseParenToken, closeStart);
+        }
+        else
+        {
+            AddDiagnostic(TextSpan.FromBounds(conditionStart, Scanner.Position), RegexDiagnosticIds.InsufficientClosingParentheses, "The condition is missing its ')'.");
+            closeToken = Scanner.MissingToken(SyntaxKind.CloseParenToken);
+        }
+
+        return new RegexConditionalReferenceSyntax(openParenToken, nameToken, closeToken, Options);
+    }
+
+    /// <summary>PCRE has none of the .NET restrictions on an expression condition; its own are checked when it is read.</summary>
+    private protected override void ReportIllegalConditionHeader(int conditionStart)
+    {
+    }
+
+    /// <summary>Reports an expression condition that is not an assertion, optionally preceded by a callout.</summary>
+    private void ReportNonAssertionCondition(int conditionStart)
+    {
+        var position = conditionStart;
+
+        // Comments are allowed in front of the assertion, and so is a callout.
+        while (Text.AsSpan(position).StartsWith("(?#", StringComparison.Ordinal) && Text.IndexOf(')', position, StringComparison.Ordinal) is var commentEnd && commentEnd >= 0)
+        {
+            position = commentEnd + 1;
+        }
+
+        if (Text.AsSpan(position).StartsWith("(?C", StringComparison.Ordinal))
+        {
+            var calloutEnd = Text.IndexOf(')', position, StringComparison.Ordinal);
+            if (calloutEnd < 0)
+                return;
+
+            position = calloutEnd + 1;
+        }
+
+        var rest = Text.AsSpan(position);
+        if (rest.StartsWith("(?=", StringComparison.Ordinal) || rest.StartsWith("(?!", StringComparison.Ordinal) ||
+            rest.StartsWith("(?<=", StringComparison.Ordinal) || rest.StartsWith("(?<!", StringComparison.Ordinal))
+            return;
+
+        if (rest.StartsWith("(*", StringComparison.Ordinal))
+        {
+            var nameEnd = position + 2;
+            while (nameEnd < Text.Length && (char.IsAsciiLetter(Text[nameEnd]) || Text[nameEnd] == '_'))
+            {
+                nameEnd++;
+            }
+
+            if (nameEnd < Text.Length && Text[nameEnd] == ':' && TryGetAlphaAssertionKind(Text[(position + 2)..nameEnd]) == SyntaxKind.Lookaround)
+                return;
+        }
+
+        AddDiagnostic(new TextSpan(conditionStart, Math.Min(3, Text.Length - conditionStart)), RegexDiagnosticIds.InvalidConditionalCondition, "The condition of a conditional group must be a group reference or an assertion.");
+    }
+
+    private void ValidateConditionName(ScannedToken nameToken)
+    {
+        var name = nameToken.Text;
+        var span = nameToken.Span;
+        switch (name)
+        {
+            case "R":
+                return;
+
+            case "DEFINE":
+                ConditionAllowsOneBranchOnly = true;
+                return;
+
+            case ['R', '&', .. var recursedName]:
+                ValidateReferencedName(span, recursedName);
+                return;
+
+            case ['R', .. var recursedNumber] when recursedNumber.All(char.IsAsciiDigit):
+                if (!int.TryParse(recursedNumber, NumberStyles.None, CultureInfo.InvariantCulture, out var recursion) || (recursion != 0 && !CaptureTable.ContainsNumber(recursion)))
+                {
+                    AddDiagnostic(span, RegexDiagnosticIds.AlternationHasUndefinedReference, $"The condition refers to undefined group {recursedNumber}.");
+                }
+
+                return;
+
+            case ['V', 'E', 'R', 'S', 'I', 'O', 'N', .. var version]:
+                if (!IsVersionCondition(version))
+                {
+                    AddDiagnostic(span, RegexDiagnosticIds.AlternationHasMalformedReference, "Malformed '(?(VERSION…' condition.");
+                }
+
+                return;
+
+            case ['<', .. var angled, '>']:
+                ValidateReferencedName(span, angled);
+                return;
+
+            case ['\'', .. var quoted, '\'']:
+                ValidateReferencedName(span, quoted);
+                return;
+
+            case ['+' or '-', _, ..] when name.AsSpan(1).IndexOfAnyExceptInRange('0', '9') < 0:
+                ReportUnknownRelativeReference(span, int.TryParse(name, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var relative) ? relative : int.MaxValue);
+                return;
+
+            case [>= '0' and <= '9', ..] when name.AsSpan().IndexOfAnyExceptInRange('0', '9') < 0:
+                if (!int.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out var number) || number == 0 || !CaptureTable.ContainsNumber(number))
+                {
+                    AddDiagnostic(span, RegexDiagnosticIds.AlternationHasUndefinedReference, $"The condition refers to undefined group {name}.");
+                }
+
+                return;
+
+            default:
+                ValidateReferencedName(span, name);
+                return;
+        }
+    }
+
+    private void ValidateReferencedName(TextSpan span, string name)
+    {
+        if (name.Length == 0 || char.IsAsciiDigit(name[0]) || !name.All(RegexCharacterTables.IsWordChar))
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.AlternationHasMalformedReference, $"'{name}' is not a valid group name.");
+        }
+        else if (!CaptureTable.TryGetNumber(name, out _))
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.AlternationHasUndefinedReference, $"The condition refers to undefined group '{name}'.");
+        }
+    }
+
+    /// <summary>Whether the text after <c>VERSION</c> is <c>=</c> or <c>&gt;=</c> and a version number.</summary>
+    private static bool IsVersionCondition(string text)
+    {
+        var span = text.AsSpan();
+        if (span.StartsWith(">=", StringComparison.Ordinal))
+        {
+            span = span[2..];
+        }
+        else if (span.StartsWith("=", StringComparison.Ordinal))
+        {
+            span = span[1..];
+        }
+        else
+        {
+            return false;
+        }
+
+        var dot = span.IndexOf('.');
+        var major = dot < 0 ? span : span[..dot];
+        if (major.Length == 0 || major.IndexOfAnyExceptInRange('0', '9') >= 0)
+            return false;
+
+        if (dot < 0)
+            return true;
+
+        var minor = span[(dot + 1)..];
+
+        return minor.Length > 0 && minor.IndexOfAnyExceptInRange('0', '9') < 0;
     }
 
     /// <summary>
@@ -119,7 +666,7 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
 
         // "\g1" and "\g-1": a bare number, possibly relative.
         var numberStart = Scanner.Position;
-        if (Scanner.Current == '-')
+        if (Scanner.Current is '-' or '+')
         {
             Scanner.Position++;
         }
@@ -129,9 +676,10 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
             Scanner.Position++;
         }
 
-        if (Scanner.Position == numberStart)
+        if (Scanner.Position == numberStart || !char.IsAsciiDigit(Scanner.CharAt(Scanner.Position - 1)))
         {
             AddDiagnostic(startToken.Span, RegexDiagnosticIds.MalformedNamedReference, "Malformed '\\g' reference.");
+            Scanner.Position = numberStart;
 
             return new RegexNamedBackreferenceSyntax(startToken, null, null, null, Options);
         }
@@ -142,13 +690,58 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
         return new RegexNamedBackreferenceSyntax(startToken, null, numberToken, null, Options);
     }
 
+    /// <summary>Parses <c>\k{name}</c>, the Perl spelling of a named backreference.</summary>
+    private RegexNamedBackreferenceSyntax ParseBracedNamedBackreference(GreenNode? leadingTrivia)
+    {
+        var start = Scanner.Position;
+        Scanner.Position += 2;
+        var startToken = Scanner.Token(SyntaxKind.NamedBackreferenceStartToken, start, leadingTrivia);
+        var openStart = Scanner.Position;
+        Scanner.Position++;
+        var openToken = Scanner.Token(SyntaxKind.OpenNameToken, openStart);
+        var nameStart = Scanner.Position;
+        var name = ReadUntil('}', SyntaxKind.NameToken);
+        var closeToken = ReadExpected('}', SyntaxKind.CloseNameToken, startToken);
+        if (name.IsPresent)
+        {
+            ReportUnknownReference(name, nameStart, trimSpaces: true, numbersAllowed: false);
+        }
+        else
+        {
+            AddDiagnostic(startToken.Span, RegexDiagnosticIds.MalformedNamedReference, "'\\k{' must be followed by a group name.");
+        }
+
+        return new RegexNamedBackreferenceSyntax(startToken, openToken, name, closeToken, Options);
+    }
+
+    /// <summary>Parses <c>\8</c> and <c>\9</c>, which PCRE always reads as backreferences, whatever digits follow.</summary>
+    private RegexBackreferenceSyntax ParseHighDigitBackreference(GreenNode? leadingTrivia)
+    {
+        var start = Scanner.Position;
+        Scanner.Position++;
+        long number = 0;
+        while (char.IsAsciiDigit(Scanner.Current))
+        {
+            number = Math.Min((number * 10) + (Scanner.Current - '0'), int.MaxValue);
+            Scanner.Position++;
+        }
+
+        var token = Scanner.Token(SyntaxKind.BackreferenceToken, start, leadingTrivia, ((int)number).ToString(CultureInfo.InvariantCulture));
+        if (!CaptureTable.ContainsNumber((int)number))
+        {
+            AddDiagnostic(token.Span, RegexDiagnosticIds.UndefinedNumberedReference, $"Reference to undefined group number {token.Text[1..]}.");
+        }
+
+        return new RegexBackreferenceSyntax(token, Options);
+    }
+
     /// <summary>Parses <c>(?&amp;name)</c> and <c>(?P&gt;name)</c>.</summary>
     private RegexRecursionSyntax ParseNamedRecursion(ScannedToken openParenToken, int questionStart)
     {
         Scanner.Position += Scanner.Current == '&' ? 1 : 2;
         var questionToken = Scanner.Token(SyntaxKind.QuestionToken, questionStart);
 
-        var target = ReadUntil(')', SyntaxKind.RecursionToken);
+        var target = ReadGroupNameToken(SyntaxKind.RecursionToken);
         ReportUnknownRecursionTarget(target);
         var closeParenToken = ReadCloseParen(openParenToken);
         RestoreOptions();
@@ -163,12 +756,36 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
         var markerToken = Scanner.Token(SyntaxKind.NamedBackreferenceStartToken, questionStart);
 
         var nameStart = Scanner.Position;
-        var name = ReadUntil(')', SyntaxKind.NameToken);
+        var name = ReadGroupNameToken(SyntaxKind.NameToken);
         var closeToken = ReadCloseParen(openParenToken);
         RestoreOptions();
-        ReportUnknownReference(name, nameStart);
+        ReportUnknownReference(name, nameStart, trimSpaces: false, numbersAllowed: false);
 
         return new RegexNamedBackreferenceSyntax(openParenToken, markerToken, name, closeToken, Options);
+    }
+
+    /// <summary>Reads a group name, reporting one that is missing or starts with a digit.</summary>
+    private ScannedToken ReadGroupNameToken(SyntaxKind kind)
+    {
+        var start = Scanner.Position;
+        if (char.IsAsciiDigit(Scanner.Current))
+        {
+            AddDiagnostic(new TextSpan(start, 1), RegexDiagnosticIds.CaptureGroupNameInvalid, "A group name must not start with a digit.");
+        }
+
+        while (!Scanner.IsAtEnd && RegexCharacterTables.IsWordChar(Scanner.Current))
+        {
+            Scanner.Position++;
+        }
+
+        if (Scanner.Position == start)
+        {
+            AddDiagnostic(new TextSpan(start, 0), RegexDiagnosticIds.CaptureGroupNameInvalid, "A group name is expected.");
+
+            return default;
+        }
+
+        return Scanner.Token(kind, start);
     }
 
     /// <summary>Parses <c>(?C)</c>, <c>(?C1)</c>, and <c>(?C"text")</c>.</summary>
@@ -177,18 +794,77 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
         Scanner.Position++;
         var questionToken = Scanner.Token(SyntaxKind.QuestionToken, questionStart);
 
-        var body = Scanner.Current == ')' ? default : ReadUntil(')', SyntaxKind.CalloutToken);
+        var bodyStart = Scanner.Position;
+        if (char.IsAsciiDigit(Scanner.Current))
+        {
+            long number = 0;
+            while (char.IsAsciiDigit(Scanner.Current))
+            {
+                number = Math.Min((number * 10) + (Scanner.Current - '0'), int.MaxValue);
+                Scanner.Position++;
+            }
+
+            if (number > 255)
+            {
+                AddDiagnostic(TextSpan.FromBounds(bodyStart, Scanner.Position), RegexDiagnosticIds.InvalidCallout, "A callout number cannot be greater than 255.");
+            }
+        }
+        else if (Scanner.Current is '`' or '\'' or '"' or '^' or '%' or '#' or '$' or '{')
+        {
+            // A delimiter is closed by itself, or "{" by "}", and a doubled closing delimiter stands for one.
+            var close = Scanner.Current == '{' ? '}' : Scanner.Current;
+            Scanner.Position++;
+            while (true)
+            {
+                if (Scanner.IsAtEnd)
+                {
+                    AddDiagnostic(TextSpan.FromBounds(bodyStart, Scanner.Position), RegexDiagnosticIds.InvalidCallout, "The callout string is missing its closing delimiter.");
+                    break;
+                }
+
+                if (Scanner.Current == close)
+                {
+                    Scanner.Position++;
+                    if (Scanner.Current != close)
+                        break;
+                }
+
+                Scanner.Position++;
+            }
+        }
+        else if (Scanner.Current != ')')
+        {
+            AddDiagnostic(new TextSpan(Scanner.Position, Scanner.IsAtEnd ? 0 : 1), RegexDiagnosticIds.InvalidCallout, "'(?C' must be followed by a number, a delimited string, or ')'.");
+        }
+
+        if (Scanner.Current != ')' && !Scanner.IsAtEnd)
+        {
+            AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.InvalidCallout, "A callout must be closed by ')'.");
+            while (!Scanner.IsAtEnd && Scanner.Current != ')')
+            {
+                Scanner.Position++;
+            }
+        }
+
+        var body = Scanner.Position > bodyStart ? Scanner.Token(SyntaxKind.CalloutToken, bodyStart) : default;
         var closeParenToken = ReadCloseParen(openParenToken);
         RestoreOptions();
 
         return new RegexCalloutSyntax(openParenToken, questionToken, body, closeParenToken, Options);
     }
 
-    /// <summary>Parses <c>\o{101}</c> and <c>\N{U+0041}</c>, both of which name a code point in braces.</summary>
-    private RegexCharacterEscapeSyntax ParseBracedNumericEscape(GreenNode? leadingTrivia, bool octal, bool hexOnly = false)
+    /// <summary>Reads <c>\o{101}</c>, <c>\x{41}</c>, and <c>\N{U+0041}</c>, all of which name a code point in braces.</summary>
+    private protected override string? TryScanDialectCharacterEscape(char letter, int escapeStart)
     {
-        var start = Scanner.Position;
-        Scanner.Position += 3;
+        if (letter is not ('o' or 'x' or 'N') || Scanner.Current != '{')
+            return null;
+
+        return ScanBracedNumericEscape(escapeStart, octal: letter == 'o', hexOnly: letter == 'x');
+    }
+
+    private string ScanBracedNumericEscape(int start, bool octal, bool hexOnly)
+    {
+        Scanner.Position++;
 
         var digitsStart = Scanner.Position;
         while (!Scanner.IsAtEnd && Scanner.Current != '}')
@@ -196,7 +872,13 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
             Scanner.Position++;
         }
 
+        // "\x{…}" and "\o{…}" may pad their digits with spaces; "\N{U+…}" may not.
         var digits = Text[digitsStart..Scanner.Position];
+        if (octal || hexOnly)
+        {
+            digits = digits.Trim(' ');
+        }
+
         var closed = Scanner.Current == '}';
         if (closed)
         {
@@ -212,10 +894,10 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
             AddDiagnostic(
                 TextSpan.FromBounds(start, Scanner.Position),
                 RegexDiagnosticIds.InsufficientOrInvalidHexDigits,
-                octal ? "The '\\o{...}' escape is not a well-formed octal value." : "The '\\N{U+...}' escape is not a well-formed code point.");
+                octal ? "The '\\o{...}' escape is not a well-formed octal value." : "The braced escape is not a well-formed code point.");
         }
 
-        return new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, start, leadingTrivia, value), Options);
+        return value;
     }
 
     private static bool TryReadCodePoint(string digits, bool octal, out int codePoint)
@@ -257,7 +939,7 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
     private ScannedToken ReadUntil(char terminator, SyntaxKind kind)
     {
         var start = Scanner.Position;
-        while (!Scanner.IsAtEnd && Scanner.Current != terminator)
+        while (!Scanner.IsAtEnd && Scanner.Current != terminator && Scanner.Current != ')')
         {
             Scanner.Position++;
         }
@@ -281,52 +963,219 @@ internal sealed class PcreRegexParser : PerlStyleRegexParser
     }
 
     /// <summary>Reports a reference that names neither an existing group number nor an existing group name.</summary>
-    /// <remarks>A relative reference such as <c>\g{-1}</c> is always in range here, so only absolute ones are checked.</remarks>
-    private void ReportUnknownReference(ScannedToken nameToken, int nameStart)
+    private void ReportUnknownReference(ScannedToken nameToken, int nameStart, bool trimSpaces = true, bool numbersAllowed = true)
     {
         if (!nameToken.IsPresent)
             return;
 
-        var name = nameToken.Text;
+        var name = trimSpaces ? nameToken.Text.Trim(' ') : nameToken.Text;
+        var span = new TextSpan(nameStart, nameToken.Text.Length);
 
-        // "\g{-2}" counts back from here, so what it needs is two groups already declared rather than a group of
-        // that number.
-        if (name is ['-', ..] &&
-            int.TryParse(name.AsSpan(1), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var back))
+        if (numbersAllowed && name is ['-' or '+', _, ..] && name.AsSpan(1).IndexOfAnyExceptInRange('0', '9') < 0)
         {
-            var declared = 0;
-            foreach (var declaredNumber in CaptureTable.Numbers)
+            ReportUnknownRelativeReference(span, int.TryParse(name, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var relative) ? relative : int.MaxValue);
+
+            return;
+        }
+
+        if (name.Length > 0 && char.IsAsciiDigit(name[0]))
+        {
+            if (!numbersAllowed || name.AsSpan().IndexOfAnyExceptInRange('0', '9') >= 0)
             {
-                if (CaptureTable.GetPosition(declaredNumber) < nameStart)
+                AddDiagnostic(span, RegexDiagnosticIds.MalformedNamedReference, $"'{name}' is not a valid group name or number.");
+            }
+            else if (!int.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out var number) || !CaptureTable.ContainsNumber(number))
+            {
+                AddDiagnostic(span, RegexDiagnosticIds.UndefinedNumberedReference, $"Reference to undefined group number {name}.");
+            }
+
+            return;
+        }
+
+        if (name.Length == 0 || !name.All(RegexCharacterTables.IsWordChar))
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.MalformedNamedReference, $"'{name}' is not a valid group name.");
+        }
+        else if (!CaptureTable.TryGetNumber(name, out _))
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.UndefinedNamedReference, $"Reference to undefined group name '{name}'.");
+        }
+    }
+
+    // ---- lookbehind length ----
+
+    private protected override void OnLookbehindParsed(RegexAlternationSyntax body, TextSpan span, int bodyStart) => _lookbehinds.Add((body, span, bodyStart));
+
+    /// <summary>
+    /// Checks every lookbehind once the whole pattern is known, since a subroutine call inside one may run a group
+    /// declared after it.
+    /// </summary>
+    /// <remarks>
+    /// Each top-level branch must have a bounded length, and a branch whose length varies may not be longer than 255
+    /// characters. A branch of a fixed length may be as long as it likes.
+    /// </remarks>
+    private protected override void OnPatternParsed()
+    {
+        foreach (var (body, span, bodyStart) in _lookbehinds)
+        {
+            var red = (Red.RegexAlternationSyntax)body.CreateRed();
+            foreach (var branch in red.Branches)
+            {
+                var (min, max) = MeasureLength(branch, bodyStart, []);
+                if (max is null)
                 {
-                    declared++;
+                    AddDiagnostic(span, RegexDiagnosticIds.UnboundedLookbehind, "The length of a lookbehind assertion must be limited.");
+                    break;
+                }
+
+                if (min != max && max > MaxLookbehindLength)
+                {
+                    AddDiagnostic(span, RegexDiagnosticIds.UnboundedLookbehind, FormattableString.Invariant($"A variable-length lookbehind branch cannot be longer than {MaxLookbehindLength} characters."));
+                    break;
                 }
             }
 
-            if (back == 0 || back > declared)
+            foreach (var escape in red.DescendantNodes().OfType<Red.RegexCharacterClassEscapeSyntax>())
             {
-                AddDiagnostic(new TextSpan(nameStart, name.Length), RegexDiagnosticIds.UndefinedNumberedReference, $"Reference to undefined group number {name}.");
+                if (escape.EscapeToken.Text == "\\C")
+                {
+                    AddDiagnostic(span, RegexDiagnosticIds.UnboundedLookbehind, "'\\C' is not allowed in a lookbehind assertion.");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>The fewest and most characters <paramref name="node"/> can match, the most being null when unbounded.</summary>
+    private (long Min, long? Max) MeasureLength(SyntaxNode node, int offset, HashSet<int> calling)
+    {
+        switch (node)
+        {
+            case Red.RegexAlternationSyntax alternation:
+            {
+                long? min = null;
+                long? max = 0;
+                foreach (var branch in alternation.Branches)
+                {
+                    var (branchMin, branchMax) = MeasureLength(branch, offset, calling);
+                    min = min is null ? branchMin : Math.Min(min.Value, branchMin);
+                    max = max is null || branchMax is null ? null : Math.Max(max.Value, branchMax.Value);
+                }
+
+                return (min ?? 0, max);
             }
 
-            return;
-        }
-
-        if (name is ['-', ..])
-            return;
-
-        if (int.TryParse(name, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var number))
-        {
-            if (!CaptureTable.ContainsNumber(number))
+            case Red.RegexSequenceSyntax sequence:
             {
-                AddDiagnostic(new TextSpan(nameStart, name.Length), RegexDiagnosticIds.UndefinedNumberedReference, $"Reference to undefined group number {name}.");
+                long min = 0;
+                long? max = 0;
+                foreach (var term in sequence.Terms)
+                {
+                    var (termMin, termMax) = MeasureLength(term, offset, calling);
+                    min = Math.Min(min + termMin, int.MaxValue);
+                    max = max is null || termMax is null ? null : Math.Min(max.Value + termMax.Value, int.MaxValue);
+                }
+
+                return (min, max);
             }
 
-            return;
+            case Red.RegexQuantifiedSyntax quantified:
+            {
+                // An assertion matches nothing however often it is repeated. Anything else repeated without limit is
+                // unbounded, even when it happens to match nothing.
+                if (quantified.Term is Red.RegexLookaroundSyntax or Red.RegexAnchorSyntax)
+                    return (0, 0);
+
+                var (termMin, termMax) = MeasureLength(quantified.Term, offset, calling);
+                var min = Math.Min(termMin * quantified.Quantifier.MinCount, int.MaxValue);
+                long? max = quantified.Quantifier.MaxCount is { } count && termMax is not null
+                    ? Math.Min(termMax.Value * count, int.MaxValue)
+                    : null;
+
+                return (min, max);
+            }
+
+            case Red.RegexLookaroundSyntax or Red.RegexAnchorSyntax or Red.RegexInlineOptionsSyntax or Red.RegexCalloutSyntax or Red.RegexBacktrackingVerbSyntax:
+                return (0, 0);
+
+            case Red.RegexConditionalSyntax conditional:
+            {
+                var (min, max) = MeasureLength(conditional.Alternation, offset, calling);
+
+                return (conditional.Alternation.Branches.Count < 2 ? 0 : min, max);
+            }
+
+            case Red.RegexGroupSyntax group:
+                return group.ChildNodes().OfType<Red.RegexAlternationSyntax>().FirstOrDefault() is { } body ? MeasureLength(body, offset, calling) : (0, 0);
+
+            case Red.RegexCharacterClassEscapeSyntax escape:
+                return escape.EscapeToken.Text switch
+                {
+                    "\\X" => (1, null),
+                    "\\R" => (1, 2),
+                    _ => (1, 1),
+                };
+
+            case Red.RegexCharacterEscapeSyntax escape when escape.Value.Length == 0:
+                return (0, 0);
+
+            case Red.RegexQuotedLiteralSyntax quoted:
+            {
+                var length = quoted.Value.EnumerateRunes().Count();
+
+                return (length, length);
+            }
+
+            case Red.RegexBackreferenceSyntax backreference:
+                return MeasureGroup(backreference.Number, offset + backreference.SpanStart, calling);
+
+            case Red.RegexNamedBackreferenceSyntax namedBackreference:
+                return MeasureGroup(ResolveReference(namedBackreference.Name, offset + namedBackreference.SpanStart), offset + namedBackreference.SpanStart, calling);
+
+            case Red.RegexRecursionSyntax recursion:
+                return recursion.TargetToken.Text is "R" or "0" ? (0, null) : MeasureGroup(ResolveReference(recursion.TargetToken.Text, offset + recursion.SpanStart), offset + recursion.SpanStart, calling);
+
+            default:
+                return (1, 1);
+        }
+    }
+
+    /// <summary>Measures the group a reference or a call names, treating a call into itself as unbounded.</summary>
+    private (long Min, long? Max) MeasureGroup(int number, int referencePosition, HashSet<int> calling)
+    {
+        if (!_captureGroups.TryGetValue(number, out var group))
+            return (0, 0);
+
+        // A reference from inside the group it names depends on its own length, which is never fixed.
+        if (group.Span.Contains(referencePosition) || !calling.Add(number))
+            return (0, null);
+
+        var length = MeasureLength(group.Group.CreateRed(), group.Span.Start, calling);
+        calling.Remove(number);
+
+        return length;
+    }
+
+    /// <summary>The group number a reference names, relative ones included.</summary>
+    private int ResolveReference(string reference, int position)
+    {
+        if (reference is ['-' or '+', _, ..] && int.TryParse(reference, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var relative))
+        {
+            var opened = 0;
+            foreach (var number in CaptureTable.Numbers)
+            {
+                if (CaptureTable.GetPosition(number) < position)
+                {
+                    opened = number;
+                }
+            }
+
+            return relative < 0 ? opened + relative + 1 : opened + relative;
         }
 
-        if (!CaptureTable.TryGetNumber(name, out _))
-        {
-            AddDiagnostic(new TextSpan(nameStart, name.Length), RegexDiagnosticIds.UndefinedNamedReference, $"Reference to undefined group name '{name}'.");
-        }
+        if (int.TryParse(reference, NumberStyles.None, CultureInfo.InvariantCulture, out var absolute))
+            return absolute;
+
+        return CaptureTable.TryGetNumber(reference, out var named) ? named : 0;
     }
 }

--- a/src/Meziantou.Framework.Language.Regex/Internals/PerlStyleRegexParser.CharacterClass.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/PerlStyleRegexParser.CharacterClass.cs
@@ -6,7 +6,9 @@
 // Permalink: https://github.com/dotnet/runtime/blob/5ec6efc171b19c0e2d591fbd451920e8f43a1552/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
 //
 // Changes: ScanCharClass builds member nodes instead of a RegexCharClass, and the explicit stack of parent classes
-// becomes recursion bounded by RegexParseOptions.MaxRecursionDepth. Which characters it consumes is unchanged.
+// becomes recursion bounded by RegexParseOptions.MaxRecursionDepth. Which characters it consumes is unchanged for .NET.
+// The rules of the other dialects -- POSIX bracket expressions, PCRE's quoting, the ECMAScript class set grammar -- are
+// additions.
 
 using Meziantou.Framework.Language.InternalSyntax;
 using Meziantou.Framework.Language.Regex.Internals;
@@ -16,6 +18,28 @@ namespace Meziantou.Framework.Language.Regex.Syntax.InternalSyntax;
 
 internal abstract partial class PerlStyleRegexParser
 {
+    /// <summary>The characters a class set has to have escaped, because unescaped they mean something else.</summary>
+    private const string ClassSetSyntaxCharacters = "()[]{}/-|";
+
+    /// <summary>
+    /// The characters that may not appear doubled. The grammar reserves them so the syntax can grow later without
+    /// changing what an existing pattern means.
+    /// </summary>
+    /// <remarks><c>&amp;</c> and <c>-</c> are not here: doubled they are the operators, which are read before this.</remarks>
+    private const string ReservedDoublePunctuators = "!#$%*+,.:;<=>?@^`~";
+
+    /// <summary>Whether the last class set member read may match a string of other than one character.</summary>
+    private protected bool LastSetMemberMayContainStrings { get; set; }
+
+    /// <summary>Whether a backslash inside a bracket expression is an ordinary character, as it is in POSIX.</summary>
+    protected virtual bool BackslashIsLiteralInClass => false;
+
+    /// <summary>
+    /// Whether a dash right after a completed range must end the class. POSIX rejects <c>[a-z-9]</c>; the Perl
+    /// dialects read that dash as an ordinary character.
+    /// </summary>
+    protected virtual bool RejectsDashAfterRange => false;
+
     /// <summary>Parses a character class, guarding against input that nests subtractions without end.</summary>
     private RegexAtomSyntax ParseCharacterClass(GreenNode? leadingTrivia)
     {
@@ -49,7 +73,7 @@ internal abstract partial class PerlStyleRegexParser
         IsInCharacterClass = true;
         try
         {
-            return ParseCharacterClassMembers(openBracketToken);
+            return UsesUnicodeSetsMode ? ParseClassSetMembers(openBracketToken) : ParseCharacterClassMembers(openBracketToken);
         }
         finally
         {
@@ -81,11 +105,15 @@ internal abstract partial class PerlStyleRegexParser
             firstChar = false;
         }
 
+        ReportPosixSyntaxOutsideClass(openBracketToken.Span.Start);
+
         var members = new List<RegexSyntaxNode>();
         RegexSyntaxNode? rangeStart = null;
         ScannedToken rangeHyphen = default;
-        var rangeStartValue = '\0';
+        var rangeStartValue = 0;
         var inRange = false;
+        var afterRange = false;
+        var noRangeStart = false;
         ScannedToken closeBracketToken = default;
 
         while (!Scanner.IsAtEnd)
@@ -119,55 +147,63 @@ internal abstract partial class PerlStyleRegexParser
                 continue;
             }
 
-            if (!inRange && Dialect.HasFeature(RegexDialectFeatures.PosixBracketExpressions) && TryParsePosixBracket(out var bracket))
+            // "\Q…\E" quotes inside a class too, and a "\E" with nothing to close is simply ignored.
+            if (Dialect.HasFeature(RegexDialectFeatures.QuotedLiterals) && !inRange && Scanner.Current == '\\' && Scanner.Peek() is 'Q' or 'E')
             {
-                members.Add(bracket);
-                firstChar = false;
+                var isEmpty = Scanner.Peek() == 'E' || Text.AsSpan(Scanner.Position + 2).StartsWith("\\E", StringComparison.Ordinal);
+                members.Add(Scanner.Peek() == 'Q' ? ParseQuotedLiteral(leadingTrivia: null) : ParseStrayQuoteEnd());
+
+                // An empty quote contributes nothing, so a "]" after it is still the first character of the class.
+                firstChar = firstChar && isEmpty;
                 continue;
             }
 
-            // In the class set grammar a class may contain another one, and "\q{…}" contributes whole strings.
-            if (UsesUnicodeSetsMode && !inRange && Scanner.Current == '[')
+            if (Dialect.HasFeature(RegexDialectFeatures.PosixBracketExpressions) && TryParsePosixBracket(out var bracket, out var isCollatingSymbol))
             {
-                members.Add(ParseNestedSetClass());
-                firstChar = false;
-                continue;
-            }
-
-            if (UsesUnicodeSetsMode && !inRange && Scanner.Current == '\\' && Scanner.Peek() == 'q' && Scanner.Peek(2) == '{')
-            {
-                members.Add(ParseClassStringLiteral());
-                firstChar = false;
-                continue;
-            }
-
-            if (UsesUnicodeSetsMode && !inRange && Scanner.Position + 1 < Text.Length &&
-                Scanner.Peek() == Scanner.Current &&
-                ReservedDoublePunctuators.Contains(Scanner.Current, StringComparison.Ordinal))
-            {
-                members.Add(SkipReservedDoublePunctuator());
-                firstChar = false;
-                continue;
-            }
-
-            // An operator turns the member before it into the first operand of a set operation. An operand is a single
-            // thing, so anything else on the left is an error, and the operator is kept as skipped text rather than
-            // folded into an operation whose parts would no longer be in source order.
-            if (UsesUnicodeSetsMode && !inRange && ClassSetOperatorLength(Scanner.Position) > 0)
-            {
-                if (members.Count == 1)
+                afterRange = inRange;
+                if (inRange)
                 {
-                    members = [ParseClassSetOperation(members[0])];
+                    // A collating symbol stands for one character, so it may end a range. A class or an equivalence
+                    // class stands for many and may not.
+                    if (isCollatingSymbol && Dialect.Family == RegexDialectFamily.Posix)
+                    {
+                        var range = new RegexCharacterRangeSyntax(rangeStart!, rangeHyphen!, bracket, Options);
+                        if (rangeStartValue > CollatingSymbolValue(bracket))
+                        {
+                            AddDiagnostic(JustParsedSpan(range), RegexDiagnosticIds.ReversedCharacterRange, $"Character range '{range}' is reversed.");
+                        }
+
+                        members.Add(range);
+                    }
+                    else
+                    {
+                        var range = new RegexCharacterRangeSyntax(rangeStart!, rangeHyphen!, bracket, Options);
+                        AddDiagnostic(JustParsedSpan(range), RegexDiagnosticIds.ShorthandClassInCharacterRange, $"'{bracket}' cannot be an endpoint of a character range.");
+                        members.Add(range);
+                    }
+
+                    inRange = false;
+                }
+                else if (isCollatingSymbol && Dialect.Family == RegexDialectFamily.Posix && TryStartRange(bracket, CollatingSymbolValue(bracket)))
+                {
+                    rangeStart = bracket;
                 }
                 else
                 {
-                    members.Add(SkipClassSetOperator(members.Count == 0));
+                    ReportClassAsRangeStart(bracket);
+                    members.Add(bracket);
                 }
 
                 firstChar = false;
                 continue;
             }
 
+            if (afterRange && RejectsDashAfterRange && Scanner.Current == '-' && Scanner.Peek() != ']')
+            {
+                AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.ReversedCharacterRange, "A range cannot be followed by '-' unless it ends the bracket expression.");
+            }
+
+            afterRange = false;
             var element = ReadClassElement();
 
             if (element.IsClassEscape)
@@ -191,16 +227,27 @@ internal abstract partial class PerlStyleRegexParser
                 }
                 else
                 {
+                    ReportClassAsRangeStart(element.Node);
                     members.Add(element.Node);
+
+                    // Where a shorthand may be an endpoint, "[\d-x]" is three members, and the "x" after the dash is
+                    // an endpoint too, so it cannot start a range of its own.
+                    if (AllowsShorthandClassInRange && Scanner.Current == '-' && Scanner.Position + 1 < Text.Length && Scanner.Peek() != ']')
+                    {
+                        var dashStart = Scanner.Position;
+                        Scanner.Position++;
+                        members.Add(new RegexLiteralSyntax(Scanner.Token(SyntaxKind.LiteralToken, dashStart), Options));
+                        noRangeStart = true;
+                    }
                 }
 
                 firstChar = false;
                 continue;
             }
 
-            // "\-" completes a range or stands for a literal dash, but never starts a range: the engine handles it
-            // before the look-ahead that a plain character would go through.
-            if (element.IsDashEscape)
+            // In .NET "\-" completes a range or stands for a literal dash, but never starts a range: the engine handles
+            // it before the look-ahead that a plain character would go through. Elsewhere it is a dash like any other.
+            if (element.IsDashEscape && Dialect.Family == RegexDialectFamily.Dotnet)
             {
                 if (inRange)
                 {
@@ -220,24 +267,14 @@ internal abstract partial class PerlStyleRegexParser
             {
                 AddRange(members, rangeStart!, rangeHyphen!, element, rangeStartValue);
                 inRange = false;
+                afterRange = true;
             }
-            else if (Scanner.Position + 1 < Text.Length && Text[Scanner.Position] == '-' && Text[Scanner.Position + 1] != ']' &&
-                ClassSetOperatorLength(Scanner.Position) == 0)
-            {
-                // The look-ahead has to decline the first "-" of a "--" operator, or "[a--b]" starts a range from "a"
-                // to "-" and the operator never gets the chance to be one.
-                var hyphenStart = Scanner.Position;
-                Scanner.Position++;
-                rangeStart = element.Node;
-                rangeStartValue = element.Value;
-                rangeHyphen = Scanner.Token(SyntaxKind.HyphenToken, hyphenStart);
-                inRange = true;
-            }
-            else
+            else if (noRangeStart || !TryStartRange(element.Node, element.Value))
             {
                 members.Add(element.Node);
             }
 
+            noRangeStart = false;
             firstChar = false;
         }
 
@@ -259,7 +296,188 @@ internal abstract partial class PerlStyleRegexParser
         }
 
         return new RegexCharacterClassSyntax(openBracketToken, caretToken, SyntaxFactory.ListNode([.. members]), closeBracketToken, Options);
+
+        // A dash that is followed by something other than the closing bracket starts a range from the member before it.
+        bool TryStartRange(RegexSyntaxNode node, int value)
+        {
+            if (Scanner.Position + 1 >= Text.Length || Text[Scanner.Position] != '-' || Text[Scanner.Position + 1] == ']')
+                return false;
+
+            var hyphenStart = Scanner.Position;
+            Scanner.Position++;
+            rangeStart = node;
+            rangeStartValue = value;
+            rangeHyphen = Scanner.Token(SyntaxKind.HyphenToken, hyphenStart);
+            inRange = true;
+
+            return true;
+        }
     }
+
+    /// <summary>
+    /// Reports a class, a shorthand or a POSIX one, followed by a dash that would make it the start of a range. The
+    /// dash is left where it is, so the rest of the class is read as if the range were not there.
+    /// </summary>
+    private void ReportClassAsRangeStart(RegexSyntaxNode member)
+    {
+        if (!ReportsShorthandClassAsRangeStart || Scanner.Current != '-' || Scanner.Peek() is ']' or '\0' || ClassSetOperatorLength(Scanner.Position) > 0)
+            return;
+
+        AddDiagnostic(
+            JustParsedSpan(member),
+            RegexDiagnosticIds.ShorthandClassInCharacterRange,
+            $"'{member}' cannot be the start of a character range.");
+    }
+
+    /// <summary>Keeps a <c>\E</c> that closes no quote, which the engines ignore.</summary>
+    private RegexCharacterEscapeSyntax ParseStrayQuoteEnd()
+    {
+        var start = Scanner.Position;
+        Scanner.Position += 2;
+
+        return new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, start, leadingTrivia: null, string.Empty), Options);
+    }
+
+    /// <summary>
+    /// Reports <c>[:alpha:]</c> written without the brackets around it, which PCRE rejects rather than reading as a
+    /// class of five characters.
+    /// </summary>
+    private void ReportPosixSyntaxOutsideClass(int openBracket)
+    {
+        if (Dialect.Family != RegexDialectFamily.Pcre || Scanner.Position != openBracket + 1 || Scanner.Current is not (':' or '.' or '='))
+            return;
+
+        if (FindPcrePosixTerminator(openBracket, Scanner.Current) is var terminator && terminator >= 0)
+        {
+            AddDiagnostic(
+                TextSpan.FromBounds(openBracket, terminator + 2),
+                RegexDiagnosticIds.InvalidPosixBracketExpression,
+                Scanner.Current == ':' ? "A POSIX named class is only allowed inside a character class." : "POSIX collating elements are not supported.");
+        }
+    }
+
+    /// <summary>
+    /// Finds the <c>:]</c>, <c>.]</c>, or <c>=]</c> that closes the POSIX construct opened at <paramref name="open"/>,
+    /// the way PCRE looks for it, or returns -1.
+    /// </summary>
+    private int FindPcrePosixTerminator(int open, char terminator)
+    {
+        for (var index = open + 2; index < Text.Length; index++)
+        {
+            var ch = Text[index];
+            if (ch == '\\' && index + 1 < Text.Length && Text[index + 1] is ']' or '\\')
+            {
+                index++;
+            }
+            else if ((ch == '[' && index + 1 < Text.Length && Text[index + 1] == terminator) || ch == ']')
+            {
+                return -1;
+            }
+            else if (ch == terminator && index + 1 < Text.Length && Text[index + 1] == ']')
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    // ---- the ECMAScript class set grammar ----
+
+    /// <summary>Reads the members of a class under the <c>v</c> flag.</summary>
+    /// <remarks>
+    /// <para>
+    /// The grammar is a union of members, or a single intersection, or a single difference; the operators take single
+    /// operands, never ranges, and may not be mixed at one level. A class may contain another.
+    /// </para>
+    /// <para>
+    /// A member may match a string rather than a character, which a negated class may not. Whether the class may
+    /// is left in <see cref="LastSetMemberMayContainStrings"/> so the class around it can apply the same rule.
+    /// </para>
+    /// </remarks>
+    private RegexCharacterClassSyntax ParseClassSetMembers(ScannedToken openBracketToken)
+    {
+        ScannedToken caretToken = default;
+        if (Scanner.Current == '^')
+        {
+            var caretStart = Scanner.Position;
+            Scanner.Position++;
+            caretToken = Scanner.Token(SyntaxKind.CaretToken, caretStart);
+        }
+
+        var members = new List<RegexSyntaxNode>();
+        var mayContainStrings = false;
+
+        while (ClassSetOperatorLength(Scanner.Position) > 0)
+        {
+            members.Add(SkipClassSetOperator(atStart: true));
+        }
+
+        if (!IsAtClassSetEnd())
+        {
+            var first = ReadClassSetMember();
+            if (ClassSetOperatorLength(Scanner.Position) > 0)
+            {
+                members.Add(ParseClassSetOperation(first, out mayContainStrings));
+                if (!IsAtClassSetEnd())
+                {
+                    AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.MalformedClassSetOperation, "A class set operation cannot be combined with other members.");
+                }
+            }
+            else
+            {
+                members.Add(first.Node);
+                mayContainStrings = first.MayContainStrings;
+            }
+
+            while (!IsAtClassSetEnd())
+            {
+                // An operator turns the member before it into the first operand of a set operation. Only the first
+                // member may be one, so any operator this far in has more than one member on its left.
+                if (ClassSetOperatorLength(Scanner.Position) > 0)
+                {
+                    members.Add(SkipClassSetOperator(atStart: false));
+                    continue;
+                }
+
+                var member = ReadClassSetMember();
+                members.Add(member.Node);
+                mayContainStrings |= member.MayContainStrings;
+            }
+        }
+
+        ScannedToken closeBracketToken;
+        if (Scanner.Current == ']')
+        {
+            var closeStart = Scanner.Position;
+            Scanner.Position++;
+            closeBracketToken = Scanner.Token(SyntaxKind.CloseBracketToken, closeStart);
+        }
+        else
+        {
+            AddDiagnostic(
+                TextSpan.FromBounds(openBracketToken.Span.Start, Math.Max(openBracketToken.Span.Start, Scanner.Position)),
+                RegexDiagnosticIds.UnterminatedBracket,
+                "Unterminated character class: expected ']'.");
+            closeBracketToken = Scanner.MissingToken(SyntaxKind.CloseBracketToken);
+        }
+
+        if (caretToken.IsPresent && mayContainStrings)
+        {
+            AddDiagnostic(
+                TextSpan.FromBounds(openBracketToken.Span.Start, closeBracketToken.End),
+                RegexDiagnosticIds.NegatedClassContainsStrings,
+                "A negated character class cannot contain strings.");
+        }
+
+        // A negated class matches single characters whatever it contains, which is what lets a class around it be
+        // negated in turn.
+        LastSetMemberMayContainStrings = mayContainStrings && !caretToken.IsPresent;
+
+        return new RegexCharacterClassSyntax(openBracketToken, caretToken, SyntaxFactory.ListNode([.. members]), closeBracketToken, Options);
+    }
+
+    private bool IsAtClassSetEnd() => Scanner.IsAtEnd || Scanner.Current == ']';
 
     /// <summary>The length of a class set operator at <paramref name="position"/>, or 0.</summary>
     /// <remarks>
@@ -278,10 +496,85 @@ internal abstract partial class PerlStyleRegexParser
         return (ch == '&' || ch == '-') && Text[position + 1] == ch ? 2 : 0;
     }
 
+    /// <summary>
+    /// Reads one member of a class set: a nested class, a string disjunction, a shorthand or property, a single
+    /// character, or a range between two characters.
+    /// </summary>
+    private ClassSetMember ReadClassSetMember()
+    {
+        var start = Scanner.Position;
+
+        if (Scanner.Current == '[')
+            return new ClassSetMember(ParseNestedSetClass(), LastSetMemberMayContainStrings, IsRange: false);
+
+        if (Scanner.Current == '\\' && Scanner.Peek() == 'q' && Scanner.Peek(2) == '{')
+            return new ClassSetMember(ParseClassStringLiteral(), LastSetMemberMayContainStrings, IsRange: false);
+
+        if (Scanner.Position + 1 < Text.Length && Scanner.Peek() == Scanner.Current && ReservedDoublePunctuators.Contains(Scanner.Current, StringComparison.Ordinal))
+            return new ClassSetMember(SkipReservedDoublePunctuator(), MayContainStrings: false, IsRange: false);
+
+        var element = ReadClassSetCharacter();
+        if (element.IsClassEscape)
+        {
+            ReportClassAsRangeStart(element.Node);
+
+            return new ClassSetMember(element.Node, LastSetMemberMayContainStrings, IsRange: false);
+        }
+
+        // "[a-]" is not a range: the dash has nothing after it, and on its own it is a syntax character.
+        if (Scanner.Current != '-' || Scanner.Peek() is '-' or ']' || Scanner.Position + 1 >= Text.Length)
+            return new ClassSetMember(element.Node, MayContainStrings: false, IsRange: false);
+
+        var hyphenStart = Scanner.Position;
+        Scanner.Position++;
+        var hyphenToken = Scanner.Token(SyntaxKind.HyphenToken, hyphenStart);
+
+        RegexSyntaxNode end;
+        if (Scanner.Current == '[' || (Scanner.Current == '\\' && Scanner.Peek() == 'q' && Scanner.Peek(2) == '{'))
+        {
+            end = Scanner.Current == '[' ? ParseNestedSetClass() : ParseClassStringLiteral();
+            var invalid = new RegexCharacterRangeSyntax(element.Node, hyphenToken, end, Options);
+            AddDiagnostic(JustParsedSpan(invalid), RegexDiagnosticIds.ShorthandClassInCharacterRange, $"'{end}' cannot be an endpoint of a character range.");
+
+            return new ClassSetMember(invalid, MayContainStrings: false, IsRange: true);
+        }
+
+        var endElement = ReadClassSetCharacter();
+        var range = new RegexCharacterRangeSyntax(element.Node, hyphenToken, endElement.Node, Options);
+        if (endElement.IsClassEscape)
+        {
+            AddDiagnostic(JustParsedSpan(endElement.Node), RegexDiagnosticIds.ShorthandClassInCharacterRange, $"Shorthand class '{endElement.Node}' cannot be an endpoint of a character range.");
+        }
+        else if (element.Value > endElement.Value)
+        {
+            AddDiagnostic(TextSpan.FromBounds(start, Scanner.Position), RegexDiagnosticIds.ReversedCharacterRange, $"Character range '{range}' is reversed.");
+        }
+
+        return new ClassSetMember(range, MayContainStrings: false, IsRange: true);
+    }
+
+    /// <summary>Reads one character of a class set, reporting a syntax character that should have been escaped.</summary>
+    private ClassElement ReadClassSetCharacter()
+    {
+        var start = Scanner.Position;
+        if (Scanner.Current != '\\' && ClassSetSyntaxCharacters.Contains(Scanner.Current, StringComparison.Ordinal))
+        {
+            Scanner.Position++;
+            AddDiagnostic(new TextSpan(start, 1), RegexDiagnosticIds.InvalidClassSetCharacter, $"'{Text[start]}' must be escaped inside a character class.");
+
+            return new ClassElement(new RegexLiteralSyntax(Scanner.Token(SyntaxKind.LiteralToken, start), Options), Text[start], IsClassEscape: false, IsDashEscape: false);
+        }
+
+        LastSetMemberMayContainStrings = false;
+
+        return ReadClassElement();
+    }
+
     /// <summary>Parses a class nested inside another, which only the class set grammar allows.</summary>
     private RegexSyntaxNode ParseNestedSetClass()
     {
         var start = Scanner.Position;
+        LastSetMemberMayContainStrings = false;
         if (!TryEnterRecursion(new TextSpan(start, 1)))
         {
             Scanner.Position++;
@@ -313,10 +606,19 @@ internal abstract partial class PerlStyleRegexParser
         var textStart = Scanner.Position;
         while (!Scanner.IsAtEnd && Scanner.Current != '}')
         {
+            if (Scanner.Current == '\\' && Scanner.Peek() == 'u' && Scanner.Peek(2) == '{' && Text.IndexOf('}', Scanner.Position, StringComparison.Ordinal) is var codePointEnd && codePointEnd >= 0)
+            {
+                // "\u{…}" has a closing brace of its own, which does not close the disjunction.
+                Scanner.Position = codePointEnd + 1;
+                continue;
+            }
+
             Scanner.Position += Scanner.Current == '\\' && Scanner.Position + 1 < Text.Length ? 2 : 1;
         }
 
-        ValidateClassStringContent(textStart, Scanner.Position);
+        var textEnd = Scanner.Position;
+        LastSetMemberMayContainStrings = ValidateClassStringContent(textStart, textEnd);
+        Scanner.Position = textEnd;
         var textToken = Scanner.Position > textStart ? Scanner.Token(SyntaxKind.QuoteTextToken, textStart) : default;
 
         ScannedToken closeBraceToken = default;
@@ -337,40 +639,53 @@ internal abstract partial class PerlStyleRegexParser
         return new RegexClassStringLiteralSyntax(startToken, textToken, closeBraceToken, Options);
     }
 
-    /// <summary>The characters a class set has to have escaped, because unescaped they mean something else.</summary>
-    private const string ClassSetSyntaxCharacters = "()[]{}/-";
-
-    /// <summary>
-    /// The characters that may not appear doubled. The grammar reserves them so the syntax can grow later without
-    /// changing what an existing pattern means.
-    /// </summary>
-    /// <remarks><c>&amp;</c> and <c>-</c> are not here: doubled they are the operators, which are read before this.</remarks>
-    private const string ReservedDoublePunctuators = "!#$%*+,.:;<=>?@^`~";
-
-    /// <summary>Checks the body of a <c>\q{…}</c> disjunction, which is not free text.</summary>
-    private void ValidateClassStringContent(int start, int end)
+    /// <summary>Checks the body of a <c>\q{…}</c> disjunction, and returns whether any alternative is not one character.</summary>
+    /// <remarks>The body is not free text: each character is read the way a class set character is.</remarks>
+    private bool ValidateClassStringContent(int start, int end)
     {
-        for (var index = start; index < end; index++)
+        var mayContainStrings = false;
+        var length = 0;
+        Scanner.Position = start;
+        while (Scanner.Position < end)
         {
-            var ch = Text[index];
+            var ch = Scanner.Current;
+            if (ch == '|')
+            {
+                mayContainStrings |= length != 1;
+                length = 0;
+                Scanner.Position++;
+                continue;
+            }
+
             if (ch == '\\')
             {
-                // Whatever follows a backslash is that character, so it needs no checking of its own.
-                index++;
+                // A backslash that ends the pattern escapes nothing; the unterminated disjunction is reported instead.
+                Scanner.Position++;
+                if (Scanner.Position < end)
+                {
+                    _ = ScanCharEscape();
+                }
+
+                length++;
                 continue;
             }
 
             if (ClassSetSyntaxCharacters.Contains(ch, StringComparison.Ordinal))
             {
-                AddDiagnostic(new TextSpan(index, 1), RegexDiagnosticIds.MalformedClassString, $"'{ch}' must be escaped inside a '\\q{{...}}' disjunction.");
+                AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.MalformedClassString, $"'{ch}' must be escaped inside a '\\q{{...}}' disjunction.");
             }
-            else if (index + 1 < end && Text[index + 1] == ch &&
+            else if (Scanner.Position + 1 < end && Scanner.Peek() == ch &&
                 (ReservedDoublePunctuators.Contains(ch, StringComparison.Ordinal) || ch == '&'))
             {
-                AddDiagnostic(new TextSpan(index, 2), RegexDiagnosticIds.ReservedClassSetPunctuator, $"'{ch}{ch}' is reserved and may not appear here.");
-                index++;
+                AddDiagnostic(new TextSpan(Scanner.Position, 2), RegexDiagnosticIds.ReservedClassSetPunctuator, $"'{ch}{ch}' is reserved and may not appear here.");
+                Scanner.Position++;
             }
+
+            Scanner.Position += char.IsHighSurrogate(ch) && Scanner.Position + 1 < end && char.IsLowSurrogate(Scanner.Peek()) ? 2 : 1;
+            length++;
         }
+
+        return mayContainStrings || length != 1;
     }
 
     /// <summary>Reports a doubled punctuator the class set grammar reserves.</summary>
@@ -389,13 +704,15 @@ internal abstract partial class PerlStyleRegexParser
     /// </summary>
     /// <remarks>
     /// The grammar is n-ary but not mixed: <c>[a--b--c]</c> is one difference of three operands, while
-    /// <c>[a&amp;&amp;b--c]</c> is an error. An operand is a single thing, so <c>[abc--d]</c> is an error too, which is
-    /// why more than one member on the left is reported rather than quietly grouped.
+    /// <c>[a&amp;&amp;b--c]</c> is an error. An intersection may match strings only when every operand may; a
+    /// difference only when its first operand may.
     /// </remarks>
-    private RegexClassSetOperationSyntax ParseClassSetOperation(RegexSyntaxNode first)
+    private RegexClassSetOperationSyntax ParseClassSetOperation(ClassSetMember first, out bool mayContainStrings)
     {
-        var operands = new List<RegexSyntaxNode> { first };
+        ReportRangeOperand(first);
+        var operands = new List<RegexSyntaxNode> { first.Node };
         var operators = new List<ScannedToken>();
+        mayContainStrings = first.MayContainStrings;
 
         string? expected = null;
         while (ClassSetOperatorLength(Scanner.Position) is var length && length > 0)
@@ -411,16 +728,36 @@ internal abstract partial class PerlStyleRegexParser
                 AddDiagnostic(operatorToken.Span, RegexDiagnosticIds.MalformedClassSetOperation, "Class set operators may not be mixed at the same level.");
             }
 
-            if (Scanner.IsAtEnd || Scanner.Current == ']')
+            if (IsAtClassSetEnd())
             {
                 AddDiagnostic(operatorToken.Span, RegexDiagnosticIds.MalformedClassSetOperation, "A class set operator needs an operand after it.");
                 break;
             }
 
-            operands.Add(ReadClassSetOperand());
+            // "&&&" is not an operator followed by "&": the grammar keeps a third "&" out so it can mean something later.
+            if (operatorToken.Text == "&&" && Scanner.Current == '&')
+            {
+                AddDiagnostic(new TextSpan(Scanner.Position, 1), RegexDiagnosticIds.MalformedClassSetOperation, "'&&' cannot be followed by another '&'.");
+            }
+
+            var operand = ReadClassSetMember();
+            ReportRangeOperand(operand);
+            operands.Add(operand.Node);
+            if (operatorToken.Text == "&&")
+            {
+                mayContainStrings &= operand.MayContainStrings;
+            }
         }
 
         return new RegexClassSetOperationSyntax(Interleave(operands, operators), Options);
+
+        void ReportRangeOperand(ClassSetMember member)
+        {
+            if (member.IsRange)
+            {
+                AddDiagnostic(JustParsedSpan(member.Node), RegexDiagnosticIds.MalformedClassSetOperation, "A range cannot be an operand of a class set operation; wrap it in a nested class.");
+            }
+        }
     }
 
     /// <summary>Keeps an operator that has no single operand before it, so the text is still accounted for.</summary>
@@ -440,33 +777,9 @@ internal abstract partial class PerlStyleRegexParser
         return new RegexSkippedTextSyntax(token, Options);
     }
 
-    /// <summary>Reads one operand of a set operation: a nested class, a string disjunction, or a single member.</summary>
-    private RegexSyntaxNode ReadClassSetOperand()
-    {
-        if (Scanner.Current == '[')
-            return ParseNestedSetClass();
+    // ---- shared ----
 
-        if (Scanner.Current == '\\' && Scanner.Peek() == 'q' && Scanner.Peek(2) == '{')
-            return ParseClassStringLiteral();
-
-        var element = ReadClassElement();
-
-        // An operand may itself be a range, as the right-hand side of "[\w--a-z]" is.
-        if (!element.IsClassEscape && Scanner.Position + 1 < Text.Length && Text[Scanner.Position] == '-' && Text[Scanner.Position + 1] != ']' &&
-            ClassSetOperatorLength(Scanner.Position) == 0)
-        {
-            var hyphenStart = Scanner.Position;
-            Scanner.Position++;
-            var hyphenToken = Scanner.Token(SyntaxKind.HyphenToken, hyphenStart);
-            var end = ReadClassElement();
-
-            return new RegexCharacterRangeSyntax(element.Node, hyphenToken, end.Node, Options);
-        }
-
-        return element.Node;
-    }
-
-    private void AddRange(List<RegexSyntaxNode> members, RegexSyntaxNode start, ScannedToken hyphen, ClassElement end, char startValue)
+    private void AddRange(List<RegexSyntaxNode> members, RegexSyntaxNode start, ScannedToken hyphen, ClassElement end, int startValue)
     {
         var range = new RegexCharacterRangeSyntax(start, hyphen, end.Node, Options);
         if (startValue > end.Value)
@@ -516,20 +829,47 @@ internal abstract partial class PerlStyleRegexParser
         return new RegexClassSubtractionSyntax(hyphenToken, nested, Options);
     }
 
+    /// <summary>The POSIX character class names every dialect that has bracket expressions knows.</summary>
+    private static bool IsPosixClassName(string name) =>
+        name is "alnum" or "alpha" or "blank" or "cntrl" or "digit" or "graph" or "lower" or "print" or "punct" or "space" or "upper" or "xdigit";
+
     /// <summary>Reads <c>[:alpha:]</c>, <c>[.ch.]</c>, or <c>[=a=]</c> for the dialects that have them.</summary>
-    private bool TryParsePosixBracket(out RegexSyntaxNode node)
+    /// <remarks>
+    /// POSIX commits as soon as it sees <c>[:</c>, <c>[.</c>, or <c>[=</c>, so a construct that is never closed is an
+    /// error there. PCRE only treats the text as one when the terminator can be found, and otherwise reads the bracket
+    /// as an ordinary character.
+    /// </remarks>
+    private bool TryParsePosixBracket(out RegexSyntaxNode node, out bool isCollatingSymbol)
     {
         node = null!;
+        isCollatingSymbol = false;
         if (Scanner.Current != '[' || Scanner.Peek() is not (':' or '.' or '='))
             return false;
 
         var marker = Scanner.Peek();
-        var terminator = $"{marker}]";
-        var closeIndex = Text.IndexOf(terminator, Scanner.Position + 2, StringComparison.Ordinal);
-        if (closeIndex < 0)
-            return false;
-
         var start = Scanner.Position;
+        int closeIndex;
+        if (Dialect.Family == RegexDialectFamily.Posix)
+        {
+            // The name holds at least one character, which is what makes "[.].]" the collating symbol "]".
+            closeIndex = start + 3 <= Text.Length ? Text.IndexOf($"{marker}]", start + 3, StringComparison.Ordinal) : -1;
+            if (closeIndex < 0)
+            {
+                Scanner.Position = Text.Length;
+                var unterminated = Scanner.Token(SyntaxKind.BadToken, start);
+                AddDiagnostic(unterminated.Span, RegexDiagnosticIds.UnterminatedBracket, $"Unterminated '[{marker}' in a bracket expression: expected '{marker}]'.");
+                node = new RegexSkippedTextSyntax(unterminated, Options);
+
+                return true;
+            }
+        }
+        else
+        {
+            closeIndex = FindPcrePosixTerminator(start, marker);
+            if (closeIndex < 0)
+                return false;
+        }
+
         Scanner.Position += 2;
         var startToken = Scanner.Token(SyntaxKind.PosixClassStartToken, start);
 
@@ -541,11 +881,48 @@ internal abstract partial class PerlStyleRegexParser
         Scanner.Position += 2;
         var endToken = Scanner.Token(SyntaxKind.PosixClassEndToken, endStart);
 
-        node = marker == ':'
-            ? new RegexPosixCharacterClassSyntax(startToken, nameToken, endToken, Options)
-            : new RegexCollatingElementSyntax(startToken, nameToken, endToken, Options);
+        var name = nameToken.Text;
+        if (marker == ':')
+        {
+            node = new RegexPosixCharacterClassSyntax(startToken, nameToken, endToken, Options);
+
+            // PCRE adds "word" and "ascii", and lets "^" negate a class.
+            var isPcre = Dialect.Family == RegexDialectFamily.Pcre;
+            var bare = isPcre && name is ['^', ..] ? name[1..] : name;
+            if (!IsPosixClassName(bare) && !(isPcre && bare is "word" or "ascii"))
+            {
+                AddDiagnostic(nameToken.Span, RegexDiagnosticIds.InvalidPosixBracketExpression, $"Unknown POSIX character class name '{name}'.");
+            }
+        }
+        else
+        {
+            node = new RegexCollatingElementSyntax(startToken, nameToken, endToken, Options);
+            isCollatingSymbol = marker == '.';
+            if (Dialect.Family == RegexDialectFamily.Pcre)
+            {
+                AddDiagnostic(TextSpan.FromBounds(start, Scanner.Position), RegexDiagnosticIds.InvalidPosixBracketExpression, "POSIX collating elements are not supported.");
+            }
+            else if (name.Length != 1 && !(name.Length == 2 && char.IsSurrogatePair(name[0], name[1])))
+            {
+                AddDiagnostic(nameToken.Span, RegexDiagnosticIds.InvalidPosixBracketExpression, $"'{name}' is not a collating element.");
+            }
+        }
 
         return true;
+    }
+
+    /// <summary>The character a collating symbol such as <c>[.a.]</c> stands for.</summary>
+    private static int CollatingSymbolValue(RegexSyntaxNode node)
+    {
+        var text = node.ToString();
+        var name = text.Length >= 4 ? text[2..^2] : string.Empty;
+
+        return name.Length switch
+        {
+            0 => 0,
+            >= 2 when char.IsSurrogatePair(name[0], name[1]) => char.ConvertToUtf32(name[0], name[1]),
+            _ => name[0],
+        };
     }
 
     /// <summary>Reads one member of a class: a shorthand, a category, an escape, or a single character.</summary>
@@ -553,42 +930,54 @@ internal abstract partial class PerlStyleRegexParser
     {
         var start = Scanner.Position;
 
-        if (Scanner.Current == '\\' && Scanner.Position + 1 < Text.Length)
+        if (Scanner.Current == '\\' && Scanner.Position + 1 < Text.Length && !BackslashIsLiteralInClass)
         {
             switch (Scanner.Peek())
             {
                 case var letter when IsShorthandClassLetterInClass(letter):
                     Scanner.Position += 2;
-                    return new ClassElement(new RegexCharacterClassEscapeSyntax(Scanner.Token(SyntaxKind.ClassEscapeToken, start), Options), '\0', IsTranslated: false, IsClassEscape: true, IsDashEscape: false);
+                    return new ClassElement(new RegexCharacterClassEscapeSyntax(Scanner.Token(SyntaxKind.ClassEscapeToken, start), Options), 0, IsClassEscape: true, IsDashEscape: false);
 
                 case 'p' or 'P' when SupportsUnicodeCategories:
-                    return new ClassElement(ParseUnicodeCategory(leadingTrivia: null), '\0', IsTranslated: false, IsClassEscape: true, IsDashEscape: false);
+                    LastSetMemberMayContainStrings = false;
+                    return new ClassElement(ParseUnicodeCategory(leadingTrivia: null), 0, IsClassEscape: true, IsDashEscape: false);
 
                 case '-':
                     Scanner.Position += 2;
-                    return new ClassElement(new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, start, leadingTrivia: null, "-"), Options), '-', IsTranslated: false, IsClassEscape: false, IsDashEscape: true);
+                    return new ClassElement(new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, start, leadingTrivia: null, "-"), Options), '-', IsClassEscape: false, IsDashEscape: true);
 
                 default:
                     Scanner.Position++;
                     var value = ScanCharEscape();
                     return new ClassElement(
                         new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, start, leadingTrivia: null, value), Options),
-                        value.Length > 0 ? value[0] : '\0',
-                        IsTranslated: true,
+                        FirstCodePoint(value),
                         IsClassEscape: false,
                         IsDashEscape: false);
             }
         }
 
-        var ch = Scanner.Current;
         Scanner.Position++;
+        if (ReadsCodePoints && char.IsHighSurrogate(Text[start]) && char.IsLowSurrogate(Scanner.Current))
+        {
+            Scanner.Position++;
+        }
 
-        return new ClassElement(new RegexLiteralSyntax(Scanner.Token(SyntaxKind.LiteralToken, start), Options), ch, IsTranslated: false, IsClassEscape: false, IsDashEscape: false);
+        return new ClassElement(new RegexLiteralSyntax(Scanner.Token(SyntaxKind.LiteralToken, start), Options), FirstCodePoint(Text[start..Scanner.Position]), IsClassEscape: false, IsDashEscape: false);
     }
 
+    /// <summary>The first code point of <paramref name="value"/>, or 0 when it is empty.</summary>
+    private static int FirstCodePoint(string value) => value.Length switch
+    {
+        0 => 0,
+        >= 2 when char.IsSurrogatePair(value[0], value[1]) => char.ConvertToUtf32(value[0], value[1]),
+        _ => value[0],
+    };
+
     /// <summary>One member of a class, with what the parser needs to know about it to read the next one.</summary>
-    /// <param name="IsTranslated">
-    /// Whether the character came from an escape. A <c>\[</c> does not open a subtraction the way a bare <c>[</c> does.
-    /// </param>
-    private readonly record struct ClassElement(RegexSyntaxNode Node, char Value, bool IsTranslated, bool IsClassEscape, bool IsDashEscape);
+    /// <param name="Value">The code point the member stands for, which is what a range compares.</param>
+    private readonly record struct ClassElement(RegexSyntaxNode Node, int Value, bool IsClassEscape, bool IsDashEscape);
+
+    /// <summary>One member of a class set, with whether it may match a string and whether it is a range.</summary>
+    private readonly record struct ClassSetMember(RegexSyntaxNode Node, bool MayContainStrings, bool IsRange);
 }

--- a/src/Meziantou.Framework.Language.Regex/Internals/PerlStyleRegexParser.Escapes.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/PerlStyleRegexParser.Escapes.cs
@@ -46,6 +46,9 @@ internal partial class PerlStyleRegexParser
                 Scanner.Position += 2;
                 return new RegexAnchorSyntax(Scanner.Token(SyntaxKind.AnchorToken, start, leadingTrivia), Options);
 
+            case 'k' when Scanner.Peek(2) == '{' && Dialect.Family == RegexDialectFamily.Pcre:
+                return TryParseDialectEscape(leadingTrivia) ?? ParseBackreferenceOrEscape(leadingTrivia);
+
             // Where the dialect has no such anchor the escape is not an anchor at all: it falls through and stands for
             // the letter, which is what an engine without it does.
             case 'A' or 'G' or 'z' or 'Z' when Dialect.HasFeature(RegexDialectFeatures.AnchorsAZ):
@@ -54,6 +57,11 @@ internal partial class PerlStyleRegexParser
 
             case 'K' when Dialect.HasFeature(RegexDialectFeatures.KeepOut):
                 Scanner.Position += 2;
+                if (LookaroundDepth > 0)
+                {
+                    AddDiagnostic(TextSpan.FromBounds(start, Scanner.Position), RegexDiagnosticIds.UnrecognizedEscape, "'\\K' is not allowed inside a lookaround.");
+                }
+
                 return new RegexAnchorSyntax(Scanner.Token(SyntaxKind.AnchorToken, start, leadingTrivia), Options);
 
             case var letter when IsShorthandClassLetter(letter):
@@ -126,8 +134,10 @@ internal partial class PerlStyleRegexParser
             {
                 var letterStart = Scanner.Position;
                 Scanner.Position++;
+                var letterToken = Scanner.Token(SyntaxKind.CategoryNameToken, letterStart);
+                ValidatePropertyName(letterToken.Span, letterToken.Text, negated: categoryStartToken.Text[1] == 'P', braced: false);
 
-                return new RegexUnicodeCategorySyntax(categoryStartToken, null, Scanner.Token(SyntaxKind.CategoryNameToken, letterStart), null, Options);
+                return new RegexUnicodeCategorySyntax(categoryStartToken, null, letterToken, null, Options);
             }
 
             AddDiagnostic(categoryStartToken.Span, RegexDiagnosticIds.MalformedUnicodePropertyEscape, "Malformed '\\p{...}' character escape.");
@@ -139,22 +149,8 @@ internal partial class PerlStyleRegexParser
         Scanner.Position++;
         var openBraceToken = Scanner.Token(SyntaxKind.OpenBraceToken, braceStart);
 
-        // Dialects that name a property as well as a value accept "Script=Greek", so the separator has to be part of
-        // the name rather than the character that ends it.
-        var namesProperties = Dialect.HasFeature(RegexDialectFeatures.UnicodePropertyNames);
         var nameStart = Scanner.Position;
-
-        // "\p{^L}" is the other way of writing "\P{L}" where the dialect has it.
-        if (namesProperties && Scanner.Current == '^')
-        {
-            Scanner.Position++;
-        }
-
-        while (!Scanner.IsAtEnd &&
-            (RegexCharacterTables.IsBoundaryWordChar(Scanner.Current) || Scanner.Current == '-' || (namesProperties && Scanner.Current == '=')))
-        {
-            Scanner.Position++;
-        }
+        ReadPropertyName();
 
         var name = Text[nameStart..Scanner.Position];
         var nameToken = Scanner.Token(SyntaxKind.CategoryNameToken, nameStart);
@@ -171,12 +167,9 @@ internal partial class PerlStyleRegexParser
             {
                 AddDiagnostic(nameToken.Span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, "The property name is empty.");
             }
-
-            // The known-name set is .NET's own. Another dialect has a different and larger one, so checking a name
-            // against this table there would reject properties that dialect really does have.
-            else if (!namesProperties && !NetUnicodeCategoryNames.IsDefined(name))
+            else
             {
-                AddDiagnostic(nameToken.Span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"Unknown Unicode property or block name '{name}'.");
+                ValidatePropertyName(nameToken.Span, name, negated: categoryStartToken.Text[1] == 'P', braced: true);
             }
         }
         else
@@ -188,6 +181,41 @@ internal partial class PerlStyleRegexParser
         }
 
         return new RegexUnicodeCategorySyntax(categoryStartToken, openBraceToken, nameToken, closeBraceToken, Options);
+    }
+
+    /// <summary>Reads the name inside <c>\p{…}</c>, stopping before whatever cannot be part of it.</summary>
+    protected virtual void ReadPropertyName()
+    {
+        // Dialects that name a property as well as a value accept "Script=Greek", so the separator has to be part of
+        // the name rather than the character that ends it.
+        var namesProperties = Dialect.HasFeature(RegexDialectFeatures.UnicodePropertyNames);
+
+        // "\p{^L}" is the other way of writing "\P{L}" where the dialect has it.
+        if (namesProperties && Scanner.Current == '^')
+        {
+            Scanner.Position++;
+        }
+
+        while (!Scanner.IsAtEnd &&
+            (RegexCharacterTables.IsBoundaryWordChar(Scanner.Current) || Scanner.Current == '-' || (namesProperties && Scanner.Current == '=')))
+        {
+            Scanner.Position++;
+        }
+    }
+
+    /// <summary>Reports a property name the dialect does not know.</summary>
+    /// <param name="span">Where the name is.</param>
+    /// <param name="name">The name as written, never empty.</param>
+    /// <param name="negated">Whether the escape is <c>\P</c>.</param>
+    /// <param name="braced">Whether the name was written in braces rather than as a single letter.</param>
+    protected virtual void ValidatePropertyName(TextSpan span, string name, bool negated, bool braced)
+    {
+        // The known-name set is .NET's own. Another dialect has a different and larger one, so checking a name against
+        // this table there would reject properties that dialect really does have.
+        if (!Dialect.HasFeature(RegexDialectFeatures.UnicodePropertyNames) && !NetUnicodeCategoryNames.IsDefined(name))
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.UnrecognizedUnicodeProperty, $"Unknown Unicode property or block name '{name}'.");
+        }
     }
 
     /// <summary>Parses a backreference, or falls back to a character escape.</summary>
@@ -207,7 +235,17 @@ internal partial class PerlStyleRegexParser
         ScannedToken openNameToken = default;
 
         // "\k" introduces a named backreference only where the dialect has named groups at all.
-        if (ch == 'k' && Dialect.HasFeature(RegexDialectFeatures.NamedGroups))
+        var isNamedReference = ch == 'k' && Dialect.HasFeature(RegexDialectFeatures.NamedGroups);
+        if (isNamedReference && AllowsUndefinedNamedBackreference && !HasAnyGroupName)
+        {
+            // With no named group anywhere in the pattern there is nothing "\k" could refer to, so it is the letter
+            // rather than a reference, whatever follows it.
+            var identity = ScanCharEscape();
+
+            return new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, backpos, leadingTrivia, identity), Options);
+        }
+
+        if (isNamedReference)
         {
             if (Scanner.Position + 1 < Text.Length)
             {
@@ -226,16 +264,6 @@ internal partial class PerlStyleRegexParser
                 {
                     Scanner.Position = openStart;
                 }
-            }
-
-            if ((!angled || Scanner.IsAtEnd) && AllowsUndefinedNamedBackreference && !HasAnyGroupName)
-            {
-                // With no named group anywhere in the pattern there is nothing "\k" could refer to, so it is the
-                // letter rather than a malformed reference.
-                Scanner.Position = backpos + 1;
-                var identity = ScanCharEscape();
-
-                return new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, backpos, leadingTrivia, identity), Options);
             }
 
             if (!angled || Scanner.IsAtEnd)
@@ -262,7 +290,7 @@ internal partial class PerlStyleRegexParser
             ch = Scanner.Current;
         }
 
-        if (angled && char.IsAsciiDigit(ch))
+        if (angled && char.IsAsciiDigit(ch) && AllowsNumberedGroups)
         {
             var nameStart = Scanner.Position;
             var number = ReadDecimal(out _);
@@ -285,11 +313,11 @@ internal partial class PerlStyleRegexParser
             if (TryParseUnangledBackreference(backpos, leadingTrivia, out var backreference))
                 return backreference;
         }
-        else if (angled && RegexCharacterTables.IsBoundaryWordChar(ch))
+        else if (angled && IsGroupNameStartAt(Scanner.Position))
         {
             var nameStart = Scanner.Position;
-            var name = ReadCaptureName();
-            var nameToken = Scanner.Token(SyntaxKind.NameToken, nameStart);
+            var name = ReadGroupName();
+            var nameToken = Scanner.Token(SyntaxKind.NameToken, nameStart, leadingTrivia: null, ValueIfDifferent(name, nameStart));
             if (!Scanner.IsAtEnd && Text[Scanner.Position] == close)
             {
                 var closeStart = Scanner.Position;
@@ -304,6 +332,16 @@ internal partial class PerlStyleRegexParser
             }
         }
 
+        // Where "\k" can only be a reference, one that is not well formed is an error rather than a letter.
+        if (isNamedReference && Dialect.Family == RegexDialectFamily.JavaScript)
+        {
+            Scanner.Position = backpos + 2;
+            var malformed = Scanner.Token(SyntaxKind.NamedBackreferenceStartToken, backpos, leadingTrivia);
+            AddDiagnostic(malformed.Span, RegexDiagnosticIds.MalformedNamedReference, "Malformed '\\k<...>' named backreference.");
+
+            return new RegexNamedBackreferenceSyntax(malformed, null, null, null, Options);
+        }
+
         // Not a backreference after all: rewind and read the whole thing as a character escape.
         Scanner.Position = backpos + 1;
         var value = ScanCharEscape();
@@ -311,9 +349,46 @@ internal partial class PerlStyleRegexParser
         return new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, backpos, leadingTrivia, value), Options);
     }
 
+    /// <summary>Returns <paramref name="value"/> when it differs from the text read since <paramref name="start"/>, else null.</summary>
+    private protected string? ValueIfDifferent(string value, int start) =>
+        Text.AsSpan(start, Scanner.Position - start).SequenceEqual(value) ? null : value;
+
     /// <summary>Reads <c>\1</c>-style backreferences, which are octal escapes when no such group exists.</summary>
     private bool TryParseUnangledBackreference(int backpos, GreenNode? leadingTrivia, out RegexAtomSyntax result)
     {
+        if (UsesJavaScriptDecimalEscapes)
+        {
+            // The whole run of digits is one number, and it names a group when the pattern has that many anywhere,
+            // before or after this point.
+            long number = 0;
+            while (char.IsAsciiDigit(Scanner.Current))
+            {
+                number = Math.Min((number * 10) + (Scanner.Current - '0'), int.MaxValue);
+                Scanner.Position++;
+            }
+
+            var token = Scanner.Token(SyntaxKind.BackreferenceToken, backpos, leadingTrivia, FormatNumber((int)number));
+            if (number <= CaptureTable.Numbers.Count)
+            {
+                result = new RegexBackreferenceSyntax(token, Options);
+
+                return true;
+            }
+
+            if (!AllowsOctalEscape)
+            {
+                AddDiagnostic(token.Span, RegexDiagnosticIds.UndefinedNumberedReference, $"Reference to undefined group number {token.Text[1..]}.");
+                result = new RegexBackreferenceSyntax(token, Options);
+
+                return true;
+            }
+
+            // The web-compatibility grammar falls back to a legacy octal escape, or to the digit itself for 8 and 9.
+            result = null!;
+
+            return false;
+        }
+
         if (UsesEcmaScriptBehavior)
         {
             // ECMAScript takes the longest prefix of the digits that names a group declared before this point.
@@ -388,6 +463,9 @@ internal partial class PerlStyleRegexParser
         if (!RecognizesPerlCharacterEscapes)
             return ch.ToString();
 
+        if (TryScanDialectCharacterEscape(ch, escapeStart) is { } dialectValue)
+            return dialectValue;
+
         if (ch is >= '0' and <= '7')
         {
             Scanner.Position--;
@@ -402,19 +480,23 @@ internal partial class PerlStyleRegexParser
 
             // In Unicode mode "\u{10FFFF}" names a code point directly, so the braces are part of the escape rather
             // than a bound applied to the letter.
+            case 'u' when !SupportsUnicodeEscape:
+                AddDiagnostic(TextSpan.FromBounds(escapeStart, Scanner.Position), RegexDiagnosticIds.UnrecognizedEscape, "The '\\u' escape is not supported by this dialect.");
+                return "u";
+
             case 'u' when UsesUnicodeMode && Scanner.Current == '{':
                 return ScanBracedCodePoint(escapeStart);
 
             case 'u':
-                return ScanHex(4, escapeStart);
+                return ScanUnicodeEscape(escapeStart);
 
-            case 'a':
+            case 'a' when HasBellAndEscapeEscapes:
                 return "\a";
 
             case 'b':
                 return "\b";
 
-            case 'e':
+            case 'e' when HasBellAndEscapeEscapes:
                 return "\u001b";
 
             case 'f':
@@ -445,6 +527,12 @@ internal partial class PerlStyleRegexParser
         }
     }
 
+    /// <summary>
+    /// Reads a character escape only some dialects have, returning the character, or null to fall through. The reading
+    /// position is just past <paramref name="letter"/>.
+    /// </summary>
+    private protected virtual string? TryScanDialectCharacterEscape(char letter, int escapeStart) => null;
+
     /// <summary>Reads up to three octal digits, stopping before the value exceeds 0377.</summary>
     private string ScanOctal()
     {
@@ -463,8 +551,9 @@ internal partial class PerlStyleRegexParser
                 break;
         }
 
-        // A lone "\0" is the null character everywhere; it is the digits after it that make it an octal escape.
-        if (!AllowsOctalEscape && (Scanner.Position - octalStart > 1 || Text[octalStart] != '0'))
+        // A lone "\0" is the null character everywhere; it is the digits after it that make it an octal escape, and
+        // where octal is not allowed even a digit it could not have taken ("\08") makes it one.
+        if (!AllowsOctalEscape && (Scanner.Position - octalStart > 1 || Text[octalStart] != '0' || char.IsAsciiDigit(Scanner.Current)))
         {
             AddDiagnostic(
                 TextSpan.FromBounds(Math.Max(0, octalStart - 1), Scanner.Position),
@@ -513,7 +602,39 @@ internal partial class PerlStyleRegexParser
             return string.Empty;
         }
 
-        return char.ConvertFromUtf32(value);
+        // A surrogate written as a code point is still one character, even though it is not a scalar value.
+        return value is >= 0xD800 and <= 0xDFFF ? ((char)value).ToString() : char.ConvertFromUtf32(value);
+    }
+
+    /// <summary>Reads the four digits of <c>\uHHHH</c>.</summary>
+    /// <remarks>
+    /// In Unicode mode a high surrogate written this way pairs with a low surrogate written the same way right after
+    /// it, so the two escapes stand for one code point.
+    /// </remarks>
+    private string ScanUnicodeEscape(int escapeStart)
+    {
+        var value = ScanHex(4, escapeStart);
+        if (ReadsCodePoints && value.Length == 1 && char.IsHighSurrogate(value[0]) &&
+            Scanner.Current == '\\' && Scanner.Peek() == 'u' && Scanner.Position + 6 <= Text.Length)
+        {
+            var low = 0;
+            for (var index = Scanner.Position + 2; index < Scanner.Position + 6; index++)
+            {
+                var digit = FromHexChar(Text[index]);
+                low = digit < 0 ? -1 : (low * 0x10) + digit;
+                if (low < 0)
+                    break;
+            }
+
+            if (low >= 0 && char.IsLowSurrogate((char)low))
+            {
+                Scanner.Position += 6;
+
+                return string.Concat(value, ((char)low).ToString());
+            }
+        }
+
+        return value;
     }
 
     /// <summary>Reads exactly <paramref name="count"/> hexadecimal digits.</summary>
@@ -575,6 +696,12 @@ internal partial class PerlStyleRegexParser
     /// <summary>Reads the character of a <c>\c</c> control escape and converts it.</summary>
     private string ScanControl(int escapeStart)
     {
+        // Inside a class the web-compatibility grammar also takes a digit or "_" as the control letter.
+        if (AllowsMalformedNumericEscape && IsInCharacterClass && (char.IsAsciiDigit(Scanner.Current) || Scanner.Current == '_'))
+        {
+            return ((char)(Text[Scanner.Position++] % 32)).ToString();
+        }
+
         if (Scanner.IsAtEnd || (AllowsMalformedNumericEscape && !char.IsAsciiLetter(Scanner.Current)))
         {
             if (AllowsMalformedNumericEscape)
@@ -601,8 +728,19 @@ internal partial class PerlStyleRegexParser
             ch = (char)(ch - ('a' - 'A'));
         }
 
+        if (AllowsAnyControlEscapeCharacter)
+        {
+            // PCRE flips a bit of whatever follows, but only a printable ASCII character may.
+            if (Text[Scanner.Position - 1] is < ' ' or > '~')
+            {
+                AddDiagnostic(TextSpan.FromBounds(escapeStart, Scanner.Position), RegexDiagnosticIds.UnrecognizedControlCharacter, "The '\\c' escape must be followed by a printable ASCII character.");
+            }
+
+            return ((char)(ch ^ 0x40)).ToString();
+        }
+
         ch = (char)(ch - '@');
-        if (ch < ' ' || AllowsAnyControlEscapeCharacter)
+        if (ch < ' ')
             return ch.ToString();
 
         if (AllowsMalformedNumericEscape)

--- a/src/Meziantou.Framework.Language.Regex/Internals/PerlStyleRegexParser.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/PerlStyleRegexParser.cs
@@ -39,11 +39,6 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     /// </remarks>
     private bool _inConditionalTest;
 
-    private int _autocap = 1;
-
-    /// <summary>Takes the next capture number without noting it.</summary>
-    protected override int NextAutoCapture() => _autocap++;
-
     protected PerlStyleRegexParser(SourceText source, RegexParseOptions parseOptions)
         : base(source, parseOptions)
     {
@@ -96,7 +91,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
 
                 // In Unicode mode a pattern is a sequence of code points, so a surrogate pair is one atom and a
                 // quantifier after it repeats the whole character rather than half of one.
-                if (UsesUnicodeMode && char.IsHighSurrogate(Text[start]) && char.IsLowSurrogate(Scanner.Current))
+                if (ReadsCodePoints && char.IsHighSurrogate(Text[start]) && char.IsLowSurrogate(Scanner.Current))
                 {
                     Scanner.Position++;
                 }
@@ -121,7 +116,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         {
             Scanner.Position += openLength;
             var openParenToken = Scanner.Token(SyntaxKind.OpenParenToken, start, leadingTrivia);
-            OptionsStack.Push(Options);
+            OptionsStack.Push((Options, DuplicateNamesAllowed));
 
             // The flag applies to this parenthesis only, never to anything nested inside it.
             var inConditionalTest = _inConditionalTest;
@@ -171,6 +166,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
 
                 case 'R':
                 case >= '0' and <= '9' when Dialect.HasFeature(RegexDialectFeatures.Recursion):
+                case '-' or '+' when Dialect.HasFeature(RegexDialectFeatures.Recursion) && char.IsAsciiDigit(Scanner.Peek()):
                     if (Dialect.HasFeature(RegexDialectFeatures.Recursion))
                         return ParseRecursion(openParenToken, questionStart);
 
@@ -185,6 +181,22 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         {
             ExitRecursion();
         }
+    }
+
+    /// <summary>How many lookarounds, of either direction, enclose the reading position.</summary>
+    private protected int LookaroundDepth { get; set; }
+
+    /// <summary>How many lookbehinds enclose the reading position.</summary>
+    private protected int LookbehindDepth { get; set; }
+
+    /// <summary>Called once the body of a lookbehind has been read, for the dialects that restrict what it may match.</summary>
+    private protected virtual void OnLookbehindParsed(RegexAlternationSyntax body, TextSpan span, int bodyStart)
+    {
+    }
+
+    /// <summary>Called once a capturing group has been read, with the number it took.</summary>
+    private protected virtual void OnCaptureGroupParsed(int number, RegexGroupSyntax group)
+    {
     }
 
     /// <summary>Parses a <c>(?…</c> header that only some dialects have, or returns null to fall through.</summary>
@@ -239,6 +251,30 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     protected virtual bool AllowsEmptyOptionGroup => false;
 
     /// <summary>
+    /// Whether the pattern is a sequence of code points rather than of UTF-16 code units, so that a surrogate pair is
+    /// one character wherever it appears, a character class and its ranges included.
+    /// </summary>
+    protected virtual bool ReadsCodePoints => UsesUnicodeMode;
+
+    /// <summary>Whether <c>\a</c> (bell) and <c>\e</c> (escape) are character escapes.</summary>
+    protected virtual bool HasBellAndEscapeEscapes => true;
+
+    /// <summary>Whether <c>\u</c> introduces a character escape at all.</summary>
+    protected virtual bool SupportsUnicodeEscape => true;
+
+    /// <summary>
+    /// Whether a backslash followed by digits follows the ECMAScript grammar: the digits name a group when the pattern
+    /// has that many, and are otherwise an error in Unicode mode or a legacy octal escape outside it.
+    /// </summary>
+    protected virtual bool UsesJavaScriptDecimalEscapes => false;
+
+    /// <summary>
+    /// Whether a shorthand class followed by a dash is reported as the start of a range. .NET makes that dash an
+    /// ordinary character; PCRE and the strict ECMAScript grammar reject it.
+    /// </summary>
+    protected virtual bool ReportsShorthandClassAsRangeStart => false;
+
+    /// <summary>
     /// Whether any character may follow <c>\c</c>. PCRE exclusive-ors whatever is there with <c>0x40</c> and accepts
     /// the result; .NET only takes it when it lands on a control character.
     /// </summary>
@@ -263,19 +299,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     protected virtual bool AllowsUndefinedNamedBackreference => false;
 
     /// <summary>Whether the pattern declares any named group, which decides what a bare <c>\k</c> means.</summary>
-    protected bool HasAnyGroupName
-    {
-        get
-        {
-            foreach (var number in CaptureTable.Numbers)
-            {
-                if (!char.IsAsciiDigit(CaptureTable.GetName(number)[0]))
-                    return true;
-            }
-
-            return false;
-        }
-    }
+    protected bool HasAnyGroupName => CaptureTable.HasNames;
 
     /// <summary>Whether the letter after a backslash names a shorthand character class at the atom level.</summary>
     protected virtual bool IsShorthandClassLetter(char letter) => IsCoreShorthandClassLetter(letter);
@@ -323,6 +347,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         var group = new RegexCapturingGroupSyntax(openParenToken, alternation, closeParenToken, Options, alternation.Options, number);
         RestoreOptions();
         NoteCaptureSpan(number, TextSpan.FromBounds(openParenToken.Span.Start, closeParenToken.End));
+        OnCaptureGroupParsed(number, group);
 
         return group;
     }
@@ -344,7 +369,9 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
             kind = SyntaxKind.NonCapturingGroup;
         }
 
-        var alternation = ParseAlternation(insideGroup: true);
+        LookaroundDepth += kind == SyntaxKind.Lookaround ? 1 : 0;
+        var alternation = ParseAlternation(insideGroup: true, resetsCaptureNumbers: kind == SyntaxKind.BranchResetGroup);
+        LookaroundDepth -= kind == SyntaxKind.Lookaround ? 1 : 0;
         var closeParenToken = ReadCloseParen(openParenToken);
         RegexGroupSyntax group = kind switch
         {
@@ -372,6 +399,11 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         }
         else
         {
+            if (Scanner.Current is '-' or '+')
+            {
+                Scanner.Position++;
+            }
+
             ReadDecimal(out _);
         }
 
@@ -390,9 +422,17 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
             return;
 
         var target = targetToken.Text;
-        if (int.TryParse(target, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var number))
+        if (target is ['-' or '+', _, ..] && int.TryParse(target.AsSpan(1), NumberStyles.None, CultureInfo.InvariantCulture, out var relative))
         {
-            if (!CaptureTable.ContainsNumber(number))
+            ReportUnknownRelativeReference(targetToken.Span, target[0] == '-' ? -relative : relative);
+
+            return;
+        }
+
+        if (int.TryParse(target, NumberStyles.None, CultureInfo.InvariantCulture, out var number))
+        {
+            // Group 0 is the whole pattern, which is always there to recurse into.
+            if (number != 0 && !CaptureTable.ContainsNumber(number))
             {
                 AddDiagnostic(targetToken.Span, RegexDiagnosticIds.UndefinedNumberedReference, $"Reference to undefined group number {target}.");
             }
@@ -406,8 +446,33 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         }
     }
 
+    /// <summary>
+    /// Reports a relative reference, <c>-1</c> for the group opened last or <c>+1</c> for the one opened next, that
+    /// names no group.
+    /// </summary>
+    private protected void ReportUnknownRelativeReference(TextSpan span, int offset)
+    {
+        // The reading position is past the reference, and the groups opened so far have taken every number below the
+        // next one to be assigned.
+        var number = offset switch
+        {
+            0 => 0,
+            < 0 => AutoCaptureNumber + offset,
+            _ => AutoCaptureNumber + offset - 1,
+        };
+
+        if (offset == 0)
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.UndefinedNumberedReference, "A relative reference cannot be zero.");
+        }
+        else if (number < 1 || !CaptureTable.ContainsNumber(number))
+        {
+            AddDiagnostic(span, RegexDiagnosticIds.UndefinedNumberedReference, FormattableString.Invariant($"Reference to undefined group, {offset:+0;-0} from here."));
+        }
+    }
+
     /// <summary>Parses a backtracking control verb such as <c>(*SKIP)</c>.</summary>
-    private RegexBacktrackingVerbSyntax ParseBacktrackingVerb(ScannedToken openParenToken)
+    private protected virtual RegexAtomSyntax ParseBacktrackingVerb(ScannedToken openParenToken)
     {
         var verbStart = Scanner.Position;
         Scanner.Position++;
@@ -447,9 +512,14 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
                 AddDiagnostic(lookbehindKindToken.Span, RegexDiagnosticIds.InvalidGroupingConstruct, $"The '{lookbehindKindToken.Text}' grouping construct is not supported by the {Dialect.Name} dialect.");
             }
 
+            LookaroundDepth++;
+            LookbehindDepth++;
             var lookbehindBody = ParseAlternation(insideGroup: true);
+            LookaroundDepth--;
+            LookbehindDepth--;
             var lookbehindClose = ReadCloseParen(openParenToken);
             var lookbehind = new RegexLookaroundSyntax(openParenToken, lookbehindKindToken, lookbehindBody, lookbehindClose, Options, lookbehindBody.Options);
+            OnLookbehindParsed(lookbehindBody, TextSpan.FromBounds(openParenToken.Span.Start, lookbehindClose.End), lookbehindKindToken.End);
             RestoreOptions();
 
             return lookbehind;
@@ -509,6 +579,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
             var number = capnum > 0 ? capnum : ResolveDeclaredNumber(nameToken);
             result = new RegexNamedGroupSyntax(openParenToken, groupKindToken, nameToken, closeNameToken, alternationBody, closeParenToken, Options, alternationBody.Options, number);
             NoteCaptureSpan(number, TextSpan.FromBounds(openParenToken.Span.Start, closeParenToken.Span.End));
+            OnCaptureGroupParsed(number, result);
         }
 
         RestoreOptions();
@@ -525,7 +596,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         var start = Scanner.Position;
         var ch = Scanner.Current;
 
-        if (char.IsAsciiDigit(ch))
+        if (char.IsAsciiDigit(ch) && AllowsNumberedGroups)
         {
             capnum = ReadDecimal(out _);
             var token = Scanner.Token(SyntaxKind.NameToken, start);
@@ -552,17 +623,28 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
             return token;
         }
 
-        if (RegexCharacterTables.IsBoundaryWordChar(ch))
+        if (IsGroupNameStartAt(Scanner.Position))
         {
-            var name = ReadCaptureName();
-            NoteCaptureName(name, groupStart);
-            var token = Scanner.Token(SyntaxKind.NameToken, start);
+            var name = ReadGroupName();
+            var token = Scanner.Token(SyntaxKind.NameToken, start, leadingTrivia: null, ValueIfDifferent(name, start));
             if (!Scanner.IsAtEnd && Scanner.Current != close && Scanner.Current != '-')
             {
                 AddDiagnostic(token.Span, RegexDiagnosticIds.CaptureGroupNameInvalid, "Invalid capture group name.");
             }
 
-            capnum = CaptureTable.TryGetNumber(name, out var declared) ? declared : -1;
+            if (NamedGroupsTakeNumbersInOrder)
+            {
+                capnum = NoteNumberedCaptureName(name, groupStart);
+                if (!IsNumberingPass)
+                {
+                    CheckGroupNameDeclaration(name, capnum, token.Span);
+                }
+            }
+            else
+            {
+                NoteCaptureName(name, groupStart);
+                capnum = CaptureTable.TryGetNumber(name, out var declared) ? declared : -1;
+            }
 
             return token;
         }
@@ -638,7 +720,28 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     }
 
     private int ResolveDeclaredNumber(ScannedToken nameToken) =>
-        nameToken.IsPresent && CaptureTable.TryGetNumber(nameToken.Text, out var number) ? number : 0;
+        nameToken.IsPresent && CaptureTable.TryGetNumber(nameToken.ValueText, out var number) ? number : 0;
+
+    /// <summary>
+    /// Whether a named group takes the next number where it stands, as in JavaScript and PCRE, rather than one after
+    /// every unnamed group, as in .NET.
+    /// </summary>
+    protected virtual bool NamedGroupsTakeNumbersInOrder => false;
+
+    /// <summary>Whether a group may be given an explicit number, as <c>(?&lt;3&gt;x)</c> does in .NET.</summary>
+    protected virtual bool AllowsNumberedGroups => true;
+
+    /// <summary>Whether a group name starts at <paramref name="position"/>.</summary>
+    protected virtual bool IsGroupNameStartAt(int position) => RegexCharacterTables.IsBoundaryWordChar(Scanner.CharAt(position));
+
+    /// <summary>Reads a group name at the reading position and returns the name it spells.</summary>
+    /// <remarks>The name may differ from its text where the dialect lets a name contain escapes.</remarks>
+    protected virtual string ReadGroupName() => ReadCaptureName();
+
+    /// <summary>Checks a group name against the groups already declared, in the pass that reports diagnostics.</summary>
+    protected virtual void CheckGroupNameDeclaration(string name, int number, TextSpan span)
+    {
+    }
 
     /// <summary>Parses <c>(?(…)yes|no)</c>.</summary>
     private RegexConditionalSyntax ParseConditional(ScannedToken openParenToken, int questionStart)
@@ -650,8 +753,10 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         }
 
         var conditionStart = Scanner.Position;
+        ConditionAllowsOneBranchOnly = false;
 
         RegexSyntaxNode? condition = ReadConditionalReference(conditionStart);
+        var maxBranches = ConditionAllowsOneBranchOnly ? 1 : 2;
         if (condition is null)
         {
             // Not a reference, so the condition is an expression. The engine rewinds to the parenthesis and lets the
@@ -660,12 +765,12 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
             ReportIllegalConditionHeader(conditionStart);
             _ignoreNextParen = true;
             _inConditionalTest = true;
-            condition = ParseAtom(leadingTrivia: null);
+            condition = ParseAtom(ConditionMayStartWithComment ? TakeTrivia() : null);
             _inConditionalTest = false;
         }
 
         var alternation = ParseAlternation(insideGroup: true);
-        if (alternation.BranchCount > 2)
+        if (alternation.BranchCount > maxBranches)
         {
             AddDiagnostic(JustParsedSpan(alternation), RegexDiagnosticIds.AlternationHasTooManyConditions, "A conditional alternation has too many branches.");
         }
@@ -677,8 +782,14 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
         return conditional;
     }
 
+    /// <summary>Set by <see cref="ReadConditionalReference"/> when the condition is one, like PCRE's <c>DEFINE</c>, that takes a single branch.</summary>
+    private protected bool ConditionAllowsOneBranchOnly { get; set; }
+
+    /// <summary>Whether a comment may stand in front of an expression condition, as PCRE allows.</summary>
+    private protected virtual bool ConditionMayStartWithComment => false;
+
     /// <summary>Reads <c>(1)</c> or <c>(name)</c>, or reports that the condition is an expression by returning null.</summary>
-    private RegexConditionalReferenceSyntax? ReadConditionalReference(int conditionStart)
+    private protected virtual RegexConditionalReferenceSyntax? ReadConditionalReference(int conditionStart)
     {
         Scanner.Position++;
         var openParenToken = Scanner.Token(SyntaxKind.OpenParenToken, conditionStart);
@@ -730,7 +841,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     }
 
     /// <summary>Reports the two headers a conditional's expression condition may not have.</summary>
-    private void ReportIllegalConditionHeader(int conditionStart)
+    private protected virtual void ReportIllegalConditionHeader(int conditionStart)
     {
         if (conditionStart + 2 >= Text.Length || Text[conditionStart + 1] != '?')
             return;
@@ -767,7 +878,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
             var closeStart = Scanner.Position;
             Scanner.Position++;
             var closeToken = Scanner.Token(SyntaxKind.CloseParenToken, closeStart);
-            OptionsStack.Pop();
+            _ = OptionsStack.Pop();
             _ignoreNextParen = false;
 
             return new RegexInlineOptionsSyntax(openParenToken, questionToken, optionsToken, closeToken, Options, Options);
@@ -802,7 +913,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     }
 
     /// <summary>Reads an <c>imnsx-imnsx</c> run and applies it, stopping at the first character it does not know.</summary>
-    private ScannedToken ScanInlineOptions(int start)
+    private protected virtual ScannedToken ScanInlineOptions(int start)
     {
         var off = false;
         while (!Scanner.IsAtEnd)
@@ -854,7 +965,7 @@ internal abstract partial class PerlStyleRegexParser : RegexParser
     {
         if (OptionsStack.Count > 0)
         {
-            Options = OptionsStack.Pop();
+            (Options, DuplicateNamesAllowed) = OptionsStack.Pop();
         }
     }
 

--- a/src/Meziantou.Framework.Language.Regex/Internals/PosixRegexParser.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/PosixRegexParser.cs
@@ -38,6 +38,66 @@ internal sealed class PosixRegexParser : PerlStyleRegexParser
     /// </summary>
     protected override bool RecognizesPerlCharacterEscapes => false;
 
+    /// <summary>A backslash is an ordinary character inside a bracket expression, so <c>[\]]</c> is <c>[\]</c> then <c>]</c>.</summary>
+    protected override bool BackslashIsLiteralInClass => true;
+
+    protected override bool RejectsDashAfterRange => true;
+
+    /// <summary>A class, as in <c>[[:alpha:]-z]</c>, cannot start a range.</summary>
+    protected override bool ReportsShorthandClassAsRangeStart => true;
+
+    protected override bool AllowsOmittedMinimumBound => true;
+
+    /// <summary>The GNU implementation's <c>RE_DUP_MAX</c>.</summary>
+    protected override long? MaxBoundValue => 32767;
+
+    /// <summary>The GNU shorthand classes are <c>\w</c> and <c>\s</c> and their negations; <c>\d</c> is just a "d".</summary>
+    protected override bool IsShorthandClassLetter(char letter) => letter is 's' or 'S' or 'w' or 'W';
+
+    /// <summary>
+    /// An extended expression may stack quantifiers freely. A basic one may stack only the GNU <c>\+</c> and <c>\?</c>:
+    /// a <c>*</c> or a bound after another quantifier is an error there.
+    /// </summary>
+    protected override bool AllowsStackedQuantifier(RegexQuantifierSyntax quantifier) =>
+        !DelimitersAreEscaped || quantifier is RegexSimpleQuantifierSyntax && !quantifier.ToString().Contains('*', StringComparison.Ordinal);
+
+    /// <summary>
+    /// Neither kind of expression can repeat an assertion. A basic one never reaches this for <c>*</c>, <c>\+</c>, or
+    /// <c>\?</c>, which are ordinary characters after an assertion, so what is left there is a bound.
+    /// </summary>
+    protected override bool IsQuantifiable(RegexTermSyntax term) => term is not RegexAnchorSyntax;
+
+    /// <summary>
+    /// A backreference is a single digit, and it must name a group that has already been closed in the branch it is in.
+    /// The GNU word anchors <c>\&lt;</c>, <c>\&gt;</c>, <c>\`</c>, and <c>\'</c> are assertions.
+    /// </summary>
+    protected override RegexAtomSyntax? TryParseDialectEscape(GreenNode? leadingTrivia)
+    {
+        var start = Scanner.Position;
+        var next = Scanner.Peek();
+        if (next is '<' or '>' or '`' or '\'')
+        {
+            Scanner.Position += 2;
+
+            return new RegexAnchorSyntax(Scanner.Token(SyntaxKind.AnchorToken, start, leadingTrivia), Options);
+        }
+
+        if (next is < '1' or > '9')
+            return null;
+
+        Scanner.Position += 2;
+        var number = next - '0';
+        var token = Scanner.Token(SyntaxKind.BackreferenceToken, start, leadingTrivia, number.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        if (!IsCaptureCompleted(number))
+        {
+            AddDiagnostic(token.Span, RegexDiagnosticIds.UndefinedNumberedReference, CaptureTable.ContainsNumber(number)
+                ? $"Group {next} is not closed before this backreference."
+                : $"Reference to undefined group number {next}.");
+        }
+
+        return new RegexBackreferenceSyntax(token, Options);
+    }
+
     protected override int AlternationSeparatorLength(int position) =>
         DelimitersAreEscaped ? EscapedLength(position, '|') : base.AlternationSeparatorLength(position);
 
@@ -57,17 +117,27 @@ internal sealed class PosixRegexParser : PerlStyleRegexParser
     private int EscapedLength(int position, char expected) =>
         position + 1 < Text.Length && Text[position] == '\\' && Text[position + 1] == expected ? 2 : 0;
 
+    /// <summary>
+    /// A brace is always an interval, even a malformed one, which is then an error rather than ordinary text. The one
+    /// exception is a basic expression's <c>*</c> right after a leading <c>^</c>, which is a character.
+    /// </summary>
     protected override bool IsQuantifierAt(int position)
     {
+        if (BoundOpenLength(position) > 0)
+            return true;
+
         if (!DelimitersAreEscaped)
             return base.IsQuantifierAt(position);
 
-        // A basic expression has no bare "+" or "?"; GNU spells them escaped, and the bound is "\{…\}".
-        if (BoundOpenLength(position) > 0)
-            return IsWellFormedBoundAt(position);
+        if (_lastAtomWasAnchor && position < Text.Length && (Text[position] == '*' || EscapedLength(position, '+') > 0 || EscapedLength(position, '?') > 0))
+            return false;
 
+        // A basic expression has no bare "+" or "?"; GNU spells them escaped.
         return SimpleQuantifierLength(position, out _) > 0;
     }
+
+    /// <summary>Whether the atom just read is an assertion, after which a basic expression has nothing to repeat.</summary>
+    private bool _lastAtomWasAnchor;
 
     protected override int SimpleQuantifierLength(int position, out char operatorCharacter)
     {
@@ -99,18 +169,62 @@ internal sealed class PosixRegexParser : PerlStyleRegexParser
 
     protected override RegexAtomSyntax ParseAtom(GreenNode? leadingTrivia)
     {
-        if (!DelimitersAreEscaped)
-            return base.ParseAtom(leadingTrivia);
+        var afterAnchor = _lastAtomWasAnchor && !IsAtSequenceStart;
+        var atom = ParseAtomCore(leadingTrivia, afterAnchor);
+        _lastAtomWasAnchor = atom is RegexAnchorSyntax;
 
+        return atom;
+    }
+
+    private RegexAtomSyntax ParseAtomCore(GreenNode? leadingTrivia, bool afterAnchor)
+    {
         var start = Scanner.Position;
+
+        if (!DelimitersAreEscaped)
+        {
+            // An unmatched ")" is an ordinary character in an extended expression.
+            if (Scanner.Current == ')')
+                return ReadLiteral(leadingTrivia);
+
+            return base.ParseAtom(leadingTrivia);
+        }
+
+        // An unmatched "\)" is an error, unlike the bare ")" of an extended expression.
+        if (GroupCloseLength(start) > 0)
+        {
+            Scanner.Position += GroupCloseLength(start);
+            var unmatched = Scanner.Token(SyntaxKind.BadToken, start, leadingTrivia);
+            AddDiagnostic(unmatched.Span, RegexDiagnosticIds.InsufficientOpeningParentheses, "Unmatched '\\)'.");
+
+            return new RegexSkippedTextSyntax(unmatched, Options);
+        }
+
+        // An interval with nothing before it has nothing to repeat, even at the start of a branch.
+        if (BoundOpenLength(start) > 0)
+        {
+            Scanner.Position += BoundOpenLength(start);
+            var stray = Scanner.Token(SyntaxKind.BadToken, start, leadingTrivia);
+            AddDiagnostic(stray.Span, RegexDiagnosticIds.QuantifierAfterNothing, "Quantifier '\\{' has nothing to repeat.");
+
+            return new RegexSkippedTextSyntax(stray, Options);
+        }
 
         // The delimiters are the escaped spellings, so the bare characters are ordinary text.
         if (Scanner.Current is '(' or ')' or '{' or '}' or '|' or '+' or '?')
             return ReadLiteral(leadingTrivia);
 
-        // "*" is a quantifier only when something precedes it; at the start of a branch it matches an asterisk.
-        if (Scanner.Current == '*' && IsAtSequenceStart)
+        // "*" is a quantifier only when something precedes it; at the start of a branch, or right after the "^" that
+        // anchors it, it matches an asterisk.
+        if (Scanner.Current == '*' && (IsAtSequenceStart || afterAnchor))
             return ReadLiteral(leadingTrivia);
+
+        // The GNU "\+" and "\?" have nothing to repeat there either, and are then the characters themselves.
+        if (Scanner.Current == '\\' && Scanner.Peek() is '+' or '?' && (IsAtSequenceStart || afterAnchor))
+        {
+            Scanner.Position += 2;
+
+            return new RegexCharacterEscapeSyntax(Scanner.Token(SyntaxKind.EscapeToken, start, leadingTrivia, Text[start + 1].ToString()), Options);
+        }
 
         // "^" asserts only where a branch begins, and "$" only where one ends. Elsewhere they are characters.
         if (Scanner.Current == '^' && !IsAtSequenceStart)

--- a/src/Meziantou.Framework.Language.Regex/Internals/RegexCaptureTable.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/RegexCaptureTable.cs
@@ -6,7 +6,8 @@
 // Permalink: https://github.com/dotnet/runtime/blob/5ec6efc171b19c0e2d591fbd451920e8f43a1552/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
 //
 // Changes: NoteCaptureSlot, NoteCaptureName, and AssignNameSlots keep their algorithm; the sparse-to-dense remapping
-// that only the matching engine needed is not here, and Hashtable is replaced by typed dictionaries.
+// that only the matching engine needed is not here, and Hashtable is replaced by typed dictionaries. Named groups that
+// take their number where they stand, as they do in JavaScript and PCRE, are an addition.
 
 using System.Globalization;
 
@@ -20,36 +21,33 @@ namespace Meziantou.Framework.Language.Regex.Internals;
 /// </remarks>
 internal sealed class RegexCaptureTable
 {
-    public static RegexCaptureTable Empty { get; } = new([], [], new Dictionary<string, int>(StringComparer.Ordinal));
+    public static RegexCaptureTable Empty { get; } = new([], [], new Dictionary<string, int>(StringComparer.Ordinal), []);
 
     private readonly Dictionary<int, int> _positions;
     private readonly Dictionary<string, int> _numbersByName;
+    private readonly Dictionary<int, string> _namesByNumber;
 
-    private RegexCaptureTable(IReadOnlyList<int> numbers, Dictionary<int, int> positions, Dictionary<string, int> numbersByName)
+    private RegexCaptureTable(IReadOnlyList<int> numbers, Dictionary<int, int> positions, Dictionary<string, int> numbersByName, Dictionary<int, string> namesByNumber)
     {
         Numbers = numbers;
         _positions = positions;
         _numbersByName = numbersByName;
+        _namesByNumber = namesByNumber;
     }
 
     /// <summary>Every capture number the pattern uses, in ascending order. Group 0 is not included.</summary>
     public IReadOnlyList<int> Numbers { get; }
 
+    /// <summary>Whether any group of the pattern has a name.</summary>
+    public bool HasNames => _numbersByName.Count > 0;
+
     public bool ContainsNumber(int number) => _positions.ContainsKey(number);
 
+    /// <summary>Resolves a name to its group number, the first one when several groups share the name.</summary>
     public bool TryGetNumber(string name, out int number) => _numbersByName.TryGetValue(name, out number);
 
     /// <summary>The name of a group, which is the number written out when the group has none.</summary>
-    public string GetName(int number)
-    {
-        foreach (var pair in _numbersByName)
-        {
-            if (pair.Value == number)
-                return pair.Key;
-        }
-
-        return number.ToString(CultureInfo.InvariantCulture);
-    }
+    public string GetName(int number) => _namesByNumber.TryGetValue(number, out var name) ? name : number.ToString(CultureInfo.InvariantCulture);
 
     /// <summary>The position of the <c>(</c> that declares a group.</summary>
     public int GetPosition(int number) => _positions.TryGetValue(number, out var position) ? position : 0;
@@ -60,8 +58,7 @@ internal sealed class RegexCaptureTable
         private readonly Dictionary<int, int> _caps = [];
         private readonly Dictionary<string, int> _capnamePositions = new(StringComparer.Ordinal);
         private readonly List<string> _capnamelist = [];
-
-        private int _autocap = 1;
+        private readonly List<(string Name, int Number)> _numberedNames = [];
 
         /// <summary>Notes a used capture slot.</summary>
         public void NoteSlot(int number, int position)
@@ -72,22 +69,20 @@ internal sealed class RegexCaptureTable
             _caps.TryAdd(number, position);
         }
 
-        /// <summary>Notes an unnamed group, taking the next free number.</summary>
-        public int NoteAutoSlot(int position)
-        {
-            var number = _autocap++;
-            NoteSlot(number, position);
-
-            return number;
-        }
-
-        /// <summary>Notes a named group.</summary>
+        /// <summary>Notes a named group whose number is assigned after every numbered one, as .NET does.</summary>
         public void NoteName(string name, int position)
         {
             if (_capnamePositions.TryAdd(name, position))
             {
                 _capnamelist.Add(name);
             }
+        }
+
+        /// <summary>Notes a named group that already took its number where it stands, as JavaScript and PCRE do.</summary>
+        public void NoteNumberedName(string name, int number, int position)
+        {
+            NoteSlot(number, position);
+            _numberedNames.Add((name, number));
         }
 
         /// <summary>
@@ -100,17 +95,27 @@ internal sealed class RegexCaptureTable
         public RegexCaptureTable Build()
         {
             var numbersByName = new Dictionary<string, int>(StringComparer.Ordinal);
+            var namesByNumber = new Dictionary<int, string>();
+
+            foreach (var (name, number) in _numberedNames)
+            {
+                numbersByName.TryAdd(name, number);
+                namesByNumber.TryAdd(number, name);
+            }
+
+            var autocap = 1;
             foreach (var name in _capnamelist)
             {
-                while (_caps.ContainsKey(_autocap))
+                while (_caps.ContainsKey(autocap))
                 {
-                    _autocap++;
+                    autocap++;
                 }
 
                 var position = _capnamePositions[name];
-                numbersByName[name] = _autocap;
-                NoteSlot(_autocap, position);
-                _autocap++;
+                numbersByName[name] = autocap;
+                namesByNumber[autocap] = name;
+                NoteSlot(autocap, position);
+                autocap++;
             }
 
             var numbers = new List<int>(_caps.Count);
@@ -124,7 +129,7 @@ internal sealed class RegexCaptureTable
 
             numbers.Sort();
 
-            return new RegexCaptureTable(numbers, _caps, numbersByName);
+            return new RegexCaptureTable(numbers, _caps, numbersByName, namesByNumber);
         }
     }
 }

--- a/src/Meziantou.Framework.Language.Regex/Internals/RegexDiagnosticIds.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/RegexDiagnosticIds.cs
@@ -4,9 +4,9 @@ namespace Meziantou.Framework.Language.Regex.Internals;
 /// <remarks>
 /// <para>
 /// The identifiers are banded: <c>REGEX0001</c>-<c>REGEX0019</c> are structural facts about brackets, parentheses, and
-/// quantifiers that every dialect shares; <c>REGEX0030</c>-<c>REGEX0034</c> concern escapes, backreferences, and Unicode
+/// quantifiers that every dialect shares; <c>REGEX0030</c>-<c>REGEX0035</c> concern escapes, backreferences, and Unicode
 /// properties, which POSIX has none of; <c>REGEX0050</c>-<c>REGEX0056</c> are constructs only .NET has;
-/// <c>REGEX0070</c>, <c>REGEX0090</c>, and <c>REGEX0110</c> are reserved for JavaScript, PCRE, and POSIX; and
+/// <c>REGEX0070</c>, <c>REGEX0090</c>, and <c>REGEX0110</c> start the bands of JavaScript, PCRE, and POSIX; and
 /// <c>REGEX0200</c> and up belong to the parser itself rather than to the grammar.
 /// </para>
 /// <para>
@@ -47,11 +47,15 @@ internal static class RegexDiagnosticIds
     public const string InvalidUnicodePropertyEscape = "REGEX0032";
     public const string MalformedUnicodePropertyEscape = "REGEX0033";
     public const string UnrecognizedUnicodeProperty = "REGEX0034";
+    public const string DuplicateGroupName = "REGEX0035";
 
     // ---- JavaScript only ----
     public const string MalformedClassSetOperation = "REGEX0070";
     public const string ReservedClassSetPunctuator = "REGEX0071";
     public const string MalformedClassString = "REGEX0072";
+    public const string InvalidClassSetCharacter = "REGEX0073";
+    public const string NegatedClassContainsStrings = "REGEX0074";
+    public const string InvalidModifiers = "REGEX0075";
 
     // ---- .NET only ----
     public const string ExclusionGroupNotLast = "REGEX0050";
@@ -60,6 +64,16 @@ internal static class RegexDiagnosticIds
     public const string AlternationHasComment = "REGEX0054";
     public const string AlternationHasMalformedReference = "REGEX0055";
     public const string AlternationHasUndefinedReference = "REGEX0056";
+
+    // ---- PCRE only ----
+    public const string InvalidBacktrackingVerb = "REGEX0090";
+    public const string InvalidCallout = "REGEX0091";
+    public const string UnboundedLookbehind = "REGEX0092";
+    public const string InvalidConditionalCondition = "REGEX0093";
+
+    // ---- POSIX bracket expressions, which PCRE shares ----
+    public const string InvalidPosixBracketExpression = "REGEX0110";
+    public const string MalformedInterval = "REGEX0111";
 
     // ---- the parser itself ----
     public const string MaxRecursionDepthExceeded = "REGEX0200";

--- a/src/Meziantou.Framework.Language.Regex/Internals/RegexParser.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/RegexParser.cs
@@ -24,6 +24,9 @@ internal abstract class RegexParser
 {
     private readonly List<Diagnostic> _diagnostics = [];
     private readonly Dictionary<int, TextSpan> _captureSpans = [];
+    private readonly List<(int Alternation, int Branch)> _alternativePath = [];
+    private readonly List<int> _completedCaptures = [];
+    private int _nextAlternationId;
     private int _depth;
 
     protected RegexParser(SourceText source, RegexParseOptions parseOptions)
@@ -45,8 +48,14 @@ internal abstract class RegexParser
     /// <summary>The options in effect at the reading position.</summary>
     protected RegexPatternOptions Options { get; set; }
 
-    /// <summary>The options saved at each open parenthesis, restored at the matching close.</summary>
-    protected Stack<RegexPatternOptions> OptionsStack { get; } = new();
+    /// <summary>
+    /// The options saved at each open parenthesis, restored at the matching close, along with whether duplicate group
+    /// names were allowed, which PCRE scopes the same way.
+    /// </summary>
+    protected Stack<(RegexPatternOptions Options, bool DuplicateNamesAllowed)> OptionsStack { get; } = new();
+
+    /// <summary>Whether a group name may be declared again, as PCRE's <c>(?J)</c> allows, at the reading position.</summary>
+    protected bool DuplicateNamesAllowed { get; set; }
 
     protected RegexCaptureTable CaptureTable { get; set; }
 
@@ -88,6 +97,7 @@ internal abstract class RegexParser
     {
         CaptureTable = captureTable;
         var root = ParseRoot();
+        OnPatternParsed();
         Captures = BuildCaptures();
 
         return root;
@@ -134,6 +144,11 @@ internal abstract class RegexParser
         }
 
         return SyntaxFactory.ListNode([.. items]);
+    }
+
+    /// <summary>Called once the whole pattern has been read, for checks that need groups declared after the point they concern.</summary>
+    private protected virtual void OnPatternParsed()
+    {
     }
 
     /// <summary>Reads the opening delimiter of a JavaScript literal. Every other dialect has none.</summary>
@@ -190,15 +205,28 @@ internal abstract class RegexParser
     protected bool IsAtSequenceStart { get; private set; }
 
     /// <summary>Parses the branches of an alternation, in order.</summary>
-    protected RegexAlternationSyntax ParseAlternation(bool insideGroup)
+    /// <param name="insideGroup">Whether a <c>)</c> ends the alternation.</param>
+    /// <param name="resetsCaptureNumbers">
+    /// Whether every branch numbers its groups from the same starting point, as a PCRE branch reset group does. The
+    /// groups after the alternation then continue from the highest number any branch reached.
+    /// </param>
+    protected RegexAlternationSyntax ParseAlternation(bool insideGroup, bool resetsCaptureNumbers = false)
     {
         var branches = new List<RegexSequenceSyntax>();
         var barTokens = new List<ScannedToken>();
         var supportsAlternation = Dialect.HasFeature(RegexDialectFeatures.Alternation);
+        var alternationId = _nextAlternationId++;
+        var firstCaptureNumber = AutoCaptureNumber;
+        var nextCaptureNumber = AutoCaptureNumber;
+        var completedBefore = _completedCaptures.Count;
+        List<int>? completedInEarlierBranches = null;
 
         while (true)
         {
+            _alternativePath.Add((alternationId, branches.Count));
             branches.Add(ParseSequence(insideGroup));
+            _alternativePath.RemoveAt(_alternativePath.Count - 1);
+            nextCaptureNumber = Math.Max(nextCaptureNumber, AutoCaptureNumber);
 
             var barPosition = PeekTriviaEnd();
             if (!supportsAlternation || IsAtBodyEnd(barPosition))
@@ -212,9 +240,56 @@ internal abstract class RegexParser
             var barStart = Scanner.Position;
             Scanner.Position += separatorLength;
             barTokens.Add(Scanner.Token(SyntaxKind.BarToken, barStart, trivia));
+
+            if (resetsCaptureNumbers)
+            {
+                AutoCaptureNumber = firstCaptureNumber;
+            }
+
+            // A group closed in one branch has not matched in the next one, so a backreference there cannot see it.
+            // The groups are set aside until the alternation ends, after which all of them have been closed.
+            if (_completedCaptures.Count > completedBefore)
+            {
+                completedInEarlierBranches ??= [];
+                completedInEarlierBranches.AddRange(_completedCaptures.Skip(completedBefore));
+                _completedCaptures.RemoveRange(completedBefore, _completedCaptures.Count - completedBefore);
+            }
+        }
+
+        if (completedInEarlierBranches is not null)
+        {
+            _completedCaptures.AddRange(completedInEarlierBranches);
+        }
+
+        if (resetsCaptureNumbers)
+        {
+            AutoCaptureNumber = nextCaptureNumber;
         }
 
         return new RegexAlternationSyntax(Interleave(branches, barTokens), Options);
+    }
+
+    /// <summary>
+    /// Where the reading position is, as the branch it is in of every alternation around it, outermost first.
+    /// </summary>
+    /// <remarks>
+    /// Two constructs can never both take part in a match when their paths first differ at the same alternation, which
+    /// is the only case in which JavaScript lets two groups share a name.
+    /// </remarks>
+    protected (int Alternation, int Branch)[] CurrentAlternativePath => [.. _alternativePath];
+
+    /// <summary>Whether two constructs, located by <see cref="CurrentAlternativePath"/>, can take part in the same match.</summary>
+    protected static bool MightBothParticipate((int Alternation, int Branch)[] first, (int Alternation, int Branch)[] second)
+    {
+        for (var index = 0; index < first.Length && index < second.Length; index++)
+        {
+            if (first[index] == second[index])
+                continue;
+
+            return first[index].Alternation != second[index].Alternation;
+        }
+
+        return true;
     }
 
     /// <summary>Parses one branch: the terms that must match one after another.</summary>
@@ -280,7 +355,7 @@ internal abstract class RegexParser
             if (quantifier is null)
                 return term;
 
-            if (term is RegexQuantifiedSyntax)
+            if (term is RegexQuantifiedSyntax && !AllowsStackedQuantifier(quantifier))
             {
                 Scanner.AddDiagnostic(
                     JustParsedSpan(quantifier),
@@ -298,6 +373,9 @@ internal abstract class RegexParser
             term = new RegexQuantifiedSyntax(term, quantifier, Options);
         }
     }
+
+    /// <summary>Whether <paramref name="quantifier"/> may apply to a term that is already quantified.</summary>
+    protected virtual bool AllowsStackedQuantifier(RegexQuantifierSyntax quantifier) => false;
 
     /// <summary>Returns whether a quantifier starts at <paramref name="position"/>.</summary>
     protected virtual bool IsQuantifierAt(int position)
@@ -325,7 +403,7 @@ internal abstract class RegexParser
         if (openLength == 0)
             return false;
 
-        var index = position + openLength;
+        var index = SkipBoundSpaces(position + openLength);
         var digits = 0;
         while (index < Text.Length && char.IsAsciiDigit(Text[index]))
         {
@@ -333,19 +411,58 @@ internal abstract class RegexParser
             digits++;
         }
 
-        if (digits == 0)
-            return false;
-
+        index = SkipBoundSpaces(index);
+        var maxDigits = 0;
         if (index < Text.Length && Text[index] == ',')
         {
-            index++;
+            index = SkipBoundSpaces(index + 1);
             while (index < Text.Length && char.IsAsciiDigit(Text[index]))
+            {
+                index++;
+                maxDigits++;
+            }
+
+            index = SkipBoundSpaces(index);
+            if (digits == 0 && (maxDigits == 0 || !AllowsOmittedMinimumBound))
+                return false;
+        }
+        else if (digits == 0)
+        {
+            return false;
+        }
+
+        return BoundCloseLength(index) > 0;
+    }
+
+    /// <summary>The largest number a bound may be, or <see langword="null"/> when the dialect sets no limit.</summary>
+    protected virtual long? MaxBoundValue => int.MaxValue;
+
+    /// <summary>Whether spaces may surround the numbers of a bound, as in PCRE's <c>{ 2 , 3 }</c>.</summary>
+    protected virtual bool AllowsSpacesInBounds => false;
+
+    /// <summary>Whether a bound may leave out its minimum, as <c>{,3}</c> does in PCRE and GNU POSIX.</summary>
+    protected virtual bool AllowsOmittedMinimumBound => false;
+
+    private int SkipBoundSpaces(int index)
+    {
+        if (AllowsSpacesInBounds)
+        {
+            while (index < Text.Length && Text[index] is ' ' or '\t')
             {
                 index++;
             }
         }
 
-        return BoundCloseLength(index) > 0;
+        return index;
+    }
+
+    /// <summary>Claims the spaces a bound may contain, as trivia of the token that follows them.</summary>
+    private GreenNode? TakeBoundSpaces()
+    {
+        var start = Scanner.Position;
+        Scanner.Position = SkipBoundSpaces(start);
+
+        return Scanner.Position > start ? SyntaxFactory.List([SyntaxFactory.Trivia(SyntaxKind.WhitespaceTrivia, Text[start..Scanner.Position])]) : null;
     }
 
     private RegexQuantifierSyntax? ParseQuantifier(GreenNode? leadingTrivia)
@@ -382,17 +499,20 @@ internal abstract class RegexParser
         Scanner.Position += BoundOpenLength(braceStart);
         var openBraceToken = Scanner.Token(SyntaxKind.OpenBraceToken, braceStart, leadingTrivia);
 
-        var minToken = ReadBound();
+        var minToken = ReadBound(TakeBoundSpaces());
         ScannedToken commaToken = default;
         ScannedToken maxToken = default;
+        var commaTrivia = TakeBoundSpaces();
         if (Scanner.Current == ',')
         {
             var commaStart = Scanner.Position;
             Scanner.Position++;
-            commaToken = Scanner.Token(SyntaxKind.CommaToken, commaStart);
+            commaToken = Scanner.Token(SyntaxKind.CommaToken, commaStart, commaTrivia);
+            commaTrivia = TakeBoundSpaces();
             if (BoundCloseLength(Scanner.Position) == 0)
             {
-                maxToken = ReadBound();
+                maxToken = ReadBound(commaTrivia);
+                commaTrivia = TakeBoundSpaces();
             }
         }
 
@@ -402,54 +522,71 @@ internal abstract class RegexParser
         if (closeLength > 0)
         {
             Scanner.Position += closeLength;
-            closeBraceToken = Scanner.Token(SyntaxKind.CloseBraceToken, closeStart);
+            closeBraceToken = Scanner.Token(SyntaxKind.CloseBraceToken, closeStart, commaTrivia);
         }
         else
         {
             closeBraceToken = Scanner.MissingToken(SyntaxKind.CloseBraceToken);
+            AddDiagnostic(TextSpan.FromBounds(braceStart, Scanner.Position), RegexDiagnosticIds.MalformedInterval, "Malformed interval: expected a bound such as '{2}', '{2,}', or '{2,5}'.");
+        }
+
+        if (closeBraceToken.IsPresent && !commaToken.IsPresent && minToken.Text.Trim().Length == 0)
+        {
+            AddDiagnostic(TextSpan.FromBounds(braceStart, closeBraceToken.End), RegexDiagnosticIds.MalformedInterval, "An interval must contain at least one bound.");
         }
 
         var quantifier = new RegexRangeQuantifierSyntax(openBraceToken, minToken, commaToken, maxToken, closeBraceToken, ReadQuantifierModifier(), Options);
-        if (quantifier.MaxCount is { } max && quantifier.MinCount > max)
+
+        // The bounds are compared as written rather than as the clamped values, so a reversed pair of numbers too
+        // large for an int is still reported.
+        if (maxToken.IsPresent && maxToken.Text.Trim().Length > 0 && CompareDecimals(minToken.Text.Trim(), maxToken.Text.Trim()) > 0)
         {
             Scanner.AddDiagnostic(
                 TextSpan.FromBounds(openBraceToken.Span.Start, closeBraceToken.End),
                 RegexDiagnosticIds.ReversedQuantifierRange,
-                FormattableString.Invariant($"Quantifier range {quantifier.MinCount},{max} is reversed."));
+                FormattableString.Invariant($"Quantifier range {minToken.Text.Trim()},{maxToken.Text.Trim()} is reversed."));
         }
 
         return quantifier;
     }
 
-    private ScannedToken ReadBound()
+    /// <summary>Compares two runs of decimal digits by the numbers they spell, whatever their size.</summary>
+    private static int CompareDecimals(string left, string right)
+    {
+        left = left.TrimStart('0');
+        right = right.TrimStart('0');
+
+        return left.Length != right.Length ? left.Length.CompareTo(right.Length) : string.CompareOrdinal(left, right);
+    }
+
+    private ScannedToken ReadBound(GreenNode? leadingTrivia)
     {
         var start = Scanner.Position;
-        var overflowed = false;
         long value = 0;
         while (char.IsAsciiDigit(Scanner.Current))
         {
-            if (!overflowed)
+            if (value <= int.MaxValue)
             {
                 value = (value * 10) + (Scanner.Current - '0');
-                if (value > int.MaxValue)
-                {
-                    overflowed = true;
-                }
             }
 
             Scanner.Position++;
         }
 
-        if (overflowed)
+        var max = MaxBoundValue;
+        if (max is not null && value > max)
         {
             Scanner.AddDiagnostic(
                 TextSpan.FromBounds(start, Scanner.Position),
                 RegexDiagnosticIds.QuantifierOrCaptureGroupOutOfRange,
-                "The quantifier or capture group number is larger than Int32.MaxValue.");
-            value = int.MaxValue;
+                max == int.MaxValue
+                    ? "The quantifier or capture group number is larger than Int32.MaxValue."
+                    : FormattableString.Invariant($"The quantifier bound is larger than {max}, the largest this dialect accepts."));
         }
 
-        return Scanner.Token(SyntaxKind.NumberToken, start, leadingTrivia: null, value.ToString(CultureInfo.InvariantCulture));
+        value = Math.Min(value, int.MaxValue);
+
+        return Scanner.Token(SyntaxKind.NumberToken, start, leadingTrivia, value.ToString(CultureInfo.InvariantCulture));
     }
 
     /// <summary>Reads the <c>?</c> or <c>+</c> that makes a quantifier lazy or possessive.</summary>
@@ -508,7 +645,8 @@ internal abstract class RegexParser
         Dialect.HasFeature(RegexDialectFeatures.ClassSetOperations);
 
     /// <summary>Whether the pattern is read as a sequence of code points rather than of UTF-16 code units.</summary>
-    protected bool UsesUnicodeMode => (Options & RegexPatternOptions.Unicode) != RegexPatternOptions.None;
+    /// <remarks>The <c>v</c> flag is the <c>u</c> flag with more, so either one turns this on.</remarks>
+    protected bool UsesUnicodeMode => (Options & (RegexPatternOptions.Unicode | RegexPatternOptions.UnicodeSets)) != RegexPatternOptions.None;
 
     protected int PeekTriviaEnd() => Scanner.PeekTriviaEnd(Options, Dialect);
 
@@ -519,11 +657,29 @@ internal abstract class RegexParser
     protected void AddDiagnostic(int start, string id, string message) =>
         Scanner.AddDiagnostic(TextSpan.FromBounds(start, Math.Max(start, Scanner.Position)), id, message);
 
-    /// <summary>Takes the next capture number, noting the slot when this is the numbering pass.</summary>
-    protected int NoteAutoCapture(int position) => CaptureBuilder?.NoteAutoSlot(position) ?? NextAutoCapture();
+    /// <summary>The number the next group that numbers itself will take.</summary>
+    protected int AutoCaptureNumber { get; set; } = 1;
 
-    /// <summary>Takes the next capture number without noting it.</summary>
-    protected abstract int NextAutoCapture();
+    /// <summary>Takes the next capture number, noting the slot when this is the numbering pass.</summary>
+    protected int NoteAutoCapture(int position)
+    {
+        var number = AutoCaptureNumber++;
+        CaptureBuilder?.NoteSlot(number, position);
+
+        return number;
+    }
+
+    /// <summary>Notes a named group that takes the next capture number where it stands.</summary>
+    protected int NoteNumberedCaptureName(string name, int position)
+    {
+        var number = AutoCaptureNumber++;
+        CaptureBuilder?.NoteNumberedName(name, number, position);
+
+        return number;
+    }
+
+    /// <summary>Whether this is the pass that only collects the capture groups, whose diagnostics are discarded.</summary>
+    protected bool IsNumberingPass => CaptureBuilder is not null;
 
     /// <summary>Notes an explicitly numbered group, as <c>(?&lt;3&gt;x)</c> declares.</summary>
     protected void NoteCaptureNumber(int number, int position) => CaptureBuilder?.NoteSlot(number, position);
@@ -537,8 +693,15 @@ internal abstract class RegexParser
         if (number > 0)
         {
             _captureSpans[number] = span;
+            _completedCaptures.Add(number);
         }
     }
+
+    /// <summary>
+    /// Whether the group <paramref name="number"/> has been closed before the reading position, in this branch or before
+    /// the alternation around it, which is what a POSIX backreference needs.
+    /// </summary>
+    protected bool IsCaptureCompleted(int number) => _completedCaptures.Contains(number);
 
     /// <summary>Enters a nested construct, or reports that the pattern nests too deeply.</summary>
     protected bool TryEnterRecursion(TextSpan span)

--- a/src/Meziantou.Framework.Language.Regex/Internals/UnicodePropertyNames.cs
+++ b/src/Meziantou.Framework.Language.Regex/Internals/UnicodePropertyNames.cs
@@ -1,0 +1,161 @@
+using System.Collections.Frozen;
+
+namespace Meziantou.Framework.Language.Regex.Internals;
+
+/// <summary>The Unicode property names the JavaScript and PCRE engines accept inside <c>\p{…}</c>.</summary>
+/// <remarks>
+/// <para>
+/// A name the engine does not know is a syntax error, so the set has to be known to report the same thing. The lists
+/// were taken from the Unicode 17 <c>PropertyAliases.txt</c> and <c>PropertyValueAliases.txt</c> files and kept only
+/// where V8 (for JavaScript) and PCRE2 10.47 (for PCRE) accept the name. An engine built against an older Unicode
+/// version knows fewer script names.
+/// </para>
+/// <para>
+/// JavaScript compares names exactly. PCRE compares them loosely: case, spaces, hyphens, and underscores are ignored,
+/// which is why its lists hold the names already in that normalized form.
+/// </para>
+/// </remarks>
+internal static class UnicodePropertyNames
+{
+    /// <summary>The General_Category values, which JavaScript accepts both alone and after <c>gc=</c>.</summary>
+    public static FrozenSet<string> JavaScriptGeneralCategoryValues { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "C", "Cased_Letter", "Cc", "Cf", "Close_Punctuation", "Cn", "Co", "Combining_Mark", "Connector_Punctuation",
+        "Control", "Cs", "Currency_Symbol", "Dash_Punctuation", "Decimal_Number", "Enclosing_Mark", "Final_Punctuation",
+        "Format", "Initial_Punctuation", "L", "LC", "Letter", "Letter_Number", "Line_Separator", "Ll", "Lm", "Lo",
+        "Lowercase_Letter", "Lt", "Lu", "M", "Mark", "Math_Symbol", "Mc", "Me", "Mn", "Modifier_Letter",
+        "Modifier_Symbol", "N", "Nd", "Nl", "No", "Nonspacing_Mark", "Number", "Open_Punctuation", "Other",
+        "Other_Letter", "Other_Number", "Other_Punctuation", "Other_Symbol", "P", "Paragraph_Separator", "Pc", "Pd",
+        "Pe", "Pf", "Pi", "Po", "Private_Use", "Ps", "Punctuation", "S", "Sc", "Separator", "Sk", "Sm", "So",
+        "Space_Separator", "Spacing_Mark", "Surrogate", "Symbol", "Titlecase_Letter", "Unassigned", "Uppercase_Letter",
+        "Z", "Zl", "Zp", "Zs", "cntrl", "digit", "punct"
+    ]);
+
+    /// <summary>The Script values, which JavaScript accepts after <c>sc=</c> and <c>scx=</c>.</summary>
+    public static FrozenSet<string> JavaScriptScriptValues { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "Adlam", "Adlm", "Aghb", "Ahom", "Anatolian_Hieroglyphs", "Arab", "Arabic", "Armenian", "Armi", "Armn",
+        "Avestan", "Avst", "Bali", "Balinese", "Bamu", "Bamum", "Bass", "Bassa_Vah", "Batak", "Batk", "Beng", "Bengali",
+        "Berf", "Beria_Erfe", "Bhaiksuki", "Bhks", "Bopo", "Bopomofo", "Brah", "Brahmi", "Brai", "Braille", "Bugi",
+        "Buginese", "Buhd", "Buhid", "Cakm", "Canadian_Aboriginal", "Cans", "Cari", "Carian", "Caucasian_Albanian",
+        "Chakma", "Cham", "Cher", "Cherokee", "Chorasmian", "Chrs", "Common", "Copt", "Coptic", "Cpmn", "Cprt",
+        "Cuneiform", "Cypriot", "Cypro_Minoan", "Cyrillic", "Cyrl", "Deseret", "Deva", "Devanagari", "Diak",
+        "Dives_Akuru", "Dogr", "Dogra", "Dsrt", "Dupl", "Duployan", "Egyp", "Egyptian_Hieroglyphs", "Elba", "Elbasan",
+        "Elym", "Elymaic", "Ethi", "Ethiopic", "Gara", "Garay", "Geor", "Georgian", "Glag", "Glagolitic", "Gong",
+        "Gonm", "Goth", "Gothic", "Gran", "Grantha", "Greek", "Grek", "Gujarati", "Gujr", "Gukh", "Gunjala_Gondi",
+        "Gurmukhi", "Guru", "Gurung_Khema", "Han", "Hang", "Hangul", "Hani", "Hanifi_Rohingya", "Hano", "Hanunoo",
+        "Hatr", "Hatran", "Hebr", "Hebrew", "Hira", "Hiragana", "Hluw", "Hmng", "Hmnp", "Hung", "Imperial_Aramaic",
+        "Inherited", "Inscriptional_Pahlavi", "Inscriptional_Parthian", "Ital", "Java", "Javanese", "Kaithi", "Kali",
+        "Kana", "Kannada", "Katakana", "Kawi", "Kayah_Li", "Khar", "Kharoshthi", "Khitan_Small_Script", "Khmer", "Khmr",
+        "Khoj", "Khojki", "Khudawadi", "Kirat_Rai", "Kits", "Knda", "Krai", "Kthi", "Lana", "Lao", "Laoo", "Latin",
+        "Latn", "Lepc", "Lepcha", "Limb", "Limbu", "Lina", "Linb", "Linear_A", "Linear_B", "Lisu", "Lyci", "Lycian",
+        "Lydi", "Lydian", "Mahajani", "Mahj", "Maka", "Makasar", "Malayalam", "Mand", "Mandaic", "Mani", "Manichaean",
+        "Marc", "Marchen", "Masaram_Gondi", "Medefaidrin", "Medf", "Meetei_Mayek", "Mend", "Mende_Kikakui", "Merc",
+        "Mero", "Meroitic_Cursive", "Meroitic_Hieroglyphs", "Miao", "Mlym", "Modi", "Mong", "Mongolian", "Mro", "Mroo",
+        "Mtei", "Mult", "Multani", "Myanmar", "Mymr", "Nabataean", "Nag_Mundari", "Nagm", "Nand", "Nandinagari", "Narb",
+        "Nbat", "New_Tai_Lue", "Newa", "Nko", "Nkoo", "Nshu", "Nushu", "Nyiakeng_Puachue_Hmong", "Ogam", "Ogham",
+        "Ol_Chiki", "Ol_Onal", "Olck", "Old_Hungarian", "Old_Italic", "Old_North_Arabian", "Old_Permic", "Old_Persian",
+        "Old_Sogdian", "Old_South_Arabian", "Old_Turkic", "Old_Uyghur", "Onao", "Oriya", "Orkh", "Orya", "Osage",
+        "Osge", "Osma", "Osmanya", "Ougr", "Pahawh_Hmong", "Palm", "Palmyrene", "Pau_Cin_Hau", "Pauc", "Perm", "Phag",
+        "Phags_Pa", "Phli", "Phlp", "Phnx", "Phoenician", "Plrd", "Prti", "Psalter_Pahlavi", "Qaac", "Qaai", "Rejang",
+        "Rjng", "Rohg", "Runic", "Runr", "Samaritan", "Samr", "Sarb", "Saur", "Saurashtra", "Sgnw", "Sharada",
+        "Shavian", "Shaw", "Shrd", "Sidd", "Siddham", "Sidetic", "Sidt", "SignWriting", "Sind", "Sinh", "Sinhala",
+        "Sogd", "Sogdian", "Sogo", "Sora", "Sora_Sompeng", "Soyo", "Soyombo", "Sund", "Sundanese", "Sunu", "Sunuwar",
+        "Sylo", "Syloti_Nagri", "Syrc", "Syriac", "Tagalog", "Tagb", "Tagbanwa", "Tai_Le", "Tai_Tham", "Tai_Viet",
+        "Tai_Yo", "Takr", "Takri", "Tale", "Talu", "Tamil", "Taml", "Tang", "Tangsa", "Tangut", "Tavt", "Tayo", "Telu",
+        "Telugu", "Tfng", "Tglg", "Thaa", "Thaana", "Thai", "Tibetan", "Tibt", "Tifinagh", "Tirh", "Tirhuta", "Tnsa",
+        "Todhri", "Todr", "Tolong_Siki", "Tols", "Toto", "Tulu_Tigalari", "Tutg", "Ugar", "Ugaritic", "Unknown", "Vai",
+        "Vaii", "Vith", "Vithkuqi", "Wancho", "Wara", "Warang_Citi", "Wcho", "Xpeo", "Xsux", "Yezi", "Yezidi", "Yi",
+        "Yiii", "Zanabazar_Square", "Zanb", "Zinh", "Zyyy", "Zzzz"
+    ]);
+
+    /// <summary>The binary properties JavaScript accepts alone.</summary>
+    public static FrozenSet<string> JavaScriptBinaryProperties { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "AHex", "ASCII", "ASCII_Hex_Digit", "Alpha", "Alphabetic", "Any", "Assigned", "Bidi_C", "Bidi_Control",
+        "Bidi_M", "Bidi_Mirrored", "CI", "CWCF", "CWCM", "CWKCF", "CWL", "CWT", "CWU", "Case_Ignorable", "Cased",
+        "Changes_When_Casefolded", "Changes_When_Casemapped", "Changes_When_Lowercased", "Changes_When_NFKC_Casefolded",
+        "Changes_When_Titlecased", "Changes_When_Uppercased", "DI", "Dash", "Default_Ignorable_Code_Point", "Dep",
+        "Deprecated", "Dia", "Diacritic", "EBase", "EComp", "EMod", "EPres", "Emoji", "Emoji_Component",
+        "Emoji_Modifier", "Emoji_Modifier_Base", "Emoji_Presentation", "Ext", "ExtPict", "Extended_Pictographic",
+        "Extender", "Gr_Base", "Gr_Ext", "Grapheme_Base", "Grapheme_Extend", "Hex", "Hex_Digit", "IDC", "IDS", "IDSB",
+        "IDST", "IDS_Binary_Operator", "IDS_Trinary_Operator", "ID_Continue", "ID_Start", "Ideo", "Ideographic",
+        "Join_C", "Join_Control", "LOE", "Logical_Order_Exception", "Lower", "Lowercase", "Math", "NChar",
+        "Noncharacter_Code_Point", "Pat_Syn", "Pat_WS", "Pattern_Syntax", "Pattern_White_Space", "QMark",
+        "Quotation_Mark", "RI", "Radical", "Regional_Indicator", "SD", "STerm", "Sentence_Terminal", "Soft_Dotted",
+        "Term", "Terminal_Punctuation", "UIdeo", "Unified_Ideograph", "Upper", "Uppercase", "VS", "Variation_Selector",
+        "WSpace", "White_Space", "XIDC", "XIDS", "XID_Continue", "XID_Start", "space"
+    ]);
+
+    /// <summary>The properties of strings, which only the <c>v</c> flag has.</summary>
+    public static FrozenSet<string> JavaScriptStringProperties { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "Basic_Emoji", "Emoji_Keycap_Sequence", "RGI_Emoji", "RGI_Emoji_Flag_Sequence", "RGI_Emoji_Modifier_Sequence",
+        "RGI_Emoji_Tag_Sequence", "RGI_Emoji_ZWJ_Sequence"
+    ]);
+
+    /// <summary>The names PCRE accepts alone other than scripts: general categories, binary properties, and its own.</summary>
+    public static FrozenSet<string> PcreProperties { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "ahex", "alpha", "alphabetic", "any", "ascii", "asciihexdigit", "bidic", "bidicontrol", "bidim", "bidimirrored",
+        "c", "cased", "caseignorable", "cc", "cf", "changeswhencasefolded", "changeswhencasemapped",
+        "changeswhenlowercased", "changeswhentitlecased", "changeswhenuppercased", "ci", "cn", "co", "cs", "cwcf",
+        "cwcm", "cwl", "cwt", "cwu", "dash", "defaultignorablecodepoint", "dep", "deprecated", "di", "dia", "diacritic",
+        "ebase", "ecomp", "emod", "emoji", "emojicomponent", "emojimodifier", "emojimodifierbase", "emojipresentation",
+        "epres", "ext", "extendedpictographic", "extender", "extpict", "graphemebase", "graphemeextend", "graphemelink",
+        "grbase", "grext", "grlink", "hex", "hexdigit", "idc", "idcompatmathcontinue", "idcompatmathstart",
+        "idcontinue", "ideo", "ideographic", "ids", "idsb", "idsbinaryoperator", "idst", "idstart",
+        "idstrinaryoperator", "idsu", "idsunaryoperator", "incb", "joinc", "joincontrol", "l", "l&", "lc", "ll", "lm",
+        "lo", "loe", "logicalorderexception", "lower", "lowercase", "lt", "lu", "m", "math", "mc", "mcm", "me", "mn",
+        "modifiercombiningmark", "n", "nchar", "nd", "nl", "no", "noncharactercodepoint", "p", "patsyn",
+        "patternsyntax", "patternwhitespace", "patws", "pc", "pcm", "pd", "pe", "pf", "pi", "po",
+        "prependedconcatenationmark", "ps", "qmark", "quotationmark", "radical", "regionalindicator", "ri", "s", "sc",
+        "sd", "sentenceterminal", "sk", "sm", "so", "softdotted", "space", "sterm", "term", "terminalpunctuation",
+        "uideo", "unifiedideograph", "upper", "uppercase", "variationselector", "vs", "whitespace", "wspace", "xan",
+        "xidc", "xidcontinue", "xids", "xidstart", "xps", "xsp", "xuc", "xwd", "z", "zl", "zp", "zs"
+    ]);
+
+    /// <summary>The script names PCRE accepts, alone or after <c>sc:</c> and <c>scx:</c>.</summary>
+    public static FrozenSet<string> PcreScripts { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "adlam", "adlm", "aghb", "ahom", "anatolianhieroglyphs", "arab", "arabic", "armenian", "armi", "armn",
+        "avestan", "avst", "bali", "balinese", "bamu", "bamum", "bass", "bassavah", "batak", "batk", "beng", "bengali",
+        "bhaiksuki", "bhks", "bopo", "bopomofo", "brah", "brahmi", "brai", "braille", "bugi", "buginese", "buhd",
+        "buhid", "cakm", "canadianaboriginal", "cans", "cari", "carian", "caucasianalbanian", "chakma", "cham", "cher",
+        "cherokee", "chorasmian", "chrs", "common", "copt", "coptic", "cpmn", "cprt", "cuneiform", "cypriot",
+        "cyprominoan", "cyrillic", "cyrl", "deseret", "deva", "devanagari", "diak", "divesakuru", "dogr", "dogra",
+        "dsrt", "dupl", "duployan", "egyp", "egyptianhieroglyphs", "elba", "elbasan", "elym", "elymaic", "ethi",
+        "ethiopic", "gara", "garay", "geor", "georgian", "glag", "glagolitic", "gong", "gonm", "goth", "gothic", "gran",
+        "grantha", "greek", "grek", "gujarati", "gujr", "gukh", "gunjalagondi", "gurmukhi", "guru", "gurungkhema",
+        "han", "hang", "hangul", "hani", "hanifirohingya", "hano", "hanunoo", "hatr", "hatran", "hebr", "hebrew",
+        "hira", "hiragana", "hluw", "hmng", "hmnp", "hung", "imperialaramaic", "inherited", "inscriptionalpahlavi",
+        "inscriptionalparthian", "ital", "java", "javanese", "kaithi", "kali", "kana", "kannada", "katakana", "kawi",
+        "kayahli", "khar", "kharoshthi", "khitansmallscript", "khmer", "khmr", "khoj", "khojki", "khudawadi",
+        "kiratrai", "kits", "knda", "krai", "kthi", "lana", "lao", "laoo", "latin", "latn", "lepc", "lepcha", "limb",
+        "limbu", "lina", "linb", "lineara", "linearb", "lisu", "lyci", "lycian", "lydi", "lydian", "mahajani", "mahj",
+        "maka", "makasar", "malayalam", "mand", "mandaic", "mani", "manichaean", "marc", "marchen", "masaramgondi",
+        "medefaidrin", "medf", "meeteimayek", "mend", "mendekikakui", "merc", "mero", "meroiticcursive",
+        "meroitichieroglyphs", "miao", "mlym", "modi", "mong", "mongolian", "mro", "mroo", "mtei", "mult", "multani",
+        "myanmar", "mymr", "nabataean", "nagm", "nagmundari", "nand", "nandinagari", "narb", "nbat", "newa",
+        "newtailue", "nko", "nkoo", "nshu", "nushu", "nyiakengpuachuehmong", "ogam", "ogham", "olchiki", "olck",
+        "oldhungarian", "olditalic", "oldnortharabian", "oldpermic", "oldpersian", "oldsogdian", "oldsoutharabian",
+        "oldturkic", "olduyghur", "olonal", "onao", "oriya", "orkh", "orya", "osage", "osge", "osma", "osmanya", "ougr",
+        "pahawhhmong", "palm", "palmyrene", "pauc", "paucinhau", "perm", "phag", "phagspa", "phli", "phlp", "phnx",
+        "phoenician", "plrd", "prti", "psalterpahlavi", "qaac", "qaai", "rejang", "rjng", "rohg", "runic", "runr",
+        "samaritan", "samr", "sarb", "saur", "saurashtra", "sgnw", "sharada", "shavian", "shaw", "shrd", "sidd",
+        "siddham", "signwriting", "sind", "sinh", "sinhala", "sogd", "sogdian", "sogo", "sora", "sorasompeng", "soyo",
+        "soyombo", "sund", "sundanese", "sunu", "sunuwar", "sylo", "sylotinagri", "syrc", "syriac", "tagalog", "tagb",
+        "tagbanwa", "taile", "taitham", "taiviet", "takr", "takri", "tale", "talu", "tamil", "taml", "tang", "tangsa",
+        "tangut", "tavt", "telu", "telugu", "tfng", "tglg", "thaa", "thaana", "thai", "tibetan", "tibt", "tifinagh",
+        "tirh", "tirhuta", "tnsa", "todhri", "todr", "toto", "tulutigalari", "tutg", "ugar", "ugaritic", "unknown",
+        "vai", "vaii", "vith", "vithkuqi", "wancho", "wara", "warangciti", "wcho", "xpeo", "xsux", "yezi", "yezidi",
+        "yi", "yiii", "zanabazarsquare", "zanb", "zinh", "zyyy", "zzzz"
+    ]);
+
+    /// <summary>The bidirectional classes PCRE accepts after <c>bc:</c>.</summary>
+    public static FrozenSet<string> PcreBidiClasses { get; } = FrozenSet.Create(StringComparer.Ordinal,
+    [
+        "al", "an", "b", "bn", "c", "control", "cs", "en", "es", "et", "fsi", "l", "lre", "lri", "lro", "m", "nsm",
+        "on", "pdf", "pdi", "r", "rle", "rli", "rlo", "s", "ws"
+    ]);
+}

--- a/src/Meziantou.Framework.Language.Regex/RegexAnchorKind.cs
+++ b/src/Meziantou.Framework.Language.Regex/RegexAnchorKind.cs
@@ -29,4 +29,10 @@ public enum RegexAnchorKind
 
     /// <summary><c>\K</c>.</summary>
     KeepOut,
+
+    /// <summary><c>\&lt;</c>, the GNU start-of-word assertion.</summary>
+    StartOfWord,
+
+    /// <summary><c>\&gt;</c>, the GNU end-of-word assertion.</summary>
+    EndOfWord,
 }

--- a/src/Meziantou.Framework.Language.Regex/RegexAnchorSyntax.cs
+++ b/src/Meziantou.Framework.Language.Regex/RegexAnchorSyntax.cs
@@ -14,6 +14,10 @@ public sealed partial class RegexAnchorSyntax : RegexAtomSyntax
         "\\G" => RegexAnchorKind.ContiguousMatch,
         "\\B" => RegexAnchorKind.NonWordBoundary,
         "\\K" => RegexAnchorKind.KeepOut,
+        "\\<" => RegexAnchorKind.StartOfWord,
+        "\\>" => RegexAnchorKind.EndOfWord,
+        "\\`" => RegexAnchorKind.StartOfInput,
+        "\\'" => RegexAnchorKind.EndOfInput,
         _ => RegexAnchorKind.WordBoundary,
     };
 }

--- a/src/Meziantou.Framework.Language.Regex/RegexConditionalReferenceSyntax.cs
+++ b/src/Meziantou.Framework.Language.Regex/RegexConditionalReferenceSyntax.cs
@@ -3,6 +3,11 @@ namespace Meziantou.Framework.Language.Regex;
 /// <summary>Represents the group reference that a conditional tests, the <c>(1)</c> or <c>(name)</c> of <c>(?(1)yes|no)</c>.</summary>
 public sealed partial class RegexConditionalReferenceSyntax : RegexSyntaxNode
 {
-    /// <summary>The group name or number being tested.</summary>
-    public string Name => NameToken.Text;
+    /// <summary>The group name or number being tested, without the angle brackets or quotes PCRE may put around a name.</summary>
+    public string Name => NameToken.Text switch
+    {
+        ['<', .. var angled, '>'] => angled,
+        ['\'', .. var quoted, '\''] => quoted,
+        var text => text,
+    };
 }

--- a/src/Meziantou.Framework.Language.Regex/RegexLookaroundSyntax.cs
+++ b/src/Meziantou.Framework.Language.Regex/RegexLookaroundSyntax.cs
@@ -4,11 +4,12 @@ namespace Meziantou.Framework.Language.Regex;
 public sealed partial class RegexLookaroundSyntax : RegexGroupSyntax
 {
     /// <summary>The direction and polarity of the assertion.</summary>
+    /// <remarks>PCRE's alpha assertions, such as <c>(*nlb:…)</c>, report the same kinds as their symbolic spellings.</remarks>
     public RegexLookaroundKind LookaroundKind => GroupKindToken.Text switch
     {
-        "?!" => RegexLookaroundKind.NegativeLookahead,
-        "?<=" => RegexLookaroundKind.PositiveLookbehind,
-        "?<!" => RegexLookaroundKind.NegativeLookbehind,
+        "?!" or "*nla:" or "*negative_lookahead:" => RegexLookaroundKind.NegativeLookahead,
+        "?<=" or "*plb:" or "*positive_lookbehind:" or "*naplb:" or "*non_atomic_positive_lookbehind:" => RegexLookaroundKind.PositiveLookbehind,
+        "?<!" or "*nlb:" or "*negative_lookbehind:" => RegexLookaroundKind.NegativeLookbehind,
         _ => RegexLookaroundKind.PositiveLookahead,
     };
 

--- a/src/Meziantou.Framework.Language.Regex/RegexNamedBackreferenceSyntax.cs
+++ b/src/Meziantou.Framework.Language.Regex/RegexNamedBackreferenceSyntax.cs
@@ -4,5 +4,5 @@ namespace Meziantou.Framework.Language.Regex;
 public sealed partial class RegexNamedBackreferenceSyntax : RegexAtomSyntax
 {
     /// <summary>The group name the reference names, or an empty string when the construct is incomplete.</summary>
-    public string Name => NameToken.Text;
+    public string Name => NameToken.ValueText;
 }

--- a/src/Meziantou.Framework.Language.Regex/RegexNamedGroupSyntax.cs
+++ b/src/Meziantou.Framework.Language.Regex/RegexNamedGroupSyntax.cs
@@ -4,5 +4,5 @@ namespace Meziantou.Framework.Language.Regex;
 public sealed partial class RegexNamedGroupSyntax : RegexGroupSyntax
 {
     /// <summary>The group name.</summary>
-    public string Name => NameToken.Text;
+    public string Name => NameToken.ValueText;
 }

--- a/src/Meziantou.Framework.Language.Regex/SyntaxFactory.cs
+++ b/src/Meziantou.Framework.Language.Regex/SyntaxFactory.cs
@@ -76,6 +76,8 @@ public static partial class SyntaxFactory
             RegexAnchorKind.ContiguousMatch => "\\G",
             RegexAnchorKind.NonWordBoundary => "\\B",
             RegexAnchorKind.KeepOut => "\\K",
+            RegexAnchorKind.StartOfWord => "\\<",
+            RegexAnchorKind.EndOfWord => "\\>",
             _ => "\\b",
         };
 

--- a/src/Meziantou.Framework.Language.Regex/readme.md
+++ b/src/Meziantou.Framework.Language.Regex/readme.md
@@ -16,14 +16,16 @@ annotations.
 
 The .NET dialect's scanner is ported from [dotnet/runtime](https://github.com/dotnet/runtime)'s own `RegexParser`, so its grammar decisions come from the engine rather than being re-derived. See `THIRD-PARTY-NOTICES.TXT`. A differential test runs every sample and several thousand generated patterns through both this parser and `System.Text.RegularExpressions`, asserting they agree on what is valid.
 
+The other dialects are checked the same way against their engines -- V8 for JavaScript, PCRE2 10.47 for PCRE, and glibc's `regcomp` for POSIX. Several thousand patterns per dialect, with the verdict and the capture groups each engine reported, are replayed by the tests.
+
 ## Dialects
 
 | `RegexDialect` | Family | Notes |
 | --- | --- | --- |
 | `Net` | .NET | balancing groups, character class subtraction, conditionals, `(?#…)`, extended mode |
-| `JavaScript` | ECMAScript | the `u` and `v` flags, `\u{…}`, `[]` and `[^]`, class set operations, no `\A`/`\Z`/`\z`/`\G`, no atomic groups, no extended mode, no inline options |
-| `PcrePerl` | PCRE | possessive quantifiers, atomic groups, `\Q…\E`, `\K`, POSIX brackets, recursion and subroutine calls, the `\g` family, callouts, `\h\H\v\V\R\X\N`, `\o{…}`, `\N{U+…}` |
-| `PosixExtended` | POSIX | extended regular expressions (ERE) |
+| `JavaScript` | ECMAScript | the `u` and `v` flags, `\u{…}`, `[]` and `[^]`, class set operations, `(?ims-ims:…)` modifiers, duplicate group names in different alternatives, no `\A`/`\Z`/`\z`/`\G`, no atomic groups, no extended mode |
+| `PcrePerl` | PCRE | possessive quantifiers, atomic groups, `\Q…\E`, `\K`, POSIX brackets, recursion and subroutine calls, the `\g` family, callouts, verbs and alpha assertions, branch reset groups, `\h\H\v\V\R\X\N`, `\o{…}`, `\N{U+…}` |
+| `PosixExtended` | POSIX | extended regular expressions (ERE), with the GNU `\w`, `\s`, `\b`, `\<`, and `\>` |
 | `PosixBasic` | POSIX | basic regular expressions (BRE): `\(…\)` groups, `\{n,m\}` bounds, GNU `\|`, `\+`, `\?`; a bare `(` or `{` is an ordinary character |
 
 Dialects within a family share a parser; `RegexDialect.Features` records what each one supports.
@@ -36,15 +38,19 @@ Every dialect parses its own grammar into its own node types, not into a pile of
 
 - **`Net`** is complete against Microsoft's regular-expression language reference, balancing groups
   (`(?<c-o>…)`, `(?'c-o'…)`, and the pop-only `(?<-o>…)`) included, with capture numbering that matches the engine.
-- **`JavaScript`** covers both Unicode flags. `u` makes a surrogate pair one atom and enables `\u{…}`; `v` adds the
-  class set grammar — nested classes, `&&`, `--`, and `\q{…}` string disjunctions.
-- **`PcrePerl`** covers recursion and subroutine calls in every spelling (`(?R)`, `(?1)`, `(?&name)`, `(?P>name)`,
-  `\g<name>`), the `\g` reference family including relative ones, `(?P=name)`, callouts, backtracking verbs,
-  `\Q…\E`, `\h\H\v\V\R\X\N`, `\o{…}`, `\N{U+…}`, `\p{^L}`, and the `J` and `U` options.
-- **`PosixExtended`** and **`PosixBasic`** cover bracket expressions, collating elements, and equivalence classes.
-  A basic expression's `\(…\)` groups, `\{n,m\}` bounds, and backreferences are all in the tree, as are the GNU
-  `\|`, `\+`, and `\?` extensions, and the positional rules that make `^`, `$`, and `*` ordinary characters where
-  they cannot be special.
+- **`JavaScript`** covers both Unicode flags. `u` makes the pattern a sequence of code points -- a surrogate pair is one
+  atom and one endpoint of a range -- and enables `\u{…}`; `v` adds the class set grammar: nested classes, `&&`, `--`,
+  and `\q{…}` string disjunctions, with the rules that keep strings out of a negated class. `\p{…}` names are checked
+  against the tables of the specification.
+- **`PcrePerl`** covers recursion and subroutine calls in every spelling (`(?R)`, `(?1)`, `(?-1)`, `(?&name)`,
+  `(?P>name)`, `\g<name>`), the `\g` reference family including relative ones, `(?P=name)`, callouts, backtracking
+  verbs, start-of-pattern options, alpha assertions such as `(*plb:…)`, every condition PCRE has (`(?(<name>)…)`,
+  `(?(R1)…)`, `(?(DEFINE)…)`, `(?(VERSION>=10.4)…)`, assertions), `\Q…\E` inside and outside a class, the
+  `J`, `U`, `^`, `r`, and `aD` options, and loosely matched `\p{…}` names. A lookbehind must have a bounded length.
+- **`PosixExtended`** and **`PosixBasic`** cover bracket expressions, collating elements, and equivalence classes, in
+  which a backslash is an ordinary character. A basic expression's `\(…\)` groups, `\{n,m\}` bounds, and
+  backreferences are all in the tree, as are the GNU `\|`, `\+`, and `\?` extensions, and the positional rules that
+  make `^`, `$`, and `*` ordinary characters where they cannot be special.
 
 Two notes on how faithful each dialect is, since they were checked against the engines themselves rather than against
 a reading of the grammars:
@@ -56,7 +62,11 @@ a reading of the grammars:
   `{5,2}`; PCRE2 rejects all three, and so does this.
 - **POSIX has no character escapes.** `\x41`, `\cA`, `\n`, and `\k` are the letters `x41`, `cA`, `n`, and `k`, which
   is what the engines see. The shorthand classes it does accept -- `\w`, `\s`, `\b` and their negations -- are the
-  GNU extensions.
+  GNU extensions. Where POSIX leaves a construct undefined, the parser does what glibc does: `a**` is fine in an
+  extended expression, a `{` always starts an interval, and a backreference must name a group already closed in its
+  branch.
+- **`JavaScript` follows the specification where V8 does not.** V8 accepts `(?<a>x)(?:y|(?<a>z))`, in which both
+  groups can take part in one match; the specification forbids it, and so does this.
 
 Java, Python, and RE2/Go are not dialects.
 
@@ -166,8 +176,9 @@ Console.WriteLine(literals[0].Options);   // None
 Console.WriteLine(literals[1].Options);   // IgnoreCase
 ```
 
-Capture groups are numbered the way the engine numbers them, which is not the order they are written in: named groups
-take the first free numbers after every explicitly numbered one.
+Capture groups are numbered the way the engine numbers them. In .NET that is not the order they are written in: named
+groups take the first free numbers after every explicitly numbered one. JavaScript and PCRE number every group where it
+stands, and a PCRE branch reset group gives each of its branches the same numbers.
 
 ```csharp
 var tree = RegexSyntaxTree.ParseText("(a)(?<x>b)(c)", RegexDialect.Net);
@@ -176,6 +187,8 @@ foreach (var capture in tree.Captures)
 {
     Console.WriteLine($"{capture.Number}: {capture.Name}");   // 1: 1 / 2: 2 / 3: x
 }
+
+// The same pattern in JavaScript or PCRE: 1: 1 / 2: x / 3: 3
 ```
 
 ## Trivia

--- a/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/JavaScriptConformance.jsonl
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/JavaScriptConformance.jsonl
@@ -1,0 +1,5265 @@
+{"pattern": "a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(a)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a", "flags": "", "valid": false}
+{"pattern": "(a", "flags": "u", "valid": false}
+{"pattern": "(a", "flags": "v", "valid": false}
+{"pattern": "a)", "flags": "", "valid": false}
+{"pattern": "a)", "flags": "u", "valid": false}
+{"pattern": "a)", "flags": "v", "valid": false}
+{"pattern": "()", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "()", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "()", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(?:)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?", "flags": "", "valid": false}
+{"pattern": "(?", "flags": "u", "valid": false}
+{"pattern": "(?", "flags": "v", "valid": false}
+{"pattern": "(?)", "flags": "", "valid": false}
+{"pattern": "(?)", "flags": "u", "valid": false}
+{"pattern": "(?)", "flags": "v", "valid": false}
+{"pattern": "[", "flags": "", "valid": false}
+{"pattern": "[", "flags": "u", "valid": false}
+{"pattern": "[", "flags": "v", "valid": false}
+{"pattern": "]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "]", "flags": "u", "valid": false}
+{"pattern": "]", "flags": "v", "valid": false}
+{"pattern": "[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]a]", "flags": "u", "valid": false}
+{"pattern": "[]a]", "flags": "v", "valid": false}
+{"pattern": "[^]a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^]a]", "flags": "u", "valid": false}
+{"pattern": "[^]a]", "flags": "v", "valid": false}
+{"pattern": "[a-]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-]", "flags": "v", "valid": false}
+{"pattern": "[-a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-a]", "flags": "v", "valid": false}
+{"pattern": "[a-z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[z-a]", "flags": "", "valid": false}
+{"pattern": "[z-a]", "flags": "u", "valid": false}
+{"pattern": "[z-a]", "flags": "v", "valid": false}
+{"pattern": "[a-a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-a]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-z]", "flags": "u", "valid": false}
+{"pattern": "[\\d-z]", "flags": "v", "valid": false}
+{"pattern": "[z-\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[z-\\d]", "flags": "u", "valid": false}
+{"pattern": "[z-\\d]", "flags": "v", "valid": false}
+{"pattern": "[\\w-\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w-\\d]", "flags": "u", "valid": false}
+{"pattern": "[\\w-\\d]", "flags": "v", "valid": false}
+{"pattern": "[a-\\w]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\w]", "flags": "u", "valid": false}
+{"pattern": "[a-\\w]", "flags": "v", "valid": false}
+{"pattern": "[\\b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\B]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\B]", "flags": "u", "valid": false}
+{"pattern": "[\\B]", "flags": "v", "valid": false}
+{"pattern": "[.]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[.]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[.]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "{", "flags": "u", "valid": false}
+{"pattern": "{", "flags": "v", "valid": false}
+{"pattern": "}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "}", "flags": "u", "valid": false}
+{"pattern": "}", "flags": "v", "valid": false}
+{"pattern": "{}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "{}", "flags": "u", "valid": false}
+{"pattern": "{}", "flags": "v", "valid": false}
+{"pattern": "{1}", "flags": "", "valid": false}
+{"pattern": "{1}", "flags": "u", "valid": false}
+{"pattern": "{1}", "flags": "v", "valid": false}
+{"pattern": "a{1}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{,1}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{,1}", "flags": "u", "valid": false}
+{"pattern": "a{,1}", "flags": "v", "valid": false}
+{"pattern": "a{1,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2,1}", "flags": "", "valid": false}
+{"pattern": "a{2,1}", "flags": "u", "valid": false}
+{"pattern": "a{2,1}", "flags": "v", "valid": false}
+{"pattern": "a{ 1}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ 1}", "flags": "u", "valid": false}
+{"pattern": "a{ 1}", "flags": "v", "valid": false}
+{"pattern": "a{1 }", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1 }", "flags": "u", "valid": false}
+{"pattern": "a{1 }", "flags": "v", "valid": false}
+{"pattern": "a{1, 2}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1, 2}", "flags": "u", "valid": false}
+{"pattern": "a{1, 2}", "flags": "v", "valid": false}
+{"pattern": "a{1,2", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2", "flags": "u", "valid": false}
+{"pattern": "a{1,2", "flags": "v", "valid": false}
+{"pattern": "a{65535}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65535}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65535}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65536}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65536}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65536}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483647}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483647}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483647}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483648}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483648}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483648}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{99999999999}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{99999999999}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{99999999999}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}{2}", "flags": "", "valid": false}
+{"pattern": "a{1}{2}", "flags": "u", "valid": false}
+{"pattern": "a{1}{2}", "flags": "v", "valid": false}
+{"pattern": "a{1}?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}+", "flags": "", "valid": false}
+{"pattern": "a{1}+", "flags": "u", "valid": false}
+{"pattern": "a{1}+", "flags": "v", "valid": false}
+{"pattern": "a**", "flags": "", "valid": false}
+{"pattern": "a**", "flags": "u", "valid": false}
+{"pattern": "a**", "flags": "v", "valid": false}
+{"pattern": "a*?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a*?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a*?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a*+", "flags": "", "valid": false}
+{"pattern": "a*+", "flags": "u", "valid": false}
+{"pattern": "a*+", "flags": "v", "valid": false}
+{"pattern": "a+?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a+?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a+?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a++", "flags": "", "valid": false}
+{"pattern": "a++", "flags": "u", "valid": false}
+{"pattern": "a++", "flags": "v", "valid": false}
+{"pattern": "a?+", "flags": "", "valid": false}
+{"pattern": "a?+", "flags": "u", "valid": false}
+{"pattern": "a?+", "flags": "v", "valid": false}
+{"pattern": "a???", "flags": "", "valid": false}
+{"pattern": "a???", "flags": "u", "valid": false}
+{"pattern": "a???", "flags": "v", "valid": false}
+{"pattern": "*", "flags": "", "valid": false}
+{"pattern": "*", "flags": "u", "valid": false}
+{"pattern": "*", "flags": "v", "valid": false}
+{"pattern": "+", "flags": "", "valid": false}
+{"pattern": "+", "flags": "u", "valid": false}
+{"pattern": "+", "flags": "v", "valid": false}
+{"pattern": "?", "flags": "", "valid": false}
+{"pattern": "?", "flags": "u", "valid": false}
+{"pattern": "?", "flags": "v", "valid": false}
+{"pattern": "a|*", "flags": "", "valid": false}
+{"pattern": "a|*", "flags": "u", "valid": false}
+{"pattern": "a|*", "flags": "v", "valid": false}
+{"pattern": "(*)", "flags": "", "valid": false}
+{"pattern": "(*)", "flags": "u", "valid": false}
+{"pattern": "(*)", "flags": "v", "valid": false}
+{"pattern": "(+)", "flags": "", "valid": false}
+{"pattern": "(+)", "flags": "u", "valid": false}
+{"pattern": "(+)", "flags": "v", "valid": false}
+{"pattern": "(|*)", "flags": "", "valid": false}
+{"pattern": "(|*)", "flags": "u", "valid": false}
+{"pattern": "(|*)", "flags": "v", "valid": false}
+{"pattern": "^*", "flags": "", "valid": false}
+{"pattern": "^*", "flags": "u", "valid": false}
+{"pattern": "^*", "flags": "v", "valid": false}
+{"pattern": "$*", "flags": "", "valid": false}
+{"pattern": "$*", "flags": "u", "valid": false}
+{"pattern": "$*", "flags": "v", "valid": false}
+{"pattern": "\\b*", "flags": "", "valid": false}
+{"pattern": "\\b*", "flags": "u", "valid": false}
+{"pattern": "\\b*", "flags": "v", "valid": false}
+{"pattern": "\\B+", "flags": "", "valid": false}
+{"pattern": "\\B+", "flags": "u", "valid": false}
+{"pattern": "\\B+", "flags": "v", "valid": false}
+{"pattern": "a|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "|a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "|a", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "|a", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "||", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "||", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "||", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(|)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(|)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(|)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "\\", "flags": "", "valid": false}
+{"pattern": "\\", "flags": "u", "valid": false}
+{"pattern": "\\", "flags": "v", "valid": false}
+{"pattern": "a\\", "flags": "", "valid": false}
+{"pattern": "a\\", "flags": "u", "valid": false}
+{"pattern": "a\\", "flags": "v", "valid": false}
+{"pattern": "[\\", "flags": "", "valid": false}
+{"pattern": "[\\", "flags": "u", "valid": false}
+{"pattern": "[\\", "flags": "v", "valid": false}
+{"pattern": "[a\\", "flags": "", "valid": false}
+{"pattern": "[a\\", "flags": "u", "valid": false}
+{"pattern": "[a\\", "flags": "v", "valid": false}
+{"pattern": "\\0", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\00", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\00", "flags": "u", "valid": false}
+{"pattern": "\\00", "flags": "v", "valid": false}
+{"pattern": "\\000", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\000", "flags": "u", "valid": false}
+{"pattern": "\\000", "flags": "v", "valid": false}
+{"pattern": "\\01", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\01", "flags": "u", "valid": false}
+{"pattern": "\\01", "flags": "v", "valid": false}
+{"pattern": "\\07", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\07", "flags": "u", "valid": false}
+{"pattern": "\\07", "flags": "v", "valid": false}
+{"pattern": "\\08", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\08", "flags": "u", "valid": false}
+{"pattern": "\\08", "flags": "v", "valid": false}
+{"pattern": "\\1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1", "flags": "u", "valid": false}
+{"pattern": "\\1", "flags": "v", "valid": false}
+{"pattern": "\\2", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\2", "flags": "u", "valid": false}
+{"pattern": "\\2", "flags": "v", "valid": false}
+{"pattern": "\\8", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\8", "flags": "u", "valid": false}
+{"pattern": "\\8", "flags": "v", "valid": false}
+{"pattern": "\\9", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\9", "flags": "u", "valid": false}
+{"pattern": "\\9", "flags": "v", "valid": false}
+{"pattern": "\\10", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\10", "flags": "u", "valid": false}
+{"pattern": "\\10", "flags": "v", "valid": false}
+{"pattern": "\\11", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\11", "flags": "u", "valid": false}
+{"pattern": "\\11", "flags": "v", "valid": false}
+{"pattern": "\\12", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12", "flags": "u", "valid": false}
+{"pattern": "\\12", "flags": "v", "valid": false}
+{"pattern": "\\18", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\18", "flags": "u", "valid": false}
+{"pattern": "\\18", "flags": "v", "valid": false}
+{"pattern": "\\19", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\19", "flags": "u", "valid": false}
+{"pattern": "\\19", "flags": "v", "valid": false}
+{"pattern": "\\99", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\99", "flags": "u", "valid": false}
+{"pattern": "\\99", "flags": "v", "valid": false}
+{"pattern": "\\377", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\377", "flags": "u", "valid": false}
+{"pattern": "\\377", "flags": "v", "valid": false}
+{"pattern": "\\400", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\400", "flags": "u", "valid": false}
+{"pattern": "\\400", "flags": "v", "valid": false}
+{"pattern": "\\777", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\777", "flags": "u", "valid": false}
+{"pattern": "\\777", "flags": "v", "valid": false}
+{"pattern": "(a)\\1", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\1", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\1", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\2", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\2", "flags": "u", "valid": false}
+{"pattern": "(a)\\2", "flags": "v", "valid": false}
+{"pattern": "(a)\\10", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\10", "flags": "u", "valid": false}
+{"pattern": "(a)\\10", "flags": "v", "valid": false}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "flags": "", "valid": true, "captures": 10, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "flags": "u", "valid": true, "captures": 10, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "flags": "v", "valid": true, "captures": 10, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "flags": "", "valid": true, "captures": 9, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "flags": "u", "valid": false}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "flags": "v", "valid": false}
+{"pattern": "\\1(a)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "\\1(a)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "\\1(a)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "\\2(a)(b)", "flags": "", "valid": true, "captures": 2, "names": []}
+{"pattern": "\\2(a)(b)", "flags": "u", "valid": true, "captures": 2, "names": []}
+{"pattern": "\\2(a)(b)", "flags": "v", "valid": true, "captures": 2, "names": []}
+{"pattern": "(a\\1)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a\\1)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a\\1)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "[\\1]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\1]", "flags": "u", "valid": false}
+{"pattern": "[\\1]", "flags": "v", "valid": false}
+{"pattern": "[\\0]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\8]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\8]", "flags": "u", "valid": false}
+{"pattern": "[\\8]", "flags": "v", "valid": false}
+{"pattern": "\\x", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x", "flags": "u", "valid": false}
+{"pattern": "\\x", "flags": "v", "valid": false}
+{"pattern": "\\x4", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4", "flags": "u", "valid": false}
+{"pattern": "\\x4", "flags": "v", "valid": false}
+{"pattern": "\\x41", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x41", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x41", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4g", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4g", "flags": "u", "valid": false}
+{"pattern": "\\x4g", "flags": "v", "valid": false}
+{"pattern": "\\xg", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\xg", "flags": "u", "valid": false}
+{"pattern": "\\xg", "flags": "v", "valid": false}
+{"pattern": "\\x{41}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{41}", "flags": "u", "valid": false}
+{"pattern": "\\x{41}", "flags": "v", "valid": false}
+{"pattern": "\\x{}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{}", "flags": "u", "valid": false}
+{"pattern": "\\x{}", "flags": "v", "valid": false}
+{"pattern": "\\x{110000}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{110000}", "flags": "u", "valid": false}
+{"pattern": "\\x{110000}", "flags": "v", "valid": false}
+{"pattern": "\\x{D800}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{D800}", "flags": "u", "valid": false}
+{"pattern": "\\x{D800}", "flags": "v", "valid": false}
+{"pattern": "\\u", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u", "flags": "u", "valid": false}
+{"pattern": "\\u", "flags": "v", "valid": false}
+{"pattern": "\\u4", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u4", "flags": "u", "valid": false}
+{"pattern": "\\u4", "flags": "v", "valid": false}
+{"pattern": "\\u004", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u004", "flags": "u", "valid": false}
+{"pattern": "\\u004", "flags": "v", "valid": false}
+{"pattern": "A", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "A", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "A", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{41}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{41}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{41}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{}", "flags": "u", "valid": false}
+{"pattern": "\\u{}", "flags": "v", "valid": false}
+{"pattern": "\\u{110000}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{110000}", "flags": "u", "valid": false}
+{"pattern": "\\u{110000}", "flags": "v", "valid": false}
+{"pattern": "\\u{10FFFF}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{10FFFF}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{10FFFF}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "😀", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "😀", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "😀", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀-😂]", "flags": "", "valid": false}
+{"pattern": "[😀-😂]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀-😂]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😂-😀]", "flags": "", "valid": false}
+{"pattern": "[😂-😀]", "flags": "u", "valid": false}
+{"pattern": "[😂-😀]", "flags": "v", "valid": false}
+{"pattern": "😀+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "😀+", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "😀+", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "flags": "", "valid": false}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c", "flags": "u", "valid": false}
+{"pattern": "\\c", "flags": "v", "valid": false}
+{"pattern": "\\cA", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ca", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ca", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ca", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cz", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cz", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cz", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1", "flags": "u", "valid": false}
+{"pattern": "\\c1", "flags": "v", "valid": false}
+{"pattern": "\\c_", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c_", "flags": "u", "valid": false}
+{"pattern": "\\c_", "flags": "v", "valid": false}
+{"pattern": "\\c@", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c@", "flags": "u", "valid": false}
+{"pattern": "\\c@", "flags": "v", "valid": false}
+{"pattern": "\\c[", "flags": "", "valid": false}
+{"pattern": "\\c[", "flags": "u", "valid": false}
+{"pattern": "\\c[", "flags": "v", "valid": false}
+{"pattern": "\\c?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c?", "flags": "u", "valid": false}
+{"pattern": "\\c?", "flags": "v", "valid": false}
+{"pattern": "[\\c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c]", "flags": "u", "valid": false}
+{"pattern": "[\\c]", "flags": "v", "valid": false}
+{"pattern": "[\\cA]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1]", "flags": "u", "valid": false}
+{"pattern": "[\\c1]", "flags": "v", "valid": false}
+{"pattern": "[\\c_]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c_]", "flags": "u", "valid": false}
+{"pattern": "[\\c_]", "flags": "v", "valid": false}
+{"pattern": "[\\c@]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c@]", "flags": "u", "valid": false}
+{"pattern": "[\\c@]", "flags": "v", "valid": false}
+{"pattern": "\\a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\a", "flags": "u", "valid": false}
+{"pattern": "\\a", "flags": "v", "valid": false}
+{"pattern": "\\e", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\e", "flags": "u", "valid": false}
+{"pattern": "\\e", "flags": "v", "valid": false}
+{"pattern": "\\f", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A", "flags": "u", "valid": false}
+{"pattern": "\\A", "flags": "v", "valid": false}
+{"pattern": "\\Z", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Z", "flags": "u", "valid": false}
+{"pattern": "\\Z", "flags": "v", "valid": false}
+{"pattern": "\\z", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\z", "flags": "u", "valid": false}
+{"pattern": "\\z", "flags": "v", "valid": false}
+{"pattern": "\\G", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\G", "flags": "u", "valid": false}
+{"pattern": "\\G", "flags": "v", "valid": false}
+{"pattern": "\\K", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\K", "flags": "u", "valid": false}
+{"pattern": "\\K", "flags": "v", "valid": false}
+{"pattern": "\\Q", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q", "flags": "u", "valid": false}
+{"pattern": "\\Q", "flags": "v", "valid": false}
+{"pattern": "\\E", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E", "flags": "u", "valid": false}
+{"pattern": "\\E", "flags": "v", "valid": false}
+{"pattern": "\\Qa\\E", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qa\\E", "flags": "u", "valid": false}
+{"pattern": "\\Qa\\E", "flags": "v", "valid": false}
+{"pattern": "\\Qab", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qab", "flags": "u", "valid": false}
+{"pattern": "\\Qab", "flags": "v", "valid": false}
+{"pattern": "\\Q\\E", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q\\E", "flags": "u", "valid": false}
+{"pattern": "\\Q\\E", "flags": "v", "valid": false}
+{"pattern": "[\\Q]\\E]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q]\\E]", "flags": "u", "valid": false}
+{"pattern": "[\\Q]\\E]", "flags": "v", "valid": false}
+{"pattern": "[\\Qa-z\\E]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Qa-z\\E]", "flags": "u", "valid": false}
+{"pattern": "[\\Qa-z\\E]", "flags": "v", "valid": false}
+{"pattern": "\\h", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\h", "flags": "u", "valid": false}
+{"pattern": "\\h", "flags": "v", "valid": false}
+{"pattern": "\\H", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\H", "flags": "u", "valid": false}
+{"pattern": "\\H", "flags": "v", "valid": false}
+{"pattern": "\\R", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\R", "flags": "u", "valid": false}
+{"pattern": "\\R", "flags": "v", "valid": false}
+{"pattern": "\\X", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\X", "flags": "u", "valid": false}
+{"pattern": "\\X", "flags": "v", "valid": false}
+{"pattern": "\\N", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N", "flags": "u", "valid": false}
+{"pattern": "\\N", "flags": "v", "valid": false}
+{"pattern": "\\C", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\C", "flags": "u", "valid": false}
+{"pattern": "\\C", "flags": "v", "valid": false}
+{"pattern": "\\g", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g", "flags": "u", "valid": false}
+{"pattern": "\\g", "flags": "v", "valid": false}
+{"pattern": "\\g1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g1", "flags": "u", "valid": false}
+{"pattern": "\\g1", "flags": "v", "valid": false}
+{"pattern": "\\g{1}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g{1}", "flags": "u", "valid": false}
+{"pattern": "\\g{1}", "flags": "v", "valid": false}
+{"pattern": "\\g-1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g-1", "flags": "u", "valid": false}
+{"pattern": "\\g-1", "flags": "v", "valid": false}
+{"pattern": "(a)\\g-1", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g-1", "flags": "u", "valid": false}
+{"pattern": "(a)\\g-1", "flags": "v", "valid": false}
+{"pattern": "(a)\\g{-1}", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g{-1}", "flags": "u", "valid": false}
+{"pattern": "(a)\\g{-1}", "flags": "v", "valid": false}
+{"pattern": "(a)\\g{+1}", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g{+1}", "flags": "u", "valid": false}
+{"pattern": "(a)\\g{+1}", "flags": "v", "valid": false}
+{"pattern": "\\g<1>", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g<1>", "flags": "u", "valid": false}
+{"pattern": "\\g<1>", "flags": "v", "valid": false}
+{"pattern": "\\L", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\L", "flags": "u", "valid": false}
+{"pattern": "\\L", "flags": "v", "valid": false}
+{"pattern": "\\l", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\l", "flags": "u", "valid": false}
+{"pattern": "\\l", "flags": "v", "valid": false}
+{"pattern": "\\U", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\U", "flags": "u", "valid": false}
+{"pattern": "\\U", "flags": "v", "valid": false}
+{"pattern": "\\i", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\i", "flags": "u", "valid": false}
+{"pattern": "\\i", "flags": "v", "valid": false}
+{"pattern": "\\I", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\I", "flags": "u", "valid": false}
+{"pattern": "\\I", "flags": "v", "valid": false}
+{"pattern": "\\j", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\j", "flags": "u", "valid": false}
+{"pattern": "\\j", "flags": "v", "valid": false}
+{"pattern": "\\m", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\m", "flags": "u", "valid": false}
+{"pattern": "\\m", "flags": "v", "valid": false}
+{"pattern": "\\o", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o", "flags": "u", "valid": false}
+{"pattern": "\\o", "flags": "v", "valid": false}
+{"pattern": "\\o{101}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{101}", "flags": "u", "valid": false}
+{"pattern": "\\o{101}", "flags": "v", "valid": false}
+{"pattern": "\\o{}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{}", "flags": "u", "valid": false}
+{"pattern": "\\o{}", "flags": "v", "valid": false}
+{"pattern": "\\o{8}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{8}", "flags": "u", "valid": false}
+{"pattern": "\\o{8}", "flags": "v", "valid": false}
+{"pattern": "\\N{U+41}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{U+41}", "flags": "u", "valid": false}
+{"pattern": "\\N{U+41}", "flags": "v", "valid": false}
+{"pattern": "\\N{U+}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{U+}", "flags": "u", "valid": false}
+{"pattern": "\\N{U+}", "flags": "v", "valid": false}
+{"pattern": "\\N{LATIN}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{LATIN}", "flags": "u", "valid": false}
+{"pattern": "\\N{LATIN}", "flags": "v", "valid": false}
+{"pattern": "\\y", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\y", "flags": "u", "valid": false}
+{"pattern": "\\y", "flags": "v", "valid": false}
+{"pattern": "\\-", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\-", "flags": "u", "valid": false}
+{"pattern": "\\-", "flags": "v", "valid": false}
+{"pattern": "\\/", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\:", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\:", "flags": "u", "valid": false}
+{"pattern": "\\:", "flags": "v", "valid": false}
+{"pattern": "\\,", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,", "flags": "u", "valid": false}
+{"pattern": "\\,", "flags": "v", "valid": false}
+{"pattern": "\\=", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\=", "flags": "u", "valid": false}
+{"pattern": "\\=", "flags": "v", "valid": false}
+{"pattern": "\\!", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\!", "flags": "u", "valid": false}
+{"pattern": "\\!", "flags": "v", "valid": false}
+{"pattern": "\\<", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<", "flags": "u", "valid": false}
+{"pattern": "\\<", "flags": "v", "valid": false}
+{"pattern": "\\>", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\>", "flags": "u", "valid": false}
+{"pattern": "\\>", "flags": "v", "valid": false}
+{"pattern": "\\@", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@", "flags": "u", "valid": false}
+{"pattern": "\\@", "flags": "v", "valid": false}
+{"pattern": "\\#", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\#", "flags": "u", "valid": false}
+{"pattern": "\\#", "flags": "v", "valid": false}
+{"pattern": "\\%", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%", "flags": "u", "valid": false}
+{"pattern": "\\%", "flags": "v", "valid": false}
+{"pattern": "\\&", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&", "flags": "u", "valid": false}
+{"pattern": "\\&", "flags": "v", "valid": false}
+{"pattern": "\\~", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~", "flags": "u", "valid": false}
+{"pattern": "\\~", "flags": "v", "valid": false}
+{"pattern": "\\`", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\`", "flags": "u", "valid": false}
+{"pattern": "\\`", "flags": "v", "valid": false}
+{"pattern": "\\\"", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\"", "flags": "u", "valid": false}
+{"pattern": "\\\"", "flags": "v", "valid": false}
+{"pattern": "\\'", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\'", "flags": "u", "valid": false}
+{"pattern": "\\'", "flags": "v", "valid": false}
+{"pattern": "\\_", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_", "flags": "u", "valid": false}
+{"pattern": "\\_", "flags": "v", "valid": false}
+{"pattern": "\\$", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p", "flags": "u", "valid": false}
+{"pattern": "\\p", "flags": "v", "valid": false}
+{"pattern": "\\pL", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pL", "flags": "u", "valid": false}
+{"pattern": "\\pL", "flags": "v", "valid": false}
+{"pattern": "\\pLu", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pLu", "flags": "u", "valid": false}
+{"pattern": "\\pLu", "flags": "v", "valid": false}
+{"pattern": "\\p{L}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lu}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lu}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lu}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L", "flags": "u", "valid": false}
+{"pattern": "\\p{L", "flags": "v", "valid": false}
+{"pattern": "\\p{}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{}", "flags": "u", "valid": false}
+{"pattern": "\\p{}", "flags": "v", "valid": false}
+{"pattern": "\\p{^L}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{^L}", "flags": "u", "valid": false}
+{"pattern": "\\p{^L}", "flags": "v", "valid": false}
+{"pattern": "\\P{^L}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{^L}", "flags": "u", "valid": false}
+{"pattern": "\\P{^L}", "flags": "v", "valid": false}
+{"pattern": "\\p{Letter}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Letter}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Letter}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Uppercase_Letter}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Uppercase_Letter}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Uppercase_Letter}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{gc=L}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{gc=L}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{gc=L}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{General_Category=Letter}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{General_Category=Letter}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{General_Category=Letter}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=Greek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=Greek}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=Greek}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx=Grek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx=Grek}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx=Grek}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script_Extensions=Greek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script_Extensions=Greek}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script_Extensions=Greek}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Greek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Greek}", "flags": "u", "valid": false}
+{"pattern": "\\p{Greek}", "flags": "v", "valid": false}
+{"pattern": "\\p{IsGreek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{IsGreek}", "flags": "u", "valid": false}
+{"pattern": "\\p{IsGreek}", "flags": "v", "valid": false}
+{"pattern": "\\p{InGreek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{InGreek}", "flags": "u", "valid": false}
+{"pattern": "\\p{InGreek}", "flags": "v", "valid": false}
+{"pattern": "\\p{Bogus}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Bogus}", "flags": "u", "valid": false}
+{"pattern": "\\p{Bogus}", "flags": "v", "valid": false}
+{"pattern": "\\p{Any}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Any}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Any}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ASCII}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ASCII}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ASCII}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Assigned}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Assigned}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Assigned}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alphabetic}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alphabetic}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alphabetic}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alpha}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alpha}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alpha}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L&}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L&}", "flags": "u", "valid": false}
+{"pattern": "\\p{L&}", "flags": "v", "valid": false}
+{"pattern": "\\p{Xan}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xan}", "flags": "u", "valid": false}
+{"pattern": "\\p{Xan}", "flags": "v", "valid": false}
+{"pattern": "\\p{Xwd}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xwd}", "flags": "u", "valid": false}
+{"pattern": "\\p{Xwd}", "flags": "v", "valid": false}
+{"pattern": "\\p{Emoji}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Emoji}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Emoji}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{RGI_Emoji}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{RGI_Emoji}", "flags": "u", "valid": false}
+{"pattern": "\\p{RGI_Emoji}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Basic_Emoji}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Basic_Emoji}", "flags": "u", "valid": false}
+{"pattern": "\\p{Basic_Emoji}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{lu}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{lu}", "flags": "u", "valid": false}
+{"pattern": "\\p{lu}", "flags": "v", "valid": false}
+{"pattern": "\\p{ L}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ L}", "flags": "u", "valid": false}
+{"pattern": "\\p{ L}", "flags": "v", "valid": false}
+{"pattern": "\\p{L }", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L }", "flags": "u", "valid": false}
+{"pattern": "\\p{L }", "flags": "v", "valid": false}
+{"pattern": "\\p{Script=}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=}", "flags": "u", "valid": false}
+{"pattern": "\\p{Script=}", "flags": "v", "valid": false}
+{"pattern": "\\p{=Greek}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{=Greek}", "flags": "u", "valid": false}
+{"pattern": "\\p{=Greek}", "flags": "v", "valid": false}
+{"pattern": "\\p{sc=Bogus}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Bogus}", "flags": "u", "valid": false}
+{"pattern": "\\p{sc=Bogus}", "flags": "v", "valid": false}
+{"pattern": "\\P{RGI_Emoji}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{RGI_Emoji}", "flags": "u", "valid": false}
+{"pattern": "\\P{RGI_Emoji}", "flags": "v", "valid": false}
+{"pattern": "[\\p{RGI_Emoji}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p{RGI_Emoji}]", "flags": "u", "valid": false}
+{"pattern": "[\\p{RGI_Emoji}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\p{RGI_Emoji}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\p{RGI_Emoji}]", "flags": "u", "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}]", "flags": "v", "valid": false}
+{"pattern": "\\k", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k", "flags": "u", "valid": false}
+{"pattern": "\\k", "flags": "v", "valid": false}
+{"pattern": "\\k<", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<", "flags": "u", "valid": false}
+{"pattern": "\\k<", "flags": "v", "valid": false}
+{"pattern": "\\k<a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<a", "flags": "u", "valid": false}
+{"pattern": "\\k<a", "flags": "v", "valid": false}
+{"pattern": "\\k<a>", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<a>", "flags": "u", "valid": false}
+{"pattern": "\\k<a>", "flags": "v", "valid": false}
+{"pattern": "\\k<1>", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<1>", "flags": "u", "valid": false}
+{"pattern": "\\k<1>", "flags": "v", "valid": false}
+{"pattern": "\\k'a'", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k'a'", "flags": "u", "valid": false}
+{"pattern": "\\k'a'", "flags": "v", "valid": false}
+{"pattern": "\\k{a}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k{a}", "flags": "u", "valid": false}
+{"pattern": "\\k{a}", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)\\k<a>", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a>x)\\k<a>", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a>x)\\k<a>", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a>x)\\k<b>", "flags": "", "valid": false}
+{"pattern": "(?<a>x)\\k<b>", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)\\k<b>", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)\\k", "flags": "", "valid": false}
+{"pattern": "(?<a>x)\\k", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)\\k", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)\\k<a", "flags": "", "valid": false}
+{"pattern": "(?<a>x)\\k<a", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)\\k<a", "flags": "v", "valid": false}
+{"pattern": "\\k<a>(?<a>x)", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\k<a>(?<a>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\k<a>(?<a>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a>x)(?<a>y)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?<a>y)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)(?<a>y)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)", "flags": "", "valid": true, "captures": 2, "names": ["a"]}
+{"pattern": "(?<a>x)|(?<a>y)", "flags": "u", "valid": true, "captures": 2, "names": ["a"]}
+{"pattern": "(?<a>x)|(?<a>y)", "flags": "v", "valid": true, "captures": 2, "names": ["a"]}
+{"pattern": "((?<a>x)|(?<a>y))", "flags": "", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "((?<a>x)|(?<a>y))", "flags": "u", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "((?<a>x)|(?<a>y))", "flags": "v", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "flags": "", "valid": true, "captures": 2, "names": ["a"]}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "flags": "u", "valid": true, "captures": 2, "names": ["a"]}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "flags": "v", "valid": true, "captures": 2, "names": ["a"]}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "flags": "", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "flags": "u", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "flags": "v", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "(?<a>x)((?<a>y)|z)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)((?<a>y)|z)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)((?<a>y)|z)", "flags": "v", "valid": false}
+{"pattern": "(?<a>", "flags": "", "valid": false}
+{"pattern": "(?<a>", "flags": "u", "valid": false}
+{"pattern": "(?<a>", "flags": "v", "valid": false}
+{"pattern": "(?<a", "flags": "", "valid": false}
+{"pattern": "(?<a", "flags": "u", "valid": false}
+{"pattern": "(?<a", "flags": "v", "valid": false}
+{"pattern": "(?<>x)", "flags": "", "valid": false}
+{"pattern": "(?<>x)", "flags": "u", "valid": false}
+{"pattern": "(?<>x)", "flags": "v", "valid": false}
+{"pattern": "(?<1a>x)", "flags": "", "valid": false}
+{"pattern": "(?<1a>x)", "flags": "u", "valid": false}
+{"pattern": "(?<1a>x)", "flags": "v", "valid": false}
+{"pattern": "(?<a1>x)", "flags": "", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "(?<a1>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "(?<a1>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "(?<_>x)", "flags": "", "valid": true, "captures": 1, "names": ["_"]}
+{"pattern": "(?<_>x)", "flags": "u", "valid": true, "captures": 1, "names": ["_"]}
+{"pattern": "(?<_>x)", "flags": "v", "valid": true, "captures": 1, "names": ["_"]}
+{"pattern": "(?<$>x)", "flags": "", "valid": true, "captures": 1, "names": ["$"]}
+{"pattern": "(?<$>x)", "flags": "u", "valid": true, "captures": 1, "names": ["$"]}
+{"pattern": "(?<$>x)", "flags": "v", "valid": true, "captures": 1, "names": ["$"]}
+{"pattern": "(?<a$>x)", "flags": "", "valid": true, "captures": 1, "names": ["a$"]}
+{"pattern": "(?<a$>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a$"]}
+{"pattern": "(?<a$>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a$"]}
+{"pattern": "(?<é>x)", "flags": "", "valid": true, "captures": 1, "names": ["é"]}
+{"pattern": "(?<é>x)", "flags": "u", "valid": true, "captures": 1, "names": ["é"]}
+{"pattern": "(?<é>x)", "flags": "v", "valid": true, "captures": 1, "names": ["é"]}
+{"pattern": "(?<𝒜>x)", "flags": "", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<𝒜>x)", "flags": "u", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<𝒜>x)", "flags": "v", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<a-b>x)", "flags": "", "valid": false}
+{"pattern": "(?<a-b>x)", "flags": "u", "valid": false}
+{"pattern": "(?<a-b>x)", "flags": "v", "valid": false}
+{"pattern": "(?<a b>x)", "flags": "", "valid": false}
+{"pattern": "(?<a b>x)", "flags": "u", "valid": false}
+{"pattern": "(?<a b>x)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u{61}>x)", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u{61}>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u{61}>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?'a'x)", "flags": "", "valid": false}
+{"pattern": "(?'a'x)", "flags": "u", "valid": false}
+{"pattern": "(?'a'x)", "flags": "v", "valid": false}
+{"pattern": "(?P<a>x)", "flags": "", "valid": false}
+{"pattern": "(?P<a>x)", "flags": "u", "valid": false}
+{"pattern": "(?P<a>x)", "flags": "v", "valid": false}
+{"pattern": "(?P<a>x)(?P=a)", "flags": "", "valid": false}
+{"pattern": "(?P<a>x)(?P=a)", "flags": "u", "valid": false}
+{"pattern": "(?P<a>x)(?P=a)", "flags": "v", "valid": false}
+{"pattern": "(?P>a)", "flags": "", "valid": false}
+{"pattern": "(?P>a)", "flags": "u", "valid": false}
+{"pattern": "(?P>a)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)(?P>a)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?P>a)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)(?P>a)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)(?&a)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?&a)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)(?&a)", "flags": "v", "valid": false}
+{"pattern": "(?&a)", "flags": "", "valid": false}
+{"pattern": "(?&a)", "flags": "u", "valid": false}
+{"pattern": "(?&a)", "flags": "v", "valid": false}
+{"pattern": "(?R)", "flags": "", "valid": false}
+{"pattern": "(?R)", "flags": "u", "valid": false}
+{"pattern": "(?R)", "flags": "v", "valid": false}
+{"pattern": "(?0)", "flags": "", "valid": false}
+{"pattern": "(?0)", "flags": "u", "valid": false}
+{"pattern": "(?0)", "flags": "v", "valid": false}
+{"pattern": "(?1)", "flags": "", "valid": false}
+{"pattern": "(?1)", "flags": "u", "valid": false}
+{"pattern": "(?1)", "flags": "v", "valid": false}
+{"pattern": "(a)(?1)", "flags": "", "valid": false}
+{"pattern": "(a)(?1)", "flags": "u", "valid": false}
+{"pattern": "(a)(?1)", "flags": "v", "valid": false}
+{"pattern": "(a)(?-1)", "flags": "", "valid": false}
+{"pattern": "(a)(?-1)", "flags": "u", "valid": false}
+{"pattern": "(a)(?-1)", "flags": "v", "valid": false}
+{"pattern": "(a)(?+1)", "flags": "", "valid": false}
+{"pattern": "(a)(?+1)", "flags": "u", "valid": false}
+{"pattern": "(a)(?+1)", "flags": "v", "valid": false}
+{"pattern": "(?+1)(a)", "flags": "", "valid": false}
+{"pattern": "(?+1)(a)", "flags": "u", "valid": false}
+{"pattern": "(?+1)(a)", "flags": "v", "valid": false}
+{"pattern": "(?-1)", "flags": "", "valid": false}
+{"pattern": "(?-1)", "flags": "u", "valid": false}
+{"pattern": "(?-1)", "flags": "v", "valid": false}
+{"pattern": "(a)(?-2)", "flags": "", "valid": false}
+{"pattern": "(a)(?-2)", "flags": "u", "valid": false}
+{"pattern": "(a)(?-2)", "flags": "v", "valid": false}
+{"pattern": "(?C)", "flags": "", "valid": false}
+{"pattern": "(?C)", "flags": "u", "valid": false}
+{"pattern": "(?C)", "flags": "v", "valid": false}
+{"pattern": "(?C1)", "flags": "", "valid": false}
+{"pattern": "(?C1)", "flags": "u", "valid": false}
+{"pattern": "(?C1)", "flags": "v", "valid": false}
+{"pattern": "(?C255)", "flags": "", "valid": false}
+{"pattern": "(?C255)", "flags": "u", "valid": false}
+{"pattern": "(?C255)", "flags": "v", "valid": false}
+{"pattern": "(?C256)", "flags": "", "valid": false}
+{"pattern": "(?C256)", "flags": "u", "valid": false}
+{"pattern": "(?C256)", "flags": "v", "valid": false}
+{"pattern": "(?C\"a\")", "flags": "", "valid": false}
+{"pattern": "(?C\"a\")", "flags": "u", "valid": false}
+{"pattern": "(?C\"a\")", "flags": "v", "valid": false}
+{"pattern": "(?C{a})", "flags": "", "valid": false}
+{"pattern": "(?C{a})", "flags": "u", "valid": false}
+{"pattern": "(?C{a})", "flags": "v", "valid": false}
+{"pattern": "(?Ca)", "flags": "", "valid": false}
+{"pattern": "(?Ca)", "flags": "u", "valid": false}
+{"pattern": "(?Ca)", "flags": "v", "valid": false}
+{"pattern": "(*FAIL)", "flags": "", "valid": false}
+{"pattern": "(*FAIL)", "flags": "u", "valid": false}
+{"pattern": "(*FAIL)", "flags": "v", "valid": false}
+{"pattern": "(*F)", "flags": "", "valid": false}
+{"pattern": "(*F)", "flags": "u", "valid": false}
+{"pattern": "(*F)", "flags": "v", "valid": false}
+{"pattern": "(*ACCEPT)", "flags": "", "valid": false}
+{"pattern": "(*ACCEPT)", "flags": "u", "valid": false}
+{"pattern": "(*ACCEPT)", "flags": "v", "valid": false}
+{"pattern": "(*COMMIT)", "flags": "", "valid": false}
+{"pattern": "(*COMMIT)", "flags": "u", "valid": false}
+{"pattern": "(*COMMIT)", "flags": "v", "valid": false}
+{"pattern": "(*PRUNE)", "flags": "", "valid": false}
+{"pattern": "(*PRUNE)", "flags": "u", "valid": false}
+{"pattern": "(*PRUNE)", "flags": "v", "valid": false}
+{"pattern": "(*SKIP)", "flags": "", "valid": false}
+{"pattern": "(*SKIP)", "flags": "u", "valid": false}
+{"pattern": "(*SKIP)", "flags": "v", "valid": false}
+{"pattern": "(*THEN)", "flags": "", "valid": false}
+{"pattern": "(*THEN)", "flags": "u", "valid": false}
+{"pattern": "(*THEN)", "flags": "v", "valid": false}
+{"pattern": "(*MARK:a)", "flags": "", "valid": false}
+{"pattern": "(*MARK:a)", "flags": "u", "valid": false}
+{"pattern": "(*MARK:a)", "flags": "v", "valid": false}
+{"pattern": "(*:a)", "flags": "", "valid": false}
+{"pattern": "(*:a)", "flags": "u", "valid": false}
+{"pattern": "(*:a)", "flags": "v", "valid": false}
+{"pattern": "(*MARK)", "flags": "", "valid": false}
+{"pattern": "(*MARK)", "flags": "u", "valid": false}
+{"pattern": "(*MARK)", "flags": "v", "valid": false}
+{"pattern": "(*BOGUS)", "flags": "", "valid": false}
+{"pattern": "(*BOGUS)", "flags": "u", "valid": false}
+{"pattern": "(*BOGUS)", "flags": "v", "valid": false}
+{"pattern": "(*UTF)", "flags": "", "valid": false}
+{"pattern": "(*UTF)", "flags": "u", "valid": false}
+{"pattern": "(*UTF)", "flags": "v", "valid": false}
+{"pattern": "(*UCP)", "flags": "", "valid": false}
+{"pattern": "(*UCP)", "flags": "u", "valid": false}
+{"pattern": "(*UCP)", "flags": "v", "valid": false}
+{"pattern": "(*CR)", "flags": "", "valid": false}
+{"pattern": "(*CR)", "flags": "u", "valid": false}
+{"pattern": "(*CR)", "flags": "v", "valid": false}
+{"pattern": "a(*UTF)", "flags": "", "valid": false}
+{"pattern": "a(*UTF)", "flags": "u", "valid": false}
+{"pattern": "a(*UTF)", "flags": "v", "valid": false}
+{"pattern": "(*", "flags": "", "valid": false}
+{"pattern": "(*", "flags": "u", "valid": false}
+{"pattern": "(*", "flags": "v", "valid": false}
+{"pattern": "(*a", "flags": "", "valid": false}
+{"pattern": "(*a", "flags": "u", "valid": false}
+{"pattern": "(*a", "flags": "v", "valid": false}
+{"pattern": "(?=a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)*", "flags": "u", "valid": false}
+{"pattern": "(?=a)*", "flags": "v", "valid": false}
+{"pattern": "(?!a)+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)+", "flags": "u", "valid": false}
+{"pattern": "(?!a)+", "flags": "v", "valid": false}
+{"pattern": "(?<=a)?", "flags": "", "valid": false}
+{"pattern": "(?<=a)?", "flags": "u", "valid": false}
+{"pattern": "(?<=a)?", "flags": "v", "valid": false}
+{"pattern": "(?<!a){2}", "flags": "", "valid": false}
+{"pattern": "(?<!a){2}", "flags": "u", "valid": false}
+{"pattern": "(?<!a){2}", "flags": "v", "valid": false}
+{"pattern": "(?<=a+)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a+)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a+)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a*)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a*)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a*)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a|bc)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a|bc)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a|bc)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(a)\\1)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(a)\\1)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(a)\\1)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(?>a)", "flags": "", "valid": false}
+{"pattern": "(?>a)", "flags": "u", "valid": false}
+{"pattern": "(?>a)", "flags": "v", "valid": false}
+{"pattern": "(?>a)*", "flags": "", "valid": false}
+{"pattern": "(?>a)*", "flags": "u", "valid": false}
+{"pattern": "(?>a)*", "flags": "v", "valid": false}
+{"pattern": "(?|(a)|(b))", "flags": "", "valid": false}
+{"pattern": "(?|(a)|(b))", "flags": "u", "valid": false}
+{"pattern": "(?|(a)|(b))", "flags": "v", "valid": false}
+{"pattern": "(?|(a)|(b)(c))\\3", "flags": "", "valid": false}
+{"pattern": "(?|(a)|(b)(c))\\3", "flags": "u", "valid": false}
+{"pattern": "(?|(a)|(b)(c))\\3", "flags": "v", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "flags": "", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "flags": "u", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "flags": "v", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "flags": "", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "flags": "u", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "flags": "v", "valid": false}
+{"pattern": "(?i)", "flags": "", "valid": false}
+{"pattern": "(?i)", "flags": "u", "valid": false}
+{"pattern": "(?i)", "flags": "v", "valid": false}
+{"pattern": "(?i)a", "flags": "", "valid": false}
+{"pattern": "(?i)a", "flags": "u", "valid": false}
+{"pattern": "(?i)a", "flags": "v", "valid": false}
+{"pattern": "(?i:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i)", "flags": "", "valid": false}
+{"pattern": "(?-i)", "flags": "u", "valid": false}
+{"pattern": "(?-i)", "flags": "v", "valid": false}
+{"pattern": "(?-i:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?im-s:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?im-s:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?im-s:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-)", "flags": "", "valid": false}
+{"pattern": "(?-)", "flags": "u", "valid": false}
+{"pattern": "(?-)", "flags": "v", "valid": false}
+{"pattern": "(?-:a)", "flags": "", "valid": false}
+{"pattern": "(?-:a)", "flags": "u", "valid": false}
+{"pattern": "(?-:a)", "flags": "v", "valid": false}
+{"pattern": "(?i-:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:a)", "flags": "", "valid": false}
+{"pattern": "(?ii:a)", "flags": "u", "valid": false}
+{"pattern": "(?ii:a)", "flags": "v", "valid": false}
+{"pattern": "(?i-i:a)", "flags": "", "valid": false}
+{"pattern": "(?i-i:a)", "flags": "u", "valid": false}
+{"pattern": "(?i-i:a)", "flags": "v", "valid": false}
+{"pattern": "(?x)", "flags": "", "valid": false}
+{"pattern": "(?x)", "flags": "u", "valid": false}
+{"pattern": "(?x)", "flags": "v", "valid": false}
+{"pattern": "(?s:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?s:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?s:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?m:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?m:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?m:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?n:a)", "flags": "", "valid": false}
+{"pattern": "(?n:a)", "flags": "u", "valid": false}
+{"pattern": "(?n:a)", "flags": "v", "valid": false}
+{"pattern": "(?n)(a)", "flags": "", "valid": false}
+{"pattern": "(?n)(a)", "flags": "u", "valid": false}
+{"pattern": "(?n)(a)", "flags": "v", "valid": false}
+{"pattern": "(?q)", "flags": "", "valid": false}
+{"pattern": "(?q)", "flags": "u", "valid": false}
+{"pattern": "(?q)", "flags": "v", "valid": false}
+{"pattern": "(?^)", "flags": "", "valid": false}
+{"pattern": "(?^)", "flags": "u", "valid": false}
+{"pattern": "(?^)", "flags": "v", "valid": false}
+{"pattern": "(?^i)", "flags": "", "valid": false}
+{"pattern": "(?^i)", "flags": "u", "valid": false}
+{"pattern": "(?^i)", "flags": "v", "valid": false}
+{"pattern": "(?^i:a)", "flags": "", "valid": false}
+{"pattern": "(?^i:a)", "flags": "u", "valid": false}
+{"pattern": "(?^i:a)", "flags": "v", "valid": false}
+{"pattern": "(?xx)", "flags": "", "valid": false}
+{"pattern": "(?xx)", "flags": "u", "valid": false}
+{"pattern": "(?xx)", "flags": "v", "valid": false}
+{"pattern": "(?J)", "flags": "", "valid": false}
+{"pattern": "(?J)", "flags": "u", "valid": false}
+{"pattern": "(?J)", "flags": "v", "valid": false}
+{"pattern": "(?U)", "flags": "", "valid": false}
+{"pattern": "(?U)", "flags": "u", "valid": false}
+{"pattern": "(?U)", "flags": "v", "valid": false}
+{"pattern": "(?a)", "flags": "", "valid": false}
+{"pattern": "(?a)", "flags": "u", "valid": false}
+{"pattern": "(?a)", "flags": "v", "valid": false}
+{"pattern": "(?u)", "flags": "", "valid": false}
+{"pattern": "(?u)", "flags": "u", "valid": false}
+{"pattern": "(?u)", "flags": "v", "valid": false}
+{"pattern": "(?aD)", "flags": "", "valid": false}
+{"pattern": "(?aD)", "flags": "u", "valid": false}
+{"pattern": "(?aD)", "flags": "v", "valid": false}
+{"pattern": "(?r)", "flags": "", "valid": false}
+{"pattern": "(?r)", "flags": "u", "valid": false}
+{"pattern": "(?r)", "flags": "v", "valid": false}
+{"pattern": "(?i", "flags": "", "valid": false}
+{"pattern": "(?i", "flags": "u", "valid": false}
+{"pattern": "(?i", "flags": "v", "valid": false}
+{"pattern": "(?i:a", "flags": "", "valid": false}
+{"pattern": "(?i:a", "flags": "u", "valid": false}
+{"pattern": "(?i:a", "flags": "v", "valid": false}
+{"pattern": "a(?i)*", "flags": "", "valid": false}
+{"pattern": "a(?i)*", "flags": "u", "valid": false}
+{"pattern": "a(?i)*", "flags": "v", "valid": false}
+{"pattern": "(?i)*", "flags": "", "valid": false}
+{"pattern": "(?i)*", "flags": "u", "valid": false}
+{"pattern": "(?i)*", "flags": "v", "valid": false}
+{"pattern": "(?#comment)", "flags": "", "valid": false}
+{"pattern": "(?#comment)", "flags": "u", "valid": false}
+{"pattern": "(?#comment)", "flags": "v", "valid": false}
+{"pattern": "(?#comment", "flags": "", "valid": false}
+{"pattern": "(?#comment", "flags": "u", "valid": false}
+{"pattern": "(?#comment", "flags": "v", "valid": false}
+{"pattern": "(?#)a", "flags": "", "valid": false}
+{"pattern": "(?#)a", "flags": "u", "valid": false}
+{"pattern": "(?#)a", "flags": "v", "valid": false}
+{"pattern": "a(?#x)*", "flags": "", "valid": false}
+{"pattern": "a(?#x)*", "flags": "u", "valid": false}
+{"pattern": "a(?#x)*", "flags": "v", "valid": false}
+{"pattern": "a(?#x){2}", "flags": "", "valid": false}
+{"pattern": "a(?#x){2}", "flags": "u", "valid": false}
+{"pattern": "a(?#x){2}", "flags": "v", "valid": false}
+{"pattern": "(?(1)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(1)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(1)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(1)a|b)(x)", "flags": "", "valid": false}
+{"pattern": "(?(1)a|b)(x)", "flags": "u", "valid": false}
+{"pattern": "(?(1)a|b)(x)", "flags": "v", "valid": false}
+{"pattern": "(?(1)a|b|c)(x)", "flags": "", "valid": false}
+{"pattern": "(?(1)a|b|c)(x)", "flags": "u", "valid": false}
+{"pattern": "(?(1)a|b|c)(x)", "flags": "v", "valid": false}
+{"pattern": "(?(a)x|y)", "flags": "", "valid": false}
+{"pattern": "(?(a)x|y)", "flags": "u", "valid": false}
+{"pattern": "(?(a)x|y)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)(?(a)x|y)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?(a)x|y)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)(?(a)x|y)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)(?('a')x|y)", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?('a')x|y)", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)(?('a')x|y)", "flags": "v", "valid": false}
+{"pattern": "(?(<a>)x|y)", "flags": "", "valid": false}
+{"pattern": "(?(<a>)x|y)", "flags": "u", "valid": false}
+{"pattern": "(?(<a>)x|y)", "flags": "v", "valid": false}
+{"pattern": "(?(R)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(R)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(R)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(R1)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(R1)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(R1)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(R&a)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(R&a)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(R&a)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x))", "flags": "", "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x))", "flags": "u", "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x))", "flags": "v", "valid": false}
+{"pattern": "(?(DEFINE)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(DEFINE)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(DEFINE)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(+1)a|b)(x)", "flags": "", "valid": false}
+{"pattern": "(?(+1)a|b)(x)", "flags": "u", "valid": false}
+{"pattern": "(?(+1)a|b)(x)", "flags": "v", "valid": false}
+{"pattern": "(?(-1)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(-1)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(-1)a|b)", "flags": "v", "valid": false}
+{"pattern": "(x)(?(-1)a|b)", "flags": "", "valid": false}
+{"pattern": "(x)(?(-1)a|b)", "flags": "u", "valid": false}
+{"pattern": "(x)(?(-1)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(VERSION>=10.0)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(VERSION>=10.0)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(VERSION>=10.0)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(?=a)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?=a)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?=a)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(?!a)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?!a)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?!a)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(?<=a)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?<=a)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?<=a)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(?:a)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?:a)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?:a)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(a)", "flags": "", "valid": false}
+{"pattern": "(?(a)", "flags": "u", "valid": false}
+{"pattern": "(?(a)", "flags": "v", "valid": false}
+{"pattern": "(?(", "flags": "", "valid": false}
+{"pattern": "(?(", "flags": "u", "valid": false}
+{"pattern": "(?(", "flags": "v", "valid": false}
+{"pattern": "(?()a)", "flags": "", "valid": false}
+{"pattern": "(?()a)", "flags": "u", "valid": false}
+{"pattern": "(?()a)", "flags": "v", "valid": false}
+{"pattern": "(?(1a)x)", "flags": "", "valid": false}
+{"pattern": "(?(1a)x)", "flags": "u", "valid": false}
+{"pattern": "(?(1a)x)", "flags": "v", "valid": false}
+{"pattern": "(?(?#c)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?#c)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?#c)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(?<n>x)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?<n>x)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?<n>x)a|b)", "flags": "v", "valid": false}
+{"pattern": "(?(?'n'x)a|b)", "flags": "", "valid": false}
+{"pattern": "(?(?'n'x)a|b)", "flags": "u", "valid": false}
+{"pattern": "(?(?'n'x)a|b)", "flags": "v", "valid": false}
+{"pattern": "[[:alpha:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]]", "flags": "u", "valid": false}
+{"pattern": "[[:alpha:]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:bogus:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:bogus:]]", "flags": "u", "valid": false}
+{"pattern": "[[:bogus:]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]", "flags": "v", "valid": false}
+{"pattern": "[[:alpha]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha]]", "flags": "u", "valid": false}
+{"pattern": "[[:alpha]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.a.]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.a.]]", "flags": "u", "valid": false}
+{"pattern": "[[.a.]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.hyphen.]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.hyphen.]]", "flags": "u", "valid": false}
+{"pattern": "[[.hyphen.]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.-.]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.-.]]", "flags": "u", "valid": false}
+{"pattern": "[[.-.]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[=a=]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[=a=]]", "flags": "u", "valid": false}
+{"pattern": "[[=a=]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[=ab=]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[=ab=]]", "flags": "u", "valid": false}
+{"pattern": "[[=ab=]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]-z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]-z]", "flags": "u", "valid": false}
+{"pattern": "[[:alpha:]-z]", "flags": "v", "valid": false}
+{"pattern": "[a-[:alpha:]]", "flags": "", "valid": false}
+{"pattern": "[a-[:alpha:]]", "flags": "u", "valid": false}
+{"pattern": "[a-[:alpha:]]", "flags": "v", "valid": false}
+{"pattern": "[[.a.]-z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.a.]-z]", "flags": "u", "valid": false}
+{"pattern": "[[.a.]-z]", "flags": "v", "valid": false}
+{"pattern": "[[:ALPHA:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:ALPHA:]]", "flags": "u", "valid": false}
+{"pattern": "[[:ALPHA:]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:^alpha:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:^alpha:]]", "flags": "u", "valid": false}
+{"pattern": "[[:^alpha:]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:word:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:word:]]", "flags": "u", "valid": false}
+{"pattern": "[[:word:]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:blank:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:blank:]]", "flags": "u", "valid": false}
+{"pattern": "[[:blank:]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[:alpha:]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[:alpha:]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[:alpha:]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]", "flags": "v", "valid": false}
+{"pattern": "[a[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[]", "flags": "v", "valid": false}
+{"pattern": "[a[b]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[b]]", "flags": "u", "valid": false}
+{"pattern": "[a[b]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[aeiou]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[aeiou]]", "flags": "u", "valid": false}
+{"pattern": "[a-z-[aeiou]]", "flags": "v", "valid": false}
+{"pattern": "[a-z-[b]c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[b]c]", "flags": "u", "valid": false}
+{"pattern": "[a-z-[b]c]", "flags": "v", "valid": false}
+{"pattern": "[a-[b]]", "flags": "", "valid": false}
+{"pattern": "[a-[b]]", "flags": "u", "valid": false}
+{"pattern": "[a-[b]]", "flags": "v", "valid": false}
+{"pattern": "[[a]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]]", "flags": "u", "valid": false}
+{"pattern": "[[a]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]b]", "flags": "u", "valid": false}
+{"pattern": "[[a]b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a--b]", "flags": "", "valid": false}
+{"pattern": "[a--b]", "flags": "u", "valid": false}
+{"pattern": "[a--b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a--]", "flags": "", "valid": false}
+{"pattern": "[a--]", "flags": "u", "valid": false}
+{"pattern": "[a--]", "flags": "v", "valid": false}
+{"pattern": "[--a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[--a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[--a]", "flags": "v", "valid": false}
+{"pattern": "[a&&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&]", "flags": "v", "valid": false}
+{"pattern": "[&&a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&a]", "flags": "v", "valid": false}
+{"pattern": "[[a]&&[b]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]&&[b]]", "flags": "u", "valid": false}
+{"pattern": "[[a]&&[b]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]--[b]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]--[b]]", "flags": "u", "valid": false}
+{"pattern": "[[a]--[b]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w&&\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w&&\\d]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w&&\\d]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w--\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w--\\d]", "flags": "u", "valid": false}
+{"pattern": "[\\w--\\d]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b&&c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b&&c]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b&&c]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a--b--c]", "flags": "", "valid": false}
+{"pattern": "[a--b--c]", "flags": "u", "valid": false}
+{"pattern": "[a--b--c]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b--c]", "flags": "", "valid": false}
+{"pattern": "[a&&b--c]", "flags": "u", "valid": false}
+{"pattern": "[a&&b--c]", "flags": "v", "valid": false}
+{"pattern": "[ab&&c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ab&&c]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ab&&c]", "flags": "v", "valid": false}
+{"pattern": "[a-z&&[aeiou]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z&&[aeiou]]", "flags": "u", "valid": false}
+{"pattern": "[a-z&&[aeiou]]", "flags": "v", "valid": false}
+{"pattern": "[[a-z]&&[aeiou]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a-z]&&[aeiou]]", "flags": "u", "valid": false}
+{"pattern": "[[a-z]&&[aeiou]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{abc}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{abc}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{abc}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{abc|d}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{abc|d}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{abc|d}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{abc}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{abc}]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{abc}]", "flags": "v", "valid": false}
+{"pattern": "[^\\q{a}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{a}]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{a}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q{a}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q{a}", "flags": "u", "valid": false}
+{"pattern": "\\q{a}", "flags": "v", "valid": false}
+{"pattern": "[|]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[|]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[|]", "flags": "v", "valid": false}
+{"pattern": "[(]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[(]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[(]", "flags": "v", "valid": false}
+{"pattern": "[)]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[)]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[)]", "flags": "v", "valid": false}
+{"pattern": "[{]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[{]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[{]", "flags": "v", "valid": false}
+{"pattern": "[}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[}]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[}]", "flags": "v", "valid": false}
+{"pattern": "[/]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[/]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[/]", "flags": "v", "valid": false}
+{"pattern": "[-]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-]", "flags": "v", "valid": false}
+{"pattern": "[\\&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\&]", "flags": "u", "valid": false}
+{"pattern": "[\\&]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\!]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\!]", "flags": "u", "valid": false}
+{"pattern": "[\\!]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\#]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\#]", "flags": "u", "valid": false}
+{"pattern": "[\\#]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\%]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\%]", "flags": "u", "valid": false}
+{"pattern": "[\\%]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\,]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\,]", "flags": "u", "valid": false}
+{"pattern": "[\\,]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\:]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\:]", "flags": "u", "valid": false}
+{"pattern": "[\\:]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\;]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\;]", "flags": "u", "valid": false}
+{"pattern": "[\\;]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\<]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\<]", "flags": "u", "valid": false}
+{"pattern": "[\\<]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\=]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\=]", "flags": "u", "valid": false}
+{"pattern": "[\\=]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\>]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\>]", "flags": "u", "valid": false}
+{"pattern": "[\\>]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\@]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\@]", "flags": "u", "valid": false}
+{"pattern": "[\\@]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\`]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\`]", "flags": "u", "valid": false}
+{"pattern": "[\\`]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\~]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\~]", "flags": "u", "valid": false}
+{"pattern": "[\\~]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\$]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\$]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\$]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\^]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\^]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\^]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!!]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!!]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!!]", "flags": "v", "valid": false}
+{"pattern": "[##]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[##]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[##]", "flags": "v", "valid": false}
+{"pattern": "[$$]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[$$]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[$$]", "flags": "v", "valid": false}
+{"pattern": "[%%]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[%%]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[%%]", "flags": "v", "valid": false}
+{"pattern": "[**]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[**]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[**]", "flags": "v", "valid": false}
+{"pattern": "[++]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[++]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[++]", "flags": "v", "valid": false}
+{"pattern": "[,,]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[,,]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[,,]", "flags": "v", "valid": false}
+{"pattern": "[..]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[..]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[..]", "flags": "v", "valid": false}
+{"pattern": "[::]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[::]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[::]", "flags": "v", "valid": false}
+{"pattern": "[;;]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[;;]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[;;]", "flags": "v", "valid": false}
+{"pattern": "[<<]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[<<]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[<<]", "flags": "v", "valid": false}
+{"pattern": "[==]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[==]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[==]", "flags": "v", "valid": false}
+{"pattern": "[>>]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[>>]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[>>]", "flags": "v", "valid": false}
+{"pattern": "[??]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[??]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[??]", "flags": "v", "valid": false}
+{"pattern": "[@@]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[@@]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[@@]", "flags": "v", "valid": false}
+{"pattern": "[^^]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^^]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^^]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^^]", "flags": "v", "valid": false}
+{"pattern": "[``]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[``]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[``]", "flags": "v", "valid": false}
+{"pattern": "[~~]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[~~]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[~~]", "flags": "v", "valid": false}
+{"pattern": "[a^^]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^^]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^^]", "flags": "v", "valid": false}
+{"pattern": "[&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&&]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&&]", "flags": "v", "valid": false}
+{"pattern": "[\\d-]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-]", "flags": "v", "valid": false}
+{"pattern": "[-\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-\\d]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-\\d]", "flags": "v", "valid": false}
+{"pattern": "[a-\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\d]", "flags": "u", "valid": false}
+{"pattern": "[a-\\d]", "flags": "v", "valid": false}
+{"pattern": "[\\s-\\S]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s-\\S]", "flags": "u", "valid": false}
+{"pattern": "[\\s-\\S]", "flags": "v", "valid": false}
+{"pattern": "[\\p{L}-z]", "flags": "", "valid": false}
+{"pattern": "[\\p{L}-z]", "flags": "u", "valid": false}
+{"pattern": "[\\p{L}-z]", "flags": "v", "valid": false}
+{"pattern": "[a-\\p{L}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\p{L}]", "flags": "u", "valid": false}
+{"pattern": "[a-\\p{L}]", "flags": "v", "valid": false}
+{"pattern": "[\\x41-\\x5A]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x41-\\x5A]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x41-\\x5A]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x5A-\\x41]", "flags": "", "valid": false}
+{"pattern": "[\\x5A-\\x41]", "flags": "u", "valid": false}
+{"pattern": "[\\x5A-\\x41]", "flags": "v", "valid": false}
+{"pattern": "[A-Z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[A-Z]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[A-Z]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA-\\cZ]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA-\\cZ]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA-\\cZ]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0-\\x20]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0-\\x20]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0-\\x20]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b-\\n]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b-\\n]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b-\\n]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\n-\\b]", "flags": "", "valid": false}
+{"pattern": "[\\n-\\b]", "flags": "u", "valid": false}
+{"pattern": "[\\n-\\b]", "flags": "v", "valid": false}
+{"pattern": "[\\--a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\--a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\--a]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\-]", "flags": "", "valid": false}
+{"pattern": "[a-\\-]", "flags": "u", "valid": false}
+{"pattern": "[a-\\-]", "flags": "v", "valid": false}
+{"pattern": "[%--]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[%--]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[%--]", "flags": "v", "valid": false}
+{"pattern": "[+--]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[+--]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[+--]", "flags": "v", "valid": false}
+{"pattern": "[a^]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[$]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[$]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[$]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]a]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]a]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]]", "flags": "u", "valid": false}
+{"pattern": "[\\\\]]", "flags": "v", "valid": false}
+{"pattern": "[a\\]", "flags": "", "valid": false}
+{"pattern": "[a\\]", "flags": "u", "valid": false}
+{"pattern": "[a\\]", "flags": "v", "valid": false}
+{"pattern": "[a\\]b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\]b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\]b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[#]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[#]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[#]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ ]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ ]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ ]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1", "flags": "u", "valid": false}
+{"pattern": "x{1", "flags": "v", "valid": false}
+{"pattern": "x{a}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{a}", "flags": "u", "valid": false}
+{"pattern": "x{a}", "flags": "v", "valid": false}
+{"pattern": "x{1,a}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1,a}", "flags": "u", "valid": false}
+{"pattern": "x{1,a}", "flags": "v", "valid": false}
+{"pattern": "x{,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{,}", "flags": "u", "valid": false}
+{"pattern": "x{,}", "flags": "v", "valid": false}
+{"pattern": "x{,5}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{,5}", "flags": "u", "valid": false}
+{"pattern": "x{,5}", "flags": "v", "valid": false}
+{"pattern": "x{ ,5}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ ,5}", "flags": "u", "valid": false}
+{"pattern": "x{ ,5}", "flags": "v", "valid": false}
+{"pattern": "x{5, }", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{5, }", "flags": "u", "valid": false}
+{"pattern": "x{5, }", "flags": "v", "valid": false}
+{"pattern": "x{1,2}{3}", "flags": "", "valid": false}
+{"pattern": "x{1,2}{3}", "flags": "u", "valid": false}
+{"pattern": "x{1,2}{3}", "flags": "v", "valid": false}
+{"pattern": "x{1}*", "flags": "", "valid": false}
+{"pattern": "x{1}*", "flags": "u", "valid": false}
+{"pattern": "x{1}*", "flags": "v", "valid": false}
+{"pattern": "x{0}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0,0}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0,0}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0,0}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{00001}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{00001}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{00001}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1}{1}", "flags": "", "valid": false}
+{"pattern": "x{1}{1}", "flags": "u", "valid": false}
+{"pattern": "x{1}{1}", "flags": "v", "valid": false}
+{"pattern": "(?:a){1}{2}", "flags": "", "valid": false}
+{"pattern": "(?:a){1}{2}", "flags": "u", "valid": false}
+{"pattern": "(?:a){1}{2}", "flags": "v", "valid": false}
+{"pattern": "^", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "^", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "^", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "$", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "$", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "$", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "^^", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "^^", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "^^", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "$$", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "$$", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "$$", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a^", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a^", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a^", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "$a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "$a", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "$a", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a^b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a^b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a^b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a$b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a$b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a$b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(^a)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(^a)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(^a)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a$)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a$)", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a$)", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "a|^b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a|^b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a|^b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a$|b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a$|b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a$|b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "^*a", "flags": "", "valid": false}
+{"pattern": "^*a", "flags": "u", "valid": false}
+{"pattern": "^*a", "flags": "v", "valid": false}
+{"pattern": "\\(a\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(\\)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(\\)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{1\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{1\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{1\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,2\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,2\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,2\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{,2\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{,2\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{,2\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{2,1\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{2,1\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{2,1\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\+", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\+", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "*a", "flags": "", "valid": false}
+{"pattern": "*a", "flags": "u", "valid": false}
+{"pattern": "*a", "flags": "v", "valid": false}
+{"pattern": "**", "flags": "", "valid": false}
+{"pattern": "**", "flags": "u", "valid": false}
+{"pattern": "**", "flags": "v", "valid": false}
+{"pattern": "\\(*a\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*a\\)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*a\\)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(^a\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(^a\\)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(^a\\)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|*b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|*b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|*b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}\\{2\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}\\{2\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}\\{2\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a*\\{2\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a*\\{2\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a*\\{2\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)\\1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)\\1", "flags": "u", "valid": false}
+{"pattern": "\\(a\\)\\1", "flags": "v", "valid": false}
+{"pattern": "\\1\\(a\\)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1\\(a\\)", "flags": "u", "valid": false}
+{"pattern": "\\1\\(a\\)", "flags": "v", "valid": false}
+{"pattern": "\\(a\\)\\2", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)\\2", "flags": "u", "valid": false}
+{"pattern": "\\(a\\)\\2", "flags": "v", "valid": false}
+{"pattern": "\\w", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(a)*", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)*", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)*", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)+?", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)+?", "flags": "u", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)+?", "flags": "v", "valid": true, "captures": 1, "names": []}
+{"pattern": "(a){2}{3}", "flags": "", "valid": false}
+{"pattern": "(a){2}{3}", "flags": "u", "valid": false}
+{"pattern": "(a){2}{3}", "flags": "v", "valid": false}
+{"pattern": "a+*", "flags": "", "valid": false}
+{"pattern": "a+*", "flags": "u", "valid": false}
+{"pattern": "a+*", "flags": "v", "valid": false}
+{"pattern": "a?*", "flags": "", "valid": false}
+{"pattern": "a?*", "flags": "u", "valid": false}
+{"pattern": "a?*", "flags": "v", "valid": false}
+{"pattern": "a*{2}", "flags": "", "valid": false}
+{"pattern": "a*{2}", "flags": "u", "valid": false}
+{"pattern": "a*{2}", "flags": "v", "valid": false}
+{"pattern": "a{2}*", "flags": "", "valid": false}
+{"pattern": "a{2}*", "flags": "u", "valid": false}
+{"pattern": "a{2}*", "flags": "v", "valid": false}
+{"pattern": "a{2}+", "flags": "", "valid": false}
+{"pattern": "a{2}+", "flags": "u", "valid": false}
+{"pattern": "a{2}+", "flags": "v", "valid": false}
+{"pattern": "(?:", "flags": "", "valid": false}
+{"pattern": "(?:", "flags": "u", "valid": false}
+{"pattern": "(?:", "flags": "v", "valid": false}
+{"pattern": "(?=", "flags": "", "valid": false}
+{"pattern": "(?=", "flags": "u", "valid": false}
+{"pattern": "(?=", "flags": "v", "valid": false}
+{"pattern": "(?<", "flags": "", "valid": false}
+{"pattern": "(?<", "flags": "u", "valid": false}
+{"pattern": "(?<", "flags": "v", "valid": false}
+{"pattern": "(?<=", "flags": "", "valid": false}
+{"pattern": "(?<=", "flags": "u", "valid": false}
+{"pattern": "(?<=", "flags": "v", "valid": false}
+{"pattern": "(?'", "flags": "", "valid": false}
+{"pattern": "(?'", "flags": "u", "valid": false}
+{"pattern": "(?'", "flags": "v", "valid": false}
+{"pattern": "(?P", "flags": "", "valid": false}
+{"pattern": "(?P", "flags": "u", "valid": false}
+{"pattern": "(?P", "flags": "v", "valid": false}
+{"pattern": "(?P=", "flags": "", "valid": false}
+{"pattern": "(?P=", "flags": "u", "valid": false}
+{"pattern": "(?P=", "flags": "v", "valid": false}
+{"pattern": "(?P>", "flags": "", "valid": false}
+{"pattern": "(?P>", "flags": "u", "valid": false}
+{"pattern": "(?P>", "flags": "v", "valid": false}
+{"pattern": "(?P<", "flags": "", "valid": false}
+{"pattern": "(?P<", "flags": "u", "valid": false}
+{"pattern": "(?P<", "flags": "v", "valid": false}
+{"pattern": "(?&", "flags": "", "valid": false}
+{"pattern": "(?&", "flags": "u", "valid": false}
+{"pattern": "(?&", "flags": "v", "valid": false}
+{"pattern": "(?R", "flags": "", "valid": false}
+{"pattern": "(?R", "flags": "u", "valid": false}
+{"pattern": "(?R", "flags": "v", "valid": false}
+{"pattern": "(?1", "flags": "", "valid": false}
+{"pattern": "(?1", "flags": "u", "valid": false}
+{"pattern": "(?1", "flags": "v", "valid": false}
+{"pattern": "(?C", "flags": "", "valid": false}
+{"pattern": "(?C", "flags": "u", "valid": false}
+{"pattern": "(?C", "flags": "v", "valid": false}
+{"pattern": "(?(1)", "flags": "", "valid": false}
+{"pattern": "(?(1)", "flags": "u", "valid": false}
+{"pattern": "(?(1)", "flags": "v", "valid": false}
+{"pattern": "(?#", "flags": "", "valid": false}
+{"pattern": "(?#", "flags": "u", "valid": false}
+{"pattern": "(?#", "flags": "v", "valid": false}
+{"pattern": "\\Q(\\E", "flags": "", "valid": false}
+{"pattern": "\\Q(\\E", "flags": "u", "valid": false}
+{"pattern": "\\Q(\\E", "flags": "v", "valid": false}
+{"pattern": "\\Q[\\E", "flags": "", "valid": false}
+{"pattern": "\\Q[\\E", "flags": "u", "valid": false}
+{"pattern": "\\Q[\\E", "flags": "v", "valid": false}
+{"pattern": "(\\Qa)\\E)", "flags": "", "valid": false}
+{"pattern": "(\\Qa)\\E)", "flags": "u", "valid": false}
+{"pattern": "(\\Qa)\\E)", "flags": "v", "valid": false}
+{"pattern": "[\\Qa\\E]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Qa\\E]", "flags": "u", "valid": false}
+{"pattern": "[\\Qa\\E]", "flags": "v", "valid": false}
+{"pattern": "[\\Q\\E]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q\\E]", "flags": "u", "valid": false}
+{"pattern": "[\\Q\\E]", "flags": "v", "valid": false}
+{"pattern": "[\\E]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\E]", "flags": "u", "valid": false}
+{"pattern": "[\\E]", "flags": "v", "valid": false}
+{"pattern": "[a\\Q]\\E]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Q]\\E]", "flags": "u", "valid": false}
+{"pattern": "[a\\Q]\\E]", "flags": "v", "valid": false}
+{"pattern": "\\E\\E", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E\\E", "flags": "u", "valid": false}
+{"pattern": "\\E\\E", "flags": "v", "valid": false}
+{"pattern": "(?x)a b", "flags": "", "valid": false}
+{"pattern": "(?x)a b", "flags": "u", "valid": false}
+{"pattern": "(?x)a b", "flags": "v", "valid": false}
+{"pattern": "(?x)a#b", "flags": "", "valid": false}
+{"pattern": "(?x)a#b", "flags": "u", "valid": false}
+{"pattern": "(?x)a#b", "flags": "v", "valid": false}
+{"pattern": "c", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "c", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "c", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)[a b]", "flags": "", "valid": false}
+{"pattern": "(?x)[a b]", "flags": "u", "valid": false}
+{"pattern": "(?x)[a b]", "flags": "v", "valid": false}
+{"pattern": "(?x)[ ]", "flags": "", "valid": false}
+{"pattern": "(?x)[ ]", "flags": "u", "valid": false}
+{"pattern": "(?x)[ ]", "flags": "v", "valid": false}
+{"pattern": "(?x)a {2}", "flags": "", "valid": false}
+{"pattern": "(?x)a {2}", "flags": "u", "valid": false}
+{"pattern": "(?x)a {2}", "flags": "v", "valid": false}
+{"pattern": "(?x)a{2} ?", "flags": "", "valid": false}
+{"pattern": "(?x)a{2} ?", "flags": "u", "valid": false}
+{"pattern": "(?x)a{2} ?", "flags": "v", "valid": false}
+{"pattern": "(?x)a\\ b", "flags": "", "valid": false}
+{"pattern": "(?x)a\\ b", "flags": "u", "valid": false}
+{"pattern": "(?x)a\\ b", "flags": "v", "valid": false}
+{"pattern": "(?x)\\", "flags": "", "valid": false}
+{"pattern": "(?x)\\", "flags": "u", "valid": false}
+{"pattern": "(?x)\\", "flags": "v", "valid": false}
+{"pattern": "(?x)(? :a)", "flags": "", "valid": false}
+{"pattern": "(?x)(? :a)", "flags": "u", "valid": false}
+{"pattern": "(?x)(? :a)", "flags": "v", "valid": false}
+{"pattern": "(?x)( ?:a)", "flags": "", "valid": false}
+{"pattern": "(?x)( ?:a)", "flags": "u", "valid": false}
+{"pattern": "(?x)( ?:a)", "flags": "v", "valid": false}
+{"pattern": "(?x)(?#)", "flags": "", "valid": false}
+{"pattern": "(?x)(?#)", "flags": "u", "valid": false}
+{"pattern": "(?x)(?#)", "flags": "v", "valid": false}
+{"pattern": "(?x)a#(", "flags": "", "valid": false}
+{"pattern": "(?x)a#(", "flags": "u", "valid": false}
+{"pattern": "(?x)a#(", "flags": "v", "valid": false}
+{"pattern": "(?x)\\p{ L}", "flags": "", "valid": false}
+{"pattern": "(?x)\\p{ L}", "flags": "u", "valid": false}
+{"pattern": "(?x)\\p{ L}", "flags": "v", "valid": false}
+{"pattern": "(?x)\\k< a>", "flags": "", "valid": false}
+{"pattern": "(?x)\\k< a>", "flags": "u", "valid": false}
+{"pattern": "(?x)\\k< a>", "flags": "v", "valid": false}
+{"pattern": "(?x)a+ +", "flags": "", "valid": false}
+{"pattern": "(?x)a+ +", "flags": "u", "valid": false}
+{"pattern": "(?x)a+ +", "flags": "v", "valid": false}
+{"pattern": "(?xx)[a b]", "flags": "", "valid": false}
+{"pattern": "(?xx)[a b]", "flags": "u", "valid": false}
+{"pattern": "(?xx)[a b]", "flags": "v", "valid": false}
+{"pattern": "[\\w--a-z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w--a-z]", "flags": "u", "valid": false}
+{"pattern": "[\\w--a-z]", "flags": "v", "valid": false}
+{"pattern": "[a-z--b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z--b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z--b]", "flags": "v", "valid": false}
+{"pattern": "[\\w--[a-z]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w--[a-z]]", "flags": "u", "valid": false}
+{"pattern": "[\\w--[a-z]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&bc]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&bc]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&bc]", "flags": "v", "valid": false}
+{"pattern": "[a&&&b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&&b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&&b]", "flags": "v", "valid": false}
+{"pattern": "[a&&b&&&c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b&&&c]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b&&&c]", "flags": "v", "valid": false}
+{"pattern": "[a--&b]", "flags": "", "valid": false}
+{"pattern": "[a--&b]", "flags": "u", "valid": false}
+{"pattern": "[a--&b]", "flags": "v", "valid": false}
+{"pattern": "[&&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&]", "flags": "v", "valid": false}
+{"pattern": "[a&b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-b-c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-b-c]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-b-c]", "flags": "v", "valid": false}
+{"pattern": "[a-b--c]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-b--c]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-b--c]", "flags": "v", "valid": false}
+{"pattern": "[\\q{a}-b]", "flags": "", "valid": false}
+{"pattern": "[\\q{a}-b]", "flags": "u", "valid": false}
+{"pattern": "[\\q{a}-b]", "flags": "v", "valid": false}
+{"pattern": "[a-\\q{b}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\q{b}]", "flags": "u", "valid": false}
+{"pattern": "[a-\\q{b}]", "flags": "v", "valid": false}
+{"pattern": "[[a]-b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]-b]", "flags": "u", "valid": false}
+{"pattern": "[[a]-b]", "flags": "v", "valid": false}
+{"pattern": "[\\d-a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-a]", "flags": "u", "valid": false}
+{"pattern": "[\\d-a]", "flags": "v", "valid": false}
+{"pattern": "[^\\q{a|b}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{a|b}]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{a|b}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{ab}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{ab}]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{ab}]", "flags": "v", "valid": false}
+{"pattern": "[^\\q{}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{}]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{}]", "flags": "v", "valid": false}
+{"pattern": "[^[\\q{ab}]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^[\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "[^[\\q{ab}]]", "flags": "v", "valid": false}
+{"pattern": "[^[^\\q{ab}]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^[^\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "[^[^\\q{ab}]]", "flags": "v", "valid": false}
+{"pattern": "[^\\q{ab}--\\q{ab}]", "flags": "", "valid": false}
+{"pattern": "[^\\q{ab}--\\q{ab}]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{ab}--\\q{ab}]", "flags": "v", "valid": false}
+{"pattern": "[^\\q{ab}&&a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{ab}&&a]", "flags": "u", "valid": false}
+{"pattern": "[^\\q{ab}&&a]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^a&&\\q{ab}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^a&&\\q{ab}]", "flags": "u", "valid": false}
+{"pattern": "[^a&&\\q{ab}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^[\\q{ab}]&&[\\q{ab}]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^[\\q{ab}]&&[\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "[^[\\q{ab}]&&[\\q{ab}]]", "flags": "v", "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}--a]", "flags": "", "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}--a]", "flags": "u", "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}--a]", "flags": "v", "valid": false}
+{"pattern": "[^a--\\p{RGI_Emoji}]", "flags": "", "valid": false}
+{"pattern": "[^a--\\p{RGI_Emoji}]", "flags": "u", "valid": false}
+{"pattern": "[^a--\\p{RGI_Emoji}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{a|}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{a|}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{a|}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{|}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{|}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{|}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\x41}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\x41}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{\\x41}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\u{1F600}}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\u{1F600}}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{\\u{1F600}}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\d}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\d}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{\\d}]", "flags": "v", "valid": false}
+{"pattern": "[\\q{\\b}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\b}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{\\b}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\p{L}}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\p{L}}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{\\p{L}}]", "flags": "v", "valid": false}
+{"pattern": "[\\q{\\q}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{\\q}]", "flags": "u", "valid": false}
+{"pattern": "[\\q{\\q}]", "flags": "v", "valid": false}
+{"pattern": "[^\\P{Lu}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\P{Lu}]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\P{Lu}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{Basic_Emoji}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{Basic_Emoji}", "flags": "u", "valid": false}
+{"pattern": "\\P{Basic_Emoji}", "flags": "v", "valid": false}
+{"pattern": "[\\P{RGI_Emoji}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\P{RGI_Emoji}]", "flags": "u", "valid": false}
+{"pattern": "[\\P{RGI_Emoji}]", "flags": "v", "valid": false}
+{"pattern": "[\\-]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\-]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\-]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a!]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a!]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a!]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!a!]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!a!]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!a!]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-!]", "flags": "", "valid": false}
+{"pattern": "[a-!]", "flags": "u", "valid": false}
+{"pattern": "[a-!]", "flags": "v", "valid": false}
+{"pattern": "[\\00]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\00]", "flags": "u", "valid": false}
+{"pattern": "[\\00]", "flags": "v", "valid": false}
+{"pattern": "[\\k]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\k]", "flags": "u", "valid": false}
+{"pattern": "[\\k]", "flags": "v", "valid": false}
+{"pattern": "[\\/]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\/]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\/]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ab]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[ab]]", "flags": "u", "valid": false}
+{"pattern": "[ab]]", "flags": "v", "valid": false}
+{"pattern": "[a]b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a]b]", "flags": "u", "valid": false}
+{"pattern": "[a]b]", "flags": "v", "valid": false}
+{"pattern": "(?im-i:a)", "flags": "", "valid": false}
+{"pattern": "(?im-i:a)", "flags": "u", "valid": false}
+{"pattern": "(?im-i:a)", "flags": "v", "valid": false}
+{"pattern": "(?x:a)", "flags": "", "valid": false}
+{"pattern": "(?x:a)", "flags": "u", "valid": false}
+{"pattern": "(?x:a)", "flags": "v", "valid": false}
+{"pattern": "(?u:a)", "flags": "", "valid": false}
+{"pattern": "(?u:a)", "flags": "u", "valid": false}
+{"pattern": "(?u:a)", "flags": "v", "valid": false}
+{"pattern": "(?ims-:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ims-:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ims-:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?I:a)", "flags": "", "valid": false}
+{"pattern": "(?I:a)", "flags": "u", "valid": false}
+{"pattern": "(?I:a)", "flags": "v", "valid": false}
+{"pattern": "(?i-ms:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-ms:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-ms:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-ims:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-ims:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-ims:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:a)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:a)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:a)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:(?-i:a))", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:(?-i:a))", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:(?-i:a))", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:", "flags": "", "valid": false}
+{"pattern": "(?i:", "flags": "u", "valid": false}
+{"pattern": "(?i:", "flags": "v", "valid": false}
+{"pattern": "\\2(a)", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "\\2(a)", "flags": "u", "valid": false}
+{"pattern": "\\2(a)", "flags": "v", "valid": false}
+{"pattern": "(?<a>.)\\k", "flags": "", "valid": false}
+{"pattern": "(?<a>.)\\k", "flags": "u", "valid": false}
+{"pattern": "(?<a>.)\\k", "flags": "v", "valid": false}
+{"pattern": "(?<\\u0061>x)\\k<a>", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u0061>x)\\k<a>", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u0061>x)\\k<a>", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u{61}>x)\\k<a>", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u{61}>x)\\k<a>", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<\\u{61}>x)\\k<a>", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?<a\\u200C>x)", "flags": "", "valid": true, "captures": 1, "names": ["a‌"]}
+{"pattern": "(?<a\\u200C>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a‌"]}
+{"pattern": "(?<a\\u200C>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a‌"]}
+{"pattern": "(?<\\u200C>x)", "flags": "", "valid": false}
+{"pattern": "(?<\\u200C>x)", "flags": "u", "valid": false}
+{"pattern": "(?<\\u200C>x)", "flags": "v", "valid": false}
+{"pattern": "(?<a‍>x)", "flags": "", "valid": true, "captures": 1, "names": ["a‍"]}
+{"pattern": "(?<a‍>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a‍"]}
+{"pattern": "(?<a‍>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a‍"]}
+{"pattern": "(?<𝒜>x)\\k<𝒜>", "flags": "", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<𝒜>x)\\k<𝒜>", "flags": "u", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<𝒜>x)\\k<𝒜>", "flags": "v", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<\\ud835\\udc9c>x)", "flags": "", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<\\ud835\\udc9c>x)", "flags": "u", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<\\ud835\\udc9c>x)", "flags": "v", "valid": true, "captures": 1, "names": ["𝒜"]}
+{"pattern": "(?<a·>x)", "flags": "", "valid": true, "captures": 1, "names": ["a·"]}
+{"pattern": "(?<a·>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a·"]}
+{"pattern": "(?<a·>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a·"]}
+{"pattern": "(?<℘>x)", "flags": "", "valid": true, "captures": 1, "names": ["℘"]}
+{"pattern": "(?<℘>x)", "flags": "u", "valid": true, "captures": 1, "names": ["℘"]}
+{"pattern": "(?<℘>x)", "flags": "v", "valid": true, "captures": 1, "names": ["℘"]}
+{"pattern": "a{2147483648,99999999999}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483648,99999999999}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2147483648,99999999999}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{3,2}", "flags": "", "valid": false}
+{"pattern": "a{3,2}", "flags": "u", "valid": false}
+{"pattern": "a{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\u{0000000041}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{0000000041}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{0000000041}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uD83D\\uDE00", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uD83D\\uDE00", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uD83D\\uDE00", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "", "valid": false}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\uD83D\\uDE02-\\uD83D\\uDE00]", "flags": "", "valid": false}
+{"pattern": "[\\uD83D\\uDE02-\\uD83D\\uDE00]", "flags": "u", "valid": false}
+{"pattern": "[\\uD83D\\uDE02-\\uD83D\\uDE00]", "flags": "v", "valid": false}
+{"pattern": "[\\uD83D-\\uDE00]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\uD83D-\\uDE00]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\uD83D-\\uDE00]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{D83D}\\u{DE00}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{D83D}\\u{DE00}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{D83D}\\u{DE00}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u{D83D}\\u{DE00}-\\u{D83D}\\u{DE02}]", "flags": "", "valid": false}
+{"pattern": "[\\u{D83D}\\u{DE00}-\\u{D83D}\\u{DE02}]", "flags": "u", "valid": false}
+{"pattern": "[\\u{D83D}\\u{DE00}-\\u{D83D}\\u{DE02}]", "flags": "v", "valid": false}
+{"pattern": "[][\\d--\\1]\\3|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[][\\d--\\1]\\3|", "flags": "u", "valid": false}
+{"pattern": "[][\\d--\\1]\\3|", "flags": "v", "valid": false}
+{"pattern": "[/\\c1--]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[/\\c1--]", "flags": "u", "valid": false}
+{"pattern": "[/\\c1--]", "flags": "v", "valid": false}
+{"pattern": "[\\0\\--$$]", "flags": "", "valid": false}
+{"pattern": "[\\0\\--$$]", "flags": "u", "valid": false}
+{"pattern": "[\\0\\--$$]", "flags": "v", "valid": false}
+{"pattern": "((?<a>x)|(?<a>y))\\k<a>", "flags": "", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "((?<a>x)|(?<a>y))\\k<a>", "flags": "u", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "((?<a>x)|(?<a>y))\\k<a>", "flags": "v", "valid": true, "captures": 3, "names": ["a"]}
+{"pattern": "(a)(?<x>b)(c)\\2", "flags": "", "valid": true, "captures": 3, "names": ["x"]}
+{"pattern": "(a)(?<x>b)(c)\\2", "flags": "u", "valid": true, "captures": 3, "names": ["x"]}
+{"pattern": "(a)(?<x>b)(c)\\2", "flags": "v", "valid": true, "captures": 3, "names": ["x"]}
+{"pattern": "\\ ", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\ ]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ *", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\ ", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\!*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\!", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\!b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\"]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\"*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\\"", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\\"b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\#*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\#", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\#b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\$", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\$b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\%", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\%b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\&", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\&b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\']", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\'*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\'", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\'b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\(]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\(", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\(b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\)]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\)b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\*]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\**", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\*b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\+]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\+b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\,", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\,b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\-*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\-", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\-b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\.]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\.", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\.b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\/", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\/b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\0", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\0b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\1b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\2]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\2*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\2", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\2b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\3", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\3]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\3*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\3", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\3b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\4", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\4]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\4*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\4", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\4b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\5", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\5]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\5*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\5", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\5b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\6", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\6]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\6*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\6", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\6b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\7", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\7]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\7*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\7", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\7b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\8*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\8", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\8b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\9]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\9*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\9", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\9b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\:*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\:", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\:b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\;", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\;*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\;", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\;b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\<", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\<b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\=*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\=", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\=b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\>*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\>", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\>b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\?]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\?b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\@", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\@b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\A]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\A", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Ab]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B*", "flags": "", "valid": false}
+{"pattern": "a\\B", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Bb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\C]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\C*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\C", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Cb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\D", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\D]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\D*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\D", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Db]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\E", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Eb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\F", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\F]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\F*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\F", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Fb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\G]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\G*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\G", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Gb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\H]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\H*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\H", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Hb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\I]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\I*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\I", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Ib]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\J", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\J]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\J*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\J", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Jb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\K]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\K*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\K", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Kb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\L]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\L*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\L", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Lb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\M", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\M]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\M*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\M", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Mb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\N]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\N", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Nb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\O", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\O]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\O*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\O", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Ob]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\P]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\P", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Pb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\Q", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Qb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\R]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\R*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\R", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Rb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\S]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\S", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Sb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\T", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\T]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\T*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\T", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Tb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\U]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\U*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\U", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Ub]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\V", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\V]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\V*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\V", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Vb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\W]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\W", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Wb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\X]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\X*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\X", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Xb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Y", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Y]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Y*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\Y", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Yb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Z*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\Z", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Zb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\[", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\[b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\\\", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\\\b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\^", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\^b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\_]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\_", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\_b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\`*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\`", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\`b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\a*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ab]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\bb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\c", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\cb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\d", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\db]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\e]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\e*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\e", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\eb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\f]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\f", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\fb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\g]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\g", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\gb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\h]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\h*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\h", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\hb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\i]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\i*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\i", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ib]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\j]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\j*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\j", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\jb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\k", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\kb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\l]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\l*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\l", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\lb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\m]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\m*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\m", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\mb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\n]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\n", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\nb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\o]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\o", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ob]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\p", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\pb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\q", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\qb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\r]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\r", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\rb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\s", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\sb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\t]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\t", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\tb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\u", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ub]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\v]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\v", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\vb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\w", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\wb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\x", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\xb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\y]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\y*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\y", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\yb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\z]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\z*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\z", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\zb]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\{]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\{b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\|]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\|b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\}b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\~", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\~b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ ", "flags": "u", "valid": false}
+{"pattern": "[\\ ]", "flags": "u", "valid": false}
+{"pattern": "\\ *", "flags": "u", "valid": false}
+{"pattern": "a\\ ", "flags": "u", "valid": false}
+{"pattern": "[a\\ b]", "flags": "u", "valid": false}
+{"pattern": "\\!*", "flags": "u", "valid": false}
+{"pattern": "a\\!", "flags": "u", "valid": false}
+{"pattern": "[a\\!b]", "flags": "u", "valid": false}
+{"pattern": "[\\\"]", "flags": "u", "valid": false}
+{"pattern": "\\\"*", "flags": "u", "valid": false}
+{"pattern": "a\\\"", "flags": "u", "valid": false}
+{"pattern": "[a\\\"b]", "flags": "u", "valid": false}
+{"pattern": "\\#*", "flags": "u", "valid": false}
+{"pattern": "a\\#", "flags": "u", "valid": false}
+{"pattern": "[a\\#b]", "flags": "u", "valid": false}
+{"pattern": "\\$*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\$", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\$b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%*", "flags": "u", "valid": false}
+{"pattern": "a\\%", "flags": "u", "valid": false}
+{"pattern": "[a\\%b]", "flags": "u", "valid": false}
+{"pattern": "\\&*", "flags": "u", "valid": false}
+{"pattern": "a\\&", "flags": "u", "valid": false}
+{"pattern": "[a\\&b]", "flags": "u", "valid": false}
+{"pattern": "[\\']", "flags": "u", "valid": false}
+{"pattern": "\\'*", "flags": "u", "valid": false}
+{"pattern": "a\\'", "flags": "u", "valid": false}
+{"pattern": "[a\\'b]", "flags": "u", "valid": false}
+{"pattern": "[\\(]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\(", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\(b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\)]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\)b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\*]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\**", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\*b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\+]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\+b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,*", "flags": "u", "valid": false}
+{"pattern": "a\\,", "flags": "u", "valid": false}
+{"pattern": "[a\\,b]", "flags": "u", "valid": false}
+{"pattern": "\\-*", "flags": "u", "valid": false}
+{"pattern": "a\\-", "flags": "u", "valid": false}
+{"pattern": "[a\\-b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\.]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\.", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\.b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\/", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\/b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\0", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\0b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1*", "flags": "u", "valid": false}
+{"pattern": "a\\1", "flags": "u", "valid": false}
+{"pattern": "[a\\1b]", "flags": "u", "valid": false}
+{"pattern": "[\\2]", "flags": "u", "valid": false}
+{"pattern": "\\2*", "flags": "u", "valid": false}
+{"pattern": "a\\2", "flags": "u", "valid": false}
+{"pattern": "[a\\2b]", "flags": "u", "valid": false}
+{"pattern": "\\3", "flags": "u", "valid": false}
+{"pattern": "[\\3]", "flags": "u", "valid": false}
+{"pattern": "\\3*", "flags": "u", "valid": false}
+{"pattern": "a\\3", "flags": "u", "valid": false}
+{"pattern": "[a\\3b]", "flags": "u", "valid": false}
+{"pattern": "\\4", "flags": "u", "valid": false}
+{"pattern": "[\\4]", "flags": "u", "valid": false}
+{"pattern": "\\4*", "flags": "u", "valid": false}
+{"pattern": "a\\4", "flags": "u", "valid": false}
+{"pattern": "[a\\4b]", "flags": "u", "valid": false}
+{"pattern": "\\5", "flags": "u", "valid": false}
+{"pattern": "[\\5]", "flags": "u", "valid": false}
+{"pattern": "\\5*", "flags": "u", "valid": false}
+{"pattern": "a\\5", "flags": "u", "valid": false}
+{"pattern": "[a\\5b]", "flags": "u", "valid": false}
+{"pattern": "\\6", "flags": "u", "valid": false}
+{"pattern": "[\\6]", "flags": "u", "valid": false}
+{"pattern": "\\6*", "flags": "u", "valid": false}
+{"pattern": "a\\6", "flags": "u", "valid": false}
+{"pattern": "[a\\6b]", "flags": "u", "valid": false}
+{"pattern": "\\7", "flags": "u", "valid": false}
+{"pattern": "[\\7]", "flags": "u", "valid": false}
+{"pattern": "\\7*", "flags": "u", "valid": false}
+{"pattern": "a\\7", "flags": "u", "valid": false}
+{"pattern": "[a\\7b]", "flags": "u", "valid": false}
+{"pattern": "\\8*", "flags": "u", "valid": false}
+{"pattern": "a\\8", "flags": "u", "valid": false}
+{"pattern": "[a\\8b]", "flags": "u", "valid": false}
+{"pattern": "[\\9]", "flags": "u", "valid": false}
+{"pattern": "\\9*", "flags": "u", "valid": false}
+{"pattern": "a\\9", "flags": "u", "valid": false}
+{"pattern": "[a\\9b]", "flags": "u", "valid": false}
+{"pattern": "\\:*", "flags": "u", "valid": false}
+{"pattern": "a\\:", "flags": "u", "valid": false}
+{"pattern": "[a\\:b]", "flags": "u", "valid": false}
+{"pattern": "\\;", "flags": "u", "valid": false}
+{"pattern": "\\;*", "flags": "u", "valid": false}
+{"pattern": "a\\;", "flags": "u", "valid": false}
+{"pattern": "[a\\;b]", "flags": "u", "valid": false}
+{"pattern": "\\<*", "flags": "u", "valid": false}
+{"pattern": "a\\<", "flags": "u", "valid": false}
+{"pattern": "[a\\<b]", "flags": "u", "valid": false}
+{"pattern": "\\=*", "flags": "u", "valid": false}
+{"pattern": "a\\=", "flags": "u", "valid": false}
+{"pattern": "[a\\=b]", "flags": "u", "valid": false}
+{"pattern": "\\>*", "flags": "u", "valid": false}
+{"pattern": "a\\>", "flags": "u", "valid": false}
+{"pattern": "[a\\>b]", "flags": "u", "valid": false}
+{"pattern": "[\\?]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\?b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@*", "flags": "u", "valid": false}
+{"pattern": "a\\@", "flags": "u", "valid": false}
+{"pattern": "[a\\@b]", "flags": "u", "valid": false}
+{"pattern": "[\\A]", "flags": "u", "valid": false}
+{"pattern": "\\A*", "flags": "u", "valid": false}
+{"pattern": "a\\A", "flags": "u", "valid": false}
+{"pattern": "[a\\Ab]", "flags": "u", "valid": false}
+{"pattern": "\\B", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B*", "flags": "u", "valid": false}
+{"pattern": "a\\B", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Bb]", "flags": "u", "valid": false}
+{"pattern": "[\\C]", "flags": "u", "valid": false}
+{"pattern": "\\C*", "flags": "u", "valid": false}
+{"pattern": "a\\C", "flags": "u", "valid": false}
+{"pattern": "[a\\Cb]", "flags": "u", "valid": false}
+{"pattern": "\\D", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\D]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\D*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\D", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Db]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E*", "flags": "u", "valid": false}
+{"pattern": "a\\E", "flags": "u", "valid": false}
+{"pattern": "[a\\Eb]", "flags": "u", "valid": false}
+{"pattern": "\\F", "flags": "u", "valid": false}
+{"pattern": "[\\F]", "flags": "u", "valid": false}
+{"pattern": "\\F*", "flags": "u", "valid": false}
+{"pattern": "a\\F", "flags": "u", "valid": false}
+{"pattern": "[a\\Fb]", "flags": "u", "valid": false}
+{"pattern": "[\\G]", "flags": "u", "valid": false}
+{"pattern": "\\G*", "flags": "u", "valid": false}
+{"pattern": "a\\G", "flags": "u", "valid": false}
+{"pattern": "[a\\Gb]", "flags": "u", "valid": false}
+{"pattern": "[\\H]", "flags": "u", "valid": false}
+{"pattern": "\\H*", "flags": "u", "valid": false}
+{"pattern": "a\\H", "flags": "u", "valid": false}
+{"pattern": "[a\\Hb]", "flags": "u", "valid": false}
+{"pattern": "[\\I]", "flags": "u", "valid": false}
+{"pattern": "\\I*", "flags": "u", "valid": false}
+{"pattern": "a\\I", "flags": "u", "valid": false}
+{"pattern": "[a\\Ib]", "flags": "u", "valid": false}
+{"pattern": "\\J", "flags": "u", "valid": false}
+{"pattern": "[\\J]", "flags": "u", "valid": false}
+{"pattern": "\\J*", "flags": "u", "valid": false}
+{"pattern": "a\\J", "flags": "u", "valid": false}
+{"pattern": "[a\\Jb]", "flags": "u", "valid": false}
+{"pattern": "[\\K]", "flags": "u", "valid": false}
+{"pattern": "\\K*", "flags": "u", "valid": false}
+{"pattern": "a\\K", "flags": "u", "valid": false}
+{"pattern": "[a\\Kb]", "flags": "u", "valid": false}
+{"pattern": "[\\L]", "flags": "u", "valid": false}
+{"pattern": "\\L*", "flags": "u", "valid": false}
+{"pattern": "a\\L", "flags": "u", "valid": false}
+{"pattern": "[a\\Lb]", "flags": "u", "valid": false}
+{"pattern": "\\M", "flags": "u", "valid": false}
+{"pattern": "[\\M]", "flags": "u", "valid": false}
+{"pattern": "\\M*", "flags": "u", "valid": false}
+{"pattern": "a\\M", "flags": "u", "valid": false}
+{"pattern": "[a\\Mb]", "flags": "u", "valid": false}
+{"pattern": "[\\N]", "flags": "u", "valid": false}
+{"pattern": "\\N*", "flags": "u", "valid": false}
+{"pattern": "a\\N", "flags": "u", "valid": false}
+{"pattern": "[a\\Nb]", "flags": "u", "valid": false}
+{"pattern": "\\O", "flags": "u", "valid": false}
+{"pattern": "[\\O]", "flags": "u", "valid": false}
+{"pattern": "\\O*", "flags": "u", "valid": false}
+{"pattern": "a\\O", "flags": "u", "valid": false}
+{"pattern": "[a\\Ob]", "flags": "u", "valid": false}
+{"pattern": "\\P", "flags": "u", "valid": false}
+{"pattern": "[\\P]", "flags": "u", "valid": false}
+{"pattern": "\\P*", "flags": "u", "valid": false}
+{"pattern": "a\\P", "flags": "u", "valid": false}
+{"pattern": "[a\\Pb]", "flags": "u", "valid": false}
+{"pattern": "[\\Q]", "flags": "u", "valid": false}
+{"pattern": "\\Q*", "flags": "u", "valid": false}
+{"pattern": "a\\Q", "flags": "u", "valid": false}
+{"pattern": "[a\\Qb]", "flags": "u", "valid": false}
+{"pattern": "[\\R]", "flags": "u", "valid": false}
+{"pattern": "\\R*", "flags": "u", "valid": false}
+{"pattern": "a\\R", "flags": "u", "valid": false}
+{"pattern": "[a\\Rb]", "flags": "u", "valid": false}
+{"pattern": "[\\S]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\S", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Sb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\T", "flags": "u", "valid": false}
+{"pattern": "[\\T]", "flags": "u", "valid": false}
+{"pattern": "\\T*", "flags": "u", "valid": false}
+{"pattern": "a\\T", "flags": "u", "valid": false}
+{"pattern": "[a\\Tb]", "flags": "u", "valid": false}
+{"pattern": "[\\U]", "flags": "u", "valid": false}
+{"pattern": "\\U*", "flags": "u", "valid": false}
+{"pattern": "a\\U", "flags": "u", "valid": false}
+{"pattern": "[a\\Ub]", "flags": "u", "valid": false}
+{"pattern": "\\V", "flags": "u", "valid": false}
+{"pattern": "[\\V]", "flags": "u", "valid": false}
+{"pattern": "\\V*", "flags": "u", "valid": false}
+{"pattern": "a\\V", "flags": "u", "valid": false}
+{"pattern": "[a\\Vb]", "flags": "u", "valid": false}
+{"pattern": "[\\W]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\W", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Wb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\X]", "flags": "u", "valid": false}
+{"pattern": "\\X*", "flags": "u", "valid": false}
+{"pattern": "a\\X", "flags": "u", "valid": false}
+{"pattern": "[a\\Xb]", "flags": "u", "valid": false}
+{"pattern": "\\Y", "flags": "u", "valid": false}
+{"pattern": "[\\Y]", "flags": "u", "valid": false}
+{"pattern": "\\Y*", "flags": "u", "valid": false}
+{"pattern": "a\\Y", "flags": "u", "valid": false}
+{"pattern": "[a\\Yb]", "flags": "u", "valid": false}
+{"pattern": "[\\Z]", "flags": "u", "valid": false}
+{"pattern": "\\Z*", "flags": "u", "valid": false}
+{"pattern": "a\\Z", "flags": "u", "valid": false}
+{"pattern": "[a\\Zb]", "flags": "u", "valid": false}
+{"pattern": "[\\[]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\[", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\[b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\\\", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\\\b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\^", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\^b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\_]", "flags": "u", "valid": false}
+{"pattern": "\\_*", "flags": "u", "valid": false}
+{"pattern": "a\\_", "flags": "u", "valid": false}
+{"pattern": "[a\\_b]", "flags": "u", "valid": false}
+{"pattern": "\\`*", "flags": "u", "valid": false}
+{"pattern": "a\\`", "flags": "u", "valid": false}
+{"pattern": "[a\\`b]", "flags": "u", "valid": false}
+{"pattern": "[\\a]", "flags": "u", "valid": false}
+{"pattern": "\\a*", "flags": "u", "valid": false}
+{"pattern": "a\\a", "flags": "u", "valid": false}
+{"pattern": "[a\\ab]", "flags": "u", "valid": false}
+{"pattern": "\\b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\b", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\bb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c*", "flags": "u", "valid": false}
+{"pattern": "a\\c", "flags": "u", "valid": false}
+{"pattern": "[a\\cb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\d", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\db]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\e]", "flags": "u", "valid": false}
+{"pattern": "\\e*", "flags": "u", "valid": false}
+{"pattern": "a\\e", "flags": "u", "valid": false}
+{"pattern": "[a\\eb]", "flags": "u", "valid": false}
+{"pattern": "[\\f]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\f", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\fb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\g]", "flags": "u", "valid": false}
+{"pattern": "\\g*", "flags": "u", "valid": false}
+{"pattern": "a\\g", "flags": "u", "valid": false}
+{"pattern": "[a\\gb]", "flags": "u", "valid": false}
+{"pattern": "[\\h]", "flags": "u", "valid": false}
+{"pattern": "\\h*", "flags": "u", "valid": false}
+{"pattern": "a\\h", "flags": "u", "valid": false}
+{"pattern": "[a\\hb]", "flags": "u", "valid": false}
+{"pattern": "[\\i]", "flags": "u", "valid": false}
+{"pattern": "\\i*", "flags": "u", "valid": false}
+{"pattern": "a\\i", "flags": "u", "valid": false}
+{"pattern": "[a\\ib]", "flags": "u", "valid": false}
+{"pattern": "[\\j]", "flags": "u", "valid": false}
+{"pattern": "\\j*", "flags": "u", "valid": false}
+{"pattern": "a\\j", "flags": "u", "valid": false}
+{"pattern": "[a\\jb]", "flags": "u", "valid": false}
+{"pattern": "\\k*", "flags": "u", "valid": false}
+{"pattern": "a\\k", "flags": "u", "valid": false}
+{"pattern": "[a\\kb]", "flags": "u", "valid": false}
+{"pattern": "[\\l]", "flags": "u", "valid": false}
+{"pattern": "\\l*", "flags": "u", "valid": false}
+{"pattern": "a\\l", "flags": "u", "valid": false}
+{"pattern": "[a\\lb]", "flags": "u", "valid": false}
+{"pattern": "[\\m]", "flags": "u", "valid": false}
+{"pattern": "\\m*", "flags": "u", "valid": false}
+{"pattern": "a\\m", "flags": "u", "valid": false}
+{"pattern": "[a\\mb]", "flags": "u", "valid": false}
+{"pattern": "[\\n]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\n", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\nb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\o]", "flags": "u", "valid": false}
+{"pattern": "\\o*", "flags": "u", "valid": false}
+{"pattern": "a\\o", "flags": "u", "valid": false}
+{"pattern": "[a\\ob]", "flags": "u", "valid": false}
+{"pattern": "[\\p]", "flags": "u", "valid": false}
+{"pattern": "\\p*", "flags": "u", "valid": false}
+{"pattern": "a\\p", "flags": "u", "valid": false}
+{"pattern": "[a\\pb]", "flags": "u", "valid": false}
+{"pattern": "\\q", "flags": "u", "valid": false}
+{"pattern": "[\\q]", "flags": "u", "valid": false}
+{"pattern": "\\q*", "flags": "u", "valid": false}
+{"pattern": "a\\q", "flags": "u", "valid": false}
+{"pattern": "[a\\qb]", "flags": "u", "valid": false}
+{"pattern": "[\\r]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\r", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\rb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\s", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\sb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\t]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\t", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\tb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u]", "flags": "u", "valid": false}
+{"pattern": "\\u*", "flags": "u", "valid": false}
+{"pattern": "a\\u", "flags": "u", "valid": false}
+{"pattern": "[a\\ub]", "flags": "u", "valid": false}
+{"pattern": "[\\v]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\v", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\vb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\w", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\wb]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x]", "flags": "u", "valid": false}
+{"pattern": "\\x*", "flags": "u", "valid": false}
+{"pattern": "a\\x", "flags": "u", "valid": false}
+{"pattern": "[a\\xb]", "flags": "u", "valid": false}
+{"pattern": "[\\y]", "flags": "u", "valid": false}
+{"pattern": "\\y*", "flags": "u", "valid": false}
+{"pattern": "a\\y", "flags": "u", "valid": false}
+{"pattern": "[a\\yb]", "flags": "u", "valid": false}
+{"pattern": "[\\z]", "flags": "u", "valid": false}
+{"pattern": "\\z*", "flags": "u", "valid": false}
+{"pattern": "a\\z", "flags": "u", "valid": false}
+{"pattern": "[a\\zb]", "flags": "u", "valid": false}
+{"pattern": "[\\{]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\{b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\|]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\|b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\}]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}*", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\}b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~*", "flags": "u", "valid": false}
+{"pattern": "a\\~", "flags": "u", "valid": false}
+{"pattern": "[a\\~b]", "flags": "u", "valid": false}
+{"pattern": "\\ ", "flags": "v", "valid": false}
+{"pattern": "[\\ ]", "flags": "v", "valid": false}
+{"pattern": "\\ *", "flags": "v", "valid": false}
+{"pattern": "a\\ ", "flags": "v", "valid": false}
+{"pattern": "[a\\ b]", "flags": "v", "valid": false}
+{"pattern": "\\!*", "flags": "v", "valid": false}
+{"pattern": "a\\!", "flags": "v", "valid": false}
+{"pattern": "[a\\!b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\"]", "flags": "v", "valid": false}
+{"pattern": "\\\"*", "flags": "v", "valid": false}
+{"pattern": "a\\\"", "flags": "v", "valid": false}
+{"pattern": "[a\\\"b]", "flags": "v", "valid": false}
+{"pattern": "\\#*", "flags": "v", "valid": false}
+{"pattern": "a\\#", "flags": "v", "valid": false}
+{"pattern": "[a\\#b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\$", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\$b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%*", "flags": "v", "valid": false}
+{"pattern": "a\\%", "flags": "v", "valid": false}
+{"pattern": "[a\\%b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&*", "flags": "v", "valid": false}
+{"pattern": "a\\&", "flags": "v", "valid": false}
+{"pattern": "[a\\&b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\']", "flags": "v", "valid": false}
+{"pattern": "\\'*", "flags": "v", "valid": false}
+{"pattern": "a\\'", "flags": "v", "valid": false}
+{"pattern": "[a\\'b]", "flags": "v", "valid": false}
+{"pattern": "[\\(]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\(", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\(b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\)]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\)b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\*]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\**", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\*b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\+]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\+b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,*", "flags": "v", "valid": false}
+{"pattern": "a\\,", "flags": "v", "valid": false}
+{"pattern": "[a\\,b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\-*", "flags": "v", "valid": false}
+{"pattern": "a\\-", "flags": "v", "valid": false}
+{"pattern": "[a\\-b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\.]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\.", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\.b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\/", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\/b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\0", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\0b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1*", "flags": "v", "valid": false}
+{"pattern": "a\\1", "flags": "v", "valid": false}
+{"pattern": "[a\\1b]", "flags": "v", "valid": false}
+{"pattern": "[\\2]", "flags": "v", "valid": false}
+{"pattern": "\\2*", "flags": "v", "valid": false}
+{"pattern": "a\\2", "flags": "v", "valid": false}
+{"pattern": "[a\\2b]", "flags": "v", "valid": false}
+{"pattern": "\\3", "flags": "v", "valid": false}
+{"pattern": "[\\3]", "flags": "v", "valid": false}
+{"pattern": "\\3*", "flags": "v", "valid": false}
+{"pattern": "a\\3", "flags": "v", "valid": false}
+{"pattern": "[a\\3b]", "flags": "v", "valid": false}
+{"pattern": "\\4", "flags": "v", "valid": false}
+{"pattern": "[\\4]", "flags": "v", "valid": false}
+{"pattern": "\\4*", "flags": "v", "valid": false}
+{"pattern": "a\\4", "flags": "v", "valid": false}
+{"pattern": "[a\\4b]", "flags": "v", "valid": false}
+{"pattern": "\\5", "flags": "v", "valid": false}
+{"pattern": "[\\5]", "flags": "v", "valid": false}
+{"pattern": "\\5*", "flags": "v", "valid": false}
+{"pattern": "a\\5", "flags": "v", "valid": false}
+{"pattern": "[a\\5b]", "flags": "v", "valid": false}
+{"pattern": "\\6", "flags": "v", "valid": false}
+{"pattern": "[\\6]", "flags": "v", "valid": false}
+{"pattern": "\\6*", "flags": "v", "valid": false}
+{"pattern": "a\\6", "flags": "v", "valid": false}
+{"pattern": "[a\\6b]", "flags": "v", "valid": false}
+{"pattern": "\\7", "flags": "v", "valid": false}
+{"pattern": "[\\7]", "flags": "v", "valid": false}
+{"pattern": "\\7*", "flags": "v", "valid": false}
+{"pattern": "a\\7", "flags": "v", "valid": false}
+{"pattern": "[a\\7b]", "flags": "v", "valid": false}
+{"pattern": "\\8*", "flags": "v", "valid": false}
+{"pattern": "a\\8", "flags": "v", "valid": false}
+{"pattern": "[a\\8b]", "flags": "v", "valid": false}
+{"pattern": "[\\9]", "flags": "v", "valid": false}
+{"pattern": "\\9*", "flags": "v", "valid": false}
+{"pattern": "a\\9", "flags": "v", "valid": false}
+{"pattern": "[a\\9b]", "flags": "v", "valid": false}
+{"pattern": "\\:*", "flags": "v", "valid": false}
+{"pattern": "a\\:", "flags": "v", "valid": false}
+{"pattern": "[a\\:b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\;", "flags": "v", "valid": false}
+{"pattern": "\\;*", "flags": "v", "valid": false}
+{"pattern": "a\\;", "flags": "v", "valid": false}
+{"pattern": "[a\\;b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<*", "flags": "v", "valid": false}
+{"pattern": "a\\<", "flags": "v", "valid": false}
+{"pattern": "[a\\<b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\=*", "flags": "v", "valid": false}
+{"pattern": "a\\=", "flags": "v", "valid": false}
+{"pattern": "[a\\=b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\>*", "flags": "v", "valid": false}
+{"pattern": "a\\>", "flags": "v", "valid": false}
+{"pattern": "[a\\>b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\?]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\?b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@*", "flags": "v", "valid": false}
+{"pattern": "a\\@", "flags": "v", "valid": false}
+{"pattern": "[a\\@b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\A]", "flags": "v", "valid": false}
+{"pattern": "\\A*", "flags": "v", "valid": false}
+{"pattern": "a\\A", "flags": "v", "valid": false}
+{"pattern": "[a\\Ab]", "flags": "v", "valid": false}
+{"pattern": "\\B", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B*", "flags": "v", "valid": false}
+{"pattern": "a\\B", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Bb]", "flags": "v", "valid": false}
+{"pattern": "[\\C]", "flags": "v", "valid": false}
+{"pattern": "\\C*", "flags": "v", "valid": false}
+{"pattern": "a\\C", "flags": "v", "valid": false}
+{"pattern": "[a\\Cb]", "flags": "v", "valid": false}
+{"pattern": "\\D", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\D]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\D*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\D", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Db]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E*", "flags": "v", "valid": false}
+{"pattern": "a\\E", "flags": "v", "valid": false}
+{"pattern": "[a\\Eb]", "flags": "v", "valid": false}
+{"pattern": "\\F", "flags": "v", "valid": false}
+{"pattern": "[\\F]", "flags": "v", "valid": false}
+{"pattern": "\\F*", "flags": "v", "valid": false}
+{"pattern": "a\\F", "flags": "v", "valid": false}
+{"pattern": "[a\\Fb]", "flags": "v", "valid": false}
+{"pattern": "[\\G]", "flags": "v", "valid": false}
+{"pattern": "\\G*", "flags": "v", "valid": false}
+{"pattern": "a\\G", "flags": "v", "valid": false}
+{"pattern": "[a\\Gb]", "flags": "v", "valid": false}
+{"pattern": "[\\H]", "flags": "v", "valid": false}
+{"pattern": "\\H*", "flags": "v", "valid": false}
+{"pattern": "a\\H", "flags": "v", "valid": false}
+{"pattern": "[a\\Hb]", "flags": "v", "valid": false}
+{"pattern": "[\\I]", "flags": "v", "valid": false}
+{"pattern": "\\I*", "flags": "v", "valid": false}
+{"pattern": "a\\I", "flags": "v", "valid": false}
+{"pattern": "[a\\Ib]", "flags": "v", "valid": false}
+{"pattern": "\\J", "flags": "v", "valid": false}
+{"pattern": "[\\J]", "flags": "v", "valid": false}
+{"pattern": "\\J*", "flags": "v", "valid": false}
+{"pattern": "a\\J", "flags": "v", "valid": false}
+{"pattern": "[a\\Jb]", "flags": "v", "valid": false}
+{"pattern": "[\\K]", "flags": "v", "valid": false}
+{"pattern": "\\K*", "flags": "v", "valid": false}
+{"pattern": "a\\K", "flags": "v", "valid": false}
+{"pattern": "[a\\Kb]", "flags": "v", "valid": false}
+{"pattern": "[\\L]", "flags": "v", "valid": false}
+{"pattern": "\\L*", "flags": "v", "valid": false}
+{"pattern": "a\\L", "flags": "v", "valid": false}
+{"pattern": "[a\\Lb]", "flags": "v", "valid": false}
+{"pattern": "\\M", "flags": "v", "valid": false}
+{"pattern": "[\\M]", "flags": "v", "valid": false}
+{"pattern": "\\M*", "flags": "v", "valid": false}
+{"pattern": "a\\M", "flags": "v", "valid": false}
+{"pattern": "[a\\Mb]", "flags": "v", "valid": false}
+{"pattern": "[\\N]", "flags": "v", "valid": false}
+{"pattern": "\\N*", "flags": "v", "valid": false}
+{"pattern": "a\\N", "flags": "v", "valid": false}
+{"pattern": "[a\\Nb]", "flags": "v", "valid": false}
+{"pattern": "\\O", "flags": "v", "valid": false}
+{"pattern": "[\\O]", "flags": "v", "valid": false}
+{"pattern": "\\O*", "flags": "v", "valid": false}
+{"pattern": "a\\O", "flags": "v", "valid": false}
+{"pattern": "[a\\Ob]", "flags": "v", "valid": false}
+{"pattern": "\\P", "flags": "v", "valid": false}
+{"pattern": "[\\P]", "flags": "v", "valid": false}
+{"pattern": "\\P*", "flags": "v", "valid": false}
+{"pattern": "a\\P", "flags": "v", "valid": false}
+{"pattern": "[a\\Pb]", "flags": "v", "valid": false}
+{"pattern": "[\\Q]", "flags": "v", "valid": false}
+{"pattern": "\\Q*", "flags": "v", "valid": false}
+{"pattern": "a\\Q", "flags": "v", "valid": false}
+{"pattern": "[a\\Qb]", "flags": "v", "valid": false}
+{"pattern": "[\\R]", "flags": "v", "valid": false}
+{"pattern": "\\R*", "flags": "v", "valid": false}
+{"pattern": "a\\R", "flags": "v", "valid": false}
+{"pattern": "[a\\Rb]", "flags": "v", "valid": false}
+{"pattern": "[\\S]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\S", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Sb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\T", "flags": "v", "valid": false}
+{"pattern": "[\\T]", "flags": "v", "valid": false}
+{"pattern": "\\T*", "flags": "v", "valid": false}
+{"pattern": "a\\T", "flags": "v", "valid": false}
+{"pattern": "[a\\Tb]", "flags": "v", "valid": false}
+{"pattern": "[\\U]", "flags": "v", "valid": false}
+{"pattern": "\\U*", "flags": "v", "valid": false}
+{"pattern": "a\\U", "flags": "v", "valid": false}
+{"pattern": "[a\\Ub]", "flags": "v", "valid": false}
+{"pattern": "\\V", "flags": "v", "valid": false}
+{"pattern": "[\\V]", "flags": "v", "valid": false}
+{"pattern": "\\V*", "flags": "v", "valid": false}
+{"pattern": "a\\V", "flags": "v", "valid": false}
+{"pattern": "[a\\Vb]", "flags": "v", "valid": false}
+{"pattern": "[\\W]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\W", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Wb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\X]", "flags": "v", "valid": false}
+{"pattern": "\\X*", "flags": "v", "valid": false}
+{"pattern": "a\\X", "flags": "v", "valid": false}
+{"pattern": "[a\\Xb]", "flags": "v", "valid": false}
+{"pattern": "\\Y", "flags": "v", "valid": false}
+{"pattern": "[\\Y]", "flags": "v", "valid": false}
+{"pattern": "\\Y*", "flags": "v", "valid": false}
+{"pattern": "a\\Y", "flags": "v", "valid": false}
+{"pattern": "[a\\Yb]", "flags": "v", "valid": false}
+{"pattern": "[\\Z]", "flags": "v", "valid": false}
+{"pattern": "\\Z*", "flags": "v", "valid": false}
+{"pattern": "a\\Z", "flags": "v", "valid": false}
+{"pattern": "[a\\Zb]", "flags": "v", "valid": false}
+{"pattern": "[\\[]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\[", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\[b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\\\", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\\\b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\^", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\^b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\_]", "flags": "v", "valid": false}
+{"pattern": "\\_*", "flags": "v", "valid": false}
+{"pattern": "a\\_", "flags": "v", "valid": false}
+{"pattern": "[a\\_b]", "flags": "v", "valid": false}
+{"pattern": "\\`*", "flags": "v", "valid": false}
+{"pattern": "a\\`", "flags": "v", "valid": false}
+{"pattern": "[a\\`b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\a]", "flags": "v", "valid": false}
+{"pattern": "\\a*", "flags": "v", "valid": false}
+{"pattern": "a\\a", "flags": "v", "valid": false}
+{"pattern": "[a\\ab]", "flags": "v", "valid": false}
+{"pattern": "\\b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\bb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c*", "flags": "v", "valid": false}
+{"pattern": "a\\c", "flags": "v", "valid": false}
+{"pattern": "[a\\cb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\d", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\db]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\e]", "flags": "v", "valid": false}
+{"pattern": "\\e*", "flags": "v", "valid": false}
+{"pattern": "a\\e", "flags": "v", "valid": false}
+{"pattern": "[a\\eb]", "flags": "v", "valid": false}
+{"pattern": "[\\f]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\f", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\fb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\g]", "flags": "v", "valid": false}
+{"pattern": "\\g*", "flags": "v", "valid": false}
+{"pattern": "a\\g", "flags": "v", "valid": false}
+{"pattern": "[a\\gb]", "flags": "v", "valid": false}
+{"pattern": "[\\h]", "flags": "v", "valid": false}
+{"pattern": "\\h*", "flags": "v", "valid": false}
+{"pattern": "a\\h", "flags": "v", "valid": false}
+{"pattern": "[a\\hb]", "flags": "v", "valid": false}
+{"pattern": "[\\i]", "flags": "v", "valid": false}
+{"pattern": "\\i*", "flags": "v", "valid": false}
+{"pattern": "a\\i", "flags": "v", "valid": false}
+{"pattern": "[a\\ib]", "flags": "v", "valid": false}
+{"pattern": "[\\j]", "flags": "v", "valid": false}
+{"pattern": "\\j*", "flags": "v", "valid": false}
+{"pattern": "a\\j", "flags": "v", "valid": false}
+{"pattern": "[a\\jb]", "flags": "v", "valid": false}
+{"pattern": "\\k*", "flags": "v", "valid": false}
+{"pattern": "a\\k", "flags": "v", "valid": false}
+{"pattern": "[a\\kb]", "flags": "v", "valid": false}
+{"pattern": "[\\l]", "flags": "v", "valid": false}
+{"pattern": "\\l*", "flags": "v", "valid": false}
+{"pattern": "a\\l", "flags": "v", "valid": false}
+{"pattern": "[a\\lb]", "flags": "v", "valid": false}
+{"pattern": "[\\m]", "flags": "v", "valid": false}
+{"pattern": "\\m*", "flags": "v", "valid": false}
+{"pattern": "a\\m", "flags": "v", "valid": false}
+{"pattern": "[a\\mb]", "flags": "v", "valid": false}
+{"pattern": "[\\n]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\n", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\nb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\o]", "flags": "v", "valid": false}
+{"pattern": "\\o*", "flags": "v", "valid": false}
+{"pattern": "a\\o", "flags": "v", "valid": false}
+{"pattern": "[a\\ob]", "flags": "v", "valid": false}
+{"pattern": "[\\p]", "flags": "v", "valid": false}
+{"pattern": "\\p*", "flags": "v", "valid": false}
+{"pattern": "a\\p", "flags": "v", "valid": false}
+{"pattern": "[a\\pb]", "flags": "v", "valid": false}
+{"pattern": "\\q", "flags": "v", "valid": false}
+{"pattern": "[\\q]", "flags": "v", "valid": false}
+{"pattern": "\\q*", "flags": "v", "valid": false}
+{"pattern": "a\\q", "flags": "v", "valid": false}
+{"pattern": "[a\\qb]", "flags": "v", "valid": false}
+{"pattern": "[\\r]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\r", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\rb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\s", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\sb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\t]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\t", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\tb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u]", "flags": "v", "valid": false}
+{"pattern": "\\u*", "flags": "v", "valid": false}
+{"pattern": "a\\u", "flags": "v", "valid": false}
+{"pattern": "[a\\ub]", "flags": "v", "valid": false}
+{"pattern": "[\\v]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\v", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\vb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\w", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\wb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x]", "flags": "v", "valid": false}
+{"pattern": "\\x*", "flags": "v", "valid": false}
+{"pattern": "a\\x", "flags": "v", "valid": false}
+{"pattern": "[a\\xb]", "flags": "v", "valid": false}
+{"pattern": "[\\y]", "flags": "v", "valid": false}
+{"pattern": "\\y*", "flags": "v", "valid": false}
+{"pattern": "a\\y", "flags": "v", "valid": false}
+{"pattern": "[a\\yb]", "flags": "v", "valid": false}
+{"pattern": "[\\z]", "flags": "v", "valid": false}
+{"pattern": "\\z*", "flags": "v", "valid": false}
+{"pattern": "a\\z", "flags": "v", "valid": false}
+{"pattern": "[a\\zb]", "flags": "v", "valid": false}
+{"pattern": "[\\{]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\{b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\|]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\|b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\}b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~*", "flags": "v", "valid": false}
+{"pattern": "a\\~", "flags": "v", "valid": false}
+{"pattern": "[a\\~b]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:\\a*?[\\!]+)(?x:\\/)\\p{sc=Greek}+[]**|([z](?i-m:[\\q{a}][](?i)[(\\d-a{\\p{RGI_Emoji}]**|(?ims-:{2,1}[\\]])+?)", "flags": "v", "valid": false}
+{"pattern": "\\k+?(?<$>x)(?-i:[\\c_😀-]{3,2}\\P{Ll}{3,2})\\-[\\s$$]|", "flags": "", "valid": false}
+{"pattern": "(?i)[^\\q{\\d}[a]][^]\\u{41}\\p{}\\p{Basic_Emoji}*]*?", "flags": "u", "valid": false}
+{"pattern": "(?<a>\\3(?>})|(?i)[\\d-a&&\\]\\c_]{3,2}(?-i:\\p{Script_Extensions=Latn})\\uD83D\\uDE00|[\\$$\\]]**|)(?i-m:[|-]*(?:${2}(?!\\p{L\\08)|){)", "flags": "v", "valid": false}
+{"pattern": "(?i)😀(?:[^/\\c1](?>(?<b>y)?)[\\q{\\d}]*){2,}\\2{2}|(?=a??|\\00[^\\&])+?\\p{ASCII}|\\p{Greek}", "flags": "u", "valid": false}
+{"pattern": "\\q{ab}\\p{Basic_Emoji}b", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:[&&\\uD83D\\uDE00-\\uD83D\\uDE02]\\d]![\\P{Lu}\\u{1F600}-\\u{1F602}^\\w])[\\x41\\u{1F600}-\\u{1F602}z]+[^]\\12{2,3}(?>(?<b>y){[]\\k)*|", "flags": "v", "valid": false}
+{"pattern": "\\k<\\u0061>|[&&\\B]*?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<b>y)(?ii:\\k<\\u0061>|\\c|\\x41){2,3}\\p{sc=Greek}[.]\\8", "flags": "v", "valid": false}
+{"pattern": "(?<!(?:\\08(?:\\3\\1[.&&[^\\q{ab}]--]))+\\8|)|", "flags": "v", "valid": false}
+{"pattern": "\\!*[\\q{a}]", "flags": "v", "valid": false}
+{"pattern": "\\c1{2,3}?", "flags": "u", "valid": false}
+{"pattern": "[]?(?ii:[][]??){2,3}?[^[\\q{ab}]\\-😂-😀]**", "flags": "u", "valid": false}
+{"pattern": "[@\\q{a|bc}\\b!\\k{3,2}}*?(?>(?>\\k<\\u0061>\\p{Lu})\\u{}**(?-i:😂[^]*(?-:\\/|[😀\\q{\\d}😀]\\#))", "flags": "u", "valid": false}
+{"pattern": "(?<$>x)[\\q{\\d}😀-😂.\\q{\\d}](?!$??(?i)(?i:[/\\p{RGI_Emoji}}-][[z-a])(?!😀*?|*?|[])", "flags": "", "valid": false}
+{"pattern": "(?<!(?-i:[/][\\q{a}\\d-a😀^][😀-😂])**|[])(\\k**(?<b>[](?<!\\p{Lu}|\\p{Lu})\\d)", "flags": "v", "valid": false}
+{"pattern": "(?![\\u{1F600}-\\u{1F602}[\\q{ab}]\\cA]|(?!(+){2,3}?{2,1}[^]|\\p{Greek}[\\b[]){[^!\\uD83D\\uDE00-\\uD83D\\uDE02\\uD83D\\uDE00-\\uD83D\\uDE02\\-]|\\k<)[-\\p{L}(]\\c1\\3", "flags": "v", "valid": false}
+{"pattern": "[a\\x41😂-😀)]z[!]", "flags": "u", "valid": false}
+{"pattern": "\\!+!(?<![]*?)*?(?-i:(?x:(?={,2}|)[\\]\\q{ab}\\d-a[^a]]{(?![\\q{a}[^a]]))[\\u{1F600}-\\u{1F602}]})|", "flags": "v", "valid": false}
+{"pattern": "[][^][z\\cA](?=\\k<😂|)|[^.\\]😂-😀]", "flags": "v", "valid": false}
+{"pattern": "(?=\\P{Ll}\\e)[a.[^a]!{2,3}?(?<=😀)(?!!)(?ii:[^\\P{Lu}!!]", "flags": "u", "valid": false}
+{"pattern": "]|(?<a>\\x4\\a**)\\p{sc=Greek}(?<b>(?-i:\\cA??(?ii:\\p{RGI_Emoji}[$$--]+?|\\k<a>)|[&&\\u{1F600}-\\u{1F602}[a]\\q{a}]z))", "flags": "", "valid": false}
+{"pattern": "(?=(?<b>y)[]\\p{ASCII}|b\\a[-\\![^\\q{ab}])[\\P{Lu}\\\\q{ab}]\\w[a-z]+?", "flags": "", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "[z\\c_z-a\\u{1F600}-\\u{1F602}][^\\c1😀]\\q{ab}", "flags": "v", "valid": false}
+{"pattern": "[b😀-😂\\-]\\1|(?![^[\\q{ab}]\\q{\\d}\\c_]|\\P{Ll}\\k+?|[^](?<b>-[[^a]]|-))z{3,2}\\p{Greek}**", "flags": "u", "valid": false}
+{"pattern": "(?ii:\\u{1F600}+?|(?<=[^\\]-\\1]{2,}(?-i:{,2}z|[!!!\\B]{\\0))(?x:\\12*?\\p{L}**$)){2}(?x:[](?x:[\\uD83D\\uDE00-\\uD83D\\uDE02😀😀-😂](?x:[\\q{a|bc}\\\\cA]{2,3}?|)+?)😂|\\p{sc=Greek}**)|", "flags": "v", "valid": false}
+{"pattern": "(?=[\\w]{3,2}^+\\12)\\-*?", "flags": "i", "valid": false}
+{"pattern": "(?!(?x:\\k<\\u0061>\\uD83D\\uDE00{2,3}|(?ii:[!!]{3,2}[😂-😀[\\q{ab}]]|)(?<=(?:{3,2}\\k<a>\\k||\\B\\p{Lu})(?-i:|[][\\]a-z])|(?<!|[\\d-a\\B])))|(?<b>\\x4|&?)", "flags": "v", "valid": false}
+{"pattern": "\\p{ASCII}|\\x4[\\]-[\\q{ab}]]{2,}(?ii:[a-z]]]|[\\w\\q{a}]|\\w[\\!]??", "flags": "u", "valid": false}
+{"pattern": "(?ii:[^-😀\\]](?:[😀\\x41](?![[\\B[]|\\u{41}[])**|){1}|\\u{41}(?>{,2}(?=[$$\\uD83D\\uDE00-\\uD83D\\uDE02\\x41]|\\d+[&&{&-]{2,3}?)(?<a1>x)[\\p{L}-.]??|)", "flags": "i", "valid": false}
+{"pattern": "\\d", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\8+[^|(?=(?<b>[]\\p{sc=Greek}{\\uD83D\\uDE00|[\\b[^a][\\q{ab}]\\b]\\p{Greek}[z\\!]))**[^[]\\0\\d-a((?-i:😂)+?|{99999999999}??){3,2}", "flags": "v", "valid": false}
+{"pattern": "\\p{Script_Extensions=Latn}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}(?-:(?i)[^\\s!](?x:[[^\\q{ab}]z.\\w]$+?)[😀]+?|){2,}\\c1|", "flags": "i", "valid": false}
+{"pattern": "[][^{]{{3,2}\\k<", "flags": "v", "valid": false}
+{"pattern": "z", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:[a-zz-a{[^\\q{ab}]][-]$)??[^\\q{\\d}(\\1]{2,3}?\\uDE00[/]??|[^&&\\]]", "flags": "v", "valid": false}
+{"pattern": "[\\1a-z😀-😂]\\p{L}|\\#+?(?:(?-i:(?<=[\\c_[^\\q{ab}]])\\uD83D\\uDE00[z])(?<b>y)(?ims-:(?x:{2,3}?)(?-:\\c|\\2\\p{L)))b", "flags": "v", "valid": false}
+{"pattern": "^|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&\\k<\\u0061>**[^\\c1@]", "flags": "v", "valid": false}
+{"pattern": "[[\\q{ab}]😀\\q{a|bc}", "flags": "v", "valid": false}
+{"pattern": "\\B??\\x41|[^[^a]]|(?>\\c(?>[\\q{a}][\\q{a|bc}&&a-z\\&]|(?x:[]\\P{RGI_Emoji})*?(?>}[^{\\uD83D\\uDE00-\\uD83D\\uDE02]{3,2})+?(?=[\\d-a])|(?i){1}*?[\\!]|)\\2**", "flags": "v", "valid": false}
+{"pattern": "[^]\\w|\\B{2,3}?[[}\\p{L}]{2,}", "flags": "u", "valid": false}
+{"pattern": "[\\&\\0z\\w](?>[((!]\\e)", "flags": "u", "valid": false}
+{"pattern": "\\uD83D\\uDE00{2,3}{1}(?<=[\\!\\u{1F600}-\\u{1F602}]|\\p{gc=Lu}{2,3}?\\c?(?-i:.\\p{gc=Lu})**|)}([!\\w\\0!!](?<b>\\uD83D\\uDE00+?\\B\\e)\\a+?)*?", "flags": "v", "valid": false}
+{"pattern": "(?-i:\\#)*\\P{RGI_Emoji}(?<a>[--\\P{Lu}😀]){2,}|", "flags": "v", "valid": false}
+{"pattern": "(?<=(?x:[^]\\p{L)\\w(!\\P{RGI_Emoji})?)", "flags": "u", "valid": false}
+{"pattern": "!*|[b\\]+\\p{L\\08((?x:(?<a>x)[|\\q{a}[^a]]+[b!!😂-😀]|\\e|){2,3}\\p{gc=Lu}{2,}|(?x:\\p{RGI_Emoji}{3,2}|(?ii:\\k<+?|[[a-\\d]|)|(?ims-:|[\\-([\\q{ab}]\\!])(|{2,3}+|\\e))+(?ii:\\p{RGI_Emoji}{😂{2,}|\\p{RGI_Emoji}\\1(?>[\\d\\q{\\d}][$$]|[^--[\\q{ab}]]]\\p{ASCII}+?\\s|))[^\\&{!\\p{L}]){2,3}", "flags": "u", "valid": false}
+{"pattern": "-[@a-\\d]?\\0(?i)(?<b>(?<b>{2}|[&&\\u{1F600}-\\u{1F602}[\\q{ab}]]\\w)\\p{Basic_Emoji}|(?-i:)$)(?<$>x)*[]", "flags": "i", "valid": false}
+{"pattern": "\\a*?[\\!|\\u{1F600}-\\u{1F602}]a", "flags": "v", "valid": false}
+{"pattern": "(?<b>(?x:\\p{}){2,3}?\\10\\c_)+[^[\\-][\\&&&[^\\q{ab}]]{2,3}?\\q{ab}??\\p{sc=Greek}|", "flags": "i", "valid": false}
+{"pattern": "[^a-\\d\\q{\\d}\\u{1F600}-\\u{1F602}z]{2,3}(?<b>\\p{sc=Greek}(?i)[😀]*?)[^^]{2,3}[^\\d\\]]{2,}[.]{2,}", "flags": "u", "valid": false}
+{"pattern": "-**(?-i:[\\B!]|[]\\k<a>){2,}|\\3", "flags": "v", "valid": false}
+{"pattern": "[](?<!{1}[])", "flags": "v", "valid": false}
+{"pattern": "[[^\\q{ab}]\\!]{2}\\p{}", "flags": "u", "valid": false}
+{"pattern": "\\p{ASCII}{2}\\p{L[\\uD83D\\uDE00-\\uD83D\\uDE02}[a]\\q{a}]", "flags": "v", "valid": false}
+{"pattern": "{,2}{3,2}[.\\c_\\!a-\\d][@\\cA]", "flags": "v", "valid": false}
+{"pattern": "(?i-m:[\\q{\\d}😀-😂]|(?<a>\\c(?i:{1}[\\&\\!!])([[^\\q{ab}]\\c_\\c1]\\uDE00{2,})))(?<$>x)\\P{Ll}(?ims-:[.b]+|[\\0]{2})*(\\x41(?!\\k)[\\q{a}\\u{1F600}-\\u{1F602}\\0\\b])**", "flags": "v", "valid": false}
+{"pattern": "\\p{}[\\x41a-\\d\\b][^](?ims-:\\c_)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>x)|[^\\1z!!]\\k<z", "flags": "i", "valid": false}
+{"pattern": "(?i:!|(?ii:\\d{2}|[]{2}[😀\\!))|\\q{ab}[]\\!\\b]])", "flags": "v", "valid": false}
+{"pattern": "[^\\q{\\d}\\q{a|bc}(}]", "flags": "v", "valid": false}
+{"pattern": "(?<a1>x)", "flags": "i", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "(?:(?>(?i-m:*[^!!|\\q{ab}]**|[^|]))+?(?<b>(?i-m:[\\c_][z[a]]||\\c{2,3}|)(?<b>y)\\k<\\u0061>)|[^](?>b[^]|(?>[--]|)))\\k<a>{2}\\uD83D*", "flags": "v", "valid": false}
+{"pattern": "[|&z-a]\\p{gc=Lu}[]\\&\\uD83D|", "flags": "i", "valid": false}
+{"pattern": "[\\d-a\\]][[]{3,2}[\\q{a|bc}\\-{\\B(?<!\\d)", "flags": "", "valid": false}
+{"pattern": "\\w?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:\\b|(?<!(?x:[[^\\q{ab}][^\\q{ab}].{2}\\0)(?i)[\\-](?<a>x)\\p{sc=Greek}|{99999999999}[\\p{L}z😀\\uD83D\\uDE00-\\uD83D\\uDE02]**[^]|[^\\-](?={2,})[[a]]*?)|)(?i-m:😀\\p{L(?<a>\\uD83D\\uDE00{(?<!\\12\\uDE00)\\cA)", "flags": "v", "valid": false}
+{"pattern": "[[a](](?x:{99999999999}{2,}|(?ii:(?-i:\\p{Lu}|[\\P{Lu}[\\q{ab}]|]&){2,3}(?<a>){2}(?i-m:[]|[]){2,}|\\p{L}[\\-]{2,3}?(?i:(?<b>y)))*|[[^a]a](?<b>y){2,}(?ii:!{2,}|(?ii:[@\\x41\\q{a}\\]]|))", "flags": "v", "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}\\p{RGI_Emoji}|]\\u{}\\08[z][\\q{ab}[^\\q{ab}]}]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "$??[\\P{Lu}[a]]{", "flags": "v", "valid": false}
+{"pattern": "\\b|[/]{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "b|[\\1\\q{}[a]]\\p{Lu}|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x:(?i:[[^\\q{ab}]a-z\\b])[]\\-)\\q{ab}\\uD83D(?<![--\\q{}\\a]{|(?ii:[^^])[|{/\\d|", "flags": "i", "valid": false}
+{"pattern": "\\u{41}\\x4(?x:(?i-m:[\\])[\\&b\\c_])(?<=\\#{2}(?!\\p{ASCII}({|)[)(?=[\\d-a\\q{a}😂-😀b]((?<a>x)\\#)|(?>\\0&**)|)|[\\q{}\\1z-a!!])|[^^\\q{a|bc}]", "flags": "", "valid": false}
+{"pattern": "[\\q{a}\\c_]\\x4|", "flags": "u", "valid": false}
+{"pattern": "[\\c_\\c_@]\\b[!![^a]b]{2,3}[^\\uD83D\\uDE00-\\uD83D\\uDE02]+?(?<=\\cA)", "flags": "v", "valid": false}
+{"pattern": "(?ii:(?-i:(?ii:\\p{Greek}(?<\\u{61}>x)*?))*?\\p{sc=Greek}|\\P{RGI_Emoji}0[\\q{\\d}[a]\\uD83D\\uDE00-\\uD83D\\uDE02])(?<b>\\10)", "flags": "v", "valid": false}
+{"pattern": "\\3\\p{ASCII}(?<$>x){3,2}", "flags": "i", "valid": false}
+{"pattern": "[!\\q{\\d}\\uD83D\\uDE00-\\uD83D\\uDE02]+", "flags": "v", "valid": false}
+{"pattern": "\\0(?<b>(?-i:[^\\B\\x41|\\!]|\\b\\w{2,3}?(?=\\--))+(?:(?i:[][^}a\\q{ab}]|)(?ii:^)z||(?=**|\\p{sc=Greek}{2,}\\w)**))(?>[^a😀😀(]\\uD83D\\uDE00(?![^}]*(?<a>[^😀[^a]--[a]][^]|[\\s😀😀]\\k<)))|", "flags": "u", "valid": false}
+{"pattern": "[]+?[^!\\d-a[\\q{ab}]]{2,}|[/\\d-a\\-](?<a>x)??", "flags": "v", "valid": false}
+{"pattern": "\\0\\-", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<b>(([\\x41-])+?(?x:\\c**|\\k<{3,2})??\\u{41}))(?=(?<b>$|){(?ii:[^\\P{Lu}\\q{}a\\][$$\\u{1F600}-\\u{1F602}])|\\a\\k<+", "flags": "i", "valid": false}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02\\c_]|(?>0(?<b>y)|(?i)[\\&[\\q{ab}]](?<b>y)[\\cA]|[^\\d\\!]|\\P{Ll}[[^\\q{ab}]])", "flags": "v", "valid": false}
+{"pattern": "{99999999999}|", "flags": "u", "valid": false}
+{"pattern": "(?>\\p{sc=Greek}^\\b)(?<b>(?<a>x)(?=(?<b>)[\\w\\]]{2,3}[a-z)]{3,2}|!\\p{sc=Greek}))+?[\\u{1F600}-\\u{1F602}\\\\]]{2,}(?<a>x)", "flags": "", "valid": false}
+{"pattern": "\\12\\e[b&(]|[\\x41@]|(?<![^\\q{}$$]+?|)?", "flags": "v", "valid": false}
+{"pattern": "\\k(?<a>\\08{2,3}?)(?=(?ims-:$(?<b>{99999999999}**)$|(?![\\d-a]{[a]\\#){\\k<\\u0061>(?-:\\1\\B(?-:{3,2}|||😀**))(?i-m:\\k<a>(?<b>y){1})", "flags": "u", "valid": false}
+{"pattern": "[\\c_\\--\\!]\\p{Lu}[^\\p{RGI_Emoji}](?<\\u{61}>x)[^-\\!\\&\\u{1F600}-\\u{1F602}]|", "flags": "u", "valid": false}
+{"pattern": "{99999999999}&", "flags": "i", "valid": false}
+{"pattern": "(?x:(?<a>(?ii:?)??[a-\\da-z|!]|\\uD83D**)??)$\\uD83D\\uDE00(?=(?ims-:(?<b>\\p{L\\#|\\d{2,3})??(?x:\\u{}|(?<a>\\u{}{3,2}\\x41+?|\\s\\cA|)??(?<b>\\12|[\\q{a|bc}a]\\1]{2}[^\\b😀\\P{Lu}[\\q{ab}]]))|(?<b>(?-i:!|{2,3}?{1})\\uDE00|(\\x41)){2}", "flags": "u", "valid": false}
+{"pattern": "(?i:(?i:\\&|\\P{Ll}|[\\c1]|(?<a>\\08{2,3}|!|\\/!!)b\\P{Ll})){3,2}", "flags": "i", "valid": false}
+{"pattern": "{99999999999}[^a-\\d](?>\\c{2}(?ims-:[a-\\d])||(?<a>[\\&\\c_a-\\d\\q{a}]\\/[/--^\\s]+?|(?x:\\cA|??|[[^\\q{ab}]!!\\w\\p{RGI_Emoji}]+?\\12^\\&\\&)(?ims-:(?:\\b{2,}\\10|0\\!)|\\w))", "flags": "", "valid": false}
+{"pattern": "(?x:[\\d-a\\q{a|bc}[\\q{ab}]])(?x:[^a-\\q{\\d}\\q{\\d}]**\\00)+0*&|{2,1}", "flags": "i", "valid": false}
+{"pattern": "[\\wa-\\d][\\q{a}\\0[\\q{ab}]\\q{ab}][\\p{L}\\p{RGI_Emoji}-\\cA]{2}[!/]\\00", "flags": "v", "valid": false}
+{"pattern": "(?>(?=[a][^😀!!\\q{\\d}]|[^--a-z\\x41[]b[a]{]))?|\\B|", "flags": "v", "valid": false}
+{"pattern": "[😂-😀]+?\\&\\3\\u{}[^]", "flags": "u", "valid": false}
+{"pattern": "\\d(?i:(?<\\u{61}>x)[][^\\q{ab}]\\w]**[])|\\w*", "flags": "i", "valid": false}
+{"pattern": "(?ims-:\\P{Ll}\\0z{2,}|(?!(?-:&\\p{}|??)??-+?[]|[\\---\\c1]+)|\\p{L)[^a-z\\q{\\d}\\c1](?i-m:((?ii:\\s)\\x41))\\c1{2}", "flags": "", "valid": false}
+{"pattern": "\\u{41}\\p{Basic_Emoji}?\\c1(?x:(?>\\12\\&||[/[^a]b]+?[^\\q{}])\\8{|[](?!(?<a1>x)))[)\\]\\q{}]", "flags": "i", "valid": false}
+{"pattern": "$z", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA\\3", "flags": "u", "valid": false}
+{"pattern": "(?<a>(?-:[]?(?>[}][])[-.\\cA&]|(?i-m:\\p{sc=Greek}{2}{,2}[^\\q{}\\c_])\\d\\x41|))\\3{3,2}", "flags": "u", "valid": false}
+{"pattern": "\\u{41}[^😀-😂\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a}😂-😀]?\\P{RGI_Emoji}[\\s\\c1\\q{\\d}]", "flags": "u", "valid": false}
+{"pattern": "[a}(]{3,2}\\d", "flags": "v", "valid": false}
+{"pattern": "\\e(?<a>[}[a]😀-😂}](?i)[^][**||(?ims-:){2}|\\k<a>{{,2}{2,}|[^](?<b>[)\\1]\\uD83D{2}(?<b>\\!)))+", "flags": "i", "valid": false}
+{"pattern": "[^](?ii:[^\\uD83D\\uDE00-\\uD83D\\uDE02]\\k<\\u0061>(?<!a*|[]{2}(?<a>??(?<a>x))))?[]", "flags": "i", "valid": false}
+{"pattern": "(?<![\\Bz\\w\\B]|(?i)\\c_|(?>\\B\\08|)b)(?i:(?x:😂)*?)(?<a>(?:\\/\\p{Lu})[])\\a\\e{2,3}", "flags": "", "valid": false}
+{"pattern": "[][😂-😀]--[^\\q{ab}]][^\\c_]\\cA\\8", "flags": "v", "valid": false}
+{"pattern": "[^[^a][^a]]{2,}|(?<$>x)?{,2}{2,}", "flags": "v", "valid": false}
+{"pattern": "[{\\b[a]]", "flags": "v", "valid": false}
+{"pattern": "(?-:[]|{1}**\\12)(?<a>[&&\\-\\]]\\1|(?-i:\\u{1F600}*|\\u{}\\-?(?ims-:\\P{Ll}{)(?<b>\\P{Ll}(?-:\\00\\k|{\\p{Greek}😂)\\a)[\\p{RGI_Emoji}!!])|\\b(?i-m:(?<a>\\B(?<b>y)\\p{L}{2,3}?))\\k<\\u0061>", "flags": "u", "valid": false}
+{"pattern": "[]{2,3}^??[----[\\q{ab}]b][😂-😀\\x41]{3,2}(?<=a||\\0[\\uD83D\\uDE00-\\uD83D\\uDE02[^a]\\q{a}\\cA]{2,})", "flags": "u", "valid": false}
+{"pattern": "\\cA\\uD83D+?(?<a>[\\]][[a]\\q{\\d}$$]?)(\\p{}[]|(?ims-:[!a-\\dz-a]|[^\\da-\\d]{2,3}?[]{[]))(?-:[](?>\\p{L}|\\p{gc=Lu})??)", "flags": "", "valid": false}
+{"pattern": "[\\q{\\d}/\\x41&&](?i)\\&", "flags": "", "valid": false}
+{"pattern": "\\u{41}[\\1]", "flags": "v", "valid": false}
+{"pattern": "]|", "flags": "v", "valid": false}
+{"pattern": "(?ii:[]{2,3}(?=(?=\\1)[^](?-:[^\\\\w-][^{]|)||}(?ims-:[]+(?<b>y)|[[^\\q{ab}]]*?\\k<b>))(?<\\u{61}>x))|\\00{2,3}?[^\\!a-\\d](?=(?<$>x)|\\k<a>[])\\&{3,2}", "flags": "i", "valid": false}
+{"pattern": "]\\/", "flags": "v", "valid": false}
+{"pattern": "\\p{ASCII}{-*?{\\w[--\\u{1F600}-\\u{1F602}]", "flags": "", "valid": false}
+{"pattern": "[\\c1\\]\\d-a\\q{\\d}]{2,3}", "flags": "v", "valid": false}
+{"pattern": "\\c1[^aza-\\d\\1]\\p{Script_Extensions=Latn}", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}{2,1}\\u{}", "flags": "u", "valid": false}
+{"pattern": "\\p{sc=Greek}[\\p{RGI_Emoji}&&[a]}]**", "flags": "u", "valid": false}
+{"pattern": "\\c_[$$\\u{1F600}-\\u{1F602}\\w](?-i:\\p{RGI_Emoji}\\/[])??(?>(?-:[^\\q{a|bc}\\-\\](?i)[\\d]{|[--]😂{2,3}{2,3}?|(?i:[^]{99999999999}{2}b)))|(?i)(?i-m:[]\\uDE00(?!\\00))", "flags": "", "valid": false}
+{"pattern": "[&a-z][\\c_\\p{L}]{2,3}?", "flags": "u", "valid": false}
+{"pattern": "${2}|", "flags": "", "valid": false}
+{"pattern": "$??[\\u{1F600}-\\u{1F602}\\uD83D\\uDE00-\\uD83D\\uDE02[a]](?<b>\\k<a>*)", "flags": "u", "valid": false}
+{"pattern": "(?<![z-a&])[]**(?>(?<b>[a-\\d]\\u{1F600}\\u{41}))", "flags": "i", "valid": false}
+{"pattern": "(?:[[^\\q{ab}]\\q{ab}😂-😀])|[]", "flags": "v", "valid": false}
+{"pattern": "(?<a>(?-:\\08(?ii:!||**)??{99999999999}|[@[^a]](?ims-:|[😂-😀\\s]*[!!{(][\\w])(?:*?))??\\!(?i-m:(?i)[\\]@\\0]{😂{99999999999}))[.]", "flags": "u", "valid": false}
+{"pattern": "[[^\\q{ab}]b}][\\c_]\\x41+?", "flags": "v", "valid": false}
+{"pattern": "(?<=(?x:[^]\\x41[\\cA\\q{}|)\\p{sc=Greek}|[\\q{}\\c1])](?i-m:((?<a>?)??\\x41\\8{|\\u{41}(?>(\\c1{2,3}[^!\\c_z][a-\\d(])+?)*){2}", "flags": "i", "valid": false}
+{"pattern": "[\\cA\\&😀-😂][)😀\\cA|][{2,3}?b[&\\!\\d]", "flags": "", "valid": false}
+{"pattern": "(?-i:[&😂-😀[\\q{ab}]a])+(?ii:(?-i:(?![&&[^\\q{ab}]\\q{a}\\q{a}])(?ii:(?<a1>x){2}))[b\\p{RGI_Emoji}!!]|[^\\]\\B\\w](?<b>(?x:+?{3,2}\\p{gc=Lu}{3,2}\\c1)+)", "flags": "i", "valid": false}
+{"pattern": "[\\cA\\u{1F600}-\\u{1F602}][]??", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^][^\\x41(](?-i:[](?:{99999999999}|(?i-m:)|(?i-m:\\k||[^!-\\c_^]{2,3}?\\a)[\\-\\q{ab}!!]\\1)[[a]\\c1]|(?ims-:(?x:{?[!]-]{2,})!)*|\\12)(?<=$*?(?<=(?-i:z|[^]\\p{RGI_Emoji}{2,3}?|0*\\p{Script_Extensions=Latn}).*?(?<=[.)\\q{a|bc}\\q{}])*|😂(?x:[@a-z-])[\\&[\\q{a}]{2}){,2}{2,3}?|\\e)", "flags": "v", "valid": false}
+{"pattern": "[\\c1$$]*[^\\c1\\c1]|[z-a](?=(?<a>\\#\\p{RGI_Emoji}(?<\\u{61}>x))(?<a>}(?-i:{2,1}{2,3}?😂[^^)(]]??||{2,3}\\uD83D)|\\uD83D\\s))|[^\\&]", "flags": "v", "valid": false}
+{"pattern": "\\u{41}(?ii:\\c1\\2(?>(?<=${3,2}0[\\d\\q{}[a]]||[\\d-a]|$*?[[\\q{ab}]\\d-a😀-😂\\b])[$$\\]){2,3})", "flags": "v", "valid": false}
+{"pattern": "[\\d-a[[\\0]{2,3}|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)[\\q{}]|[^[\\q{ab}]\\!\\😂-😀]**😂", "flags": "i", "valid": false}
+{"pattern": "\\p{Script_Extensions=Latn}+?(?:(?<$>x)|(?<=[^ba-z]|[^{]{{]{2,3}?)|(?-:(?ims-:|{2,1})+b|\\#|[\\q{}]{2,3}?[^}!!/])){[\\b][{&\\q{a|bc}]", "flags": "v", "valid": false}
+{"pattern": "\\uDE00**[{/\\x41\\w][\\P{Lu}]\\x41|", "flags": "u", "valid": false}
+{"pattern": "{2,1}|(?!\\1[!][---]|(?i)\\u{41})(?i)[][a-\\d\\&)!!]", "flags": "v", "valid": false}
+{"pattern": "[^\\1a-z\\s\\q{a|bc}][]((?=\\12(?>\\e??)[^\\d-a\\sa-z\\d-a])", "flags": "u", "valid": false}
+{"pattern": ".*?(?-i:[[^a][\\q{ab}]]|[^]\\u{}(?x:[-]|\\p{Basic_Emoji}(?<=[^a-z\\0\\q{a}]+(?<a1>x))(?:){2}))*?((?=\\p{L}|{1}+|\\uD83D\\uDE00)(?:[]\\uD83D\\uDE00)??|)??[\\uD83D\\uDE00-\\uD83D\\uDE02-(?=^+?(?<b>y)(?!\\8[^\\1)/.]\\p{Greek}|)+)", "flags": "u", "valid": false}
+{"pattern": "(?<b>\\uD83D)(?ims-:\\p{sc=Greek}(?i)(?ii:\\k\\08+?{2,1})\\k[[a]a-\\d]**(?<a>{1}{2,3}(?<a>😀)|(?=|)*[]))|", "flags": "v", "valid": false}
+{"pattern": "(?-:(?-i:\\s|)|(?:[!!\\q{ab}))(?>[a-\\d\\c1-!!])+|\\k<b>(?ii:(?<b>{1}[[^a][^\\q{ab}]@](?<b>y))+|!)**\\a", "flags": "v", "valid": false}
+{"pattern": "}|\\P{RGI_Emoji}[\\]a-\\d\\c1\\w{3,2}(?x:!\\/[^\\p{L}]{3,2})|[\\q{a}\\\\!", "flags": "u", "valid": false}
+{"pattern": "\\b{99999999999}*((?=}(?>[-^]\\!|){2}|!|)(?<a1>x))[](?ii:[/|[^\\q{ab}]]{\\uD83D{3,2}[])", "flags": "v", "valid": false}
+{"pattern": "\\x41\\10(?i)[^[^a]($$]**[^[\\q{ab}]\\-\\0.]\\2{2,3}?{2,1}", "flags": "u", "valid": false}
+{"pattern": "(?<b>{(?<=[^][^\\d-a\\&\\u{1F600}-\\u{1F602}]+)(?-:[[!/])|(?x:(?i){2,3}{2,3}){2,3}\\P{Ll}?(?:(?<![]**+?)|(?-:\\u{1F600}[[^a]&])?[]))(?<=[^b]+[[^\\q{ab}]/@]])(?<=[a-\\d!]**\\![^\\c1^]|", "flags": "v", "valid": false}
+{"pattern": "(?<a>[.\\q{a}[\\q{ab}]]*?(?i)\\p{Basic_Emoji}+?_|[^]*?|\\B){2,}", "flags": "u", "valid": false}
+{"pattern": "\\c_(?-i:(?<!\\#))(?<=[]](?<=-)){2,3}?", "flags": "v", "valid": false}
+{"pattern": "]\\k<\\u0061>\\e[\\w&&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{ab}\\cA(?i)\\/||\\q{ab}", "flags": "v", "valid": false}
+{"pattern": "(?:\\2|(?<b>(?i)[a-\\d\\]&&]||))+?&{2,3}|", "flags": "v", "valid": false}
+{"pattern": "[\\0|\\10[]{1}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\cA].\\2[\\p{RGI_Emoji}]\\q{ab}*?", "flags": "v", "valid": false}
+{"pattern": "b", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s(?ims-:[^a\\q{a}\\-]\\10(?!(?<b>[\\s](?<b>y))[\\d-a\\q{ab}\\x41]|(?ims-:[\\q{\\d}\\d-a]😀\\-|\\c_)(?:\\&+[^)+)|)", "flags": "u", "valid": false}
+{"pattern": "[}](?!\\0|(?<!(?-i:[b&&\\B]\\p{}|\\#|\\a|[]?[\\P{Lu}]*?)|[[^\\q{ab}]](?-i:[&\\&!!😀]**{[\\u{1F600}-\\u{1F602}\\u{1F600}-\\u{1F602}[^a]\\w])|\\0)(?x:\\u{1F600}?(*?(?<\\u{61}>x)\\B)\\c1*?)|[^]**b(?i)\\uD83D\\uDE00{,2}[\\!!!\\d-a])*\\0", "flags": "v", "valid": false}
+{"pattern": ".(?i:\\p{sc=Greek}{2,3}(?x:[$$b]**\\0(?<b>[))??(?-:[a-\\d@\\B^]+{2,1}[^\\d-a[a][^\\q{ab}]z-a]|)|(?<a>\\u{}|(?!*?[\\&&\\p{L}}]??))(?ii:\\s(?<a>){2,3})*?\\k<\\u0061>)*\\p{}\\x4_", "flags": "v", "valid": false}
+{"pattern": "\\0{(?:(?<a>(?x:[!/]{2,3}\\uDE00)[}(\\&\\p{RGI_Emoji}]|)){3,2}", "flags": "u", "valid": false}
+{"pattern": "[z\\b^]{2,}|[\\x41\\&\\][!!b]\\u{1F600}", "flags": "u", "valid": false}
+{"pattern": "(?=(?<=(\\u{41}**[]{2,}))[^\\b*?)+?(?ii:[^@\\]](?<=[[^a]\\d\\P{Lu}\\0]**|(?i)|{2,}\\c_(?<$>x)\\x4))[z-a😀]{2,3}?(?-i:\\uDE00|[|\\c_[a]z-a]*[!!][])", "flags": "", "valid": false}
+{"pattern": "(?i-m:(?:(?ii:|[^\\-\\q{}]\\00)\\x4\\c|b){2,3}?[|z-az!|[^.\\cA])", "flags": "u", "valid": false}
+{"pattern": "[\\q{ab}][](?i)(?i)(?<a>x)??\\p{gc=Lu}{", "flags": "v", "valid": false}
+{"pattern": "[^\\s]|(?:\\q{ab}|(?i:(?-i:\\x4[\\&])|)(?<$>x)\\k<a>", "flags": "v", "valid": false}
+{"pattern": "[)]\\!(?<!(?!\\k<\\u0061>[]{2,}\\p{L{2,3}|\\k<a>?{99999999999}(?<={,2})?)|\\p{gc=Lu})(?i)](?ii:(?=[a-\\d\\q{a|bc})]**)+|", "flags": "v", "valid": false}
+{"pattern": "\\p{Basic_Emoji}[a-z\\p{RGI_Emoji}]{2,3}[[\\q{ab}]\\&--\\uD83D\\uDE00-\\uD83D\\uDE02][\\da-\\d](?i-m:[^(}[][&&][]|[}]\\-|\\p{L)|", "flags": "u", "valid": false}
+{"pattern": "(?i:(?>\\/{3,2})){3,2}", "flags": "i", "valid": false}
+{"pattern": "[\\w\\c_a-\\d]+([]{2,}\\u{}[[^\\q{ab}]\\u{1F600}-\\u{1F602}\\q{ab}\\q{a|bc}])[^]{", "flags": "v", "valid": false}
+{"pattern": "{1}[😀]{99999999999}", "flags": "u", "valid": false}
+{"pattern": "\\k<b>*\\p{sc=Greek}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=[\\]]\\k<a>{2,}(?ims-:(?<b>y)\\k*(?-i:[^\\cA\\!\\u{1F600}-\\u{1F602}a-z]{2,}|\\w{2,3}\\uDE00[}]{3,2})|))(?i:(?:\\e\\!*[@\\q{ab}\\q{}]+)**&*?\\cA{){2}(?i-m:[(\\1/]**|)(?ii:[^\\p{L}\\1\\d-a]|\\p{}{3,2})(?ii:[\\-]|(?!(?ii:}|\\u{41})\\q{ab}(?<a1>x))(?x:[](?i:[]+?)\\/+?))", "flags": "v", "valid": false}
+{"pattern": "(?i:(?ii:(?<=[\\b]|[😀\\s]|){2,})??|(?<a>[^\\-[])\\k<b>){2,1}", "flags": "v", "valid": false}
+{"pattern": "\\q{ab}", "flags": "v", "valid": false}
+{"pattern": "\\p{L\\d", "flags": "v", "valid": false}
+{"pattern": "[^!--]\\p{L(?<b>(?:[\\P{Lu}\\B]*?)|(?<a>x)[a-z\\q{a}]|[|z-a[\\q{ab}]\\uD83D\\uDE00-\\uD83D\\uDE02]😂)*\\k<!", "flags": "v", "valid": false}
+{"pattern": "[]&\\d(?i)[^a-\\d\\0](?x:}|)\\8|\\#", "flags": "u", "valid": false}
+{"pattern": "[\\\\d-a\\])]", "flags": "v", "valid": false}
+{"pattern": "\\c_(?<\\u{61}>x)[)&b](?-i:[\\q{\\d}\\d-aa-z.]{2,})|(?-i:\\x41(?<$>x)(?=[^\\p{L}\\w]\\c_*?(?<=[\\q{a}\\0😀-😂]{2,}\\a*?)){3,2})", "flags": "i", "valid": false}
+{"pattern": "(?i)[]*[]**{,2}[\\B[a]]", "flags": "v", "valid": false}
+{"pattern": "(?i-m:(?i-m:\\&[^\\q{ab}\\P{Lu}]{2}|)+?[](?i-m:\\-(\\&|{99999999999}\\a|[\\-](?-i:[[^a]\\p{L}}\\q{a}]{3,2})[\\!&😀-😂]*))*?\\c_??", "flags": "i", "valid": false}
+{"pattern": "(?i)[\\q{}]\\P{RGI_Emoji}", "flags": "i", "valid": false}
+{"pattern": "[^[\\q{ab}]\\d\\w\\P{Lu}](?<=[^z-a\\uD83D\\uDE00-\\uD83D\\uDE02$$\\B]{99999999999}|\\3", "flags": "i", "valid": false}
+{"pattern": "\\!*\\/|[--[^a]\\q{\\d}]|[\\q{ab}(][\\q{a|bc}b]\\d-a]", "flags": "v", "valid": false}
+{"pattern": "(?-:{,2}(?i-m:(?i)}{2,3}[a]|+?\\p{ASCII}{2,3}?[\\u{1F600}-\\u{1F602}]{(?<a>-\\u{1F600})|\\P{RGI_Emoji}|\\p{Greek})(😀(?<a>\\e\\uD83D{){2,3}|\\u{1F600})|[^z[\\c_]{2,3}[^[\\q{ab}]a-z\\!\\uD83D\\uDE00-\\uD83D\\uDE02](?<b>[^]-|\\p{}\\12|))_", "flags": "v", "valid": false}
+{"pattern": "😂\\uDE00*", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:[\\d-a]|\\/)\\2[[]\\p{RGI_Emoji}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\&z\\p{L}]\\p{L|(?![]{2,3})", "flags": "u", "valid": false}
+{"pattern": "(?<b>y)", "flags": "v", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "[\\&\\d&\\cA](?i)\\12{2}[^[\\q{ab}]]\\&b][$$[]|[][^-a-\\d(z]??a", "flags": "", "valid": false}
+{"pattern": "\\k<0_\\p{Lu}|{", "flags": "u", "valid": false}
+{"pattern": "\\p{ASCII}*?", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[{\\p{RGI_Emoji}\\q{ab}\\p{}[\\-&", "flags": "i", "valid": false}
+{"pattern": "[a-z!\\b]**\\k<a>??(?=\\p{Script_Extensions=Latn}||\\3|)\\b{2,}", "flags": "v", "valid": false}
+{"pattern": "\\p{Basic_Emoji}(?-:\\c(?<a>a)+\\e|\\2[]|)*[$$/\\B\\q{\\d}]", "flags": "i", "valid": false}
+{"pattern": "]**[\\B[a]]??\\1\\x41??", "flags": "", "valid": false}
+{"pattern": "[\\-]{2,1}??|[😀\\cA]+[^\\w)}\\q{\\d}]{", "flags": "", "valid": false}
+{"pattern": "[][--!\\uD83D\\uDE00-\\uD83D\\uDE02\\P{Lu}]{(?x:\\p{ASCII}[z-a\\q{ab}\\d-a}](?ii:\\p{L*\\/\\w)||(?-:(?<={99999999999}|[]*?)|\\p{ASCII}(?<!\\b(?<$>x))|(?<b>y)(?x:[^😂-😀]\\#[\\s😂-😀\\c_]){2,3}?)\\p{Basic_Emoji}{2}(?<$>x))[^\\Bz\\\\q{a}]", "flags": "", "valid": false}
+{"pattern": "\\p{Script_Extensions=Latn}{2}^](?i-m:(?=()(?=\\p{Script_Extensions=Latn}[]{3,2}|_[b\\c1]|[\\c_])||\\B(?=[\\p{L}{a-z!!]*?[[😀]\\s)\\u{41})[--]\\uD83D\\uDE00){|", "flags": "", "valid": false}
+{"pattern": "[\\q{a}][\\P{Lu}\\q{a|bc}]\\w", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:[^}..][\\-@\\p{RGI_Emoji}(](?-i:\\uD83D))(?ii:(?i-m:[\\P{Lu}\\u{1F600}-\\u{1F602}[\\q{ab}]]??[^&&\\q{ab}\\0.]$|(?i)[^]])[$$z-a](?<=[@]+?\\c_?|😀)|)\\p{}", "flags": "v", "valid": false}
+{"pattern": "[\\p{L}|$$]{2,}[]{2,3}?(?<a>b[]{2,})(?-i:[&&])a", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "0[)-[^\\q{ab}]\\]]", "flags": "v", "valid": false}
+{"pattern": "(?i-m:([b[\\q{ab}]\\B[\\q{ab}]]\\d)?|😀(?>\\c_\\p{Lu}|(?<a1>x))|[^\\x41[&&)])(?>(?=(?<b>\\00|\\b[^-$$z-a])\\q{ab})[\\]{2})(?ii:\\p{})", "flags": "v", "valid": false}
+{"pattern": "\\00[]|\\u{1F600}\\p{Lu}[)", "flags": "u", "valid": false}
+{"pattern": "\\p{gc=Lu}+?[\\c1\\0\\p{L}z]", "flags": "u", "valid": false}
+{"pattern": "(?<!(?i:[[^a]](?<![])[]|\\k<a>(?>\\-z{2}|^*?\\x4)(?>\\P{Ll}\\q{ab}[^^]|)??){2}|(?ii:(?-:&\\k<+?)|\\e(?:(?<$>x){2,}[--\\1{&][\\c1]*|(\\B\\&))(?i:[😀\\u{1F600}-\\u{1F602}]|z?(?>_|\\p{RGI_Emoji})*?\\w{2,})|(?i-m:\\b+|[^]|(?=\\p{Basic_Emoji}?|\\k<\\u0061>))*?)\\12", "flags": "u", "valid": false}
+{"pattern": "\\w|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[^\\q{ab}]\\!](?>\\p{Lu}|)\\p{}+?", "flags": "i", "valid": false}
+{"pattern": "(?ii:_\\p{ASCII})**[\\d(]\\s*", "flags": "u", "valid": false}
+{"pattern": "(?ims-:(?i-m:[^($$][😂-😀]{)\\p{gc=Lu}|a)(?ii:[]]\\q{\\d}]**\\w{)", "flags": "i", "valid": false}
+{"pattern": "[]\\&{2,3}?", "flags": "v", "valid": false}
+{"pattern": "(?ii:[^|](?=(?-i:[]\\p{sc=Greek}[^\\c1])|\\cA\\uDE00)(?i:\\10+(?<!\\u{1F600}?){3,2}|[\\uD83D\\uDE00-\\uD83D\\uDE02]**\\k<)|(?<$>x)[[^a]a/}{\\00(?-i:\\10[(])*", "flags": "", "valid": false}
+{"pattern": "(?=\\--[|/\\q{ab}])", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-:([]|a)[--\\b😂-😀]{2}){b", "flags": "u", "valid": false}
+{"pattern": "{{3,2}|\\q{ab}|(?<$>x)+\\cA", "flags": "v", "valid": false}
+{"pattern": "(?x:[--\\cA](?<=[]{2,}[]??\\12{2,}|)|\\k<)+?(?x:\\0**)\\u{}", "flags": "u", "valid": false}
+{"pattern": "\\00\\x4{2,3}\\p{Greek}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uD83D\\uDE00(?>(?ims-:[^]|)+?[\\s{]\\k<b>*(?<b>\\08?(?<b>(?<a>[(\\q{}]??[^\\B\\d\\p{RGI_Emoji}]|{2,3}[\\q{a})😀-😂])+?(?i-m:{+?)))", "flags": "", "valid": false}
+{"pattern": "[|]|(?-i:[]|)\\c1", "flags": "v", "valid": false}
+{"pattern": "(?<=\\p{L}{(?<$>x))", "flags": "v", "valid": false}
+{"pattern": "(&(?<!(?=])(?![^\\sa/]{2,3}[!)\\cAa-\\d]{2,})\\p{gc=Lu}){2,}[z-a\\s\\x41\\!])", "flags": "v", "valid": false}
+{"pattern": "][--\\q{}]|(?<\\u{61}>x)|[\\-\\sa-z\\p{RGI_Emoji}]*|", "flags": "u", "valid": false}
+{"pattern": "[z-a]*\\2[]+?\\p{gc=Lu}??(?<=(?:[/\\1])(?x:\\0{2,3}?[zz-a]|[]){3,2}\\k<\\u0061>|[[^\\q{ab}]\\q{}]]][]\\08)", "flags": "v", "valid": false}
+{"pattern": "(?<b>[/&&]|[)])\\0[^\\w]z[]", "flags": "", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "\\x41{3,2}(?ims-:\\k(?=[a-\\d[a]\\]]){2,3}?)*|[^\\c_][^[a]\\]a??", "flags": "v", "valid": false}
+{"pattern": "[b\\p{RGI_Emoji}][^][\\c1--\\0--][^$$](?<a>x)", "flags": "v", "valid": false}
+{"pattern": "\\c(?-:(?ii:(?:[a-\\d&)(?<a>[^\\s[a]a-\\d😀-😂][^[a]])|\\w)😂||\\q{ab})", "flags": "i", "valid": false}
+{"pattern": "\\k(?i-m:{1}{2,3}[^]{2,3}?[^])\\12\\uDE00??\\w*", "flags": "", "valid": false}
+{"pattern": "[^\\&\\0😀]*[.]?\\x41[\\b]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<b>(\\p{ASCII}[{\\&])(?<![\\u{1F600}-\\u{1F602}\\q{ab}]|(?ii:[])?(?ii:|\\10))\\0)", "flags": "", "valid": false}
+{"pattern": "(?-i:[^\\0}](?x:\\x4\\p{RGI_Emoji}[\\!])|(?!\\u{41}[^!![^a]\\cA\\x41][.a]?|[][]z)*?[][z-a[^a]&&](?<b>y)", "flags": "u", "valid": false}
+{"pattern": "[a\\1.](?![\\p{L}[\\q{ab}]\\&][^}]{2,3}\\B*?|[\\][\\q{ab}]z\\!][\\-\\q{}]^)", "flags": "", "valid": false}
+{"pattern": "[\\q{}b][\\c_😀]((?>\\p{Lu}|(?i:.😂))|(?x:[😀[^\\q{ab}]\\q{ab}]|(?=[\\u{1F600}-\\u{1F602}\\&b??\\w)??)", "flags": "", "valid": false}
+{"pattern": "{,2}+(?-i:\\w\\c_??|.**(?=\\uD83D\\uDE00z[\\uD83D\\uDE00-\\uD83D\\uDE02(\\uD83D\\uDE00-\\uD83D\\uDE02@]{3,2})\\2{2,3}?", "flags": "i", "valid": false}
+{"pattern": "(?i:\\/+(?ii:(?<a>\\c_|\\0*^)(?<a>{2,3}|\\8{2})[^\\p{RGI_Emoji}[^\\q{ab}]}])", "flags": "", "valid": false}
+{"pattern": "\\u{41}\\1", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)\\p{gc=Lu}-|[\\P{Lu}!--\\p{RGI_Emoji}]|", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "0+[]*?\\uD83D", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!\\B][aa\\!]+|", "flags": "v", "valid": false}
+{"pattern": "\\e\\w😂", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q{ab}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!b){2}(?<a>[]){", "flags": "v", "valid": false}
+{"pattern": "[^\\]?(?-i:(?ims-:(?=[^[^a][^\\q{ab}]\\q{}\\c_]*]{2,})(?>{2,}))**(?<a>(?<=😂?\\c|{2,3})_**).)", "flags": "v", "valid": false}
+{"pattern": "(?<b>[{\\u{1F600}-\\u{1F602}[^\\q{ab}]])\\p{L}+", "flags": "v", "valid": false}
+{"pattern": "[^{}\\x41]?](?=\\12)", "flags": "v", "valid": false}
+{"pattern": "z", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[](?<=[^@^-!!][{\\!]\\k<\\u0061>|[z[^\\q{ab}]]{3,2}(?ii:😂\\12[a-za-\\d\\u{1F600}-\\u{1F602}]|[^](?ims-:){3,2}|[^])+(?x:[]{3,2}\\p{gc=Lu}[{)z]|(?![^\\c_\\q{\\d}][]!|{2,}))|)|(?i:$(?-i:(?<b>[\\s\\]]))|{2,1}\\e)\\k<\\u0061>{2,3}?\\p{sc=Greek}{3,2}", "flags": "", "valid": false}
+{"pattern": "[](?<a>(?<!\\p{L)b(?<b>0.(?<a>\\d{2,}|&{))??||[\\cA\\x41\\!])(?<$>x)(?>\\0|(?ims-:(?<b>y))[^]{2}(?<a>(?<=[^])(?<a>[^!|][\\q{a|bc}\\d-a]))){2}", "flags": "v", "valid": false}
+{"pattern": "[😂-😀[^\\q{ab}]]|\\u{41}(?-i:^)**((?ii:(?:{99999999999}[\\]]{3,2}|\\8\\u{1F600}){2,}\\uDE00|)])|", "flags": "v", "valid": false}
+{"pattern": "[\\p{L}/[/]{", "flags": "v", "valid": false}
+{"pattern": "[^!\\d-a+\\12", "flags": "u", "valid": false}
+{"pattern": "😂[^\\&\\&!!\\!][^\\p{RGI_Emoji}]|\\1[]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "&", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-:[^}]\\p{L)$(?>[z[])[^z\\q{\\d}]", "flags": "v", "valid": false}
+{"pattern": "[(\\1(]\\cA*(?<=[z]|(?<![\\b/\\q{ab}}](?<=)(?<!))(?-:(?x:[[^a]\\&]|\\08+[a-\\d[a]😀]|[](?i-m:\\x4|\\s[😀-😂!!]\\10)[a-\\d])).", "flags": "i", "valid": false}
+{"pattern": "(?![\\c1a)!](?=[\\u{1F600}-\\u{1F602}&\\0])(?-i:[$$[^a]])|)((?ims-:[z-a\\B--(]))\\p{L}", "flags": "v", "valid": false}
+{"pattern": "(\\c1{)[\\p{RGI_Emoji}(\\0\\]]\\2*?\\uD83D", "flags": "v", "valid": false}
+{"pattern": "[^\\\\d](?<$>x)(?:(?i:(?-:]**|)?[]\\k<||\\2{){2,1}(?<=([^]a[$$]|\\8-)(?<a>(?<a1>x)\\k<\\u0061>)\\uD83D**))\\p{RGI_Emoji}", "flags": "", "valid": false}
+{"pattern": "[\\q{a|bc}\\cA\\w][\\uD83D\\uDE00-\\uD83D\\uDE02]\\uD83D\\uDE00(?>[😂-😀\\p{L}\\d--]|[^])", "flags": "v", "valid": false}
+{"pattern": "(?<a1>x){3,2}\\u{1F600}{2,}({99999999999})|\\k<b>{2,3}", "flags": "v", "valid": false}
+{"pattern": "(?<!(?-i:(?i)+)(?<b>[[\\q{ab}]\\B\\0][\\d-a]{2,3}?))", "flags": "v", "valid": false}
+{"pattern": "[.\\\\cA\\c1][^^][^](?i-m:[a-\\d]{2}\\8)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p{L}😂-😀\\d-a]\\k<b>|[^\\q{ab}\\&a-\\d\\p{L}](?<b>(?ims-:\\e\\k<\\u0061>*?))", "flags": "", "valid": false}
+{"pattern": "(\\p{gc=Lu}|(?x:\\c(?<a>]${2}[a-z[(])[\\q{}-|]{2,3}?|(?i-m:[^(!\\B&&])(\\00{2,3}?\\u{41})\\q{ab}))(?x:${,2}[^/])", "flags": "u", "valid": false}
+{"pattern": "(?<=[\\&]\\k<b>|(?i-m:\\k<b>??(?i:[[a]z[\\q{ab}]]{){2,3})[\\0]*{1})\\p{Script_Extensions=Latn}[\\q{a|bc}\\-\\d-a]??|[[^\\q{ab}]\\q{}]*0{2,3}?", "flags": "u", "valid": false}
+{"pattern": "[a-\\d\\c1]{{1}**", "flags": "", "valid": false}
+{"pattern": "(?<=\\x41){[", "flags": "u", "valid": false}
+{"pattern": "[[\\q{ab}]][][^\\B)][a-\\da]*", "flags": "v", "valid": false}
+{"pattern": "{2,1}[\\u{1F600}-\\u{1F602}]|", "flags": "u", "valid": false}
+{"pattern": "(?<=[{\\P{Lu}]😀{2,3}!{2})+?[&(\\q{\\d}\\12\\p{Lu}", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}{3,2}(?!(?i:\\c|(?i-m:[\\1\\q{a}\\q{ab}\\!]{2,})+|[^\\uD83D\\uDE00-\\uD83D\\uDE02&&(a]\\P{Ll}){2,3}b|{)|}{2,1}", "flags": "", "valid": false}
+{"pattern": "[^]{", "flags": "u", "valid": false}
+{"pattern": "\\P{RGI_Emoji}(?<=(?<\\u{61}>x))+(?=[^]|&)\\0", "flags": "i", "valid": false}
+{"pattern": "(?i)[^][^\\u{1F600}-\\u{1F602}$$]|\\s[]", "flags": "i", "valid": false}
+{"pattern": "[^](?:0|\\u{1F600}**\\&{2})[][\\q{ab}]\\1]", "flags": "i", "valid": false}
+{"pattern": "\\0|(?i)_[/]||(?>(?-:😂)\\s{|[^[^\\q{ab}]\\q{a}[a]a-z]|[^]😀)(?i:[]){2,3}?[\\p{RGI_Emoji}\\u{1F600}-\\u{1F602}\\q{a|bc}]{", "flags": "u", "valid": false}
+{"pattern": "\\/(?ims-:\\08\\#|[^|\\Bz\\d-a](?<a>[z😂-😀\\-]|\\cA)??(?x:\\k<\\u0061>*\\u{}[)|\\s|${2,3}?(?>[\\uD83D\\uDE00-\\uD83D\\uDE02\\c_\\s]{2,3}|)|(?-i:\\w\\![\\uD83D\\uDE00-\\uD83D\\uDE02😀-😂])))\\p{Basic_Emoji}", "flags": "v", "valid": false}
+{"pattern": "(?=(?:[😂-😀!\\d@][|\\uD83D\\uDE00-\\uD83D\\uDE02{)])\\#)??[a-z]](?<b>(?i:\\x41)\\uD83D|\\p{}+)", "flags": "v", "valid": false}
+{"pattern": "0\\3\\10|\\k<\\u{41}+?", "flags": "v", "valid": false}
+{"pattern": "^{99999999999}(?![\\&])", "flags": "i", "valid": false}
+{"pattern": "\\0{2,3}\\cA??\\s(?i:(?i:(?ii:[/]\\x4{2,3}{99999999999}*?)(?=!)+)[^\\1)😀-😂])\\u{}", "flags": "v", "valid": false}
+{"pattern": "[{!!\\b]|^(?i:.\\p{L)(}**(?>.{2,3}?|[😀-😂😀!!]^|(?![a-|\\c1][^\\u{1F600}-\\u{1F602}][]|{??[]|){99999999999})[]", "flags": "", "valid": false}
+{"pattern": "(?ii:\\a|(?x:(?:!+?)[^\\d\\p{L}$$]?)*?\\a(?!\\u{41}|\\s)", "flags": "", "valid": false}
+{"pattern": "$[\\]\\q{}]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\d\\q{a}|z-a]+?(?-i:\\uDE00|(?>[^}])[])[(?ii:(?i:[]*(?-i:\\3)\\P{Ll}|[^\\x41\\uD83D\\uDE00-\\uD83D\\uDE02]\\uDE00\\P{Ll}?)\\1|)", "flags": "i", "valid": false}
+{"pattern": "(?i:\\8{2,3}?(?!]\\p{sc=Greek}{3,2}|[^\\q{}\\c1|][\\0]|)[^\\!][^](?!\\-|(?i:\\x4\\k))[@\\uD83D\\uDE00-\\uD83D\\uDE02]{2,}", "flags": "u", "valid": false}
+{"pattern": "\\p{Script_Extensions=Latn}\\u{41}[]{2,}\\P{Ll}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x:[](?!\\P{RGI_Emoji}[z-a.]\\p{Greek}|😂*(?<b>&[(z-a|]{2,3}?)(?<b>[\\q{\\d}😀/][\\d-a{]))+|(?ims-:\\p{gc=Lu}{2,}))|\\B", "flags": "", "valid": false}
+{"pattern": "[{a-z]{99999999999}*?(?>[(a-\\d\\B][}]😀-😂@]|(?i)[z-a]**|(?<\\u{61}>x)??a{2,3}){2,3}?\\p{L", "flags": "v", "valid": false}
+{"pattern": "[]\\c1*[^[\\q{ab}]/}(]{2,}\\#{2}", "flags": "", "valid": false}
+{"pattern": "[\\-](?=[^z][!![^\\q{ab}](]b)**\\w", "flags": "i", "valid": false}
+{"pattern": "[\\p{RGI_Emoji}]\\p{RGI_Emoji}][]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "-(?=a][^[^\\q{ab}]/]??)", "flags": "u", "valid": false}
+{"pattern": "{\\p{L\\p{Basic_Emoji}", "flags": "v", "valid": false}
+{"pattern": "[^][\\b-](?<\\u{61}>x)\\3", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\u{}z*(?<a>x)(?ims-:[\\!\\c1][^[^a]\\u{1F600}-\\u{1F602}])", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "[a-\\da-z{,2}[]", "flags": "u", "valid": false}
+{"pattern": "\\u{1F600}z*\\/", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]{2,3}(?<!(?<b>\\p{Script_Extensions=Latn}\\B[&&\\cA--a-\\d]{2,3}?", "flags": "", "valid": false}
+{"pattern": "(?<=0\\p{Script_Extensions=Latn}+[^[^\\q{ab}]😀[a]]+){2,3}", "flags": "", "valid": false}
+{"pattern": "[[^\\q{ab}]--/]+{,2}", "flags": "v", "valid": false}
+{"pattern": "(?ii:\\-**|){2,}\\uDE00\\P{RGI_Emoji}[[^\\q{ab}]]|\\p{RGI_Emoji}", "flags": "u", "valid": false}
+{"pattern": "[^^\\cA]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[$$]??[\\d-a(?-i:(\\p{ASCII}{|$))", "flags": "v", "valid": false}
+{"pattern": "\\12(?i-m:(?<b>\\#a)b|(?![][^[^a]{][^]{2,3}){2,3}|\\p{Lu}**[][]|[]{2,}", "flags": "v", "valid": false}
+{"pattern": "[!\\d-a]|[&\\P{Lu}\\cA](?i)\\uD83D{2,3}\\0{2,3}[]", "flags": "v", "valid": false}
+{"pattern": "\\u{41}(?i-m:\\e\\/)[😂-😀😀-😂\\cAa-z](?i-m:.[^{[^\\q{ab}]\\&])(?!(?=\\p{L😂)*)", "flags": "u", "valid": false}
+{"pattern": "[😀-😂][^][\\q{ab}]](?<\\u{61}>x){(?<\\u{61}>x)[\\p{L}a-\\d]", "flags": "v", "valid": false}
+{"pattern": "😀(?i-m:[\\c_\\1\\&[](?ims-:(?-:\\08{2}[^!\\B]??)[^\\q{ab}](?<b>y)))[$$\\p{RGI_Emoji}]", "flags": "u", "valid": false}
+{"pattern": "(?<a>[--&}])\\p{RGI_Emoji}[\\q{ab}[^a]]", "flags": "i", "valid": false}
+{"pattern": "(?i:\\u{1F600}??\\0|[a-\\d😀-😂)(?i:\\k<a>(?<a>\\10(?<a1>x)){[}(]|(?=[^\\-\\q{ab}\\s]|(?x:\\p{}}{2,3}?{2,3}?)|[^😀-😂!\\]\\b][😀a]+\\c1{3,2}))[|\\c1]*?\\u{41}{3,2}|", "flags": "i", "valid": false}
+{"pattern": "\\uD83D\\3$[--]{3,2}", "flags": "u", "valid": false}
+{"pattern": "[^!(\\q{a}]\\c\\00\\s", "flags": "u", "valid": false}
+{"pattern": "\\p{L{2}(?i-m:\\00)\\p{Lu}", "flags": "v", "valid": false}
+{"pattern": "[(😀-😂\\b][^\\P{Lu}\\\\-]*(?<a>x)?", "flags": "v", "valid": false}
+{"pattern": "\\p{ASCII}*\\uDE00(?:{,2}|[\\]\\-]]\\&**|)|[)b(](?:(?i-m:[]\\p{gc=Lu}|(?<a1>x)|[\\w\\!][/[a]])\\!(?<b>y)??)", "flags": "", "valid": false}
+{"pattern": "]\\k<\\u0061>*?{1}\\#", "flags": "v", "valid": false}
+{"pattern": "\\uD83D", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<a>\\k<b>[^(a-\\d]??(?x:(?<=(?<a1>x))(?<=\\12[]{2}|[\\d😀\\u{1F600}-\\u{1F602}]\\p{}\\e)?(?<a>x)|(?<a>\\uD83D(?i-m:[{]+?[|😀-😂\\1]]{3,2}|.){2,}|(?>(?<\\u{61}>x)[\\d[a]]+)(?<=|!+?))){3,2}", "flags": "", "valid": false}
+{"pattern": "(?:\\c1{2}(?>\\-(?<\\u{61}>x)))(?:[-(z\\s](?<a>\\c**(😀|\\c_\\k<\\u0061>+|)+(?<![.\\q{a}][a]]\\#\\p{gc=Lu}||0\\uD83D)){|\\a[\\p{L}\\-\\!]\\!*)", "flags": "u", "valid": false}
+{"pattern": "[]\\c1b", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)\\P{Ll}\\c\\10{1}", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?ii:[/a-\\d--]*?([\\B\\@\\q{a}]{2,3}?[\\0{z][^\\s\\c_\\sb]))[\\]-](?<a>x)", "flags": "v", "valid": false}
+{"pattern": "[|\\k<|[z-a]+?(?=\\p{gc=Lu}?(?i)\\uD83D\\uDE00|{2,}(?i)[&&\\B](?x:[^\\P{Lu}]|[\\c_]))", "flags": "v", "valid": false}
+{"pattern": "(?i:[^][]|(?-:(?i:[^]){3,2}|[--])\\c1{2,3}(?!(?>\\uD83D\\!{)[|]\\p{Lu}|\\p{Lu}+))", "flags": "v", "valid": false}
+{"pattern": "[^\\P{Lu}[\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "\\00\\p{Lu}(?ii:(?<a>\\c[\\s\\q{}]|).+?[--][^a]]|\\u{41}{)|\\1$", "flags": "v", "valid": false}
+{"pattern": "(?>[\\]][-\\u{1F600}-\\u{1F602}(])\\k<\\u0061>{2,3}(?>(?:[)a\\cA]+?\\k<b>)?|\\u{1F600}\\12*?|([^]|(?>z))*[[\\q{ab}]\\-][\\s[a]\\1\\!])", "flags": "", "valid": false}
+{"pattern": "[\\cA](?ims-:(?:\\c_[]|(?i:[--^\\![\\q{ab}]]|\\&{){3,2})[😀\\x41\\d]||[^]??[&&]|\\uDE00**)+(?<b>y)", "flags": "v", "valid": false}
+{"pattern": "\\c1[&]\\uD83D\\uDE00[^\\b\\B\\x41][\\p{L}a-\\d|", "flags": "i", "valid": false}
+{"pattern": "[\\q{\\d}](?!(?i:(?i)\\q{ab}{2,3}b(?i:[\\\\uD83D\\uDE00-\\uD83D\\uDE02--\\q{ab}]😀))*(?-i:\\k||\\b\\p{}(?i-m:?\\2))|(?<!\\u{41}[\\uD83D\\uDE00-\\uD83D\\uDE02]\\uD83D\\uDE00))\\10+?", "flags": "v", "valid": false}
+{"pattern": "\\P{RGI_Emoji}{3,2}(?=[(\\q{ab}]??)\\&{2}(?<b>y)", "flags": "v", "valid": false}
+{"pattern": "[[^a]😂-😀-\\q{}][^\\uD83D\\uDE00-\\uD83D\\uDE02\\s][^\\s&&{\\q{\\d}]{&{2,}(?:(?<a>[\\p{RGI_Emoji}**){3,2}(?ims-:[^😂-😀[^\\q{ab}]]){2}\\c1*){2,3}?", "flags": "", "valid": false}
+{"pattern": "[^\\c_]|[\\0\\q{a}[a]]*\\P{RGI_Emoji}|\\2(?>\\p{ASCII}[\\]\\c1[^\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "(?i)[]{|!(?i-m:(?-i:[&&]]+)|\\k<\\u0061>(?x:😀\\u{1F600}))(?<=😂)*", "flags": "v", "valid": false}
+{"pattern": "[^][^]{2}(?i:\\p{Basic_Emoji}{2}|)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]{3,2}[\\sa-z]{2,}[]?[--!!\\q{ab}]+[^\\]b]|", "flags": "i", "valid": false}
+{"pattern": "[(\\c1\\c_.](?<a>\\x4\\uD83D\\0|)[\\-]", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)[\\0]", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?i-m:(?!(?>[\\c1]@])\\p{gc=Lu}|\\1|[\\d-a\\q{}a-\\d]\\10)\\a(\\x41[^\\d][]|\\&[^\\c_]\\c_)*?|){99999999999}", "flags": "u", "valid": false}
+{"pattern": "[]*{|\\c\\uD83D\\uDE00[\\P{Lu}|\\s]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>[^z-a\\q{a}^&]|(?x:(?>\\p{ASCII}|))\\10\\b)(?<\\u{61}>x)\\0[😂-😀]+?", "flags": "", "valid": false}
+{"pattern": "(?i)[\\1\\P{Lu}]||[\\u{1F600}-\\u{1F602}[)\\0]\\q{ab}[]", "flags": "u", "valid": false}
+{"pattern": "-{2,3}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[](?<!!\\s(?i-m:(?i)[a-z\\d!!&&]){2,3}|(?<$>x)(?![^a-z\\sz-a]**)\\/)][\\0\\s]\\d", "flags": "i", "valid": false}
+{"pattern": "]\\aa*?[]", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)**(?i)(?-:\\b\\q{ab}|(?>?_|\\a))(?<$>x)|\\p{gc=Lu}[\\P{Lu}z-a\\cA!]{2,3}?", "flags": "i", "valid": false}
+{"pattern": "\\8[^\\q{ab}[^\\q{ab}]\\![\\q{ab}]]|a{(?<a>(?ims-:(?=\\8{2,3}?[!!--\\d]{|[][]\\d-a\\q{ab}z]{2}(?<a1>x))|)+[b&\\q{ab}](?-i:\\a(?<=\\08\\k<b>**[b]{2,}|[!😀-😂!]]$)|[^\\1\\1][\\]b\\uD83D\\uDE00-\\uD83D\\uDE02](?![\\c_![a]\\]{2}||\\k<[{\\](\\d-a]{2,}))|_[z.\\-]", "flags": "u", "valid": false}
+{"pattern": "\\k<[\\x41&&^[a]][\\!z-a]\\p{gc=Lu}", "flags": "i", "valid": false}
+{"pattern": "(?<![^a@\\s)]|(?x:(?:[]\\10||{2,}[^\\c1\\uD83D\\uDE00-\\uD83D\\uDE02\\c1]*?[^\\q{ab}])(?-i:(?i-m:\\x41{3,2}[a-\\d😀\\b\\b])[\\p{L}]\\q{}b*😂)){,2}(?-:\\d(?i:[^\\q{\\d}\\c1]\\/)|\\d\\a)\\3", "flags": "i", "valid": false}
+{"pattern": "((?<b>(?-i:\\d[{\\B])[](?i-m:[^]\\s))(?i:{,2}{3,2}](?-:[|[])|)\\/{3,2}[\\d-az\\c_\\!](?<\\u{61}>x)\\c", "flags": "u", "valid": false}
+{"pattern": "[^]\\d-a**|[^\\uD83D\\uDE00-\\uD83D\\uDE02](?ii:{99999999999}{2,3}[(\\c_(?i-m:^)+?|\\p{L}[\\B\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a|bc}])", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)|(?-i:\\k<a>[\\]&&(]|(?<![\\q{}\\u{1F600}-\\u{1F602}\\uD83D\\uDE00-\\uD83D\\uDE02](?i:[😀-😂\\w\\q{a|bc}]{3,2}(?<a>x)){,2}|\\cA(?i-m:\\3)|\\#)?*?\\q{ab}", "flags": "u", "valid": false}
+{"pattern": ".\\uDE00[][\\q{a}\\\\1]*?", "flags": "u", "valid": false}
+{"pattern": "(?<=\\00|\\k<|)(?=[$$\\w)][^[^a]|$$\\q{a}]*?(?!\\k<)|(?x:\\k<\\u0061>{3,2}(?<b>[^z-a\\\\&&]|\\ca\\w){{3,2})(?=(?i)[^😂-😀😀-😂\\c1\\cA]{2,3}?\\c|z\\u{})+?[^\\q{}a])*?", "flags": "v", "valid": false}
+{"pattern": "\\c_(?-i:\\p{sc=Greek}|[[^a]\\-]][-[\\b]\\00)**[\\q{ab}}[\\w!](?=(?!(?-:[!\\p{L}😀-😂][\\q{a|bc}|a-\\d[a]])|)??[[a]\\q{}[\\]\\e)", "flags": "u", "valid": false}
+{"pattern": "\\2(?i)(?<a1>x){2}(?:[])|[!!/!!]{3,2}[^b😀]{2}\\p{Basic_Emoji}\\p{ASCII}{2,3}", "flags": "", "valid": false}
+{"pattern": "[\\c_&&[^\\q{ab}][^a]][]!]\\10|[^\\]\\s]\\d**", "flags": "v", "valid": false}
+{"pattern": "\\e[a-\\d}]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\b\\uD83D(?i:\\u{}?(?-i:(?!\\p{sc=Greek}||[\\q{a|bc})]\\k<\\u0061>))[^]**(?!(?x:\\k<)?\\p{}[]){2,3}\\p{Basic_Emoji}", "flags": "u", "valid": false}
+{"pattern": "\\10|(?ims-:\\k<a>\\p{L}{2,1})[[^a]\\]](?:$\\12(?<=\\2(?=[\\c_]😀{2})])|)**(?-i:(?=[](?-i:a){2,}\\0)0$|\\p{}{2,}\\12(?<!(?=\\d|\\/)**[\\w\\p{L}\\](])){2}", "flags": "v", "valid": false}
+{"pattern": "\\c1\\q{ab}|(?i-m:(?ii:(?<a>x)[\\d]*{|(?<\\u{61}>x)|[a-\\d.\\s[^\\q{ab}]][\\b\\B]))", "flags": "v", "valid": false}
+{"pattern": "\\08(?<b>\\#|(?<=[|\\&a-z@]??\\&(?ims-:\\8)**|\\p{L}{2,}[/][\\uD83D\\uDE00-\\uD83D\\uDE02\\d-a]??|)|(?i-m:(?<=[^\\b😀\\p{RGI_Emoji}$$[^]|\\q{ab}**)[^[a]@\\q{}](?i-m:z|\\c_)|(?!(?<$>x))+\\p{Basic_Emoji}|)[])\\/*{,2}", "flags": "i", "valid": false}
+{"pattern": "(?ii:\\p{ASCII})*[\\b\\p{RGI_Emoji}-]", "flags": "u", "valid": false}
+{"pattern": "\\p{ASCII}[^!]\\-(?ims-:\\10|", "flags": "v", "valid": false}
+{"pattern": "[\\d\\cA[^\\q{ab}][^a]]|(?i-m:[\\q{\\d}]||\\u{41}\\uDE00[\\1])", "flags": "v", "valid": false}
+{"pattern": "(?<b>[!]+?(?:\\cA(?-:)(?<=\\12|)){2}\\1)(?<a>b(?<!^[^\\q{a}][]{3,2}))[^]", "flags": "i", "valid": false}
+{"pattern": "[]\\b", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<b>(?i)[\\&--😂-😀](?i-m:\\p{Greek}[😀](?i){,2}*)\\p{gc=Lu})[!!\\q{a|bc}[^a]\\q{a}][]b|", "flags": "v", "valid": false}
+{"pattern": "(?i)😂(?i)(?i:$|\\p{L[^😀|z-a\\1]\\p{ASCII}|)+|\\2(?<=(?-:\\uDE00??(?x:)\\k<{2,3}?||z)|(?ii:[\\p{L}\\q{a}\\p{L}$$](?:\\p{L|\\p{RGI_Emoji}))-[!!]+)\\u{}[[^a]}]]", "flags": "i", "valid": false}
+{"pattern": "[😀(]!??(?<\\u{61}>x)[\\B!][\\q{a|bc}{]{2}", "flags": "v", "valid": false}
+{"pattern": "[|^.]", "flags": "v", "valid": false}
+{"pattern": "(?!(?<b>\\B(?ii:[^\\]\\B])|\\2{3,2}(?>\\k<a>[]\\q{ab}))(?x:[😀z])|(?!(?i:\\uDE00{2,3}0|[^]{2,1}+?))?(?i-m:\\x41)", "flags": "v", "valid": false}
+{"pattern": "(?:\\uD83D[\\w[\\q{ab}]\\uD83D\\uDE00-\\uD83D\\uDE02\\cA]\\d|[a-z|\\P{Lu}!](?<=\\10+?(?i-m:[][])(?<a>x))(?ii:[^\\cA\\d-a\\p{L}\\p{L}]**(?>\\p{RGI_Emoji}\\q{ab}*\\u{41})[a-\\d\\b]*)|\\P{Ll}[]\\p{L\\-", "flags": "u", "valid": false}
+{"pattern": "[^](?ii:[\\!]{,2}{2}(?i)\\/{||\\c){2,3}?", "flags": "", "valid": false}
+{"pattern": "(?:(?<b>[^&&])*?|[\\c1[^a]|]\\-)+[.[^\\q{ab}]][\\cA&\\-]\\p{Lu}", "flags": "v", "valid": false}
+{"pattern": "\\u{41}|[^\\q{\\d}\\c_[\\q{ab}]]\\p{Basic_Emoji}(?<![^][\\wz-a\\q{\\d}][^\\c_a\\cA]){2,3}", "flags": "", "valid": false}
+{"pattern": "(?<!\\b{2,3}\\e{", "flags": "v", "valid": false}
+{"pattern": "\\uDE00(?-i:(?i-m:[^😀]|{(?ims-:[|\\w\\]])|[!]{2,3}?){2})", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-:(?-:😂[^.]{)|([}\\!\\&](?ii:*[\\b\\0^a]?)))\\d", "flags": "v", "valid": false}
+{"pattern": "(?![&&](?<![z-a(]]{2,}(?>)(?<b>[\\c1]\\p{Greek}))|\\d)**{\\u{41}?(?!(?ims-:\\p{RGI_Emoji}{[\\c_a-z{2,}(?ii:[b\\q{ab}{]|))\\/|[]|)&", "flags": "i", "valid": false}
+{"pattern": "(?<a>[\\P{Lu}\\c_])\\1", "flags": "u", "valid": false}
+{"pattern": "(?-:b\\w{2,3})**(?<a>x)(?x:[\\uD83D\\uDE00-\\uD83D\\uDE02\\c_]{2})*(?:[\\c_\\c_\\p{RGI_Emoji}]{2,3}|(?ims-:(?<a>[&]a))|[\\d]\\p{Greek})(?<=\\#[a/b\\B]{|[\\p{L}\\d{][^])|", "flags": "u", "valid": false}
+{"pattern": "\\P{RGI_Emoji}|\\d[\\u{41}+\\u{1F600}", "flags": "", "valid": false}
+{"pattern": ".\\08", "flags": "u", "valid": false}
+{"pattern": "\\k|[]{2,3}(?!(?<!\\10)\\c_)a{2,}(?<=[[]\\x41{3,2}{1}|\\a|(?<a>[\\cA\\cA{😀-😂]\\p{ASCII}\\p{Basic_Emoji})[\\]\\](?-:[\\&][\\x41\\q{a}\\P{Lu}\\q{a}][^]){2})", "flags": "u", "valid": false}
+{"pattern": "\\0[^\\x41\\x41@][]|\\q{}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\P{Lu}](?<a>(?<=[a|[^\\q{ab}]]*[](?<a>\\P{Ll}[]*))!)(?i)(?i)\\p{Greek}\\3|[\\x41\\q{a}\\P{Lu}]\\08(?ims-:[])|😂{2,}(?<b>(?!\\p{sc=Greek}\\u{1F600})){2,}(?i:[^]??|\\p{L}\\k<b>|)(\\k*?(?i:0{2,3}[^^\\0]){|\\p{}{2,3})", "flags": "i", "valid": false}
+{"pattern": "[\\q{a}]\\p{sc=Greek}{2,3}(?=\\p{}\\#{2}|){(?i:[\\c1\\w\\p{L}{2}", "flags": "", "valid": false}
+{"pattern": "[\\P{Lu}](?!(?<b>[\\-\\-}\\w]|(?<a>\\k<\\u0061>|)?)|[\\q{}{😀-😂]{3,2}[^\\q{ab}]|)(?i)[[^a][^a]]\\![\\1]|[&&z-a\\uD83D\\uDE00[\\]a-zz-a]*?\\P{Ll}[^@a-z\\c1]", "flags": "u", "valid": false}
+{"pattern": "(?x:\\c_|[$$](?>[[\\q{ab}]]|[\\cAa\\q{ab}&&]*?[](?<=\\80))+)??[|](?i)\\2?\\3[](?x:\\a)*", "flags": "v", "valid": false}
+{"pattern": "(?<=[!]\\x41)[]|\\k<a>??\\p{RGI_Emoji}(?:!{2}|\\p{L??\\8😂{2}|){2}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4+|b|(?ims-:{99999999999}){2,3}?(?<!$|[][$$&\\x41](?-:(?<=[^\\-\\s]]??)\\b|\\08)[[^\\q{ab}]!--]", "flags": "i", "valid": false}
+{"pattern": "[()a]\\p{RGI_Emoji}{", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x:\\p{ASCII}{1}|((?ims-:a)(?ims-:||b)(?<!|[^])(?-:[\\d😀]]\\p{L{3,2}(?i:{,2}{2,}|[^]\\d-a\\&][])|}\\w)+){,2}|[^](?ims-:[z-a😀-😂😂-😀]{2,}[^-\\&])|", "flags": "i", "valid": false}
+{"pattern": "[--[^\\q{ab}][\\q{ab}]@]|", "flags": "v", "valid": false}
+{"pattern": "\\s+?|(?<b>[\\-(])\\b", "flags": "i", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "(?!\\p{Script_Extensions=Latn}[^])+?[]|", "flags": "v", "valid": false}
+{"pattern": "[\\p{L}^\\P{Lu}[^a]]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{99999999999}|(?i-m:[\\p{RGI_Emoji})$$[]?)", "flags": "v", "valid": false}
+{"pattern": "(?x:\\x41\\p{}😂*|[]){2,3}?|\\e+(?<$>x)", "flags": "u", "valid": false}
+{"pattern": "(?-:[\\-😂-😀😀-😂]||\\k<b>{2})+\\&{2,}(?>[^/\\|])(?x:_\\uD83D|[^😀]|)\\-", "flags": "", "valid": false}
+{"pattern": "[\\p{RGI_Emoji}b}b]^(?i-m:[z-a]{2,3}?[]\\P{Ll}){2,3}?\\q{ab}\\c_", "flags": "u", "valid": false}
+{"pattern": "\\p{Greek}\\/[a-\\d](?x:(?>.\\/|(?<a>\\P{Ll}\\00)){3,2}|(?i)[^)]{2,}(?<\\u{61}>x)||([]*?\\c$|\\w[\\-😀\\!\\uD83D\\uDE00-\\uD83D\\uDE02]{2,3}?)\\p{Lu}{2,}\\p{Greek})", "flags": "", "valid": false}
+{"pattern": "\\c1{3,2}[][.[\\q{ab}]\\]{2,3}[\\q{a|bc}\\w\\1]&", "flags": "v", "valid": false}
+{"pattern": "(?<!(?<=\\k*?|\\w{[\\&](?!||[[^a]{]))\\w\\p{sc=Greek}){2}|[.&&\\q{a}](?i:(?i-m:\\k<\\u0061>))(?i-m:(?ims-:\\00{,2}*[[😂-😀[^\\q{ab}][^\\q{ab}]]+)|a){2,}]??", "flags": "v", "valid": false}
+{"pattern": "(?<b>y)\\p{Script_Extensions=Latn}{3,2}\\0", "flags": "u", "valid": false}
+{"pattern": "(?x:[\\u{1F600}-\\u{1F602}[\\-]*\\p{ASCII}([a-\\d----|])||[^\\q{a|bc}😀-😂{]{2,3}?\\00)[&a-\\d/\\&]", "flags": "", "valid": false}
+{"pattern": "(?<b>y)(?<a1>x)", "flags": "v", "valid": true, "captures": 2, "names": ["b", "a1"]}
+{"pattern": "[]+[\\0\\u{1F600}-\\u{1F602}\\c1😀]|[|./\\u{1F600}-\\u{1F602}]*[^&&\\0](?>\\p{Greek}{)", "flags": "v", "valid": false}
+{"pattern": "[@z-a\\q{}!!]b(?x:\\12\\k<\\u0061>{[&])[^|\\c_\\]]", "flags": "v", "valid": false}
+{"pattern": "[\\p{L}/\\B--][[^a]]", "flags": "i", "valid": false}
+{"pattern": "\\1|[@z\\q{a}]**\\8(?=(?<a1>x)[|]*?\\p{Basic_Emoji}??)", "flags": "v", "valid": false}
+{"pattern": "(?i)\\u{}(?i:[\\q{a}-]]{2,3}|(?ii:+?[\\d(\\p{RGI_Emoji}]{3,2}|){2,3}?[&b)&]|[\\P{Lu}/\\!😀])(?<a1>x)😀[\\B]{,2}(\\00(?i:[$$\\q{ab}😀]|\\uD83D\\uDE00|(?<b>{[^\\q{a}]]))(?>(?<b>[az[^\\q{ab}]]\\p{L\\a||[\\1b\\|]\\b)\\p{L)|[\\B\\1](?ims-:\\k{|😂+{99999999999})(?<b>y)**)", "flags": "v", "valid": false}
+{"pattern": "[[a]{\\[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?ii:([\\q{a}]{99999999999})))?\\uD83D\\uDE00[][[a]\\](?i-m:(?<b>\\8[!!\\b]*)(?<$>x)|\\P{Ll})", "flags": "i", "valid": false}
+{"pattern": "[]{(?<b>]_)\\p{Script_Extensions=Latn}\\c", "flags": "v", "valid": false}
+{"pattern": "(?-:^\\uD83D??\\uDE00)", "flags": "v", "valid": false}
+{"pattern": "[(\\c1!][^\\!😀-😂\\s\\p{RGI_Emoji}]+?[\\]\\w", "flags": "v", "valid": false}
+{"pattern": "\\uD83D\\uDE00", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{RGI_Emoji}[^\\cA@]+?[]\\p{L}[^\\q{}[^a]]{2}", "flags": "v", "valid": false}
+{"pattern": "[]\\b?", "flags": "v", "valid": false}
+{"pattern": "[@]+b(?=(?ims-:\\8{,2}*?)[(-\\q{a|bc}😂-😀]|]{2,3}\\k<b>?\\-{3,2})|{1}{3,2}[^az-a\\q{}\\b]|", "flags": "v", "valid": false}
+{"pattern": "{a(?ims-:(?x:(?x:\\3\\uD83D\\uDE00|)[}@^$$]{2,}|(?<=[\\c_{2}){2,3}?{99999999999}[^\\d]*?)|\\08)", "flags": "v", "valid": false}
+{"pattern": "(?!(?>\\k<{2}\\k{2}|$|))\\da(?i:(?i-m:😀{2,}(?ii:\\00(?<b>y){1})(?=[\\w[[\\q{ab}]\\cAa-\\d\\p{RGI_Emoji}]{3,2})|(?<b>\\10{,2}{2}|\\uDE00){2}[\\u{1F600}-\\u{1F602}]|)|{,2}\\p{gc=Lu}+?\\p{ASCII})+?", "flags": "i", "valid": false}
+{"pattern": "[\\p{L}\\q{a}.@](?!(?-i:(?![^\\!\\[\\u{1F600}-\\u{1F602}])&[]){3,2}[|^]?)\\uD83D+", "flags": "v", "valid": false}
+{"pattern": "(?>[\\d😀-😂^]{2,3}\\k<a>*?)?|(([z-a](?-i:[^]{2,3}?[\\cA😀]|\\0??)*(?>\\p{ASCII}{3,2}\\#|\\B[\\1a-\\d-]{2,3}))|[[^\\q{ab}][\\q{ab}]\\c1(?i:[--])){(?=(?<b>\\x41{3,2}\\cA)[\\&\\c1)][&&[^a]--^]|[z-a$$--\\q{ab}])", "flags": "i", "valid": false}
+{"pattern": "(?ims-:(?<=(?ii:{1}\\P{Ll}{99999999999}))(?<=(?i-m:{2,3})b{)|[a-z])+?", "flags": "v", "valid": false}
+{"pattern": "(?<b>{2,1}[\\1][^\\B^\\d\\u{1F600}-\\u{1F602}]+||[^\\]\\q{a}😂-😀]|\\e[&&]", "flags": "v", "valid": false}
+{"pattern": "\\p{sc=Greek}\\k", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:(?:\\q{ab}{2,3}[^][])|\\08\\p{Lu}){99999999999}", "flags": "v", "valid": false}
+{"pattern": "(?x:[!)\\]\\uD83D\\uDE00-\\uD83D\\uDE02](?i){\\c\\p{RGI_Emoji}|[](?-i:(?i-m:[^$$])|\\s(?-i:\\u{}))", "flags": "i", "valid": false}
+{"pattern": "(?!(?<!(?ims-:{,2}|{2,1}\\cA{2,3}?[&a-\\d])[\\u{1F600}-\\u{1F602}!!]|\\k<\\u0061>|\\-(?={2,})?)}|[\\\\q{a|bc}]|[^][$$\\0&]\\P{Ll}", "flags": "", "valid": false}
+{"pattern": "\\p{L", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[.[^a]\\c1]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>(?i-m:\\3(?>|\\q{ab}|\\p{ASCII})[|!]{2,3}?)${2})|", "flags": "", "valid": false}
+{"pattern": "(?-i:[])", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s$$](?x:[^\\0][[\\c1]([z]+[^@[\\c1]\\d|^(?=\\x4{)|))(?<=[!]+(?<b>[](?>[^!]?a+)\\a{3,2}|(?-i:b)\\10[a-\\d[\\q{ab}][^a]])**)??\\p{gc=Lu}", "flags": "u", "valid": false}
+{"pattern": "[^a-\\dz-a]+[a-\\d)\\P{Lu}\\!\\p{L*\\#(?=(?<a1>x)|{99999999999}(?<a>a{2})\\c){3,2}", "flags": "", "valid": false}
+{"pattern": "(?<a1>x)[^[](\\p{gc=Lu})[^\\P{Lu}\\]]", "flags": "i", "valid": true, "captures": 2, "names": ["a1"]}
+{"pattern": "\\k<b>?|(?<!(?i)\\s(?i-m:[\\cA].{3,2}){3,2}|(?i:??)?|b\\&{3,2})[\\q{a|bc}\\P{Lu}\\w[](?:\\u{}{99999999999}|(?!\\x4\\p{L})|((?:{)\\0\\k<\\u0061>){2}(?<=\\k<a>", "flags": "v", "valid": false}
+{"pattern": "😀*?[^😀&&&\\uD83D\\uDE00-\\uD83D\\uDE02]{3,2}", "flags": "v", "valid": false}
+{"pattern": "{,2}|\\p{L}\\!(?x:(?i:\\08\\B(?-:\\p{})|\\cA|(?<b>(?<a>x)(?<a>x)|{\\p{})[\\b])[\\\\q{}(]+?!)+?\\p{Basic_Emoji}|", "flags": "v", "valid": false}
+{"pattern": "(?i-m:[(.]\\10{\\c1|[^[^\\q{ab}]\\c_|])+?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[][\\p{L}\\0@]{3,2}", "flags": "v", "valid": false}
+{"pattern": "(?<=[^][\\P{Lu}\\d-a\\0]|\\d)|(?<=\\k<)", "flags": "v", "valid": false}
+{"pattern": "(?<b>[\\q{}&a-\\d\\p{L}]+?[[a]){2}[-\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "", "valid": false}
+{"pattern": "\\c{3,2}[\\\\q{a}]{2}&+\\s|(?<!\\p{ASCII}+$+|[][^\\c1]{99999999999})", "flags": "", "valid": false}
+{"pattern": "\\a\\p{L}", "flags": "v", "valid": false}
+{"pattern": "(?i:\\c]+?)??(?i:(?<a>x))|(?i-m:a){2,1}{2,3}", "flags": "v", "valid": false}
+{"pattern": "a[\\P{Lu}\\&](?i)[^z😀-😂\\d-a]??|(?-i:\\x41\\k<[\\p{RGI_Emoji}a-z\\0\\q{}]\\k<\\u0061>{3,2}!**[!!]**\\k<a>", "flags": "", "valid": false}
+{"pattern": "\\k<a>{2,}\\w{2,}\\w|[&&!!/](?<a>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?i:(?ims-:[]\\8(?>[^][!$$$$\\-]|{,2}[\\p{L}}]\\B{)){\\c(?<=}[\\b\\0]\\q{ab}))", "flags": "v", "valid": false}
+{"pattern": "[\\d\\d]**[[^\\q{ab}]]{3,2}|\\/\\&[\\P{Lu}--😀-😂]{2,3}", "flags": "u", "valid": false}
+{"pattern": "(?>(?ims-:(?:[^[^\\q{ab}][^a]\\B+\\uD83D?)\\#))", "flags": "u", "valid": false}
+{"pattern": "!\\c_{2,3}?_{2,3}?[]", "flags": "v", "valid": false}
+{"pattern": "(?>\\c?|\\k<b>[\\uD83D\\uDE00-\\uD83D\\uDE02](?-:[](?ii:[])(?-:)|[^\\q{a}][\\p{L}]**))(?ims-:[\\p{L}])(?-i:{2,1}[]\\p{L}??)[\\&]", "flags": "v", "valid": false}
+{"pattern": "(?i)(?i-m:\\u{41}|[^[\\q{ab}]\\b@]??\\1{||\\p{Greek})[\\q{a|bc}^]{3,2}![[a-z]*(?<a>x)", "flags": "", "valid": false}
+{"pattern": "\\c[$$[^a]z-a]0+?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1]**]*?", "flags": "i", "valid": false}
+{"pattern": "(?<![(!])*?[^\\].\\e|[\\b\\d-a]", "flags": "v", "valid": false}
+{"pattern": "[@][\\q{\\d}!![]**", "flags": "i", "valid": false}
+{"pattern": "\\c??(?:\\k<a>|)*\\e\\d{3,2}[\\q{a|bc}]", "flags": "i", "valid": false}
+{"pattern": "\\a?[\\1z-a][|[]😀-😂]{|\\00", "flags": "i", "valid": false}
+{"pattern": "(?<$>x)[[^\\q{ab}]]", "flags": "", "valid": true, "captures": 1, "names": ["$"]}
+{"pattern": "(?!(?i-m:(?:\\00[\\q{}a]{\\uD83D\\uDE00|{99999999999}??)$)|\\p{Lu}[]*)(?<=(?<a>x)(?-:[]\\k<\\u0061>[^[^a]\\c_\\1]**|(?={2,3}\\u{1F600}?)(?ims-:[][--[]|[^}]])**\\10*?))\\e+[a-z\\d]+", "flags": "", "valid": false}
+{"pattern": "(?<a>(?>[\\0\\uD83D\\uDE00-\\uD83D\\uDE02]{2,}(?:||\\0)\\k|(?-:\\2\\k<[\\1b)(?<b>[\\q{}\\q{}\\B]|[&]\\0*)*?(?:-(?<$>x)|[😀)]{2,3}\\p{Lu}))[[a]😂-😀@]???[\\p{L}[^a]\\c1}][^\\uD83D\\uDE00-\\uD83D\\uDE02[a]\\P{Lu}](?<![\\c_]??(?ims-:(?<=(?<$>x)))**", "flags": "i", "valid": false}
+{"pattern": "&", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]_|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Basic_Emoji}$(?![\\s}\\]](?ims-:][]*?\\s)?(?i:(?<b>y)?(?ii:[a-z[a]{\\s]))+[\\cAa-\\d@^]{2,3}", "flags": "i", "valid": false}
+{"pattern": "(?i:[\\p{L}^z-a😀]\\k<b>[^--]|[^\\uD83D\\uDE00-\\uD83D\\uDE02])|", "flags": "i", "valid": false}
+{"pattern": "\\k<\\u0061>(?=(?:\\00\\b)||(?!\\00\\uD83D{3,2}[-]{2,}|{2,1}&))[^\\q{a|bc}\\c_", "flags": "", "valid": false}
+{"pattern": "(?>((?<a>x)*?-)[^]{2,}|(?-i:(?>[\\q{\\d}[!😀]??[\\c1.{a]**|))?(?![^\\-(😀\\d](?=$\\p{L)(?i-m:[{2}){3,2})|)[^a-\\d^\\p{L", "flags": "u", "valid": false}
+{"pattern": "(?<\\u{61}>x)", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?![a--]){2,3}?\\c_(?i)(?<=\\uDE00\\p{L}){|\\00(?<=[😂-😀\\c_&&](?ims-:[[a][\\q{ab}]]{2,3}||\\c_{2,3}?|))(?=[]*?)?\\p{sc=Greek}", "flags": "u", "valid": false}
+{"pattern": "(?:\\P{Ll}\\p{gc=Lu}[😀-😂])(?>\\q{ab}\\q{ab}[]**||(?i-m:b+?(?<b>[\\][^a]@z]\\b+|{2}){2,}|{,2}[😀\\c1]))[]{2,3}?", "flags": "", "valid": false}
+{"pattern": "[\\1\\u{1F600}-\\u{1F602}]\\x41", "flags": "i", "valid": false}
+{"pattern": "\\!{2,3}(?<a>(?<a>[\\q{a|bc}{\\p{RGI_Emoji}{]|(?<a1>x)[])|\\-{3,2}b)", "flags": "v", "valid": false}
+{"pattern": "\\b**", "flags": "u", "valid": false}
+{"pattern": "\\2(?<a>[\\0}[^a]][^$$\\d-a\\x41]|\\p{Lu}|\\uDE00){99999999999}{2}", "flags": "i", "valid": false}
+{"pattern": "[^\\q{a|bc}]\\u{1F600}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=\\p{L[\\q{\\d}\\uD83D\\uDE00-\\uD83D\\uDE02[^a]\\P{Lu}]+?|)\\d{(?=\\x41|[&--](?ims-:[^.]||(?ims-:[^😂-😀\\1\\P{Lu}\\cA]{3,2}{3,2}[!!\\x41][a-\\d]+|)[^\\&])", "flags": "", "valid": false}
+{"pattern": "\\p{Basic_Emoji}*?[😂-😀(?i:[^\\u{1F600}-\\u{1F602}\\q{ab}\\q{}]{2,}(?<b>[{]**|\\u{41}|[]|^**\\1))\\P{Ll}", "flags": "u", "valid": false}
+{"pattern": "(?x:\\p{ASCII}(?i-m:\\p{Greek}*)|)|(?<=(?<a>\\d(?x:\\00|)|{1}{2}[\\c1&]{2}[&&\\cA\\u{1F600}-\\u{1F602}]{3,2})|)??[]", "flags": "i", "valid": false}
+{"pattern": "[\\0\\d&]\\p{Script_Extensions=Latn}", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{a}]a-\\d].", "flags": "v", "valid": false}
+{"pattern": "[bz-a](?=(\\p{gc=Lu}|\\uD83D\\uDE00+\\c|[a-\\d\\]])??\\a)(?<b>[!]{2}[--\\q{ab}|b])(?i-m:[-[\\q{ab}]]{3,2}[\\d-a{]??)", "flags": "", "valid": false}
+{"pattern": "[\\&][[^|[\\x41\\b--😂-😀][!\\0\\q{a|bc}]", "flags": "u", "valid": false}
+{"pattern": "[z-a]+|([][^](?<a>}*?|\\u{1F600}|)*?)(?i:z|(?<=[!]??)|[\\x41z\\]]|)", "flags": "", "valid": false}
+{"pattern": "\\b(?i)![^\\]\\p{L}\\c_][\\1\\q{ab}\\cA]{3,2}z", "flags": "u", "valid": false}
+{"pattern": "[^][^\\s\\q{}\\p{L}]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[][^]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uDE00{2,3}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\P{Lu}&\\uD83D\\uDE00-\\uD83D\\uDE02]\\p{}(?-:[]|(?i:[.a\\q{ab}\\p{RGI_Emoji}]\\0)(?=[b\\&]\\B|\\3**[{!!])(?i-m:[^\\b-[^a]]\\u{41}{2,3}?))(?i-m:&&(?ims-:\\!{2,3})){2,3}(?<!😀*?\\k<\\u0061>|)", "flags": "u", "valid": false}
+{"pattern": "\\00|(?:(?ims-:[[\\q{ab}]/](?-:[😀-😂]**)|\\!|[^[a-z\\!\\u{1F600}-\\u{1F602}]\\12))", "flags": "v", "valid": false}
+{"pattern": "\\b(?<a>[^]-)\\uDE00|\\p{Lu}[]", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\u{1F600}\\P{Ll}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B+?[]😀", "flags": "", "valid": false}
+{"pattern": "(?=(?<!\\#[\\0\\d-a]))(?ims-:(?i-m:[]{2}|[&&&&.!!]))", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "_[]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q{ab}${3,2}", "flags": "v", "valid": false}
+{"pattern": "\\p{L[)\\x41--\\c1](?<=.(?:(?<b>||)+?\\c_\\10|\\&)(?<a>\\c1|\\/\\d)|(?=(?<a1>x)|).)(?<!(?=(?<a>[[a-\\d]\\#|\\P{Ll}{2,3}?)_)|\\p{sc=Greek})?", "flags": "v", "valid": false}
+{"pattern": "[^z-a.]??(?<$>x)[^!!]\\e", "flags": "i", "valid": false}
+{"pattern": "(?<a>[](?!(?![\\p{L}\\P{Lu}\\q{ab}\\]])|-)|]**|(😀\\p{L}|)**[]|){\\8|(?ii:[^[\\q{ab}]\\-]*|[^/]\\![\\1])[^a\\uD83D\\uDE00-\\uD83D\\uDE02]\\p{Greek}", "flags": "u", "valid": false}
+{"pattern": "(?<=(?<a>\\k<\\u0061>\\u{41}\\p{L)\\e(?-:(?>[[^\\q{ab}]\\cAa-\\d][)]\\p{ASCII}|[[a]\\uD83D\\uDE00-\\uD83D\\uDE02\\x41-|\\!)(?i-m:\\k<a>??)[\\P{Lu}/\\!]*|\\s\\B)|[\\q{a}\\P{Lu}]{2}|(?<a>(?=**))|)[\\-z-a]", "flags": "v", "valid": false}
+{"pattern": "\\c[$$](a|(?i-m:(?:[-.\\x41\\cA])[|\\s\\x41][[^\\q{ab}]\\!\\q{a}]))[{2,3}?", "flags": "", "valid": false}
+{"pattern": "(?<b>(?i-m:(?:))!){2}(?<a>(?<a>x)?(?!(?!b)(?=.\\p{Basic_Emoji}|\\p{L)|(?<=\\k*?[]|{,2}|){2,3}\\P{RGI_Emoji}|)(?ims-:(?>[][^😂-😀][\\q{}-[^a]\\c_]*?|)!(?<=\\0+?){2,3}?|{\\c1))(?<$>x)*?{99999999999}", "flags": "u", "valid": false}
+{"pattern": "(?:[.--][^.]|)\\10", "flags": "", "valid": false}
+{"pattern": "[/[^a]]", "flags": "v", "valid": false}
+{"pattern": "(?i:[\\P{Lu}])\\k<??", "flags": "v", "valid": false}
+{"pattern": "[^]\\8{2,3}|", "flags": "v", "valid": false}
+{"pattern": "\\s\\b{2}", "flags": "i", "valid": false}
+{"pattern": "(?:{1}+(?=\\uD83D\\uDE00|(?<b>**(?<b>y)+?{1}|\\3){2,3}?|\\1{2,3}|(?ii:{1}\\w-)(?<a>x)))\\10(?-i:{1}(?ims-:(?<a>[\\u{1F600}-\\u{1F602}])(?<=[!a-\\d]😀][]\\p{L)b|[\\c_\\q{\\d})](?ims-:[\\c1]\\k|)|(?:\\q{ab}|+|.*}+{2,}))(?<=[^(]][^[^\\q{ab}]])*?", "flags": "v", "valid": false}
+{"pattern": "[--a-\\dz-a\\cA](?i:[]{2,3}(?<a>\\uDE00[\\s\\!]{2,3}|[^\\0z-a]|(?<a>[z-a\\d😀-😂$$]|\\e{3,2}|[\\-\\q{}a]$a*)[\\]){[^\\d\\d){(?=!\\p{RGI_Emoji}*[}\\q{\\d}\\s\\p{RGI_Emoji}]|[^[^\\q{ab}]^\\w[a]]{99999999999}[^\\q{\\d}]|)[]", "flags": "u", "valid": false}
+{"pattern": "\\e(?<b>y)", "flags": "v", "valid": false}
+{"pattern": "(?>(?<a1>x){(?ims-:[--[a]]\\k<a>?)){99999999999}\\08{2}[[]]|\\b", "flags": "", "valid": false}
+{"pattern": "[-\\w[^\\q{ab}]\\q{a}]*?[z-a&&\\d-a]**", "flags": "v", "valid": false}
+{"pattern": "[/--](?ims-:\\p{ASCII}(?i-m:(?i-m:{2,}|[])\\B\\p{ASCII}|\\#+?[])|(\\x4\\p{Lu}{2,}){3,2}(?![]{99999999999}|([&^\\-[^a]]\\3)*))*?", "flags": "u", "valid": false}
+{"pattern": "\\a[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ims-:{99999999999}[]\\1)[^\\c1\\P{Lu}][^(?x:(?i:\\k<a>)\\2[-]|((?-:[\\u{1F600}-\\u{1F602}a]){2}|\\B**[^][}]|))\\#{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\u{1F600}|[]$\\p{L}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "](?>(?<a>[!😀-😂--]){2}z|(?ims-:$|{1}[^😀\\q{\\d}\\Ba-z])[a][\\!--[^\\q{ab}][a]])\\a[\\b]\\x41]", "flags": "v", "valid": false}
+{"pattern": "(?ims-:{,2}[^[a]!!]{|(?<=[[a]$$\\][\\B]|(?:[&]+|{99999999999}?)|)){2,1}{", "flags": "v", "valid": false}
+{"pattern": "[z-a\\0😂-😀](?<b>[^😂-😀\\q{a}/]**\\10)(?:[&&&]||(?<$>x)(?<b>[^&!}]*\\P{RGI_Emoji}{,2})[\\u{1F600}-\\u{1F602}\\q{\\d}]??)\\#\\P{RGI_Emoji}", "flags": "u", "valid": false}
+{"pattern": "[/\\B\\a-z]{3,2}\\d[[^a]]*?_", "flags": "i", "valid": false}
+{"pattern": "(\\-[[^\\q{ab}]\\c_\\uD83D\\uDE00-\\uD83D\\uDE02]*?)", "flags": "i", "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<a>(?<a1>x)(?i-m:(?={,2}{3,2}\\k<b>)&\\p{Basic_Emoji}))a(?ims-:[^\\]]{2,3}){|", "flags": "v", "valid": false}
+{"pattern": "(?i){((?>\\u{41})[a-\\d]{2})??|\\u{41}[^](?=&(?>0|)[])\\0{2,}", "flags": "v", "valid": false}
+{"pattern": "\\P{Ll}*?|\\p{Greek}\\1(?i)(?=\\p{Lu}}[^]|(?x:{2,3}|[^]\\u{1F600}+?(?<$>x)))b😀|\\s(?-i:(?>\\k{\\cA|\\p{Script_Extensions=Latn}|\\u{41}\\c_{2,3}?){2})*?\\k<?(?![!]|\\08.)??|", "flags": "v", "valid": false}
+{"pattern": "[]\\/\\c_[&&]{99999999999}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<b>(?<a>x)|\\uDE00\\b|\\x41\\s*)+[{][^\\c1\\uD83D\\uDE00-\\uD83D\\uDE02😀-😂\\P{Lu}](?ii:\\-+{99999999999}){2,3}?", "flags": "", "valid": false}
+{"pattern": "(?<b>[\\d-a\\q{a}]{2,3}(?!(?ims-:[\\s]{)\\c_**(?-:\\p{Lu}{2}*))|[^😀-😂](?<$>x)})**|(?i-m:\\uDE00[]?\\08)", "flags": "u", "valid": false}
+{"pattern": "(?ims-:\\x41|(?-i:\\u{})\\p{ASCII}||b\\x41|[^[\\q{ab}]]|)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0]+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[{\\&\\q{a}\\u{1F600}-\\u{1F602}][^😂-😀a-\\d\\cA\\B]([\\q{}(\\u{1F600}-\\u{1F602}{](?=!(?-:)|[][\\p{RGI_Emoji}\\0)]\\10)(?x:(?:\\a\\s?)?|))*?[^\\q{\\d}\\q{ab}]😂{2}", "flags": "v", "valid": false}
+{"pattern": "(?<!(?-i:(?i)[^][]??(?i-m:&{2,}\\p{Greek}{2}\\P{RGI_Emoji}?)\\u{1F600}|[a^\\]\\w{2,3}?){2}[\\p{L}\\c1\\p{RGI_Emoji}])\\c]", "flags": "v", "valid": false}
+{"pattern": "{1}[\\q{\\d}]", "flags": "", "valid": false}
+{"pattern": "[^\\d}[\\q{ab}]/\\x4[\\1]((\\B*?}\\#{2,3}?||\\1\\![]??[\\q{a}\\0\\cA])\\3", "flags": "v", "valid": false}
+{"pattern": "([\\s\\@[\\q{ab}]]\\00a|)+[|", "flags": "", "valid": false}
+{"pattern": "[(a\\u{1F600}-\\u{1F602}](?:[^\\p{L}](?<!(?<={2,3}||))\\b|)+z{99999999999}", "flags": "v", "valid": false}
+{"pattern": "\\p{RGI_Emoji}\\P{Ll}[\\0@😂-😀][(]**(?ims-:(?<!\\p{L}|\\b|[]b)*|\\b{2,3}?\\0)", "flags": "u", "valid": false}
+{"pattern": "(?i-m:[--\\b&&]{2,3}){2}$*(?-:\\cA😀😀)(?-i:[\\q{ab}!!bz]\\0)??[[\\B]", "flags": "v", "valid": false}
+{"pattern": "(?>(?-i:[😀-😂\\B][!!\\x41\\q{ab}\\q{\\d}](?<b>[\\q{}[a]\\q{a}{|\\c1|0{2,1}|))|[\\Ba-\\dz-a](?i:z){2}|[[a-\\d\\c_]{3,2}{,2}\\c1z{2,3}?[[[^\\q{ab}]](?<b>😀){2}", "flags": "i", "valid": false}
+{"pattern": "[a]$[](?<a>{){3,2}(?x:[\\&\\c_\\q{\\d}](?i-m:^(?-i:\\c)})(?ims-:(?:[\\w\\!\\q{}\\d-a]|{3,2})\\P{RGI_Emoji}(?-i:[^z]{3,2})|)", "flags": "u", "valid": false}
+{"pattern": "(?<![]){[^\\w^\\]\\b](?i-m:-{2,3}|\\p{Lu})!", "flags": "u", "valid": false}
+{"pattern": "(?i-m:\\e|\\u{1F600}{2}(?>[[^a]\\c1[^\\q{ab}]$$][^\\p{L}\\P{Lu}]{)\\10(\\d(?<a1>x))", "flags": "u", "valid": false}
+{"pattern": "\\k<{2}\\p{Basic_Emoji}*?|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=[]|\\uD83D\\uDE00[^z[a]a])&\\P{Ll}\\P{Ll}{2,}&", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p{L}\\c1\\c1\\-]\\k<b>[^]]\\!{,2}+?", "flags": "v", "valid": false}
+{"pattern": "(?ii:[](?i:[|)[a[])[/\\P{Lu}]**😀[]{2,1}", "flags": "u", "valid": false}
+{"pattern": "\\/(?<a>(?ims-:😀{3,2}(?i:-\\00{2,}))\\P{RGI_Emoji})[^&&\\]](?<\\u{61}>x)+", "flags": "v", "valid": false}
+{"pattern": "[\\p{L}]|\\k<\\u0061>|(?i:(\\2))??|{99999999999}\\c1", "flags": "", "valid": false}
+{"pattern": "\\p{La|\\k<b>{\\x41", "flags": "v", "valid": false}
+{"pattern": ".*?[]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!(?:z[\\P{Lu}\\d-a\\d-a]|(?<=?))[^])", "flags": "i", "valid": false}
+{"pattern": "\\uD83D", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>\\w{2,3})(?-:\\c_{2}|(?<=\\&+))\\c|(?!!{(?>\\1)\\x4*?)[\\w]|", "flags": "", "valid": false}
+{"pattern": "(?<=[)\\q{a|bc}]|[^😀-😂&&\\-\\u{1F600}-\\u{1F602}(?-i:_\\u{41}??))\\p{Lu}{2,}", "flags": "", "valid": false}
+{"pattern": "\\u{41}(?=(?![\\d-a[^a]\\q{}\\&]){2,3}\\x41[*?)(?<!\\uD83D{2,3}?)", "flags": "i", "valid": false}
+{"pattern": "[\\c1](?x:[(\\q{\\d}]\\x41|\\q{ab}+?\\p{RGI_Emoji})", "flags": "v", "valid": false}
+{"pattern": "[z-az-a][&\\q{ab}\\s\\c_]((?-:[(\\]]|)|[/$$(?ii:\\P{RGI_Emoji}+(?<a1>x)|\\u{41}+?))(?i-m:[a](?<$>x)|[^\\q{\\d}]\\a\\k<\\u0061>)|", "flags": "v", "valid": false}
+{"pattern": "[^\\x41$$^\\u{1F600}-\\u{1F602}](?<a1>x)*?", "flags": "i", "valid": false}
+{"pattern": "\\B+(?<=([--z]{3,2}[😀\\P{Lu}](?i)😂*)(?-i:\\p{L))\\/\\-", "flags": "v", "valid": false}
+{"pattern": "(?i:\\d|!{99999999999})[^]\\!!][^@\\0]{2,3}?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{a}\\1](?<a>\\e|\\p{Script_Extensions=Latn}|(?<!\\08)|(?ims-:]!{2}(?i-m:^\\uD83D\\uDE00)||\\u{}{){2,}\\c[$$!!]\\w", "flags": "u", "valid": false}
+{"pattern": "\\P{RGI_Emoji}[(\\u{1F600}-\\u{1F602}\\Ba]\\00b{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\&|", "flags": "u", "valid": false}
+{"pattern": "\\x4|(?ii:(?>\\a|\\P{RGI_Emoji}|\\p{Basic_Emoji})a(?-:[\\!😀])", "flags": "v", "valid": false}
+{"pattern": "\\k<b>[^(\\c1]??[^\\0\\![]]??", "flags": "v", "valid": false}
+{"pattern": "[\\\\1\\s][|😂-😀a-\\d]+?\\uD83D\\uDE00", "flags": "u", "valid": false}
+{"pattern": ".", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\0][^\\-][^]-", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Basic_Emoji}(?![^\\uD83D\\uDE00-\\uD83D\\uDE02\\c_\\q{ab}^][\\p{RGI_Emoji}}.][\\b\\q{a}\\&\\u{1F600}-\\u{1F602}]|[^[z\\d-a\\uD83D\\uDE00-\\uD83D\\uDE02](?<b>y){2,3}?)[--a\\w]\\c_*?", "flags": "", "valid": false}
+{"pattern": "[\\]](?>\\/[]??)*?[\\d.\\c_[][!\\q{a|bc}\\]]", "flags": "v", "valid": false}
+{"pattern": "&(?x:[^a](?-:\\p{L}){2,3}?\\x41|(?<=\\k<|.){2,3})[!)\\d-a\\s]\\10{3,2}|[}\\p{RGI_Emoji}}\\w]", "flags": "v", "valid": false}
+{"pattern": "(?<b>y){2}(?<!\\p{ASCII}|\\d{2,}(?ims-:[a-z](?<b>y){3,2})+?$)(?:\\k<a>)\\08*(?<a>x)", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)[]]\\1{2,}[\\s\\uD83D\\uDE00-\\uD83D\\uDE02\\[\\q{ab}]](?i:\\c*?(?<b>[^\\c1a-z\\P{Lu}]+\\p{L+|(?-i:[][\\])[^a]][\\c_])??[😀-😂[^a]a\\b])", "flags": "", "valid": false}
+{"pattern": "(?ims-:(?ims-:(?x:[\\!&&!!])(?ims-:[^\\P{Lu}\\d/]{,2}{3,2}|??{,2}**)[\\c_-\\&]|)||[😂-😀]{3,2}(?ii:[]](?<b>\\b)))(?-:(?<!{1}{\\x41||[(?<a1>x){|]??)|)(?<![a-z\\q{a}{&&|(?<!0|[^\\w\\q{a}](?<b>\\1||[^/])))\\&{2,3}?", "flags": "v", "valid": false}
+{"pattern": "(?i-m:\\b|\\P{Ll}|\\p{Script_Extensions=Latn}|\\-|(?i:(?-:[|[^.])[!]{2,3}?|(?ii:\\#))(?![]*))[{😀a-z]a\\p{Greek}[]{2,}", "flags": "v", "valid": false}
+{"pattern": "\\cA(?-i:(?i-m:(?i-m:{3,2})*|(?<b>[😀&(\\x41]😀?[^]))|\\08{2,3}?(?<a>\\-[]!|)){2}[/\\&]\\p{Greek}[\\0\\b]+", "flags": "", "valid": false}
+{"pattern": "\\-*?\\c", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{Ll}{1}|\\00{1}", "flags": "u", "valid": false}
+{"pattern": "[$$](?<a>\\x41|\\u{1F600}\\p{Basic_Emoji})(?i)[\\x41}\\w][\\]![^a]@]\\p{sc=Greek}|[^]", "flags": "i", "valid": false}
+{"pattern": "[]{3,2}(\\e{2,}(?-:(?ims-:\\p{}|\\x4|\\k<\\u0061>)(?ii:|[}(}]\\uD83D\\uDE00{2,3}?)[])(b{2,3}?)\\k<a>|", "flags": "v", "valid": false}
+{"pattern": "[/[\\q{ab}][\\q{ab}]\\uD83D\\uDE00-\\uD83D\\uDE02]+?|(?x:!(?<b>\\uDE00)|[\\d-a[^\\q{ab}]\\c_\\d-a]0\\2{2,})\\e[^\\1", "flags": "", "valid": false}
+{"pattern": "[a-\\d\\B\\p{L}!!]\\p{Lu}\\B", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s|(?ims-:(?i-m:[@[\\q{ab}]]\\/*?)??\\k<b>)[^]{2}", "flags": "u", "valid": false}
+{"pattern": "(?i:(?ii:\\8*?-|)|[^\\x41\\uD83D\\uDE00-\\uD83D\\uDE02){2,}\\d(?-i:[[\\q{ab}]]|[{\\p{L}](?i)\\p{}[^😀-😂]|\\p{Greek}(?-:[^\\B\\c_]|(?<b>(?-i:{\\p{sc=Greek}{2,3}[\\da\\uD83D\\uDE00-\\uD83D\\uDE02)]|\\x41+)\\/(?<![]|))}+)(?ims-:[\\d-a](?:[\\1\\B)\\p{L}][])|(?=(?:\\q{ab}|*?\\k*\\p{ASCII}))){2,}", "flags": "u", "valid": false}
+{"pattern": "(?i:(?<!(?i:-)[){2,1}||\\p{Lu}[!]*(?x:[\\p{L}\\b\\w][](?<=\\p{Greek})|(?ims-:+{|+?|[^]\\q{}\\!\\q{a}])))[]*", "flags": "u", "valid": false}
+{"pattern": "[\\P{Lu}\\0\\x41\\q{\\d}]*?(?ims-:(?<!(?i-m:![^]+|)|(?=\\k<b>{2,}))$[\\b}[^\\q{ab}]\\1+?)?(?i-m:\\p{sc=Greek})", "flags": "u", "valid": false}
+{"pattern": "(?x:[]😂+?|\\p{Script_Extensions=Latn}[^😀](?<a>x))[^\\c_b\\c1]|\\k<b>[z-aa-\\d&]*?[^[\\q{ab}]&&---]{3,2}", "flags": "v", "valid": false}
+{"pattern": "(?>\\p{Script_Extensions=Latn}(?ii:[]\\s**|(?<!\\uD83D)))|", "flags": "u", "valid": false}
+{"pattern": "(?<b>y)&|[a-z](?ii:\\u{41}**", "flags": "", "valid": false}
+{"pattern": "(?ii:(?<a>(?i:[]|\\s{2,3}?\\w+)}(?-:\\2[]|))||(?<a>\\P{RGI_Emoji})|)(?i)[\\x41$$\\u{1F600}-\\u{1F602}&&](?>[[^\\q{ab}]|\\s]{2,3}?|(?i-m:|)\\p{Script_Extensions=Latn}?\\P{Ll}|)(?-:[a-\\d!][\\q{a}]??)", "flags": "v", "valid": false}
+{"pattern": "(?i-m:[}][!!\\P{Lu}\\0](?x:\\cA{\\w[$$[a]--}]))", "flags": "i", "valid": false}
+{"pattern": "[]+?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "([\\\\d\\w]+?|\\p{Script_Extensions=Latn}??[\\c1az](?!(?i-m:[^\\uD83D\\uDE00-\\uD83D\\uDE02\\1[^\\q{ab}]]{2,})[!)\\x41@](?!)))(?i)\\p{ASCII}\\p{RGI_Emoji}+?\\a(?<a>[^]😀[-\\c1[a]])(?>[^\\uD83D\\uDE00-\\uD83D\\uDE02😀]*?$*?|[\\d\\uD83D\\uDE00-\\uD83D\\uDE02]**\\-{)", "flags": "u", "valid": false}
+{"pattern": "(?>(?x:[]+\\a)?\\x41[\\c1\\b[a]]|(?i)[^\\]]\\u{}(?<=\\B|(?<$>x)|\\p{L)(?<a1>x)){2,3}(?-i:[]+?+?(?:\\p{Script_Extensions=Latn}(?=(?i-m:\\10)(?i:\\p{Basic_Emoji}\\a){3,2}|(?-i:]||[\\x41])??$)+?(?-i:[]|](?i)\\p{RGI_Emoji}(?i-m:[\\p{RGI_Emoji}\\p{RGI_Emoji}|😀])?|\\uD83D+?(?<!&\\b|?\\uD83D\\uDE00+?)\\uD83D\\uDE00|)+?\\08", "flags": "i", "valid": false}
+{"pattern": "(\\00(?<=\\b{)(?<b>(?i:|)(?ims-:[\\![a]a-\\d])|)|\\3)|", "flags": "i", "valid": true, "captures": 2, "names": ["b"]}
+{"pattern": "{2,1}(?>[]+(?:[\\s[^\\q{ab}]\\b]|\\d)[.]/])", "flags": "v", "valid": false}
+{"pattern": "[]\\p{Basic_Emoji}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{ab}\\\\-]{2,}\\u{41}", "flags": "v", "valid": false}
+{"pattern": "[^z-a]", "flags": "", "valid": false}
+{"pattern": "\\!\\8(?-:\\uDE00+?(?!(?:[])||(?ii:\\P{Ll}\\k<b>)+)\\3)[a-\\d\\uD83D\\uDE00-\\uD83D\\uDE02", "flags": "v", "valid": false}
+{"pattern": "(?x:(?<a>x){2,3}(?<!(?<![^\\q{a}\\c_[\\q{ab}]]||)(?:\\/\\s)\\&*?)||[/😀-😂\\d-a][^\\q{a|bc}z-a😀]\\8)", "flags": "i", "valid": false}
+{"pattern": "(?<=.+\\08??)[^[^\\q{ab}]]a-z](?:[^.z]$\\x4)[^[a]\\uD83D\\uDE00-\\uD83D\\uDE02\\w](?ii:\\P{Ll}*){|", "flags": "", "valid": false}
+{"pattern": "[\\cA\\c1\\c_[\\q{ab}]]{,2}|\\x41[\\q{\\d}\\c_\\uD83D\\uDE00-\\uD83D\\uDE02😀]{[.\\c1]*", "flags": "i", "valid": false}
+{"pattern": "\\uDE00(?<=\\a|\\p{Greek}|[^\\^]\\p{sc=Greek}", "flags": "v", "valid": false}
+{"pattern": "[^]\\k(?!\\x41(?i:b?\\-\\uDE00)+?||(?i:&$(?-i:[))]\\b|\\q{ab})|\\3(?!\\u{1F600}{|)(?-:(|)|.(?i:[^]\\P{RGI_Emoji}[]{){3,2}\\2)[\\q{}[^a]z-a])??", "flags": "v", "valid": false}
+{"pattern": "[}&&]{3,2}(?!\\e\\p{Lu}\\u{41}|){3,2}(?-i:[z-aa-\\da-z]**|[^}][])+?", "flags": "v", "valid": false}
+{"pattern": "\\/|\\p{Script_Extensions=Latn}|\\d\\8", "flags": "v", "valid": false}
+{"pattern": "[|\\c1\\P{RGI_Emoji}", "flags": "u", "valid": false}
+{"pattern": "(?=]|(?=[^\\B\\q{}]|[\\s😀z-a]|)(?i:[][^$$\\x41ba-\\d](?<b>{2,3})+|\\uDE00\\uD83D\\uDE00\\p{Basic_Emoji}+?)$)[$$](?-:((?<a>}[)b\\q{\\d}]{2,3}?[^\\cA])|[][\\p{RGI_Emoji}&&]*|)**(?:(?<!|{|[z-a\\!\\p{L}😀]\\a*|[\\q{\\d}😀][\\q{ab}]])|))", "flags": "u", "valid": false}
+{"pattern": "[\\s]{{2}|[]\\p{gc=Lu}+?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1(\\#)\\u{41}", "flags": "", "valid": true, "captures": 1, "names": []}
+{"pattern": "\\10{2,}\\/[\\P{Lu}]0\\a", "flags": "u", "valid": false}
+{"pattern": "😂\\u{41}|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{a}](?!(?ims-:[\\q{a|bc}(?<=${2,3}??)|(?x:[\\q{a}]|)))", "flags": "", "valid": false}
+{"pattern": "(?<\\u{61}>x){2,3}?{1}[^\\q{}\\uD83D\\uDE00-\\uD83D\\uDE02\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a|bc}]{2,}[^!!/]😀", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=[z\\b|]+{,2}{2,3}", "flags": "i", "valid": false}
+{"pattern": "[\\-^$$]{", "flags": "v", "valid": false}
+{"pattern": "\\q{ab}", "flags": "u", "valid": false}
+{"pattern": "\\k<\\u0061>(?<b>\\p{Basic_Emoji})(?-:\\8{3,2}[]])", "flags": "u", "valid": false}
+{"pattern": "([\\1)(?!$\\c_?(?<=(?i)\\u{}*?|\\c_{2}|\\08**[[[\\c_\\!])\\!**\\a", "flags": "u", "valid": false}
+{"pattern": "]\\8??\\2", "flags": "v", "valid": false}
+{"pattern": "\\0[(@$$\\d][&]\\P{Ll}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\q{a}\\b\\b]{2,}(?i)\\p{L}(?<a>x)(?i:_(?i-m:\\w\\p{gc=Lu}+?(?x:[)^\\x41/]??|\\p{gc=Lu}|))?|}{2})", "flags": "", "valid": false}
+{"pattern": "\\w(?<a>[^\\u{1F600}-\\u{1F602}\\p{RGI_Emoji}\\0]|[^z[\\q{ab}]\\!])\\p{RGI_Emoji}", "flags": "i", "valid": false}
+{"pattern": "[]\\#\\B{\\b", "flags": "v", "valid": false}
+{"pattern": "[\\d-a\\d](?>😂\\u{1F600}?\\uDE00|\\08){2,}", "flags": "v", "valid": false}
+{"pattern": "(?:[^\\!]{2,})[]|\\k\\u{1F600}\\p{RGI_Emoji}{2}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]\\u{}\\w{\\p{Script_Extensions=Latn}+[]", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}(?i:[])", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)\\k<a>|\\u{}**[\\!]\\p{sc=Greek}(\\u{41}([\\q{a|bc}{\\P{Lu}\\q{a|bc}]b)(?-i:(}){2,3}?(?i-m:\\2|[\\B\\u{1F600}-\\u{1F602}]|[-\\p{RGI_Emoji}](?<$>x))|[]))", "flags": "i", "valid": false}
+{"pattern": "\\k<a>{2,}(?!\\/{2,3})", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L{2}\\#[😂-😀😀]|z{2,3}?[!]", "flags": "v", "valid": false}
+{"pattern": "(?<=[](?i:(?<a>x)**(|\\q{ab})|(?x:\\u{}\\p{sc=Greek}|[\\u{1F600}-\\u{1F602}z-a\\s\\q{a}]|)[])*)|_(?ims-:(?i:[😀-😂!!]|(?i:(?<a>x))(?-i:b|[^\\p{L}\\uD83D\\uDE00-\\uD83D\\uDE02]{)|(?<!\\p{RGI_Emoji}\\p{}|\\2{2,3}))[\\p{L}\\w\\c1]\\p{Greek}{2,3}){2,3}?\\a(?<a>x)|", "flags": "i", "valid": false}
+{"pattern": "\\uDE00|[{z-a][\\&\\d]|-{2,3}[a-z}\\]]", "flags": "i", "valid": false}
+{"pattern": "\\k<|(?<a>(?<a>\\p{L}[](?<=))[]*)\\c{2}", "flags": "u", "valid": false}
+{"pattern": "\\d\\p{gc=Lu}+(?x:{1}(?<a>\\p{L\\a?[.^]|{2,1}\\k<a>|(?-:\\k<b>))[/]", "flags": "i", "valid": false}
+{"pattern": "\\c|[\\w\\d-a\\d-a\\-]\\u{}\\u{41}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=(?>\\08|(?:[^)-][\\0\\q{ab}/-]|\\k<**[\\q{}\\0])){3,2}\\2|[[]][[^\\q{ab}]--\\d{])[.[a]](?i:(?<b>[^z-a\\u{1F600}-\\u{1F602}]{2}\\k<\\u0061>**)\\8|[&&\\d]){", "flags": "i", "valid": false}
+{"pattern": "\\uD83D\\uDE00[^!!]", "flags": "v", "valid": false}
+{"pattern": "\\2(?x:[\\B](?<=(?i-m:$){2,3}){2,3}?)!*?|", "flags": "i", "valid": false}
+{"pattern": "\\!(?<b>[])\\a{2,1}*\\uD83D\\uDE00", "flags": "v", "valid": false}
+{"pattern": "[\\sa-z\\p{RGI_Emoji}]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-:[\\q{\\d}a\\P{Lu}😀]**||\\c1)(?=\\u{}\\#{2,3}[--])(?i)\\08{2}(?i-m:\\q{ab}{3,2}[][\\P{Lu}]**)[]", "flags": "v", "valid": false}
+{"pattern": "(?<=[|\\p{gc=Lu}\\B{){[(\\q{a}[](?ims-:(?!(?-:[😀]{)(?<a>\\q{ab}{2}[])**[!!!\\x41]|[^/\\q{a|bc}\\b])**|\\k+?[(]{2,3}?)", "flags": "", "valid": false}
+{"pattern": "\\p{sc=Greek}(?:\\10\\3(?<b>y))&+[z-a](?<b>y)", "flags": "i", "valid": false}
+{"pattern": "\\p{Lu}(\\B|[\\P{Lu}\\q{}][\\x41\\b\\B)](?>[^)\\B][^\\q{a|bc}$${\\q{a|bc}])*)*?", "flags": "v", "valid": false}
+{"pattern": "(?-:\\cA|[}-]{3,2})**\\uD83D\\uDE00**", "flags": "i", "valid": false}
+{"pattern": "\\k<{2}[^\\c_&&a-z\\c1]", "flags": "u", "valid": false}
+{"pattern": "((?<a1>x)\\10{2,3}|(?i-m:\\c|)|)(?<=(?<a>x)**[\\!\\x41\\c1](?-i:(?i-m:\\00|(?<a1>x)){2,3}[.}]}{))(?x:(?<b>y)|[^\\s{])(?>(?x:(?<\\u{61}>x))(?<b>y)|[^]\\u{}(?!\\P{Ll}(?=\\p{sc=Greek}\\p{RGI_Emoji}??|(?<\\u{61}>x)\\p{}[^\\q{a|bc}\\1)]))|)+", "flags": "i", "valid": false}
+{"pattern": "\\!{3,2}[\\b!&😀\\k??\\p{ASCII}[^😂-😀[^\\q{ab}]-\\0]", "flags": "v", "valid": false}
+{"pattern": "\\k", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\1@]|", "flags": "v", "valid": false}
+{"pattern": "[.\\s0", "flags": "i", "valid": false}
+{"pattern": "(?-:\\p{ASCII})\\uDE00{.", "flags": "u", "valid": false}
+{"pattern": "(?x:[\\0])[\\0][\\B\\-][\\d]((?<b>y))", "flags": "", "valid": false}
+{"pattern": "\\![--[^\\q{ab}]\\q{a|bc}\\c_[@([][😀😂-😀|]{2}", "flags": "v", "valid": false}
+{"pattern": "\\x41{2,3}?[^😀\\cA{][]\\p{sc=Greek}", "flags": "v", "valid": false}
+{"pattern": "[-\\p{L}@a-\\d].", "flags": "u", "valid": false}
+{"pattern": "[&&--]{2,3}?", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Ba-z\\0\\b](?<a>x)[][$$^]{", "flags": "v", "valid": false}
+{"pattern": "[\\c1\\1\\s]", "flags": "u", "valid": false}
+{"pattern": "(?<$>x)(?-:[]{99999999999}|\\0(?<a>[\\\\q{}\\q{}]\\B?\\d))[](\\P{Ll})", "flags": "", "valid": false}
+{"pattern": "[[\\q{a}]?{,2}(?-:\\k<b>(?i:(?:*?)\\p{L[\\c1\\x41|)\\P{Ll}{2,3}?)", "flags": "v", "valid": false}
+{"pattern": "(?-i:(?<\\u{61}>x)[][^$$]{2,3})|(\\12(?>{,2}{2,3}\\P{Ll}|(?<=[]]{2,3}?)(?-i:[\\p{RGI_Emoji}]))\\u{1F600})", "flags": "v", "valid": false}
+{"pattern": "(?-:\\08|😀)[](?ims-:(\\p{gc=Lu}^{3,2})|\\cA[]])", "flags": "", "valid": false}
+{"pattern": "(?=0[/])(\\-\\00${|\\uDE00+\\p{Basic_Emoji}[\\0\\u{1F600}-\\u{1F602}]?)\\B(?<=[\\0]+?)", "flags": "u", "valid": false}
+{"pattern": "[[^a]]\\uD83D\\uDE00{+?", "flags": "v", "valid": false}
+{"pattern": "[\\b--&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^z\\u{1F600}-\\u{1F602}\\cA\\s]\\p{Basic_Emoji}", "flags": "u", "valid": false}
+{"pattern": "\\p{Greek}(?i:\\b{2,3}0)[/😀-😂]\\P{Ll}", "flags": "v", "valid": false}
+{"pattern": "[]\\u{41}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{}{3,2}\\a", "flags": "", "valid": false}
+{"pattern": "\\u{1F600}(?<=(?i)[\\u{1F600}-\\u{1F602}\\u{1F600}-\\u{1F602}]{3,2}|[$$[^\\q{ab}]\\u{1F600}-\\u{1F602}\\q{ab}]{||(?i:[\\q{ab}\\w\\w]\\10{3,2}(?<b>\\d+?\\c_|[\\b--!+?)|\\c)|)*|\\p{L}(?>(?<=(?>[\\uD83D\\uDE00-\\uD83D\\uDE02]{2,3}[^\\d-a[a]\\!]|){2,}[a-\\d]\\d)*|(?>[\\1\\]][\\1z\\c1z-a](?>[]){|(?<a>\\uDE00|)*?))", "flags": "v", "valid": false}
+{"pattern": "(?-:[(!\\&](?ii:{1}{2}[\\b&&\\u{1F600}-\\u{1F602}]|\\00(?-i:\\&{3,2}|[{]]$)\\d)|(\\00)(?:\\p{gc=Lu}|(?<=\\c1\\k<a>{|[^]\\p{Basic_Emoji}))b)??\\08[^a-z😀(][--\\b--]", "flags": "i", "valid": false}
+{"pattern": "[](?>[[\\q{ab}](]{)|\\00*?|", "flags": "v", "valid": false}
+{"pattern": "[[^\\q{ab}]z-az-a!]|(?i-m:[]+\\B|(?!\\u{}[\\cA{\\s]|[](?ii:[^\\c1@--\\c1]*|\\k)).[])", "flags": "", "valid": false}
+{"pattern": "([a-\\d\\]]})?", "flags": "u", "valid": false}
+{"pattern": "(?<![\\-]\\k<b>+\\3|\\p{Lu}{2}{*?)", "flags": "v", "valid": false}
+{"pattern": "(?<=😀|[!bz]+)+[]][\\q{}]", "flags": "", "valid": false}
+{"pattern": "(?<!\\p{Basic_Emoji}$)[[^a]z-a][][||😀\\q{}][\\0\\1]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uD83D[^z\\!--\\u{1F600}-\\u{1F602}][^\\&@a)]\\p{Script_Extensions=Latn}", "flags": "u", "valid": false}
+{"pattern": "\\p{Lu}}😀\\8", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!(?=\\w|(?-i:))|0\\d[/\\q{\\d}\\d-a]){[]", "flags": "v", "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}]|(?<a>x)[!\\p{RGI_Emoji}]", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "[^😀😀\\q{a}!!]\\#+?(?<!😀)([\\\\w😀-😂][][/a-za-z]|){(?x:(?x:_(?-:)**?-|(?<a1>x)(?<![][^😂-😀😂-😀]{2,3}?[]))", "flags": "", "valid": false}
+{"pattern": "z(?<!\\k<b>(?-:\\B(?=0[]|[{][😀\\p{L}\\d\\q{a|bc}]){\\10)\\c|[\\u{1F600}-\\u{1F602}\\!\\q{}\\B]{1}){2,3}\\1(?<=\\c_\\p{Basic_Emoji}\\b)(?i:\\d??[^]{[]?|[![^\\q{ab}]]{2,3}?", "flags": "", "valid": false}
+{"pattern": "[\\u{1F600}-\\u{1F602}b]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<b>(?-:[\\q{ab}(**[]\\-{2,3}?)[\\u{1F600}-\\u{1F602}]*[\\cA\\p{L}])(?ii:[!!!{3,2}|(?-i:(?:😀[^)\\d-a\\cA])|)a\\k)+$(?<a>[^]\\k<b>)\\e", "flags": "", "valid": false}
+{"pattern": "(?i-m:[]*)", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "&(?<!\\p{L}{\\3)", "flags": "v", "valid": false}
+{"pattern": "(?<!(?-i:(\\3|\\12)(?<b>z))(?:(?<=(?<\\u{61}>x))|[^\\q{a}z-a[^a]]*?){2,3}?", "flags": "i", "valid": false}
+{"pattern": "[\\x41\\1/]]\\c1{2,3}[^\\q{\\d}--😀-😂\\P{Lu}]", "flags": "v", "valid": false}
+{"pattern": "b\\3\\10{2,3}\\b(?<a>x)", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?ims-:[^\\u{1F600}-\\u{1F602}][a-\\dz](?<\\u{61}>x)|(?i)[^bz]\\12{+?|[][\\q{a}\\q{ab}](?i:*?|[^])\\![{\\q{\\d}]]{2,}){2}(?!\\12|[^[^\\q{ab}]\\&!!](?<a>x){2}){2,3}?(?<b>(?i)[^@][^-\\](?i-m:[\\-😀-😂\\]])?|[]{(?ii:|[\\q{a}!!]\\08))|(?i)[^\\]](?<a>x)\\a+", "flags": "", "valid": false}
+{"pattern": "(?-i:[.}][😂-😀😀])[^\\s\\p{L}](?<b>[^.\\x41{])\\u{}", "flags": "", "valid": false}
+{"pattern": "(?ims-:[]((?<b>[!\\c_\\w]|)[\\0$$[a]](?!\\q{ab}{2,3}))|(?i)(?-i:\\#|\\u{}[^])(?i)+|[\\u{1F600}-\\u{1F602}\\P{Lu}]?\\c)\\uD83D(?x:\\B(?i:\\B||(?<b>|\\u{41}+)\\u{1F600})&|[\\u{1F600}-\\u{1F602}\\1&\\&](?-i:_{3,2}|[\\x41][^]|}\\p{gc=Lu}){,2})(?:[-](?x:\\!z|)[^@]){2,}", "flags": "v", "valid": false}
+{"pattern": "[^😂-😀--!!]", "flags": "u", "valid": false}
+{"pattern": "\\&[\\s\\w^\\0]", "flags": "u", "valid": false}
+{"pattern": "[-[\\\\c1]][^]😀(?i-m:a)**", "flags": "v", "valid": false}
+{"pattern": "(?<b>[?)\\p{L", "flags": "v", "valid": false}
+{"pattern": "(?x:^|){2,3}?]z?\\8+?|", "flags": "u", "valid": false}
+{"pattern": "[^z][-[a]a-z\\q{a}]??(?=(?<a>[]|[!!])||(?![^-[a]\\p{RGI_Emoji}]+|[b\\c1.]{2}\\c_)|\\uD83D\\uDE00{[])(?ims-:\\3{2,}[\\q{a}\\][\\uD83D\\uDE00-\\uD83D\\uDE02&])+?[^\\q{a}\\-.]|", "flags": "v", "valid": false}
+{"pattern": "\\uD83D\\uDE00\\/**(?<a>(?ims-:(?=?)[^😀-😂&&\\s\\uD83D\\uDE00-\\uD83D\\uDE02][\\q{a|bc}]{2,3}|[\\d-a][^\\1]\\ba]|)|.{2,3}\\B(?:(?-:[a-z\\d-a\\cA]))|)", "flags": "v", "valid": false}
+{"pattern": "\\k<\\u0061>*(?=[\\P{Lu}(\\d-a](\\x4[^(!!\\q{a}]))[.az]|", "flags": "i", "valid": true, "captures": 1, "names": []}
+{"pattern": "[&][^][\\P{Lu}\\p{RGI_Emoji}\\s][!]", "flags": "u", "valid": false}
+{"pattern": "[[^\\q{ab}])[a]/]", "flags": "", "valid": false}
+{"pattern": "(?<b>(?=[\\0]|[\\B\\P{Lu}]{(?i:[\\c1(}a-\\d]+){2,3}(?<=[a-\\d[]\\c|))(?<=[^[^\\q{ab}]&&\\}](?!_{2,3}|(?<a>x))**)\\0{2,3}|\\P{Ll}+?([[^a]\\uD83D\\uDE00-\\uD83D\\uDE02😀-😂]|(?<a>x)**\\p{ASCII}{2,3}?))**[][\\d-a\\]&{2,1}+", "flags": "", "valid": false}
+{"pattern": "\\p{L??[\\1&&]\\p{RGI_Emoji}", "flags": "u", "valid": false}
+{"pattern": "(?<a>[\\q{ab}$$--\\1]\\p{L})|[^b.\\0\\p{RGI_Emoji}]+?", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\b**{,2}\\3{[^\\x41\\w😀^]", "flags": "i", "valid": false}
+{"pattern": "[\\-\\u{1F600}-\\u{1F602}\\!--]|(?ims-:(?i-m:\\10)([\\b$$\\]!!][()]\\12)|[[^\\q{ab}]\\!a-\\d]{2,}|)", "flags": "", "valid": false}
+{"pattern": "[\\q{a|bc}[^a]\\]{2,3}?(?i:\\q{ab}\\p{L}||(?<b>.)[)&&!a-z]\\P{RGI_Emoji}{2}{1}", "flags": "u", "valid": false}
+{"pattern": "(?:a|(?i)(?>\\s{|{2,3}?)?\\8{|[^z]😂[]+?[]{).[😀]][^\\d]{3,2}a??", "flags": "v", "valid": false}
+{"pattern": "(?<a>\\q{ab}(?<=\\a**[\\p{L}]|{1}(?ims-:\\q{ab}{2}|\\#){2}\\B)[^\\p{L}])\\p{Greek}(?<$>x)(?>[\\x41[a]z-aa-z]{2,})", "flags": "v", "valid": false}
+{"pattern": "(?-i:(?>\\k<a>|[😂-😀\\uD83D\\uDE00-\\uD83D\\uDE02\\p{RGI_Emoji}]0\\x4)(?-i:\\u{}|\\!*?||[^😂-😀\\wa][\\w\\1\\p{RGI_Emoji}]))(?>(?=(?<!\\c\\P{Ll}{3,2}){2,3}?|(?!{2,1}\\P{Ll}|\\s)[-]|)[]{2,1})**", "flags": "i", "valid": false}
+{"pattern": "[{a-z\\B\\c1]{2,}\\!*?", "flags": "v", "valid": false}
+{"pattern": "(?<=[b]\\3|\\k<a>+?[^\\q{a|bc}](?ii:(?-i:\\-?))){2,3}(?i)(?!\\p{Greek}|(?<$>x)[^a😀-😂\\q{a}]+z)?[!a$$][(😀-😂/](?>(?<a1>x)(?<a>\\cA[^]**))+?", "flags": "u", "valid": false}
+{"pattern": "[^]a-\\d/!!][^{]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!(?ims-:(?:\\u{}😀|[^][[{])[}&&](?i:{,2}|\\u{41})|\\cA{(?![😀a]).)[^]|[&&]||(?-:^|[])[\\-]|){2,3}?\\u{41}(?![\\d-a{z-a]**[!][--]*)|$", "flags": "u", "valid": false}
+{"pattern": "\\s\\p{Greek}{2,3}?$", "flags": "v", "valid": false}
+{"pattern": "[[a]\\d-a\\c1]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:[\\q{}\\q{ab}😀-😂]??(?<b>y){2}|)\\P{Ll}{2}", "flags": "", "valid": false}
+{"pattern": "[]\\w[@\\x41\\p{RGI_Emoji}\\x41]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Basic_Emoji}\\w(?:(?i-m:[^&\\s])(?:[[^\\q{ab}]--\\0]\\1)){(?ii:[^\\q{\\d}}**|)\\p{RGI_Emoji}", "flags": "v", "valid": false}
+{"pattern": "{99999999999}+|\\#\\u{}[^^^](?<=(?![\\x41\\]](?-:)|\\P{Ll}[^\\u{1F600}-\\u{1F602}])(?-i:(?<![^\\ba][\\uD83D\\uDE00-\\uD83D\\uDE02z]\\c_?\\p{Script_Extensions=Latn}\\k)[\\w\\q{a|bc}]|(?-i:\\w(?i:|\\s\\uD83D)\\c1|(?i)\\1[\\0.]?\\B\\p{ASCII}+)(?i)[z-az-aa-z]-(?<![^\\q{ab}\\&^]\\&{2}{2}[^z-a\\P{Lu}b]{2})", "flags": "v", "valid": false}
+{"pattern": "(?i)(?!](?i:_)+?(?>))**[\\p{RGI_Emoji}\\q{a}.]?(?![😀-😂a\\w!]\\a\\p{gc=Lu}{2,3}?){\\P{Ll}{1}\\e|(?-i:[\\q{\\d}b]\\p{gc=Lu}\\p{sc=Greek}|$|[\\q{a|bc}z-a😀-😂])", "flags": "v", "valid": false}
+{"pattern": "[&/a[^\\q{ab}]]{2,3}\\e$(?i:z||\\u{}|$)[\\P{Lu}@]", "flags": "u", "valid": false}
+{"pattern": "(?i:.|(?i)[^]{3,2}[][^--](?=0|\\P{Ll}\\p{L|[^z]{2,})|)[\\d\\q{ab}]**", "flags": "v", "valid": false}
+{"pattern": "[|\\c1\\c1]", "flags": "u", "valid": false}
+{"pattern": "(?![(\\]]](?!\\u{1F600}(?ims-:|)\\2)\\12|[\\!\\q{}@](?<!\\u{}+?)(?=\\x4{2}))_+\\uD83D\\uDE00*?$", "flags": "u", "valid": false}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02\\q{ab}a-\\d\\0(?-i:\\-|(?ii:[]*)|(?<=\\c{2,3}?0|[\\!}\\1])(?ii:(?ii:a{2,3}\\/{2,1})*?[😀-😂@.]|[\\p{RGI_Emoji}[\\q{ab}]$$]|(?>0)?))\\u{}[]", "flags": "i", "valid": false}
+{"pattern": "[\\w\\wa-\\d]", "flags": "v", "valid": false}
+{"pattern": "\\b+?|[]", "flags": "i", "valid": false}
+{"pattern": "\\10(?-:[^]\\p{Lu})(?ii:[^😀-😂^[^\\q{ab}]])", "flags": "v", "valid": false}
+{"pattern": "(?!(?ii:\\p{RGI_Emoji}\\k<\\u0061>*\\uDE00)*?)(?<$>x){1}\\3", "flags": "i", "valid": false}
+{"pattern": "(?!(?ii:[]z)\\p{Lu}|)+\\12*?\\u{41}*?(?>\\c)", "flags": "u", "valid": false}
+{"pattern": "[][^a-z]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)\\3\\k<\\u0061>(?<=(?<={\\0))|[^z]*{,2}z", "flags": "i", "valid": false}
+{"pattern": "[[[\\q{ab}].]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=[^]b|\\3)|[^\\a-z]|\\s[\\!]|", "flags": "v", "valid": false}
+{"pattern": "{,2}?\\k", "flags": "u", "valid": false}
+{"pattern": "\\p{}(?=\\p{L}|{99999999999}{2,3}?[\\x41b-a]**)]|", "flags": "v", "valid": false}
+{"pattern": "\\b\\c__[](?<b>y)", "flags": "v", "valid": false}
+{"pattern": "[^](?x:[]??(?<=\\c_\\P{Ll}*[\\uD83D\\uDE00-\\uD83D\\uDE02😀])[\\d-a\\]--]{){2}[\\cA!\\[a]][^]|", "flags": "u", "valid": false}
+{"pattern": "[]\\-*?[\\uD83D\\uDE00-\\uD83D\\uDE02!$$😀|\\B[a-z\\x41&&(]{", "flags": "v", "valid": false}
+{"pattern": "\\00\\q{ab}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)[😀😀a-\\d[^\\q{ab}]][{[!}]\\08|_\\p{L??", "flags": "i", "valid": false}
+{"pattern": "[^\\x41](?<!\\/|[\\q{}])", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^|[$$]]{2}|\\p{L{2}\\k(?>(?:(?i)[\\c1]\\k<a>!{2})|\\cA)(?-:[(\\q{a}\\]|[^(?i-m:(?<=[]_|))[^]", "flags": "i", "valid": false}
+{"pattern": "(?<![\\u{1F600}-\\u{1F602}a-zz-a]\\d\\p{Script_Extensions=Latn})[\\P{Lu}\\q{}\\P{Lu}\\q{a|bc}]\\00", "flags": "v", "valid": false}
+{"pattern": "(?<=.{1}|(?<!😂[^])|\\u{1F600}\\p{Basic_Emoji}\\c1)(?<a>a[\\s\\c1]\\u{}){2,}[\\](?<a>x)|[]**", "flags": "u", "valid": false}
+{"pattern": "(?<b>[^a-\\d\\c_]\\p{ASCII}){2,3}?[^$${/a]\\p{Basic_Emoji}\\p{Basic_Emoji}|[^\\x41!!$$]", "flags": "v", "valid": false}
+{"pattern": "[\\x41^][\\P{Lu}}[]{2,}[^\\q{\\d}](?i-m:\\08){2,}\\p{RGI_Emoji}", "flags": "v", "valid": false}
+{"pattern": "\\x4[\\q{}^\\q{\\d}?😂(?>[\\!&]${2,}|[^.&&$$]|(?<\\u{61}>x)\\w[\\P{Lu}\\s\\P{Lu}\\q{}])\\e", "flags": "u", "valid": false}
+{"pattern": "(?-:[^z-a\\!]\\c1\\08*)(?ii:[^][($$($$]||\\x41{2,3}(?ims-:\\p{ASCII}){2}(?i-m:\\u{1F600}*|[$$\\cA](?i-m:|\\/|[[^\\q{ab}][\\q{ab}]|😀-😂])*(?=[^\\c1]{99999999999}{1}|$[\\uD83D\\uDE00-\\uD83D\\uDE02z-a--][\\c1\\P{Lu}.]))?(?<b>[^[\\q{ab}]\\c1![^a]]_[😀$$[\\b])\\k<b>(?ii:\\c[^\\P{Lu}a]0)*", "flags": "u", "valid": false}
+{"pattern": "(?ims-:[\\s\\q{a}\\d]|[][z-a]|\\-(?<![\\]\\1(?:+?|\\08)|(?<a>\\10+?|(?=]**)\\cA?|))\\3(?i)[\\q{ab}(?x:(?:[^\\u{1F600}-\\u{1F602}\\P{Lu}\\w])\\08|^??)**${2,}|{", "flags": "v", "valid": false}
+{"pattern": "_(?ii:(?i-m:\\08**|\\p{L{2,3}\\k<a>)|[\\d](?=(?<a1>x)(?<b>[[@.--]*?))|)", "flags": "v", "valid": false}
+{"pattern": "(?>[a-\\d][[^a]])(?ii:(?<b>(?-i:[[^a]\\cA!z-a]{2}??[]|\\c_{2}[z\\q{ab}\\u{1F600}-\\u{1F602}]|)[[^\\q{ab}]\\1|]*!)\\c_\\8)", "flags": "u", "valid": false}
+{"pattern": "(?:\\k)\\10|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:.(?ii:[\\0@]{2}\\#\\u{}{2,3}|(?<=[\\0b]{2,3}?)[\\B?))", "flags": "i", "valid": false}
+{"pattern": "[/😂-😀!!][][^&&[a]][😀-😂z-a]", "flags": "", "valid": false}
+{"pattern": "\\3{2,}{1}(?>(?x:[^/|]??\\10*(?:)){2,})(?x:(?<b>[\\c1])(?!${2,3}?|(?!\\2){3,2}\\08{2}\\uD83D\\uDE00{2,})|)**", "flags": "", "valid": false}
+{"pattern": "😀[^]\\00??(?>(?ii:[\\b\\cAz-aa]\\P{RGI_Emoji}(?![^z-a\\q{a|bc}]*\\k<b>|)||\\u{})\\c)[}\\s&]|", "flags": "", "valid": false}
+{"pattern": "(?ims-:[😀\\]\\p{L}\\u{1F600}-\\u{1F602}]+?_|\\a|)[[a]z](?<!\\1?(?<a>x)[/\\da-\\d])(?ii:(?i)\\u{1F600}{3,2}|[\\q{a}[^\\q{ab}]]{(?-:[]|\\e)\\w)\\08|", "flags": "v", "valid": false}
+{"pattern": "[][a-z&&]??", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>0||(?>[\\q{}{\\uD83D\\uDE00-\\uD83D\\uDE02[^])\\B)", "flags": "", "valid": false}
+{"pattern": "(?-i:(?<!(?<a>(?<b>y)&\\uD83D)+\\p{Basic_Emoji})|){2,3}?(?:(?i:{99999999999}\\p{Script_Extensions=Latn}|\\P{Ll}\\p{RGI_Emoji}|))", "flags": "v", "valid": false}
+{"pattern": "(?<b>[\\cA][^]\\P{RGI_Emoji})[b]\\0z(?i-m:[\\d-a}]\\a*)", "flags": "u", "valid": false}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02\\d\\B\\u{1F600}-\\u{1F602}](?-i:(?>(?<b>|\\P{Ll})\\u{41}(?>😂|(?<b>y)){3,2})\\b)\\!(?<b>y)[]**", "flags": "i", "valid": false}
+{"pattern": "(?!\\k[a-z]??(?>\\k|(?={2})|(?<b>y)))", "flags": "v", "valid": false}
+{"pattern": "[^\\q{}]|", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}\\8\\12{2,3}?", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}\\B\\p{sc=Greek}[^\\s[a][^\\q{a|bc}\\d-a&(]", "flags": "v", "valid": false}
+{"pattern": "\\&*[\\]\\cA&\\]]+?(?=}\\w|$)\\uD83D(?ii:\\3\\k\\-{2,}|", "flags": "u", "valid": false}
+{"pattern": "\\k[/\\d[a]\\b][^\\B^\\d-a\\!](?x:[^]]$)", "flags": "v", "valid": false}
+{"pattern": "\\!\\2{2,3}?(?!(?<b>(?<b>[]||\\/)(?=\\s))|(?x:\\p{RGI_Emoji}{2,3}[/\\]]\\e){2,3}?)(?:\\p{Script_Extensions=Latn}{2,}(?=\\p{L}\\b{2,3}?|[😀---a-\\d]|(?<=)(?x:\\3){){3,2}){2,}", "flags": "i", "valid": false}
+{"pattern": "\\B(?i)[\\s]|[](?-i:(?<=\\w-**)?){,2}[^\\p{L}](?:(?x:(?:\\!)**|[b\\cA\\p{L}]))", "flags": "v", "valid": false}
+{"pattern": "\\p{Lu}\\b(?<b>y)(?ims-:\\p{gc=Lu}{99999999999}\\!|[^\\uD83D\\uDE00-\\uD83D\\uDE02😀](?ims-:(?i-m:-${|-+?||[/[^\\q{ab}]b}]\\00)??[[a]{])??)", "flags": "v", "valid": false}
+{"pattern": "\\#*(?=[\\q{ab}](?<=!{2,}(?<!^*|[\\q{a|bc}])(?i:[]|})|(?i:\\k<\\u0061>)))", "flags": "", "valid": false}
+{"pattern": "{(?<\\u{61}>x)]", "flags": "v", "valid": false}
+{"pattern": "[a-\\dz]\\x4[b[a]\\p{RGI_Emoji}]{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\&\\&{2,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[|--😀\\][\\!-\\!]\\12+?(?<$>x)(?>\\2)", "flags": "v", "valid": false}
+{"pattern": "[😀\\Bab]|$\\12[a\\]$$]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{99999999999}(?<a1>x)\\d*?", "flags": "i", "valid": false}
+{"pattern": "\\uD83D\\uDE00[]\\q{a}]", "flags": "u", "valid": false}
+{"pattern": "][\\/-]", "flags": "v", "valid": false}
+{"pattern": "\\/+?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[](?<a>([\\d[\\q{ab}][](?i-m:\\w{2,3}?[^{\\q{a|bc}.])(?=))(?>\\k<a>)(?-i:😂?\\u{1F600}[&}\\cA]))\\0", "flags": "i", "valid": false}
+{"pattern": "[\\}]\\x41[^", "flags": "i", "valid": false}
+{"pattern": "\\u{41}[^--!(](?:(?i:(?<\\u{61}>x)(?<$>x)||[$$\\c_|]{2,3}?[^a-\\d\\1])*(?x:[\\cA\\0\\&]\\p{Lu}*?|))|", "flags": "v", "valid": false}
+{"pattern": "(?![^\\c1\\B]|(?-i:-?|(?<=\\3\\q{ab})(?i:{3,2}^{))[z\\p{RGI_Emoji}😂-😀])", "flags": "v", "valid": false}
+{"pattern": "(?x:(?i:(?x:[!!&\\]\\uD83D\\uDE00-\\uD83D\\uDE02]\\q{ab}[^|a^\\])\\0[\\B])|\\0)", "flags": "v", "valid": false}
+{"pattern": "(?<a>((?x:{2,3}){){\\#{2,}|(?:(?>[-&&\\b\\B])(?<a>x)[^.^[[])??[^](?i)[^[]||[😀]??[-\\q{ab}^\\q{a}](?ims-:\\b{2,3}\\p{L}+[^😀z]|[][😀-😂][a]a-z]{99999999999})+?)(?-i:((?=\\x41{2,3})}+?)(?!\\k<\\u0061>|(?<a>[b{2})?\\c1\\k<a>)||\\1{)(?-i:_{2,3}?[](?<=[^]|[^[a\\p{L}]){3,2}||[([\\q{a|bc}])(?-i:b(?:(?ii:\\c|\\p{Script_Extensions=Latn}^)\\cA\\00)(?i)\\3**[]|\\kz*?", "flags": "u", "valid": false}
+{"pattern": "(?i:[](?i)\\k<a>|(?i:[\\q{a|bc}!!$$a]\\0))[][\\d-a\\1a]?(?<b>(?ims-:[^\\c_}.}])**)", "flags": "", "valid": false}
+{"pattern": "[\\P{Lu}\\B.]?(?ims-:(?<=(?<a>x))[&\\1😀\\-])\\P{RGI_Emoji}\\k<b>(?<=(?i:\\0+?[\\B]+?|)**\\s*|[/\\uD83D\\uDE00-\\uD83D\\uDE02[^.\\c_--&]){2}", "flags": "v", "valid": false}
+{"pattern": "\\x41\\#", "flags": "v", "valid": false}
+{"pattern": "(?ims-:[]|)", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<b>(?!\\u{41})(?i-m:\\12[\\p{RGI_Emoji}{2,3}?)[^]", "flags": "v", "valid": false}
+{"pattern": "[|[\\u{1F600}-\\u{1F602}\\][^a]a-\\d][^\\q{ab}a😂-😀]\\p{Basic_Emoji}[^{]+", "flags": "v", "valid": false}
+{"pattern": "((?<\\u{61}>x)??\\x41|[\\uD83D\\uDE00-\\uD83D\\uDE02]|(?-:[\\1\\q{a|bc}](?:\\u{}{2,1}\\p{}){||\\c{2,}))*?[\\dz&]", "flags": "v", "valid": false}
+{"pattern": "(?<a>[^b\\!]+)[^]", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\x41\\/", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u{1F600}-\\u{1F602}@[\\q{ab}]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\u{1F600}-\\u{1F602}\\s][\\P{Lu}]]??|\\p{Script_Extensions=Latn}{2,}[@\\d-a]**[^\\q{}\\c1\\d-az]", "flags": "v", "valid": false}
+{"pattern": "[^!\\-\\P{Lu}a-z]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\1]+(?<b>y)", "flags": "v", "valid": false}
+{"pattern": "\\k<a>{2}", "flags": "v", "valid": false}
+{"pattern": "(?=(?i-m:[\\q{a}😀-😂]*\\!|))[[^a]](?i-m:[]{2,})[^a-z[^\\q{ab}]\\1\\p{RGI_Emoji}]\\00", "flags": "u", "valid": false}
+{"pattern": "(?ii:(?-:(?ii:){\\a)|!(?>\\08{3,2}|(+[^-\\q{}\\cA)])\\e{3,2}[^\\q{}])\\p{L)+?\\uD83D{3,2}(?i)\\w{2,3}?|\\x41[\\d/\\p{RGI_Emoji}]{,2}", "flags": "v", "valid": false}
+{"pattern": "[^\\B\\uD83D\\uDE00-\\uD83D\\uDE02\\0](?:[&&!&&])", "flags": "v", "valid": false}
+{"pattern": "(?<a>(?ims-:(?-i:\\p{Script_Extensions=Latn}(?<$>x)|\\k)|)\\uD83D\\uDE00)[@{b\\&]\\uD83D\\uDE00|(?<!$)\\s?", "flags": "", "valid": false}
+{"pattern": "a\\p{ASCII}[@\\]]?|&??", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12**[^!&\\1]??[{]|", "flags": "v", "valid": false}
+{"pattern": "[&&\\P{Lu}](?ii:(?!(?ims-:)\\uDE00[^]{2,})(?-i:(?>\\p{L{3,2}|[[^a]\\q{}]?))?)\\c1(?i:[^a\\q{\\d}/$$]??a+){2,3}?-{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\k<b>{(?i-m:\\uD83D\\uDE00{2,3}(?=[][^]+?(?=[[!!\\cA]{2,3}|)))(?:[{😂-😀\\B[^a]][\\P{Lu}](?!(?:\\B[^][])😂{3,2})(?x:[[\\q{ab}]\\1\\d/]\\P{Ll}**(?ims-:(?x:{2,3}\\B|[^]|{2,1})??)|^)(?![^\\d\\c1b](?<a>(?<b>y){2,3}?|(?i:|\\x41{+?[^]*)(?<b>y))){2,3}", "flags": "v", "valid": false}
+{"pattern": "\\P{Ll}{2,}_[@z|.][-\\1][)\\&/\\x41]", "flags": "v", "valid": false}
+{"pattern": "\\p{Greek}(?i)\\x4", "flags": "", "valid": false}
+{"pattern": "[|]{2,}[^]", "flags": "v", "valid": false}
+{"pattern": "\\p{}{2,}\\a{2,3}?[\\b\\]+a|", "flags": "", "valid": false}
+{"pattern": "[^](?=\\![&&]|\\cA{2,3})\\12{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "😂(?<b>y)[😂-😀----z-a]", "flags": "", "valid": false}
+{"pattern": "[z-a\\d-a\\]]??.(?i-m:!?[!😀-😂]??)|(?<a1>x)[^]", "flags": "", "valid": false}
+{"pattern": "😀\\b[&&]{3,2}(?i:[\\p{L}\\x41|z\\00)", "flags": "v", "valid": false}
+{"pattern": "\\p{L[(@}!!]|", "flags": "u", "valid": false}
+{"pattern": "a[\\-\\&]{2,3}?(?<a>\\p{Basic_Emoji})", "flags": "v", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\uD83D\\uDE00(?<a>x)??[|]", "flags": "v", "valid": false}
+{"pattern": "\\p{ASCII}(?i:\\uD83D\\uDE00[\\q{}(?<=[\\c1\\P{Lu}\\p{L}]|\\p{Lu}(?<a>\\c1\\p{gc=Lu}{2,3}))|[^{]]\\1*?)[$$\\uD83D\\uDE00-\\uD83D\\uDE02[^a]😂-😀]a{2,3}?[]", "flags": "", "valid": false}
+{"pattern": "(?i)[]\\k<a>\\0?", "flags": "", "valid": false}
+{"pattern": "(?:(?i:[--\\c_\\&]+(?-:[]\\/{||[]|)|(?i)({2,1})|[\\-\\]]$|)[a-\\d\\-[]\\p{Script_Extensions=Latn}+(?<a>x)[\\d-az/\\p{RGI_Emoji}]", "flags": "v", "valid": false}
+{"pattern": "[^}\\0z-a^]|[\\cA*|", "flags": "i", "valid": false}
+{"pattern": "[|]{2,}(?:[\\q{a|bc}]??|(?>[^\\p{RGI_Emoji}&\\q{}]|\\k<a>{3,2}|(?![\\P{Lu}\\-!)])|&\\uD83D\\uDE00{)**|(?i-m:\\&{2,3}[!!\\u{1F600}-\\u{1F602}\\c1[]|[](?i:\\08)[&&]+)[\\1[]){2,3}?\\2?\\0??(?:(?<a>[^\\P{Lu}{\\q{}](?<b>y)|){2}|z)", "flags": "v", "valid": false}
+{"pattern": "\\10**(?i:\\#(?=(?i:{2,3}?[\\P{Lu}])[{\\u{1F600}-\\u{1F602}\\p{RGI_Emoji}]|))a", "flags": "", "valid": false}
+{"pattern": "(?-:[^](?<\\u{61}>x))[^^][\\s\\&\\cA\\q{a|bc}]+?", "flags": "v", "valid": false}
+{"pattern": "[a][^]{(?<a>x)|{", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?x:]?[)(?<b>[\\c1])\\10\\e*?", "flags": "", "valid": false}
+{"pattern": "((?ims-:(?i-m:\\p{Script_Extensions=Latn}b)|\\p{RGI_Emoji}){2,})}[😀]--](?<b>\\2(?i:\\1|[^\\](?i-m:\\uD83D\\uDE00|{2,1}])\\1)|[}{|(?<=(?=\\x41??\\u{1F600}{3,2}][[\\q{a|bc}😂-😀😀-😂]){,2})*", "flags": "i", "valid": false}
+{"pattern": "[[^a]\\c_\\p{L}]+?\\cA\\p{RGI_Emoji}+[]]|[\\q{ab}]", "flags": "u", "valid": false}
+{"pattern": "\\/*?[😀\\s&\\](?<a1>x)|\\b[&&\\]\\0(]|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)(?i:\\P{RGI_Emoji})?(?<!(?<![(]😀\\q{a}]{3,2}(?<a1>x)|\\x4{2}\\a{2,3}?{3,2})*[&\\][a]]])[]|{2,1}*+?|", "flags": "v", "valid": false}
+{"pattern": "{[!\\a-z\\d][[\\q{\\d}[^\\q{ab}]]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "$[^\\q{\\d}\\w]*?", "flags": "v", "valid": false}
+{"pattern": "{2,1}?&", "flags": "v", "valid": false}
+{"pattern": "[\\]]\\p{RGI_Emoji}{2}(?<b>[\\d-a\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a}][\\1z^\\B])[^(\\P{Lu}😀-😂b]\\p{Script_Extensions=Latn}", "flags": "u", "valid": false}
+{"pattern": "[\\cA[!](?i-m:\\c[😂-😀\\w[^\\q{ab}]]|(?=\\3(?<\\u{61}>x)[😀\\q{a|bc}a-z]*)[])*[\\P{Lu}[\\q{ab}]]|[^}(]", "flags": "i", "valid": false}
+{"pattern": "[\\w(]|[]??{,2}", "flags": "v", "valid": false}
+{"pattern": "z(?-:(?>[^a\\u{1F600}-\\u{1F602}\\1]\\uDE00)|z[(b\\1]|\\w*?(?-:\\P{Ll}\\B||]😂[^\\&\\q{ab}b])?\\!", "flags": "v", "valid": false}
+{"pattern": "[&&\\-!!&&]|\\&?(?ii:\\12+?[^.|](?ii:(?<=\\3)||\\p{RGI_Emoji}_{{)", "flags": "v", "valid": false}
+{"pattern": "b{2,}&(?<=\\c1(?<\\u{61}>x)|)(?ii:[{😀]*[](?-i:(?ims-:[]\\k<b>{2,3}|[😀])(?<![^][^[^\\q{ab}]])|(?ii:[]{2,})))[^/😀\\B!]", "flags": "u", "valid": false}
+{"pattern": "[^\\]", "flags": "v", "valid": false}
+{"pattern": "(?!((?x:\\!?[[\\!])+\\c[|])[\\u{1F600}-\\u{1F602}\\P{Lu}]**|\\b|&", "flags": "", "valid": false}
+{"pattern": "(?ims-:(?i:\\p{Basic_Emoji}(?-i:\\p{ASCII}|)|]|})*[😂-😀--\\u{1F600}-\\u{1F602}]{2,})\\1{2,3}?(?i-m:[\\p{RGI_Emoji}]\\x41\\d??)\\p{RGI_Emoji}(?<=[^\\1\\!\\d][\\q{a}]|(?-i:^)*\\00{2,3}?)", "flags": "", "valid": false}
+{"pattern": "(?>(?!\\/(?<b>(?<a>x)[(][]{2,3}?|\\d*?\\10|)))\\p{sc=Greek}[\\0😀-😂😀\\q{a}]_[^\\!]**|", "flags": "", "valid": false}
+{"pattern": "(?>[[\\q{ab}]])\\q{ab}\\10[]", "flags": "v", "valid": false}
+{"pattern": "(?<b>\\3\\B)|[[]\\k<b>\\c_", "flags": "v", "valid": false}
+{"pattern": "(?<a>^{2,}\\P{Ll}|$_{2,}[\\w😀-😂]|)(?i:\\x4*\\k<a>+?\\k<\\u0061>)", "flags": "v", "valid": false}
+{"pattern": "\\p{Lu}(?x:(?<b>y))(?i:(?=\\p{Script_Extensions=Latn}|[]?[^]|\\12[😂-😀]\\0\\x4", "flags": "v", "valid": false}
+{"pattern": "[^][\\0]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p{RGI_Emoji}]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02😀$$\\q{a|bc}]|[]", "flags": "i", "valid": false}
+{"pattern": "\\12[@$$\\w\\d-a]\\k<a>z(?x:(?>[\\!][(\\-[^a]\\1]?\\p{Basic_Emoji})\\p{sc=Greek}(?={1}|[^][]){2,}?", "flags": "v", "valid": false}
+{"pattern": "[\\P{Lu}a-\\d$$]\\uD83D\\uDE00+?z\\e", "flags": "u", "valid": false}
+{"pattern": "(?<![^])[^)\\0-]", "flags": "v", "valid": false}
+{"pattern": "\\x41|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s]\\P{RGI_Emoji}\\p{}[^]+", "flags": "v", "valid": false}
+{"pattern": "!\\p{sc=Greek}{", "flags": "v", "valid": false}
+{"pattern": "[a-z\\p{L}]|(?-i:(?ii:[])\\k<{3,2}", "flags": "u", "valid": false}
+{"pattern": "[^[^\\q{ab}]^/]\\&|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!a-\\dz-a]{2,}{1}+|[\\1a-\\d][]?", "flags": "i", "valid": false}
+{"pattern": "\\10$", "flags": "v", "valid": false}
+{"pattern": "[^a-z\\1\\uD83D\\uDE00-\\uD83D\\uDE02\\cA]{2}\\q{ab}{(?i)(?<a1>x)[\\P{Lu}\\c_\\!]+[]**||(?<a>[\\c_[\\q{ab}]][\\1]|&|\\q{ab})\\&|", "flags": "u", "valid": false}
+{"pattern": "\\2${2,3}?[\\-b](?-i:(?x:(?<b>[\\wa-\\d\\s]|)*[!!]?|(?-i:[\\q{a}\\c_\\-]+\\u{41})(?<b>\\k<){2,3}\\p{Greek})[😀]{2,3}|(?:(?<![^)\\!]\\cA){3,2}\\p{ASCII}{2,3}|\\P{RGI_Emoji}&)\\1\\k<){2,}", "flags": "v", "valid": false}
+{"pattern": "\\/\\p{}[&&[\\q{ab}]]\\#|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>[]\\c_[\\1]){2,3}?[^]", "flags": "v", "valid": false}
+{"pattern": "(?!\\3|)[^\\][^\\!\\uD83D\\uDE00-\\uD83D\\uDE02](?<b>(?<\\u{61}>x)*?)|(?<!\\k<a>*(?-i:z?)*\\2|(?ii:\\a|(?!\\p{L}[{]|{[😀\\P{Lu}\\p{L}\\q{a|bc}]*?){2}[^]?)|[\\\\b][^$$\\cA])|", "flags": "u", "valid": false}
+{"pattern": "\\p{Greek}|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[][^\\p{L}](?i:\\p{ASCII}|(?!\\u{}[^![a]]{2,}))[^]\\s](?:(?<a>\\10\\P{Ll}|(?<=a\\p{gc=Lu}*)\\P{Ll}(?i:{3,2}|\\P{RGI_Emoji}**|[&\\p{L}\\s\\d]-))[\\q{}](?i-m:\\uD83D[^\\q{a|bc}\\u{1F600}-\\u{1F602}(^])|\\p{Basic_Emoji})", "flags": "v", "valid": false}
+{"pattern": "\\u{1F600}(?ims-:((?={1}[^\\q{a|bc}}$$!!])?\\12[^]|[}\\x41a-\\d](?ii:\\s|[]*?|\\p{Script_Extensions=Latn})**(?ii:{2,3}?[]\\uD83D\\uDE00-\\uD83D\\uDE02]*?**)*?){3,2})", "flags": "v", "valid": false}
+{"pattern": "(?<a>(?<![\\P{Lu}$$|/+)[\\q{a|bc}\\1\\x41b][😀]]+?)[]|\\p{Lu}|(?>\\cA(?i)b|[\\s(/]?|[^]*-)", "flags": "u", "valid": false}
+{"pattern": "(?i:[^\\p{L}a-\\db]*?|[^\\B\\&|)])[\\1\\d-a^z-a]|\\k<a>{2}\\u{41}", "flags": "v", "valid": false}
+{"pattern": "[\\d😀-😂]\\0\\/[\\][^\\q{ab}]|]", "flags": "v", "valid": false}
+{"pattern": "(?!\\0\\p{ASCII}(?<a1>x))(?:😂0+\\3)[](\\q{ab})(?<=(?<b>[^\\w!]_)[^^]](?i:\\12||b*?[\\&\\P{Lu}]+[^\\\\b\\q{\\d}]", "flags": "i", "valid": false}
+{"pattern": "\\u{1F600}(?<a>\\P{RGI_Emoji}a[^])[^😀\\1$$\\q{}][^@]]|[\\0^\\x41\\cA]", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "[\\-)\\q{a|bc}]{.", "flags": "u", "valid": false}
+{"pattern": "[@]a-\\d|[^]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:^[^\\!b\\x41])(?-i:\\&{2,3}?|[[\\q{ab}]\\p{RGI_Emoji}\\B[^a]]|$){3,2}|(?<a>(?<=(?x:😀|_{2,3}|[\\p{L}b\\-\\x41]*?[\\q{\\d}])+[^\\b]|(?!\\P{Ll}\\12|[$$\\b])[\\d-az]*\\12|)|\\uD83D\\uDE00(?<\\u{61}>x){2,3}(?ims-:(?<a>[😀[\\q{ab}]\\q{a}\\q{}]\\p{ASCII}|[\\cA^]0**\\s)!|)+?(?ii:[])([]{2}\\10+(!|)){2,3}?", "flags": "u", "valid": false}
+{"pattern": "[[^a]\\p{RGI_Emoji}][^|\\q{a|bc}}(]+?", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{}z\\q{\\d}]((?>[\\![^a]&@]a)){2}(?ii:})[^]", "flags": "", "valid": false}
+{"pattern": "\\p{ASCII}|!\\c1*|[^\\p{RGI_Emoji}z.]", "flags": "u", "valid": false}
+{"pattern": "\\u{41}\\cA(?-i:(?x:(?-i:\\#||\\uDE00\\0)??)**(?:0\\p{L(?-i:[😂-😀\\q{}b]\\P{RGI_Emoji}{2}[\\s\\B\\c1z-a]){2})(?<a>([]]\\b)(?!\\1{3,2}.\\10|){3,2})+|[\\1\\d-a]{2,}[^[^\\q{ab}]\\q{a}&])\\12(?<$>x){2,3}?", "flags": "", "valid": false}
+{"pattern": "\\p{}*?[|]", "flags": "v", "valid": false}
+{"pattern": "(?<=(?i:(?>[^])|\\a)\\12|\\q{ab})+?(?<a1>x)?[", "flags": "", "valid": false}
+{"pattern": "😂😀$[^-z]\\q{ab}", "flags": "u", "valid": false}
+{"pattern": "(?![\\c1](}*|[]?)|(?<a1>x))", "flags": "v", "valid": false}
+{"pattern": "😂\\k<b>{3,2}(?x:(?ims-:[)][z--\\cA]|))|", "flags": "u", "valid": false}
+{"pattern": "[([(\\c_&]|(?ims-:(?i:\\k<\\u0061>*?|\\p{sc=Greek})(?>!)+\\p{Basic_Emoji}))(?i:😂\\c_)?z**", "flags": "v", "valid": false}
+{"pattern": "(?i)(\\c_{2,}|(0[\\cA\\]))**\\k{2,3}?[\\uD83D\\uDE00-\\uD83D\\uDE02\\s]|[😀-😂]](?-i:[^&\\@@](?<b>\\x41|\\u{41}*?)|\\8)*?(?!(?i-m:(?:\\!))*?\\k(?!\\k<\\u0061>(?i:{2,3}))|\\k<\\u0061>)|", "flags": "v", "valid": false}
+{"pattern": "\\u{}[^\\]!!\\x41\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "v", "valid": false}
+{"pattern": "[z-aa-\\d&&\\c_]\\p{}", "flags": "i", "valid": false}
+{"pattern": "(?-i:[]\\12|[]{2,3}?(?ii:(?i-m:!{2,3}|\\p{Greek}|)+?[\\d-a!]|[^}\\w\\-])(?ims-:[&\\d\\p{RGI_Emoji}&&](?-i:[]{2,3}?|)[]))\\&(?<!(?<b>[{\\c1\\p{L}][]\\x41|)+?)*?[\\q{a|bc}]*", "flags": "u", "valid": false}
+{"pattern": "(?i)[\\q{a|bc}!$$][&]\\e[\\q{a|bc}!!\\d\\q{a}]", "flags": "v", "valid": false}
+{"pattern": "(?>\\3)", "flags": "v", "valid": false}
+{"pattern": "&|(?-:[\\d-a\\cA@]}(?i-m:}[^]\\uD83D|))(?i-m:\\c1{3,2}\\uD83D\\uDE00+?(?ii:(?-:??\\uDE00??|\\s&)(?i-m:|\\1)|(?<!??|{2,3}a){2}|))(?=[\\q{a|bc}\\p{RGI_Emoji}]{2,3}(?<a>[a]\\p{Greek})(?=\\p{ASCII}|(?<a>\\u{})|(?!\\p{Lu}**[b[^\\q{ab}]])*?))\\p{L|", "flags": "v", "valid": false}
+{"pattern": "[^😀@\\w]{2,}\\w{99999999999}[😂-😀!!][^😀-😂\\p{RGI_Emoji}a-z[]", "flags": "u", "valid": false}
+{"pattern": "&\\k<\\10(?<$>x)", "flags": "v", "valid": false}
+{"pattern": "\\c_\\p{L{3,2}(?<=[a]+?){2,3}", "flags": "u", "valid": false}
+{"pattern": "[)]|[^😀-😂[a]\\P{Lu}\\q{a}]{2,}", "flags": "", "valid": false}
+{"pattern": "(?i:${2}\\!*?){2,3}?", "flags": "u", "valid": false}
+{"pattern": "(?i-m:\\&|(?<\\u{61}>x)\\cA\\a)(?<a>(?:\\!+?)[])\\p{ASCII}", "flags": "v", "valid": false}
+{"pattern": "$[^\\[\\P{Lu}!!]\\8(?ims-:\\a[\\d-a]|[)$$])\\12", "flags": "v", "valid": false}
+{"pattern": "\\w|_(?<\\u{61}>x)", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?:\\e{2,}[[\\q{ab}]](?ii:(?=[\\uD83D\\uDE00-\\uD83D\\uDE02\\d\\d-a!!])[a😀-😂]\\cA|(?-:$){3,2}))(?!^){2}", "flags": "u", "valid": false}
+{"pattern": "[@\\-\\q{\\d}]{\\-[{{}]{2,3}", "flags": "u", "valid": false}
+{"pattern": "[^\\1\\q{a}](?ii:(?>b|[\\p{RGI_Emoji}{😀-😂]]{2,})*?\\3[^]", "flags": "v", "valid": false}
+{"pattern": "(?<=[^\\p{RGI_Emoji}$$@][[^\\q{ab}]@](?<=(?>\\k)\\10))\\P{RGI_Emoji}\\-[[]|", "flags": "", "valid": false}
+{"pattern": "[\\q{a}\\1\\x41]+?\\p{ASCII}{2,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)[[\\q{ab}]a!!]{3,2}[^)|\\s]{(?!\\p{Basic_Emoji}){2}\\e\\!", "flags": "i", "valid": false}
+{"pattern": "(?<a1>x)[\\c_]{3,2}", "flags": "", "valid": false}
+{"pattern": "[\\P{Lu}😂-😀\\B[a]][\\q{a|bc}}]\\s{2,3}", "flags": "i", "valid": false}
+{"pattern": "[😀\\u{1F600}-\\u{1F602}\\c1][\\d-a]", "flags": "v", "valid": false}
+{"pattern": "{,2}\\p{RGI_Emoji}{2,3}?_[\\d-a\\&]|(?ims-:(?!\\3{3,2}(\\3|{99999999999}[zz😀]|)*[\\]])(?ii:\\08+?))*?", "flags": "v", "valid": false}
+{"pattern": "(\\q{ab}*\\c1{2,}|[[-[a]z-a][@!!])|(?ims-:\\uD83D\\uDE00(?ii:(?-:*?[!\\]|)(?<a>\\P{RGI_Emoji}!|)+?|(?<!-)|)(?x:[\\q{a|bc}$$]([!+?|)[\\c_])+?|)|[|\\0]{2,}(?:\\0{3,2}\\k<{2,3}){2,}", "flags": "u", "valid": false}
+{"pattern": "[^\\cA]\\x4\\k<[\\cA!!]?", "flags": "v", "valid": false}
+{"pattern": "[^\\u{1F600}-\\u{1F602}😀-😂\\1\\d][^\\q{ab}][]|\\!\\q{a|bc}][]((?<\\u{61}>x)*|\\x4(?<b>(?<\\u{61}>x)){2}(?<a1>x)?)", "flags": "v", "valid": false}
+{"pattern": "((?<$>x)+|\\08)[@\\q{a}\\cA\\q{}][@.[\\1][\\q{ab}\\]\\c_]", "flags": "v", "valid": false}
+{"pattern": "(?:[^\\p{RGI_Emoji}]|\\e{3,2})*?{,2}\\b\\3", "flags": "i", "valid": false}
+{"pattern": "(?<b>\\uD83D\\uDE00{2})$[^\\q{a|bc}\\q{\\d}]|\\d*|", "flags": "v", "valid": false}
+{"pattern": "\\k<(?<a1>x){2,3}b", "flags": "v", "valid": false}
+{"pattern": "[^\\d-a]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{1F600}{2,3}?(?i)(?:(?i:&|[-[a]\\q{a|bc}]+|^[\\c_]??|)|(?:\\u{41}[@\\1])(?ii:\\p{gc=Lu})+?|(?<a>z|$)[^\\d!])**[[--]|(?ims-:[^\\0\\B@\\d](?<=[}\\uD83D\\uDE00-\\uD83D\\uDE02\\c_])[]|(?<a>x))(?=\\1?[^](?i-m:{+?(?ii:b|\\P{Ll}\\00+[\\q{\\d}\\cAa-z\\B]+?)|\\8\\cA)(?:(\\s{2,3}?|[^\\!]|[\\q{\\d}[\\q{ab}]])|(?-:[^[\\q{ab}][a]](?x:.){2,}|[])[a-z[]{2,3}[^}|\\uD83D\\uDE00-\\uD83D\\uDE02|]*)", "flags": "u", "valid": false}
+{"pattern": "(?:[\\cA\\s\\c_]\\x4{3,2}(?<$>x)**)(?=[\\-\\b]+\\p{Greek}**){2}\\p{}", "flags": "v", "valid": false}
+{"pattern": "😂*(?>(?ii:\\c1[|b]]*?)", "flags": "v", "valid": false}
+{"pattern": "[}\\z-a]", "flags": "v", "valid": false}
+{"pattern": "[]\\![z&&][\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "u", "valid": false}
+{"pattern": "\\k<b>.{+?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "b+|😀**^", "flags": "v", "valid": false}
+{"pattern": "\\s{3,2}(?>\\p{}\\1)+?", "flags": "v", "valid": false}
+{"pattern": "(?=[}.\\q{}]\\d(?<=(?<=\\cA!|)|)|\\w+[^z-a])(?<a1>x){2,}[}\\d\\{^*?", "flags": "v", "valid": false}
+{"pattern": "[a-z$$]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[](?<![a&&/])+", "flags": "i", "valid": false}
+{"pattern": "b([](?<a1>x)|&_\\u{1F600}){3,2}[]{\\2", "flags": "u", "valid": false}
+{"pattern": "[^\\\\1\\q{a|bc}\\q{a|bc}]{3,2}$[\\d-az-a][][\\!/]]", "flags": "v", "valid": false}
+{"pattern": "[]+?(?i)(?x:\\12\\p{sc=Greek}|\\a)\\p{Lu}+(?<=^(?i:\\b[&!!\\q{a}](?-i:[\\-](?<\\u{61}>x)|\\d|)+){2,3}?[😀a-\\d]|(?=[😂-😀)\\!😀]\\3)|", "flags": "v", "valid": false}
+{"pattern": "(?<b>{2,1}(?i-m:[\\q{ab}-\\-](?<a>\\c1|\\#){2,3})[]|(?i-m:(?ims-:[\\c1b]{2,3}?[^az-a\\q{a}--]|)){[\\!\\q{\\d}😀\\&{2,3}?)+", "flags": "v", "valid": false}
+{"pattern": "(?<=(?=(?<=){2,3}|\\x4[]){2,3}?|(?i)(?-i:{2,3}\\p{ASCII}|)(?i)[^b\\c1b\\]]\\u{}|[^\\[\\q{ab}]\\c_\\u{1F600}-\\u{1F602}]{2}|\\/(?ii:(?-:(?x:||[a\\b]😂)[\\&\\1\\-]\\3)\\p{L}{2,3}\\x41*?|(?<a>x)[\\?(?<=[\\1|\\q{ab}]+[]*?){2,3}?)?(?<![-^a-z{]\\p{})[\\x41b]", "flags": "v", "valid": false}
+{"pattern": "\\1|(?<$>x){3,2}\\k<|", "flags": "v", "valid": false}
+{"pattern": "(?x:(?i-m:(?i:|(?-i:[\\d@[^a]]*?||[][^[^\\q{ab}]\\x41]??)*?(?-:}{3,2}[\\d])){2})\\/*?", "flags": "u", "valid": false}
+{"pattern": "\\c_[^\\q{\\d}][^]??|[z-a😀-😂\\x41]", "flags": "v", "valid": false}
+{"pattern": "(?![^z\\b]{2,3}$|[^(]{2,})\\p{sc=Greek}\\c(?>\\q{ab}(?i-m:(?i-m:(?<\\u{61}>x){2,})(?<a>[]|[$$😀-😂]\\&)|\\k<{2,3}?(?!.|\\!)))[\\!]", "flags": "i", "valid": false}
+{"pattern": "[][]*\\k<\\u0061>", "flags": "v", "valid": false}
+{"pattern": "((?-i:(?<a1>x)(\\u{}||)*|\\p{gc=Lu}{,2}))**[\\P{Lu}-\\d\\w]\\p{L}(?ii:[^\\d\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a}]){2,3}[\\-\\s\\-\\q{}]", "flags": "u", "valid": false}
+{"pattern": "\\p{sc=Greek}|-[[^a]]\\p{Script_Extensions=Latn}(?i:(?<a>(?i)*?(?<a>x)\\-**(?<\\u{61}>x)|(?<!|{)))", "flags": "i", "valid": false}
+{"pattern": "0+?[b@-\\&]&\\k(?<a>(?<!(?x:|.)(?i)[\\!\\!\\q{a}]**{2,}(?i)}{2,3}?[--\\q{ab}}])[]b😂-😀\\x41]??|(?<a>-{1}[^\\p{RGI_Emoji}@&])|(?!}[]|[^])+?)", "flags": "i", "valid": false}
+{"pattern": "\\p{Lu}\\k<b>\\p{L", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{99999999999}[[&&[^\\q{ab}]\\x41](?<=(?i:\\-[]).[\\]\\x41z\\uD83D\\uDE00-\\uD83D\\uDE02])(?i:😀b[^a-z\\q{\\d}--\\!]|[\\0--][^!\\p{RGI_Emoji}z])", "flags": "u", "valid": false}
+{"pattern": "\\P{RGI_Emoji}(?<a>[a][\\!\\]([\\-😀-😂]\\p{Script_Extensions=Latn}+[]{2,})|)\\u{1F600}|(?<b>y)|", "flags": "u", "valid": false}
+{"pattern": "(?<![^\\&-][^[\\q{ab}]]_|[(z-a])(?<![\\c_\\&\\q{}])|(?>^{2,3}[\\!^[a]\\cA]|$+?|){2,}(?i-m:&(?x:(?:\\cA|[^[^a]\\p{L}]|\\k[^\\q{ab}\\s])[}\\\\q{}]{2,}(\\c1{3,2}\\b))(?=\\12)|)\\u{1F600}", "flags": "", "valid": false}
+{"pattern": "[\\(\\cA]{2,3}?(?-i:(?ims-:[^\\q{a}\\P{Lu}\\c_)!{2}\\w|[[^a]\\q{a}\\1])**\\k<a>", "flags": "i", "valid": false}
+{"pattern": "[^😂-😀]{3,2}(?i-m:(?:[]{2,3}?||\\e[^(\\q{a}\\1!]*?|[^!\\d|\\q{\\d}])**[]\\p{RGI_Emoji}**)[^\\p{RGI_Emoji}\\cA|\\#", "flags": "v", "valid": false}
+{"pattern": "[\\q{a}\\x41\\q{ab}]-", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "_", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!(?x:[]|(?<\\u{61}>x)\\k<a>)[^.\\&\\d-a\\cA])(?<=[])[]", "flags": "", "valid": false}
+{"pattern": "(?=[\\c1\\\\B\\]](?<!\\u{1F600}\\cA[^])\\08", "flags": "i", "valid": false}
+{"pattern": "😂*(?>(?-:(?<a>[^|-]]?{2})*?[&&[\\q{ab}]\\])[\\q{a|bc}[^\\q{ab}]\\q{}]|(?<b>(?-:[\\1\\c1]){3,2}\\08(?<!\\P{Ll}|)|(?:\\p{Greek})(?x:!|\\p{gc=Lu})[]))|(?:\\p{L}|\\c[){2}[\\cA[^\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "[\\&bz\\!](?>(?<b>[!!\\cA]{3,2}|[]?(?-i:[^!]{2,3}?_|)(?-i:[\\p{RGI_Emoji}\\c1(][\\d!]|[^z-a\\x41^|]{2}[^\\q{ab})))(?i-m:[][^[^a]\\d-a][\\c_😀/\\uD83D\\uDE00-\\uD83D\\uDE02]){2,}-\\q{ab}", "flags": "i", "valid": false}
+{"pattern": "(?x:[\\1\\uD83D\\uDE00-\\uD83D\\uDE02[^a]]*?[!\\q{}\\q{a}]|][]*?\\!)(?ii:[^/][^\\c1[^\\q{ab}]!])[\\1][.&&\\0$$]{", "flags": "v", "valid": false}
+{"pattern": "(?i:\\p{sc=Greek}|\\cA{2}){2,3}?\\12\\a", "flags": "v", "valid": false}
+{"pattern": "(?i:$|[a\\x41😀[]{2,3})+|[\\0)\\q{a|bc}\\p{L}][.]**(?-i:(?>{,2}\\&)?|\\p{Lu})", "flags": "v", "valid": false}
+{"pattern": "(?:(?=[b\\p{L}](?-i:\\uDE00|{2,1})){2,3}|\\P{RGI_Emoji}(?-i:\\a{2,3}[^\\p{L}\\c1a\\d]))[\\x41\\b][!!|}]{2,3}?", "flags": "", "valid": false}
+{"pattern": "{(?i)(?i-m:[\\bzz-a]|\\p{Script_Extensions=Latn}{2,3}|[\\d\\s[^a]-]{**)(?ii:[^](?x:[@bz]\\k<b>{2,})){3,2}|{,2}[^--\\u{1F600}-\\u{1F602}][\\q{ab}]]", "flags": "v", "valid": false}
+{"pattern": "\\-(?=(?!\\!)|(?<=^[!\\p{L}^\\p{RGI_Emoji}](?-i:\\p{sc=Greek}|){2,3}){3,2}(?-i:(?<!\\2||{,2}|\\p{Script_Extensions=Latn}{[])(?-i:[])|[😀][|))", "flags": "i", "valid": false}
+{"pattern": "[](?i:[\\p{RGI_Emoji}😂-😀\\q{\\d}])(?<\\u{61}>x)|[\\c1z]{99999999999}", "flags": "u", "valid": false}
+{"pattern": "[$$\\0\\w][\\p{L}-b]", "flags": "v", "valid": false}
+{"pattern": "(?-i:(?<b>y)|[\\q{a}])[^\\c_z([a]]$[\\0&\\0$$]??(?<!\\p{}{2,3}?[]z-a\\-\\u{1F600}-\\u{1F602}])|", "flags": "i", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "\\k<a>**\\p{L}{2}|(?<a>\\cA|){2,3}", "flags": "u", "valid": false}
+{"pattern": "(?ims-:\\00", "flags": "", "valid": false}
+{"pattern": "\\-", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]((?-i:[^--{😂-😀])+[-a])[😂-😀|]", "flags": "v", "valid": false}
+{"pattern": "\\b[]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Greek}|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^a-\\db\\x41\\p{L}]", "flags": "v", "valid": false}
+{"pattern": "\\k<\\u0061>|\\3{2,}(?x:[\\b!](?-:\\w(?-:)(?<a>{2,3}?))\\u{41})[^]", "flags": "u", "valid": false}
+{"pattern": "{2,1}[]😀?(?>\\08|[])??.", "flags": "i", "valid": false}
+{"pattern": "(?=\\p{sc=Greek}\\p{L)[\\c_!!{]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀z](?>\\k[a\\P{Lu}\\x41[[\\0|]|(?<=(?-i:\\p{Greek}{2}{3,2})(?=\\p{RGI_Emoji}+?{)|))[]\\00\\u{1F600}", "flags": "u", "valid": false}
+{"pattern": "(?>[\\0]\\#|[[\\q{ab}]])[^\\!\\c_\\u{1F600}-\\u{1F602}]{3,2}{99999999999}[^\\]😂-😀]\\B", "flags": "", "valid": false}
+{"pattern": "(?ii:{2,1}|)\\P{Ll}\\08[)!\\u{1F600}-\\u{1F602}]|", "flags": "v", "valid": false}
+{"pattern": "\\B(?<b>(?x:(?>[^.\\q{a|bc}]|)(?<a>])*})[@)\\uD83D\\uDE00-\\uD83D\\uDE02@]\\2)*|{2,1}(?i-m:[@]\\P{Lu}-])", "flags": "u", "valid": false}
+{"pattern": "(?!\\s)|\\p{sc=Greek}{2,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1\\q{}\\q{ab}\\q{a}]\\cA\\p{}\\p{Basic_Emoji}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ims-:[\\q{a|bc}z\\p{RGI_Emoji}\\b]**\\&|(?<\\u{61}>x)*?)", "flags": "u", "valid": false}
+{"pattern": "\\2z(?:\\q{ab}??\\u{1F600})(?<a>(?<a>[}-\\]+?))*?", "flags": "u", "valid": false}
+{"pattern": "(?![^\\p{RGI_Emoji}\\c_&]+?(?i:[b\\p{L}][\\-]\\uDE00)(?=[^[^\\q{ab}]\\q{}]+))[(\\q{\\d}\\q{\\d}]|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{2,1}\\k_\\12+", "flags": "", "valid": false}
+{"pattern": "\\uD83D\\uDE00*[\\s\\q{}a\\u{1F600}-\\u{1F602}][){.\\c_]|a+[[\\q{ab}]\\]\\u{1F600}-\\u{1F602}\\!]", "flags": "v", "valid": false}
+{"pattern": "[^😂-😀$$$$😀-😂]\\P{Ll}[)\\p{RGI_Emoji}]0|", "flags": "i", "valid": false}
+{"pattern": "((?-:(\\!??\\k<\\q{ab})(?<![}\\q{ab}-]{2}|[a-\\d\\u{1F600}-\\u{1F602}]\\p{sc=Greek}|\\p{L}|\\p{RGI_Emoji}\\p{L}[!!a-z]{)\\!*\\p{L})", "flags": "u", "valid": false}
+{"pattern": "(?i:(?:}{,2}||(?x:_){(?<=\\c_*?[\\q{\\d}@]{)){2}-)[b]*?\\u{1F600}", "flags": "u", "valid": false}
+{"pattern": "(?<b>((?x:+?|(?<\\u{61}>x)\\k{3,2})|[}!a-\\d!]?[^}.b/]{2,3}(?<b>\\c\\p{L}[\\c_!!!\\p{L}]))+)(?<!([)\\P{Lu}]\\k<a>\\c){1}**)(?ims-:0)\\c", "flags": "v", "valid": false}
+{"pattern": "\\x4|\\w+(?:[&\\q{ab}-]+?(?-i:\\p{ASCII}{)|[!]\\p{RGI_Emoji}**[😀a-\\d]{2,})(?i:(?ims-:[-!!😀-😂][\\x41\\c1)-][[]*){2,}){3,2}", "flags": "v", "valid": false}
+{"pattern": "\\x41|😀", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&[]", "flags": "u", "valid": false}
+{"pattern": "\\c|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B&", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[-\\q{a}\\s\\s(?i:\\c){2,3}[\\&[^a]](?i-m:(?i)(?-:[\\d-a]|\\#*)**[\\q{ab}]|a(?<!\\uD83D\\uDE00|(?<a>\\B*?)+?\\!)?\\p{ASCII})", "flags": "v", "valid": false}
+{"pattern": "\\w(?<!(?-:[][^|!{]|\\b(?i-m:[@[^a])][^\\-[^\\q{ab}]]{2,3}|[a\\1!!\\q{a|bc}]|))|\\p{Greek})", "flags": "v", "valid": false}
+{"pattern": "[/z-a[^\\q{ab}]]|\\#+(?-i:(?x:(?:\\p{L})[😀-😂\\&[\\q{ab}]z](?i:\\8|[\\q{}[[^\\q{ab}]a-\\d][^][\\P{Lu}!!😀-😂])|(?<!|{)+?[]{(?ii:\\x4))[]??\\a{2,3})", "flags": "v", "valid": false}
+{"pattern": "[^|]0[]|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^}\\uD83D\\uDE00-\\uD83D\\uDE02\\s]**", "flags": "i", "valid": false}
+{"pattern": "(?<=\\w+?(?:[^]*))\\p{Basic_Emoji}??[^a-z][\\p{RGI_Emoji}){[^a]](?-i:$){", "flags": "v", "valid": false}
+{"pattern": "(?<!\\uDE00(?i-m:[^\\p{RGI_Emoji}]|\\w)[\\1]|)(?!\\k*?[^\\\\P{Lu}]([\\c_-b)]))[[\\q{ab}]/(\\q{\\d}]|{2,1}(?i-m:(?<!(?![^]{2,3}?|\\p{Greek}|[/])+[]\\c1]|)[z(b(?i-m:(?-:(?<a1>x)[^z-az-a])+?[^&\\cAa-z]))", "flags": "v", "valid": false}
+{"pattern": "(?=[b\\b|/][^\\!z-a\\u{1F600}-\\u{1F602}&]?[@[a]]|[^\\P{Lu}}(\\q{a|bc}]\\c1**[\\1\\q{ab})]|)|", "flags": "v", "valid": false}
+{"pattern": "(?!\\u{41}(?<a1>x){2,3})[\\q{\\d}]", "flags": "", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "[](?i:\\k<b>{2}(?i-m:_)*{2,1})\\p{L}|\\uD83D\\uDE00", "flags": "v", "valid": false}
+{"pattern": "[]\\s", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<a>[]{2}(?i)[\\cA😂-😀][\\\\.\\d-a](?<a1>x){3,2}", "flags": "v", "valid": false}
+{"pattern": "\\k<\\u0061>(?x:$*?(?<a>x)+?[^\\b\\b\\1]|)*", "flags": "v", "valid": false}
+{"pattern": "\\s(?:[^/]|\\p{gc=Lu}{2,})|(?<b>y)??", "flags": "u", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "[\\c1\\c_\\c1]\\P{RGI_Emoji}(?i)[z\\B@]]{,2}(?i:(?<a>|\\k<b>|z+?)\\p{gc=Lu}\\k|)|", "flags": "v", "valid": false}
+{"pattern": "\\d(?<a>(?i:(?=\\u{41}{3,2}[^}]??|\\0{)\\u{1F600}{[]|))", "flags": "v", "valid": false}
+{"pattern": "[^]{", "flags": "v", "valid": false}
+{"pattern": "(?<![^]{[^&&)\\&[\\q{ab}]])|[\\w](?x:[\\a-z\\]){2,3}|[[^a]|\\!&]_", "flags": "u", "valid": false}
+{"pattern": "(?i-m:[\\z\\q{}]\\p{gc=Lu}(?:\\u{41}(?=[[a]\\cA@]])|(?i-m:(?-:|[^])??(?i:[]+?\\k{3,2}||[\\c1!!^a-z][^\\d😀-😂\\u{1F600}-\\u{1F602}])(?<b>[\\q{ab}\\b😀-😂😀]+?&)|[]\\-[])|[\\c1@[\\q{ab}]](?x:[^\\&\\u{1F600}-\\u{1F602}]\\p{}(?<!\\k<a>{[/&]+?|))){2,}|(?>(?i:[\\!\\p{RGI_Emoji}b😀])\\p{RGI_Emoji}\\k<\\d{3,2}\\p{gc=Lu}(?i:{99999999999}?|\\w?)*", "flags": "i", "valid": false}
+{"pattern": "\\p{sc=Greek}(?>(?>\\k<?){2,}", "flags": "v", "valid": false}
+{"pattern": "\\P{RGI_Emoji}[\\u{1F600}-\\u{1F602}|].\\&(?-i:\\P{RGI_Emoji}(?-:[\\d\\p{L}][z(]|(?x:\\p{Greek}\\d{2,3}?\\p{sc=Greek}+?)|a(?<b>y))[^}[\\q{ab}]😀-😂b]*?)", "flags": "u", "valid": false}
+{"pattern": "(\\k<a>|(?<\\u{61}>x)((?ii:[\\q{}&$$\\w])+|(?!\\b|[&&&&^])(?i)[^]||[}a\\B)", "flags": "i", "valid": false}
+{"pattern": "\\k<a>(?=\\b^{2,}\\0)[]\\u{1F600}{2,3}?", "flags": "v", "valid": false}
+{"pattern": "(?-:[])0[]\\p{Basic_Emoji}{2}|", "flags": "v", "valid": false}
+{"pattern": "\\p{L}[^[](?i-m:((?=[^a-\\d\\P{Lu}]|[])(?i)\\k<\\u0061>||![]]){2,}\\8(?<a>(?<$>x)*?[(\\d$$a-z](?ii:\\c|*?)))(?=[)]-]|[^😂-😀\\q{\\d}\\c1\\p{RGI_Emoji}]\\8|(?![](?!||\\p{RGI_Emoji}))){2,3}?😀", "flags": "", "valid": false}
+{"pattern": "\\B[\\q{a}]**[{\\0a-zz-a]|\\c[\\![^a]\\x41--]{2,}", "flags": "i", "valid": false}
+{"pattern": "\\uD83D**|\\u{1F600}\\e|(?ii:[![^a]\\u{1F600}-\\u{1F602}]|(?ii:😂[(](?!\\B[\\uD83D\\uDE00-\\uD83D\\uDE02&😀]{2}[!!]))+[])", "flags": "v", "valid": false}
+{"pattern": "(?![\\c1][a-\\dz-a][^\\uD83D\\uDE00-\\uD83D\\uDE02a]?|[\\q{ab}{]|&\\e)", "flags": "v", "valid": false}
+{"pattern": "[^]+\\u{1F600}{2,3}[]\\e", "flags": "v", "valid": false}
+{"pattern": "(?<!\\x41)\\q{ab}?[-}[^a]]|_", "flags": "v", "valid": false}
+{"pattern": "\\p{ASCII}[\\s\\b\\1]?(?-:\\b|.\\u{41})(?i)[!]{2,}[^[a]]](?i:\\p{})\\P{RGI_Emoji}", "flags": "i", "valid": false}
+{"pattern": "\\p{gc=Lu}[\\0]**[$$\\B\\B[^\\q{ab}]]", "flags": "i", "valid": false}
+{"pattern": "[]|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w[a]\\c_](?x:(?<b>\\c{|\\p{sc=Greek}{2,3}?)(?<!\\12\\p{Basic_Emoji}))(?i-m:[()!|[\\-])??", "flags": "v", "valid": false}
+{"pattern": "\\a[!]{3,2}(?i:(?i)(?<b>y)|\\2.)[\\]}\\b]{2}\\p{Basic_Emoji}{", "flags": "v", "valid": false}
+{"pattern": "[^(?<!!\\s*\\s*?|^[\\0\\q{}](?x:(|\\08**?[^\\d-a\\0/]|(?i:[^]_**\\3??)))[]\\k**([😀-😂a-z]|[^])", "flags": "i", "valid": false}
+{"pattern": "[^]|\\p{ASCII}[z[\\q{ab}]]*{99999999999}**", "flags": "", "valid": false}
+{"pattern": "[[^a]/\\c1](?<=_?|[&]{2}{2,1})??]{3,2}", "flags": "v", "valid": false}
+{"pattern": "[\\c_\\q{ab}]{|\\#[\\0[a]a\\q{a|bc}]*?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!\\#)\\uD83D\\uDE00(?-i:(?x:[\\p{L}|[z-a|a-\\d)]\\d)\\00{3,2}(?i:[\\uD83D\\uDE00-\\uD83D\\uDE02)]{2,}(?<!!|).|[\\d\\P{Lu}\\u{1F600}-\\u{1F602}]|[\\d]*?(?!)){2}){2,3}[\\uD83D\\uDE00-\\uD83D\\uDE02]|[^", "flags": "", "valid": false}
+{"pattern": "(?<=\\p{ASCII}(?-:(?i-m:[^😀-😂a-z]\\p{Lu}??\\uD83D\\uDE00)(?<=[\\q{ab}]|[😀-😂\\q{a|bc}[^a]\\])|))\\b[z-a\\s]\\08", "flags": "", "valid": false}
+{"pattern": "!??{,2}|b\\p{L??{1}", "flags": "v", "valid": false}
+{"pattern": "😀(?ims-:0(?<=(?=&{2,}|\\0\\x41|[\\&}\\w)]+?)]{2,3}(?ims-:{,2}😀?\\uDE00){2,3}?|(?ii:[\\x41]{|(?<a1>x))*?(?!z[^]|[\\B.])[^^z|\\0]))", "flags": "v", "valid": false}
+{"pattern": "\\uD83D\\uD83D\\uDE00?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c_(?i:[\\0\\b[\\c1]*?\\p{Lu})**\\q{ab}{3,2}\\p{L}", "flags": "u", "valid": false}
+{"pattern": "(?-i:\\d)(?-i:[^[\\q{a}][\\\\/a-z])(?i:[&&{2}[\\B\\c1\\P{Lu}\\q{\\d}]+?\\b", "flags": "i", "valid": false}
+{"pattern": "(?<a>x){2,3}(?:[\\]\\0^\\B][/\\!\\d]{2,3}|){\\p{L", "flags": "v", "valid": false}
+{"pattern": "\\p{sc=Greek}(?ii:[^[^\\q{ab}]!![a]][][\\q{ab}\\d]|😀(?<$>x)\\d){2,3}?\\12(?-:\\P{RGI_Emoji}{}(?<a>(?-i:[^^][b&\\0]|)\\u{41}(?ii:\\k[^b\\B)]|\\q{ab}\\k){)**|(?i:[z\\d-a\\uD83D\\uDE00-\\uD83D\\uDE02](?x:[|][\\q{ab}]]\\B|{(?<$>x))|(?i:{2}||[\\!\\q{}\\c_\\b]+\\p{ASCII}\\uDE00)(?!(?<\\u{61}>x)[]+?)\\cA*?)(?<b>\\c)(?!\\p{L}|(?-i:[\\!])[z&$$\\]]{2}[^\\x41])", "flags": "v", "valid": false}
+{"pattern": "(?<a1>x){2}|\\P{Ll}", "flags": "v", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "(?x:(?i-m:\\00[)](?i:*\\p{}|[([\\q{ab}]\\q{a}{){2,}|\\P{Ll}?)|\\B[\\w!)+?[\\q{a|bc}/b😂-😀]{2}[]{2,3}?(?x:(?i:\\p{Greek}(?i)\\x41+?[[a]z-a[^\\q{ab}]\\]))**(?i:\\k<(?ii:\\p{Greek}(?<!{2,1}(?<a1>x)?)+))+", "flags": "v", "valid": false}
+{"pattern": "[^\\p{L}\\p{L}\\-\\q{\\d}][^a\\uD83D\\uDE00-\\uD83D\\uDE02}\\B]*?[\\0[^\\q{ab}]\\x41!]\\10}", "flags": "v", "valid": false}
+{"pattern": "(?ims-:[\\P{Lu}[^a]/]\\p{gc=Lu}\\uD83D\\uDE00)\\1", "flags": "v", "valid": false}
+{"pattern": "(?i).\\q{ab}|??!{2,}", "flags": "", "valid": false}
+{"pattern": "(?<=\\3|[]){99999999999}*?[\\u{1F600}-\\u{1F602}\\d]_", "flags": "i", "valid": false}
+{"pattern": "0(?![\\q{a|bc}])**", "flags": "i", "valid": false}
+{"pattern": "\\-[]\\k<a>(0(?<b>\\p{Basic_Emoji}{|(?=(?<b>y)[]{)))&", "flags": "u", "valid": false}
+{"pattern": "[\\p{L}|-??(?ii:(?<a1>x)[](?i-m:\\u{41}[@a-z]|(?i)😂\\p{Script_Extensions=Latn}[-/]))[\\])]", "flags": "u", "valid": false}
+{"pattern": "[\\q{a}[^]\\-\\p{Script_Extensions=Latn}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[/\\uD83D\\uDE00-\\uD83D\\uDE02\\&@]", "flags": "v", "valid": false}
+{"pattern": "{99999999999}**|!\\3[^!!\\B](?<!(?ims-:(?!\\q{ab}{2}(?<\\u{61}>x)[^}-[^\\q{ab}]])|[[a]--\\d\\w][^/}[^\\q{ab}])|[^a-\\d]{3,2}(?<=(?!\\p{Basic_Emoji}){2,}))", "flags": "v", "valid": false}
+{"pattern": "(?-i:[--]{3,2})|\\0(?-:\\10)}[.\\x41a[\\q{ab}]]??", "flags": "u", "valid": false}
+{"pattern": "\\uD83D\\uDE00[]\\0(?-:\\k<b>(?i-m:[&&\\d-a\\p{L}][[a]\\s]|(?-:[^\\]\\k<\\u0061>||][\\B\\p{L}]|))[^\\p{RGI_Emoji}]{2,3}?||(?ims-:\\c_){2,3})", "flags": "v", "valid": false}
+{"pattern": "&\\p{gc=Lu}😂(?:\\w?[\\q{a}\\x41]]{3,2})b**", "flags": "v", "valid": false}
+{"pattern": "(?i:(?ii:\\x41[z-a[z-a]{2,3}|\\c)(?<b>[^&&]{2,}{1}&|\\B)[b\\B]|[&-]|(?<a>\\p{L{2,}(?i-m:\\k<a>|[\\c_]$|[.\\u{1F600}-\\u{1F602}a-\\da]))([{\\]][]|(?ims-:\\p{Lu}\\uDE00{2,}){(?i-m:{2}[{\\q{\\d}\\p{L}]{2,})?))[(\\&😀\\d]*(?ims-:([^\\cA]|[\\&{\\u{1F600}-\\u{1F602}][&&])|\\p{sc=Greek}*|\\!|[\\s\\x41])[.!!]\\k<", "flags": "v", "valid": false}
+{"pattern": "[]\\!(?i)[\\u{1F600}-\\u{1F602}]*?😀{3,2}[\\B\\!](?<b>{2,1}(?i-m:\\00(?:|a\\d{2,}){[\\db\\][^\\q{ab}]]||\\cA[])\\uDE00)(?>{1}|[\\P{Lu}](?-:(?=|\\x4[aa]?)+?(?<b>|{,2}**|){|\\k<\\u0061>?(?-:\\cA||{1})[^😀-😂}]|))|", "flags": "", "valid": false}
+{"pattern": "(?<!(?>\\p{Greek}]))", "flags": "i", "valid": false}
+{"pattern": "[^\\0[a]\\p{L}]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=&[\\-@\\c1!!])", "flags": "v", "valid": false}
+{"pattern": "😀{3,2}[b[^\\q{ab}]{\\&]", "flags": "v", "valid": false}
+{"pattern": "\\p{ASCII}\\d[\\d-a\\u{1F600}-\\u{1F602}[^\\q{ab}]]", "flags": "", "valid": false}
+{"pattern": "[^]\\p{}", "flags": "v", "valid": false}
+{"pattern": "(](?:(?<b>\\08{2,})(?-i:\\1|.)){2,3}?)[\\d-a]", "flags": "", "valid": true, "captures": 2, "names": ["b"]}
+{"pattern": "(?<$>x)+(?>[[\\p{RGI_Emoji}\\])[\\**", "flags": "v", "valid": false}
+{"pattern": "[\\uD83D\\uDE00-\\uD83D\\uDE02/-]", "flags": "", "valid": false}
+{"pattern": "[\\q{}&&][](?ims-:\\c[^}]|(?:[]||\\p{RGI_Emoji}(?i:[\\q{\\d}\\0}]\\x4?)*?)){2,3}?", "flags": "v", "valid": false}
+{"pattern": "(?=(?i)[\\q{a|bc}z-a\\d-a][\\B\\q{a}-][{\\q{}])(?<!a|){2,}", "flags": "v", "valid": false}
+{"pattern": "\\uD83D|[](?<=[\\q{}(]{3,2}|[(\\d\\&][^]\\p{ASCII})?(?i)\\B|[^\\\\s-!!]", "flags": "v", "valid": false}
+{"pattern": "(?-i:!(?<b>a)|[]|)??{,2}(?<=\\c1[[^a]])|", "flags": "v", "valid": false}
+{"pattern": "(?<a1>x)[]]|\\x4\\uD83D|", "flags": "", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "-[-](?i:[{]{3,2}\\/|(?:(?<![]+[^😀-😂&&]??))(?<b>(\\s|\\c_|)(?ims-:\\!(?<!\\a\\p{RGI_Emoji}|\\s[^]){))", "flags": "", "valid": false}
+{"pattern": "\\10\\c_|\\b{(?ii:(?i:\\p{Script_Extensions=Latn}[[a]]|[^]|\\p{Lu}(?x:\\p{gc=Lu}{3,2}[\\]]??|[^]))[\\q{\\d}@[^a][\\q{ab}]]|[\\c1--\\q{a|bc}]+?\\P{RGI_Emoji}[]|)", "flags": "", "valid": false}
+{"pattern": "\\k<[]{2}{99999999999}|\\1", "flags": "u", "valid": false}
+{"pattern": "\\c_{99999999999}[]z-a]{2,1}{2,}\\u{}", "flags": "u", "valid": false}
+{"pattern": "[\\!a\\uD83D\\uDE00-\\uD83D\\uDE02$$*?|[^]", "flags": "u", "valid": false}
+{"pattern": "(?ii:(?<!\\3(?<![!!]\\P{Ll}|[^a😀-😂!a]*?)??(?:\\d0{||\\#)|(?<![^\\cA\\!]|)(?<a1>x)+?)+)|.", "flags": "v", "valid": false}
+{"pattern": "\\k{99999999999}\\uDE00_(?x:[]??(?-:[/[\\q{ab}]]|{1}[^@]||b{2})|)", "flags": "", "valid": false}
+{"pattern": "[@\\d-a]!\\uDE00(?x:(?ims-:(?i-m:[(\\d\\p{RGI_Emoji}/]|{99999999999}\\10{)|)", "flags": "", "valid": false}
+{"pattern": "[^]+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x:[\\P{Lu}^\\q{a}])[^-😀-😂\\w\\]{3,2}\\1[](?i)a|\\p{ASCII}[|\\q{a}\\-!!]*?", "flags": "v", "valid": false}
+{"pattern": "(?ims-:[]*?(?<b>(?-i:|[\\c_[^\\q{ab}]a-\\d]*)\\p{Basic_Emoji}){2}\\p{Lu})+\\2**", "flags": "i", "valid": false}
+{"pattern": "_(?>\\a{2,}|[^[]*)(?-i:(?-i:\\B(?<=😂|a**\\k{2,})[\\d\\s])\\b{)[a-\\d\\B(@]", "flags": "i", "valid": false}
+{"pattern": "(?<a1>x)(?i:[\\d-a\\x41[^a]\\0][]{(\\p{Script_Extensions=Latn}|\\k<b>**)|(?x:z{2,3}){2,3}?|[\\-|)*?(?-:[😀-😂\\w\\!][]|){3,2}\\u{41}*?{99999999999}", "flags": "i", "valid": false}
+{"pattern": "\\-b|[\\q{a|bc}\\w\\cA]", "flags": "v", "valid": false}
+{"pattern": "&[--a\\1]\\c[a-\\d[\\w][\\Bz-a]", "flags": "u", "valid": false}
+{"pattern": "(?x:_+?(?>(?i-m:\\uD83D\\uDE00*?).{2,3}?[^\\q{}a]??||(?![^z][&])??[^\\0!][\\!]|))\\08**(?i)[-@\\c1\\q{a}][?[^\\B]", "flags": "", "valid": false}
+{"pattern": "\\3\\u{}(?<b>(?=(?i)|!\\3$)[a-z&&])[][^z-a)]", "flags": "v", "valid": false}
+{"pattern": ".\\a", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d\\x41][]\\p{Script_Extensions=Latn}{{99999999999}", "flags": "v", "valid": false}
+{"pattern": "]\\k<\\u0061>\\a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>{99999999999})(?<a>\\e|(?ii:(?<b>y)\\p{sc=Greek}??)[a.[$$]){2,3}", "flags": "u", "valid": false}
+{"pattern": "(?<a>x)|[^b-]", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?x:\\k<a>\\x41|(?i)[\\w\\d-a\\ba]+?\\8{2}\\k[}a-z\\b](?-i:[\\x41a-z[^a][a]]\\P{RGI_Emoji}", "flags": "", "valid": false}
+{"pattern": "[^[^a]z-a]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?>\\q{ab}|(?i:[-\\-]{2,3}|\\k<||{2,1}+.**\\p{}?)(?-:[}😀.]){2,}\\p{gc=Lu}{2,3}?)|)", "flags": "v", "valid": false}
+{"pattern": "[@\\d-a\\][\\q{a|bc}\\c_\\d-a]", "flags": "v", "valid": false}
+{"pattern": "[!b\\x41]+\\08{2,3}\\/", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^.\\1](?<b>(?-i:[^\\s]\\00)(?<=\\cA)|[\\w\\c_\\q{a}]){3,2}((?ims-:(?i-m:)[}\\d\\u{1F600}-\\u{1F602}]*|){2,3}[\\!b\\x41]", "flags": "i", "valid": false}
+{"pattern": "[\\q{a|bc}\\&[z-a]\\p{Lu}\\p{gc=Lu}", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}[^]\\0{99999999999}|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^!\\q{ab}$$\\p{L}]{2}(?<![])\\c_(?>[{^\\c_]\\p{Basic_Emoji}*)[\\q{\\d}\\s\\b]", "flags": "u", "valid": false}
+{"pattern": "[\\!$$\\q{a|bc}]\\1(\\uDE00|[\\B[\\q{ab}]])|(?<b>(?:[/-b\\])$??\\3|(?!(?=[^\\-][]\\B^]{3,2}[\\P{Lu}!!]|\\p{Lu}{2}|[^\\B@\\b]|😀)(?<a>[!!]\\c_|[|]\\w(?x:\\w\\c_))|[}]{2}){2,3}{2,1}", "flags": "v", "valid": false}
+{"pattern": "[\\0\\-.[a]](?-:(?ims-:(?<={1})(?=\\p{}\\c_|\\uDE00)[\\&]??|))", "flags": "i", "valid": false}
+{"pattern": "(?ims-:(?i-m:[\\p{RGI_Emoji}😂-😀]&(?-i:))|(?-i:(?ims-:\\c1|][^😀-😂\\p{RGI_Emoji}]{2,3}?|[z-a!!]*?(?>\\b{2,3}|[\\c_\\u{1F600}-\\u{1F602}[](?=+)[]){[\\b\\!\\s]+)*?(?-:\\1|\\P{Ll}{99999999999}|[]{){3,2}[^\\p{RGI_Emoji}/\\q{a|bc}]([])+", "flags": "", "valid": false}
+{"pattern": "\\k<[\\P{Lu}\\\\p{RGI_Emoji}](?:(?i-m:[&]{2})[\\u{1F600}-\\u{1F602}\\uD83D\\uDE00-\\uD83D\\uDE02\\q{}]??[\\q{}\\s])", "flags": "i", "valid": false}
+{"pattern": "[](?![\\c1](?<a1>x)|[\\q{a|bc}\\q{ab}}]\\12)", "flags": "", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "[@\\c1z--](?<a>\\uD83D\\uDE00*?(0)$)$\\&^", "flags": "u", "valid": false}
+{"pattern": "(?>{2,1}{2,}|\\d??){2,3}|(?ims-:[😂-😀\\c_\\c1]\\a)(?-:(?:(?!\\8)[^\\p{RGI_Emoji}]|!\\p{L})\\a\\b+)[\\c_(][\\c1b\\P{Lu}\\q{a|bc}]", "flags": "v", "valid": false}
+{"pattern": "\\3", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]{2,}|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:\\k<|(?=\\x41\\e*?|\\p{L**)(?<!\\uD83D(?-i:[^]]{2,}{3,2}\\uD83D)[^]|[]*[\\B\\x41]))\\u{}[)!!\\s](?ims-:(?i-m:(?<b>\\uD83D|)|(?-:\\p{L\\B{3,2}\\x4){2})**|[]*)[!--]", "flags": "v", "valid": false}
+{"pattern": "[\\c_&\\x41\\d]", "flags": "v", "valid": false}
+{"pattern": "[\\q{ab}\\d-a\\cA\\c1]\\k<(?-i:(?<b>y){3,2}|\\B)[😂-😀\\!\\p{L}]((?!(?<$>x)(\\uD83D{2,3})){2,})", "flags": "v", "valid": false}
+{"pattern": "[]\\12[.z-az-a]\\2\\k<b>", "flags": "v", "valid": false}
+{"pattern": "(?<b>(?<a>(?>\\-\\/|\\uD83D\\uDE00|!){2,3}?|\\u{1F600}{2,}[a$$\\p{L}]\\b)[^]?)[^a-\\d](?i)(?<\\u{61}>x)??[^^@{\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "v", "valid": false}
+{"pattern": "(?:[😀])\\p{gc=Lu}(?<=(?<=😂(?!|)|(?<a>ba{2,}||\\uD83D{2,}[^\\q{}b[\\q{ab}]\\c_]))(?i)[[\\q{ab}]&&a-\\d][\\1][][\\uD83D\\uDE00-\\uD83D\\uDE02\\p{RGI_Emoji}{}])(?-:[[\\q{ab}]\\uD83D\\uDE00-\\uD83D\\uDE02)\\]+\\u{1F600}[😂-😀!&&\\-]|(?<!(?<b>\\p{Basic_Emoji}|)+){2,3}?)|", "flags": "v", "valid": false}
+{"pattern": "\\0?", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}{[]+?[\\P{Lu}\\1+", "flags": "v", "valid": false}
+{"pattern": "\\3{", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "$[\\p{RGI_Emoji}😂-😀]{2}", "flags": "i", "valid": false}
+{"pattern": "[\\\\q{ab}](?<!(?ii:\\u{}}?|\\q{ab}{|-{){2}(?<a>(?ims-:\\d\\p{sc=Greek}{2,3}?)|(?<=[\\q{a}\\B[][])\\p{gc=Lu}\\00)||(?:[]|(?<b>y)){|(?i-m:(?i:[\\q{a}\\1]|){|[!&&😀])\\8)", "flags": "v", "valid": false}
+{"pattern": "(?i:([]?)**)", "flags": "u", "valid": false}
+{"pattern": "\\p{gc=Lu}[!!](?<a1>x)+(?i-m:(?<b>(\\u{1F600}|{2,1}))(?i)[][^!\\-\\w]{1}||[\\0](?<a1>x){2,3}?(?-:[^]|\\k<?[\\!/\\c1-]{3,2}|(?<![]|\\P{Ll}{2,3}?|[^\\!.]\\8)*?){)+?\\u{}", "flags": "", "valid": false}
+{"pattern": "[]]😂(?=[@a-z\\cA](?:[\\c_😂-😀]![]?)|(?>(?ii:\\p{gc=Lu})+||(?ii:\\s+)*?))-", "flags": "v", "valid": false}
+{"pattern": "\\u{}(?ims-:\\q{ab}{2}(?=\\/(?:[.]||\\10\\&)(?<![^!!(\\w{]\\P{RGI_Emoji}{2}){2,3}|\\k)(?i)[^[^\\q{ab}]😀$$]{2,3}(?<b>y)\\00|[]||(?-i:(?ii:\\10|[^\\]]){2,3})[\\q{}\\s&(]😀*?)", "flags": "v", "valid": false}
+{"pattern": "[}!!]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<\\u{61}>x)??|b[^)]|[\\u{1F600}-\\u{1F602}\\d[a]\\!]{2,3}?", "flags": "", "valid": false}
+{"pattern": "[\\b\\P{Lu}[a]]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<\\u{61}>x)((?>[^z-aa-\\d\\]](?-i:{99999999999}{2}|\\p{L)?|\\cA^)(?<a>[\\P{Lu}.])(?ii:(?<a>\\k<)|!(?-:(?-:\\k})\\k<b>))", "flags": "v", "valid": false}
+{"pattern": "[\\c1\\-]{2}|\\1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12\\p{L|[^]+b(?=\\/)", "flags": "u", "valid": false}
+{"pattern": "(?!(?x:[\\0\\d]\\k<b>))]+(?i:(?=[\\p{L}b][^]{|[^\\B])[^]\\p{sc=Greek}{3,2}|\\00*|(?<b>(?>\\p{}{99999999999}?\\/$))[]", "flags": "v", "valid": false}
+{"pattern": "(?i)\\10(?<b>(?x:[^[a]a&&\\u{1F600}-\\u{1F602}]?[^[^a]a-z)\\uD83D\\uDE00-\\uD83D\\uDE02]){3,2}(?:||?\\b){|[&&]||(?<!\\p{sc=Greek}**\\P{Ll})[^&&\\P{Lu}(?-i:{2,3}?[\\u{1F600}-\\u{1F602}😂-😀😀][😀\\w\\q{ab}\\&]))", "flags": "v", "valid": false}
+{"pattern": "[^]??[()&&{]\\#|\\c1*?\\0", "flags": "v", "valid": false}
+{"pattern": "[^!!]\\0", "flags": "v", "valid": false}
+{"pattern": "\\e{3,2}[\\!\\c_\\q{}]{2,}\\00|", "flags": "v", "valid": false}
+{"pattern": "😂{2,3}?(?i)(([][|]{2,3}?-**||\\u{41}[]|\\3)(?!**[])[[a][^a]])(?i:(?i-m:\\uD83D){2,3}?(?<b>\\2))??", "flags": "v", "valid": false}
+{"pattern": "(?<=(?i:\\p{gc=Lu}${2,}){2,}(?<=![\\cA)]\\p{})\\uD83D\\uDE00)\\uDE00(?i-m:\\10(?i)a(?i:[\\d-a][--][^😂-😀\\1]{2}|[^-[a])/][\\cA\\1[)][^]))\\q{ab}|[\\P{Lu}\\uD83D\\uDE00-\\uD83D\\uDE02--]", "flags": "i", "valid": false}
+{"pattern": "0[][bbz-a[\\q{ab}]]|z|[^\\bz[^\\q{ab}]]", "flags": "u", "valid": false}
+{"pattern": "[z-a\\s", "flags": "i", "valid": false}
+{"pattern": ".?[z\\0[^\\q{ab}]](?<![\\q{a|bc}@[\\q{ab}]b]\\10[\\c_!!])(?i:[^a-z\\q{}|][--]**\\p{L})\\k<b>", "flags": "u", "valid": false}
+{"pattern": "\\p{Script_Extensions=Latn}[]😂??", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>(?=[^\\B[^\\q{ab}]]){3,2}|(?<a>x))", "flags": "v", "valid": false}
+{"pattern": "(?i:(?-:😀{3,2}\\p{}(?>😀))(?<![^\\q{\\d}](?=\\u{1F600})!+?)|\\P{RGI_Emoji})](?:[^a-z]?){2}", "flags": "", "valid": false}
+{"pattern": "[\\x41]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\uD83D[](?!\\p{})", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:(?i:\\a*(?:{2,1}\\p{gc=Lu})[@]*)(?=\\08)_", "flags": "v", "valid": false}
+{"pattern": "(?-i:[\\q{a}|[^a]\\&]|[\\p{L}\\p{L}/\\]|)", "flags": "i", "valid": false}
+{"pattern": "😀(?ims-:(?:\\uD83D\\uDE00(?ims-:{99999999999}??|[]{2,3}?))*?\\k<a>\\cA|(?:(?-:\\uD83D[^\\1/a]||$[\\0]\\-)\\s[/{]|[^{\\-a\\!]))", "flags": "i", "valid": false}
+{"pattern": "(?ims-:(?>\\s\\w\\10{3,2})*\\P{Ll}\\1+|[\\&](?=!\\c\\k*|\\B[^\\q{a}z}a])?\\08)\\p{L*?", "flags": "v", "valid": false}
+{"pattern": "!(?>(?<=(?ii:[|\\]--(]{2,}[^!}]|[\\q{ab}a[^\\q{ab}]]{2,3}?)|)[^\\uD83D\\uDE00-\\uD83D\\uDE02]{2,}||\\u{41}|)[\\c1\\d-a&&$$][^[^a]\\cA!!\\-]", "flags": "", "valid": false}
+{"pattern": "[-][\\!!([\\q{ab}]]|\\c_(?<b>\\-*?[^]?|[|]|\\a|(?ii:\\P{RGI_Emoji}|\\p{Greek}))", "flags": "u", "valid": false}
+{"pattern": "😀(?i-m:\\p{}{2,}(?<b>\\k<a>)\\u{}){2}[z-a.]|(?ims-:\\08{2}\\12){2}|", "flags": "", "valid": false}
+{"pattern": "(?<a>x)(?<b>[}\\da-\\d])\\0(?i-m:(?-i:(?<b>\\2)??\\u{41}{2,3})*?)😂", "flags": "v", "valid": false}
+{"pattern": "(?:😂$(?-:(?<=😂$)\\k<a>+?)(?<a>\\k<\\u0061>?)\\8", "flags": "v", "valid": false}
+{"pattern": "(?=[](?<!\\P{Ll}|(?ims-:[^z{]]+?\\x41||)(?ii:))){2}\\-z", "flags": "u", "valid": false}
+{"pattern": "\\uDE00", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\#[\\w\\x41\\P{Lu}\\u{1F600}-\\u{1F602}]+😀{2,}(?i:[^\\u{1F600}-\\u{1F602}[[[\\q{ab}](]|(?i-m:[\\q{a|bc}$$](?!\\-|\\p{Lu}{1}\\!**)[^\\c_\\0{]){2,3}?)(?<b>\\12){2}", "flags": "", "valid": false}
+{"pattern": "\\0", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!!)a-z](\\!(?i:\\k)|\\x41*?(?![^-(\\c1\\q{ab}][\\uD83D\\uDE00-\\uD83D\\uDE02\\1.]{2}[^\\uD83D\\uDE00-\\uD83D\\uDE02])[^)\\d]{2,}", "flags": "v", "valid": false}
+{"pattern": "[\\sb]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "^[^]|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\2|\\u{1F600}(?<b>(?i)b[^\\]\\d\\cA[\\q{ab}]]|[\\u{1F600}-\\u{1F602}@](?x:{2,3}[\\b\\s\\q{\\d}]{2,3}|\\p{gc=Lu})?(?<a>b+?||))", "flags": "", "valid": false}
+{"pattern": "[]??", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "😂", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:(?-i:(?i-m:[\\uD83D\\uDE00-\\uD83D\\uDE02[^.}$$]\\P{RGI_Emoji})(?<=\\u{41}|-+[!\\s.]{){))+?|[\\P{Lu}]*(?ims-:(?<b>\\12\\w{2,3}|\\p{Lu}(?=[]|\\w|(?<$>x)){2,3}[^[^\\q{ab}]\\q{a|bc}[a]])(?-i:(?-i:[^\\1/@]??**[[\\q{ab}]b])\\u{}{\\p{sc=Greek}|(?=[]??{,2}|))*|[^\\0\\cA\\0\\c1]*)[]", "flags": "v", "valid": false}
+{"pattern": "[^\\p{L}{2}", "flags": "", "valid": false}
+{"pattern": "[&&\\c_](?<a>\\8??(?i:(?<a1>x)\\b)[])|(?<!z|\\p{Greek}{3,2}[\\b--b]){2,3}?|", "flags": "i", "valid": false}
+{"pattern": "]{3,2}\\w", "flags": "i", "valid": false}
+{"pattern": "[\\u{1F600}-\\u{1F602}{|](?ii:[b😀-😂/a-z])[\\q{\\d}😀-😂\\c1](?<a1>x)\\12", "flags": "u", "valid": false}
+{"pattern": "[-😀]*?", "flags": "v", "valid": false}
+{"pattern": "{1}\\p{L(?>{99999999999}(?=(?ims-:[]\\k<a>)))", "flags": "", "valid": false}
+{"pattern": "[\\b\\cA]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=($(?-i:[😀-😂a|]{2,}[\\q{\\d}😀(]|)*?)){2,}-\\00\\8(?x:(?ims-:\\10\\cA)**$??)", "flags": "", "valid": false}
+{"pattern": "{2,1}[-a😂-😀\\1]{[)]*(?x:[\\x41\\dz-a]\\x41\\uD83D**|_(?ii:\\p{L\\w[/\\cA]|(?:{2,1}[\\1]{3,2}[]|)\\08|[\\]]+)|${2,})", "flags": "u", "valid": false}
+{"pattern": "[\\cA[\\q{ab}]\\q{a|bc}][]{2,3}[^[^a]}]|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]{2,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b\\q{a}}\\s]\\3}\\uDE00??", "flags": "v", "valid": false}
+{"pattern": "(?:[z-a\\b\\s[a]]){2}\\/(?<b>-[]\\c1|)|", "flags": "i", "valid": false}
+{"pattern": "(?i)a|[\\q{a|bc}]{2}\\d(?>(?<a>[^]??(?i:\\1*)\\08|){2,3}?(?i-m:[\\d]-)(?-:\\p{ASCII})|(?<b>\\p{Script_Extensions=Latn}|((?i)[a.]\\0\\k(?<![^😀\\1\\1]|\\p{gc=Lu}||[^[^a]!]|[^\\b\\q{\\d}]\\b**){2,3}|(?=]{2,}|[^\\p{RGI_Emoji}\\cA\\-]{3,2}||)|[\\c1])?\\cA{2,3}(?i)\\00[\\p{L}z-a&!](?i:[]0+)", "flags": "v", "valid": false}
+{"pattern": "(?<!\\p{L)(?i:(?!(?<a>*[^\\!😂-😀\\1]{2})|)|\\08)\\k<\\8[[{", "flags": "u", "valid": false}
+{"pattern": "(?=[^\\c1\\q{ab}]*\\p{Lu})??\\P{Ll}\\p{L}{2,3}_??[z😀]{", "flags": "v", "valid": false}
+{"pattern": "[{[\\q{\\d}]\\08{2}", "flags": "v", "valid": false}
+{"pattern": "\\k<(?-i:\\0)[^\\p{L}][]??", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}(?-i:\\q{ab}|(?<=[](?<={2}||[[a]]0{2,3}?|)[!\\0a-\\d]))(?<$>x)", "flags": "v", "valid": false}
+{"pattern": "[\\&\\c1\\1]{2,3}?[\\d-a\\\\1|]{((?i)\\&](?-:{3,2}[\\wa-\\d])|[\\q{a|bc}z-a)]{2,3}?(?ims-:\\B\\1||??)[\\-\\uD83D\\uDE00-\\uD83D\\uDE02a-\\d]+?||(?!0[^[!!z\\b]**[^{2})\\k<\\u0061>\\p{RGI_Emoji}?)|", "flags": "i", "valid": false}
+{"pattern": "[\\cA](?-i:[\\cAz-a\\1a-z])[\\]\\q{ab}\\uD83D\\uDE00-\\uD83D\\uDE02\\q{ab}]", "flags": "u", "valid": false}
+{"pattern": "[\\])|]", "flags": "v", "valid": false}
+{"pattern": "[[^\\q{ab}]](?:\\00**[\\d-a@[]\\p{}+[^😂-😀[^a]@\\u{1F600}-\\u{1F602}]", "flags": "", "valid": false}
+{"pattern": "(?i)(?:(?i-m:[^[^a]]|\\x41+?z){2,3}{,2})[[^\\q{ab}][a]{[a]][\\p{L}$$\\&\\-](?ii:[^\\q{}\\u{1F600}-\\u{1F602}[^\\q{ab}]\\q{}])b", "flags": "i", "valid": false}
+{"pattern": "[[^a]\\P{Lu}\\w]+?(?:[\\p{L}z]+?(?<b>[\\c1\\q{a|bc}}a-z]+?|[^\\{(a][]|({3,2}(?<!^\\p{RGI_Emoji}))|[\\u{1F600}-\\u{1F602}\\p{L}]+(?<!\\/(?<=\\w**||[\\]\\p{RGI_Emoji}](?<$>x)$))(\\uD83D\\uDE00{2,3}(?i-m:\\cA\\k\\08)+?)+?[][\\P{Ll}", "flags": "v", "valid": false}
+{"pattern": "{\\cA[^\\]{\\s](?i)[\\\\😂-😀\\p{RGI_Emoji}](?<=(?<!|{1}|)|){2}(?-i:(?x:(?ii:\\p{Basic_Emoji})?[^a-]|&(?>\\w])){2,3}?)", "flags": "v", "valid": false}
+{"pattern": "[}\\uD83D\\uDE00-\\uD83D\\uDE02-\\x41](?i:[$$\\[\\q{ab}]\\q{}](?x:b[^])**[b|[])[]{2,3}[\\uD83D\\uDE00-\\uD83D\\uDE02z-a[^\\q{ab}]\\q{}]", "flags": "u", "valid": false}
+{"pattern": "$(?<a>(?i:\\p{Basic_Emoji}.)*(?!^)\\00)[]", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "(?-i:\\12a(?>[^]|[]b)]**\\1)|(?-:a(?<=[\\x41]|\\p{Script_Extensions=Latn}|)[])[\\P{Lu}\\d$$\\!])\\p{ASCII}", "flags": "v", "valid": false}
+{"pattern": "(?>(?<b>[(😀-😂!][\\q{a}\\]]{2,}\\p{sc=Greek})[^\\p{L}])", "flags": "i", "valid": false}
+{"pattern": "[\\cA]\\00|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0\\00[[]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "$[\\c1]0", "flags": "v", "valid": false}
+{"pattern": "\\P{Ll}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?![[]{2,}\\p{RGI_Emoji})?\\a(?i-m:[&}])|[]*?", "flags": "v", "valid": false}
+{"pattern": "\\w[^&&\\.]{2}(?<!(?-:(?<$>x)|\\x4{3,2}(?<\\u{61}>x)|)\\p{Script_Extensions=Latn}|(?-:\\q{ab}\\p{Lu}(?=|{2,1}*?[(\\p{L}[\\q{ab}]])*|(?i)[[\\q{ab}](]|\\c{2,})\\/[^[\\q{ab}]-\\w]{2})[\\d-a]|", "flags": "u", "valid": false}
+{"pattern": "(?i-m:[(\\]]{3,2}|[[^a]]*\\u{}\\00?)|(?>[(?i-m:[)\\q{}b!!][]|){)", "flags": "v", "valid": false}
+{"pattern": "(?x:\\x41[]{\\w|\\2|(?i)(?<!\\k|\\c_\\p{}[]){3,2}\\k|.*?(?<b>[]))\\u{1F600}{2,3}", "flags": "i", "valid": false}
+{"pattern": "[^](?-:[^|\\p{RGI_Emoji}\\1](?-:[!(]\\12.)(?<a>]{3,2}\\x41(?>(?<$>x)|)|))", "flags": "i", "valid": false}
+{"pattern": "😂{([^--[^\\q{ab}]b*?|{1}|[😀-😂a-z😀-😂\\s]+|){2,3}?(?-i:[]((?<b>|[$$\\-[\\d-a])(?-i:\\p{gc=Lu}(?=$0|[\\-$$-]\\1)(?-i:[\\q{a|bc}}(]??|[!!\\q{ab}\\0{)??))(?<b>y)\\x41+?", "flags": "u", "valid": false}
+{"pattern": "[\\cA]|--{2,}\\p{}+?[]\\x41", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": ".{2,3}?(?ims-:[^})]+\\k<a>[\\d-a&--(]|(?i)(?>??\\w)*?[^]*?(?=\\u{}(?<b>y)))*?", "flags": "", "valid": false}
+{"pattern": "\\0[^](?ims-:[]{)", "flags": "u", "valid": false}
+{"pattern": "$[]/]", "flags": "v", "valid": false}
+{"pattern": "\\u{1F600}(😀z&??||[[\\-[\\q{ab}]]?&)]|(?ii:[^\\b\\x41\\q{\\d}]|\\cA[\\1--(]{2})|", "flags": "u", "valid": false}
+{"pattern": "0*?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ims-:[^\\w]]]*?){(?ims-:[&&\\uD83D\\uDE00-\\uD83D\\uDE02\\d-a\\P{Lu}]{99999999999}(?x:[[a]]\\10|[^\\P{Lu}\\x41]|(?<=\\k<?))|[][\\c_]{2,}\\x4)[^|\\p{L}!!😀-😂](?<b>y)(?-:(?<a1>x)(?-i:\\p{Lu}|\\q{ab}))", "flags": "i", "valid": false}
+{"pattern": "(?<b>\\uD83D\\uDE00\\00{2,3}[])?[\\cAb^]{2,3}[\\b\\q{}\\q{ab}]|(?-:[\\q{a}])", "flags": "u", "valid": false}
+{"pattern": "\\p{Lu}z", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "0\\P{Ll}??\\p{Greek}", "flags": "v", "valid": false}
+{"pattern": "\\c{?\\uD83D\\uDE00+", "flags": "v", "valid": false}
+{"pattern": "\\k<a>-\\2(?<={2,1}\\![^\\q{a|bc}]|\\p{Script_Extensions=Latn})?(?i)\\k<a>\\P{RGI_Emoji}|\\12", "flags": "i", "valid": false}
+{"pattern": "\\8\\p{L", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]]|\\P{Ll}*?{1}{2}|", "flags": "i", "valid": false}
+{"pattern": "(?i:(?-:(?<!-|)*){2}[!!😀-😂\\d]|[^\\d😂-😀]-[]/])[/\\q{a|bc}]", "flags": "", "valid": false}
+{"pattern": "\\c_?(?=\\p{Basic_Emoji}\\10+?(?>(?>z+[])*(?:(?x:\\p{Script_Extensions=Latn}[])+[\\u{1F600}-\\u{1F602}]|0))(?i:[\\c1\\p{RGI_Emoji}]|😀|(?<=[\\P{Lu}\\uD83D\\uDE00-\\uD83D\\uDE02\\&]|(?i-m:[b([\\q{ab}]\\q{\\d}])(?<!\\P{Ll}|😀\\p{Basic_Emoji}{2,3}))?(?>_(?i:)|[^[\\q{ab}]]]|\\P{RGI_Emoji}{2,}(?<$>x)[&--/]))*?", "flags": "i", "valid": false}
+{"pattern": "(?<$>x)", "flags": "i", "valid": true, "captures": 1, "names": ["$"]}
+{"pattern": "\\&{3,2}\\3[\\uD83D\\uDE00-\\uD83D\\uDE02]", "flags": "i", "valid": false}
+{"pattern": "[\\&]+[]\\]]", "flags": "v", "valid": false}
+{"pattern": "\\-(?i-m:😀(?<=\\P{Ll}[\\-])\\u{})\\uDE00{\\0{", "flags": "v", "valid": false}
+{"pattern": "\\P{RGI_Emoji}(?i-m:\\k<b>*&{3,2}[^]\\uD83D\\uDE00-\\uD83D\\uDE02]+?|)", "flags": "v", "valid": false}
+{"pattern": "\\u{1F600}|[😀\\uD83D\\uDE00-\\uD83D\\uDE02\\!|]+?(?i)(?i-m:(?i:**|\\-)\\p{Lu}|(?ii:]{2,3}?\\12?[\\1!!]|){2,3}$(?<b>\\p{Basic_Emoji}[^!\\p{L}\\d])|)*?[]\\k<\\u0061>", "flags": "i", "valid": false}
+{"pattern": "[/\\b\\-\\b](?i:[z!]??[😀--]\\b)[^[^\\q{ab}]]{2,}(?<=(?>[😀\\]/a-z]))??", "flags": "v", "valid": false}
+{"pattern": "(?ims-:[]\\2\\p{}){2,3}?b\\&{1}", "flags": "v", "valid": false}
+{"pattern": "(?ims-:\\uDE00?(?<a1>x)|[😀\\1.\\c1])(?i:\\!\\s[z😀-😂\\q{a|bc}]|[\\1])(?<a1>x)[^]", "flags": "v", "valid": false}
+{"pattern": "[^{@a-\\d\\b][&&]\\P{RGI_Emoji}", "flags": "v", "valid": false}
+{"pattern": "(?-:\\uD83D[^b}\\p{L}](?-:\\uDE00\\p{sc=Greek}{2,3}?|\\p{ASCII}+)|(?i)\\k<\\u0061>(?-:\\1|[]))|[^\\!](?:[[^\\p{L}\\p{L}][^😂-😀a-z|\\&]\\-?", "flags": "i", "valid": false}
+{"pattern": "\\p{Greek}[^|\\cA\\0😂-😀](-{2,})a", "flags": "i", "valid": false}
+{"pattern": "[\\B\\q{a|bc}\\uD83D\\uDE00-\\uD83D\\uDE02]z??", "flags": "", "valid": false}
+{"pattern": "[\\&{--]\\-(?i-m:(?<!(?x:*[\\p{RGI_Emoji}]|\\a😂){2,})", "flags": "i", "valid": false}
+{"pattern": "(?i-m:\\#|[\\w\\uD83D\\uDE00-\\uD83D\\uDE02&z-a](?i)[😀\\u{1F600}-\\u{1F602}\\s](?i:[^\\1|z-a|\\k<?|[z-a]]{1}[[z-a]+?|)**{2})[)[\\q{ab}](!!]|(?x:[\\x41]{2}^(?=(?-:.[])[^-a\\x41]))[^z-a]", "flags": "i", "valid": false}
+{"pattern": "\\k<b>(?<!{\\p{RGI_Emoji}|[\\c_\\p{L}bz](?-:\\00\\p{ASCII}{2,3}?|(?i-m:\\p{RGI_Emoji}|{99999999999}+?{3,2}(?i-m:!|\\q{ab}[]\\#)\\2)[\\q{ab}]*?)(?<a>${2,3}?(?<\\u{61}>x)(?!(?<b>[\\x41]{2,3})\\k<\\u0061>{2,})|\\p{RGI_Emoji}[])", "flags": "i", "valid": false}
+{"pattern": "\\k<b>[\\s](?<=[\\cA[^a]]{3,2}|[!!a-zz-a@][-\\p{RGI_Emoji}]|)[.]{2,3}|\\00", "flags": "u", "valid": false}
+{"pattern": "[^\\&^]\\cA\\p{Basic_Emoji}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:z|)(?ii:(?<!\\P{Ll}))", "flags": "", "valid": false}
+{"pattern": "\\p{Lu}(?>(?<b>[\\q{a}\\b(]+)**${[]|\\p{ASCII}??)\\P{RGI_Emoji}", "flags": "", "valid": false}
+{"pattern": "[^)\\b.^]?0(?i)(?i)(?<!.{\\c1){2,3}{2,3}[\\P{Lu}[\\q{ab}]]||\\p{RGI_Emoji}{[^\\&a-z😀-😂\\P{Lu}(?!\\00\\#)", "flags": "v", "valid": false}
+{"pattern": "\\p{L}+?\\2(?<!\\k<b>)[]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<![z]!{2,1}?)(?<b>[^\\p{L}{](?<$>x)(?ims-:[^]()[&&]))[^a-z\\0😂-😀][\\P{Lu}|]\\-{3,2}", "flags": "", "valid": false}
+{"pattern": "(?-:(?=[^\\u{1F600}-\\u{1F602}]+?\\p{Lu}|[^😀\\x41^](?>\\p{L}[\\b][!!!\\q{ab}]|{,2}){2,3})+|(?!\\p{ASCII}[&^\\&\\uD83D\\uDE00-\\uD83D\\uDE02](?<b>-[&)]+?|[]))(?>0\\k<b>|(?i)[\\d-a&\\q{\\d}][^$$z\\c_$$]+)+)\\/😀+\\10", "flags": "v", "valid": false}
+{"pattern": "[^]{3,2}|(?i:{[\\d]|[b{]|[^-!][{\\q{\\d}$$]{2,3}?[])[", "flags": "", "valid": false}
+{"pattern": "[^.\\q{\\d}a]", "flags": "u", "valid": false}
+{"pattern": "\\2\\p{RGI_Emoji}(?<=[[\\q{ab}]&z-a&](?ii:(?ims-:\\d\\p{ASCII}{2,}{2,3}|)|\\/){2}[^\\p{L}\\0$$]]|", "flags": "u", "valid": false}
+{"pattern": "(?-:[^\\u{1F600}-\\u{1F602}\\wa][^\\c1-](?<!(?>[^{2,}|[[^\\q{ab}]$$😂-😀]**[])*)|(?i)\\k*?)(?i)[^]?|[\\c_\\d](?<a1>x)[\\P{Lu}][\\u{1F600}-\\u{1F602}]", "flags": "v", "valid": false}
+{"pattern": "\\p{L}\\#", "flags": "v", "valid": false}
+{"pattern": "(?<b>\\a[[^a]a-\\da\\-]|😂?)*", "flags": "u", "valid": false}
+{"pattern": "[\\d-a()](?<$>x){\\-[\\]]", "flags": "", "valid": true, "captures": 1, "names": ["$"]}
+{"pattern": "[^\\p{ASCII}{2,3}?", "flags": "i", "valid": false}
+{"pattern": "[]\\k<|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:[z-a|!!]\\cA|[^&]\\00??)(?ims-:(?!b{2,}|[\\!\\!{[a]]))\\e", "flags": "u", "valid": false}
+{"pattern": "[\\0\\w]|[](?<=(?i)\\w{2,}|(?:[[^a][^\\q{ab}]]||b{3,2}{3,2}[^}@😀])(?!\\p{L}|)+{2,3}|\\p{Script_Extensions=Latn})", "flags": "i", "valid": false}
+{"pattern": "(?>(?>[]|)\\08)[^\\d\\\\P{Lu}$$][]", "flags": "v", "valid": false}
+{"pattern": "(?<=(?ims-:(?i)??\\uDE000*?(?-:(?<\\u{61}>x)[^])|[^\\Ba-z[b]&*?(?=[\\&&$$]\\P{RGI_Emoji}{2,3}?[])))\\x41*((?-i:[)??[\\q{a|bc}\\d-a.][\\][^\\q{ab}]]??|_*\\x4(\\8(?-i:[\\q{ab}\\&/a]|\\p{Basic_Emoji}{2,3}?)|\\B[.\\q{a}]))|[^z-a\\d\\P{Lu}]", "flags": "u", "valid": false}
+{"pattern": "(?=^(?i:\\x41*(?<a1>x)**|(?-i:[\\d-a\\d-a\\uD83D\\uDE00-\\uD83D\\uDE02]\\p{L*?[]|[^\\1])\\&{2,3}|\\k)(?-i:\\8|[\\d[^a]ab]|(?<a>(?<b>\\&\\12[^\\q{ab}\\&\\1b]||\\e)??|(?-i:|\\p{L))\\p{Lu}{2}\\c_|){2,3}?", "flags": "i", "valid": false}
+{"pattern": "(?i)(?>(?-:\\uDE00|\\p{Lu}*[][^a-\\d[^\\q{ab}]\\w)])??|(?>][[^a]]\\c_[^\\q{ab}]]{2,3}.)|)|(?ims-:(?i-m:\\P{Ll}[^\\d[\\q{ab}]z-a\\-]|{2,3}?\\p{ASCII}))\\p{RGI_Emoji}[z[^\\q{ab}]$$@]+?", "flags": "", "valid": false}
+{"pattern": "[\\P{Lu}!z-a](?ims-:}{3,2})(?<b>y)|", "flags": "v", "valid": false}
+{"pattern": "\\c1[^[^a]\\q{\\d}[^a][\\q{ab}]]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^.a\\w[\\q{ab}]][$$\\]]{3,2}{99999999999}|\\c_(?i-m:(?<a>[^!\\d-a&]|[)].{3,2}\\12)|\\p{ASCII}+?)", "flags": "v", "valid": false}
+{"pattern": "][](?i)(?<=\\e{2,3}[😀-😂[^\\q{ab}]])\\uDE00(?i-m:\\p{L|\\cA(?<a1>x)+?){2,}(?<a>(?<=[^])+?$\\c){[|]", "flags": "i", "valid": false}
+{"pattern": "\\2([^\\c_\\][^\\q{ab}]]*?\\p{Greek}\\u{1F600}{2,3}|[\\0\\q{a|bc}\\-]\\p{Greek}\\x4(?-i:(?:&(?x:\\p{RGI_Emoji}??)|(?ii:\\a[]+[z\\d-a[\\q{ab}]b]|)(?<b>y)\\0){2,3}?", "flags": "u", "valid": false}
+{"pattern": "(?<\\u{61}>x)*\\uDE00(?![!\\Bz]*[\\q{a}][\\B\\u{1F600}-\\u{1F602}]{2,3}|[^\\c_[^a][^a]](?-:(?>|){2,3}[^\\P{Lu}])??)[]", "flags": "u", "valid": false}
+{"pattern": "\\08*?[^\\a\\p{L}]{\\3**\\a**", "flags": "v", "valid": false}
+{"pattern": "\\#\\uD83D\\u{}", "flags": "u", "valid": false}
+{"pattern": "(?<=(?=^(?ims-:\\k[\\!{2,}[\\P{Lu}]+?|${2,})))\\0", "flags": "i", "valid": false}
+{"pattern": "(?<b>[\\d\\q{}(-]|[\\p{RGI_Emoji}\\q{a}*?[^b@\\])[\\cA}]*\\/\\p{sc=Greek}", "flags": "i", "valid": false}
+{"pattern": "z[a-zz-a[\\b]", "flags": "v", "valid": false}
+{"pattern": "(?<a>x)(?x:[][[a]\\p{L}\\uD83D\\uDE00-\\uD83D\\uDE02\\b])[[\\q{ab}]]{2,3}|", "flags": "v", "valid": false}
+{"pattern": "\\uD83D\\uDE00\\uD83D😀", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1**(?-:\\p{Greek}\\/)(?<b>(?i)([\\q{a}]]|[]|)\\k<a>[\\da-\\d^][^!!z\\q{ab}\\w]\\e|[|]**.*[]{2,3}?)[\\q{\\d}a!!]", "flags": "i", "valid": false}
+{"pattern": "\\p{ASCII}[^\\cA&|\\u{1F600}-\\u{1F602}]{|", "flags": "i", "valid": false}
+{"pattern": "(?-:\\k<\\u0061>[!.](?<b>(?:{2,1})\\k<a>{))\\P{Ll}|[!}\\]]??\\P{Ll}{2}", "flags": "v", "valid": false}
+{"pattern": "\\uD83D\\d(?<b>y)", "flags": "v", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "[\\c_$$\\p{L}[^\\q{ab}]](?i)-{2,3}[^\\w\\cA", "flags": "", "valid": false}
+{"pattern": "\\1(?>([a-z](?<b>\\p{Greek}))|(?:[]|[^]*\\uDE00😀**|){2,3}\\x4)(?>[\\P{Lu}]]\\-||[\\q{ab}!--@]+?((?x:\\x4|[\\x41\\p{L}.])|(?<a>)[\\q{a}&&]))**b*?", "flags": "v", "valid": false}
+{"pattern": "[\\d-a({]+[[^\\q{ab}]{2,3}(?<![}z-a{)", "flags": "v", "valid": false}
+{"pattern": "[^[^a]](?i:z{2,3}[^[z-a](?<!(?=[^]|😂**){2}|(?<a>x)|))\\e\\2(?<!(?i)\\p{gc=Lu}(?<b>y)|(|[[😀]\\&)+[😀-😂$$\\0\\]*||(?:(?<a>)*(?-i:|[\\]]{2,3}?\\e_+)(?ims-:[\\sa[]){2,})*[\\q{\\d}]]z)", "flags": "v", "valid": false}
+{"pattern": "(?i)(?![^])+\\uD83D*?|[😂-😀\\q{}](?-i:😀**[|\\d-a@]|\\x4\\p{RGI_Emoji}|)", "flags": "i", "valid": false}
+{"pattern": "(?<b>(?i)[\\q{a|bc}-]*(?>{2,}\\p{L|{1}(?<$>x){)[^\\q{ab}\\p{L}\\q{a|bc}][^]\\00", "flags": "", "valid": false}
+{"pattern": "[^)]\\B[\\d-a&&]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[}\\B\\c_]\\a?", "flags": "v", "valid": false}
+{"pattern": "(?!(?<b>][^&-\\B]){){3,2}(?x:\\u{1F600}\\p{gc=Lu}*?[\\q{a}}a-z]?)?(?<![^\\uD83D\\uDE00-\\uD83D\\uDE02\\w[\\q{ab}]](?>\\/|({,2}?|[\\w![\\q{ab}][]{|)|\\u{1F600}(?-i:\\u{1F600})(?<$>x))(?i:([[\\w\\-]{2,3}?[)😂-😀z])(?<$>x)\\1|(|[|[\\q{ab}]\\P{Lu}{]))||\\e(?=0{3,2}\\p{RGI_Emoji}))+?b", "flags": "v", "valid": false}
+{"pattern": "\\08{2}", "flags": "u", "valid": false}
+{"pattern": "[.@](?<$>x)\\k<a>(?<a>(?i)(?<=\\B|^[^!]|\\p{Lu}{2,}\\-?(?i)\\p{RGI_Emoji}(?-i:[😀-😂😂-😀]+|[^|\\]]|*?)+?[😂-😀^\\q{a}}]", "flags": "", "valid": false}
+{"pattern": "\\u{1F600}\\p{gc=Lu}[^b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "([^[^\\q{ab}]])[^\\d-a\\q{\\d}?", "flags": "v", "valid": false}
+{"pattern": "[\\p{RGI_Emoji}\\-\\u{1F600}-\\u{1F602}@][^]+\\c_{3,2}[@]", "flags": "v", "valid": false}
+{"pattern": "[\\w\\q{a|bc}].{3,2}(?<\\u{61}>x)?", "flags": "i", "valid": false}
+{"pattern": "[^[a]](?<b>\\10(?<\\u{61}>x)||(?i:\\a|\\p{ASCII}))(?i)[\\b😀\\q{\\d}\\&]\\c1**||", "flags": "v", "valid": false}
+{"pattern": "(?![])+?\\u{}*[a😀-😂\\d-a\\!]", "flags": "u", "valid": false}
+{"pattern": "(?>[^\\1](?>[--])\\q{ab}|(?i:\\u{}|\\x4[\\p{RGI_Emoji}\\q{a}\\b]_)\\c1|)+?|(?i:[])\\k<a>((?<=\\p{L}\\x4+0??|0+?(?:[]&&]|[[^\\q{ab}]][[^\\q{ab}]]))[\\-\\q{ab}\\q{\\d}\\x41]|{99999999999}|[[\\s](?!.))", "flags": "v", "valid": false}
+{"pattern": "(?=[][][\\1$$\\p{L}\\s]+?||\\c_\\&(?=\\k<b>?)|)-{2,}(((?>[^\\p{L}$$\\q{\\d}\\c1]??[^\\s$$\\q{\\d}\\b]|\\p{Greek}+?))|(?ii:(?<a>x){2,3}[^!]\\s)[]){2,3}", "flags": "u", "valid": false}
+{"pattern": "[\\w][😂-😀\\d-az\\!](?-i:(?-:\\1[\\uD83D\\uDE00-\\uD83D\\uDE02\\x41\\u{1F600}-\\u{1F602}]_{2,3}|[])\\8]||[^]+?$+(?<b>\\k[(\\]\\uD83D\\uDE00-\\uD83D\\uDE02z]))(?<a>[\\q{\\d}][}\\b\\x41\\uD83D\\uDE00-\\uD83D\\uDE02])+?(?<![\\q{\\d}]+?|{,2}([][😂-😀\\x41](?:\\u{}||[]\\/\\a)){2,3})", "flags": "v", "valid": false}
+{"pattern": "{((?<=(?x:[\\q{}]?[])|[^😀((?-i:[]){2,3}?|)[--\\s)]\\00{2,3}?)", "flags": "", "valid": false}
+{"pattern": "[\\b[\\d]\\p{L}(?i:(?ims-:[^\\c_]|(?-:\\uD83D)(?<={2,})\\p{Greek})[\\q{a}\\cA😀-😂\\1])\\2", "flags": "u", "valid": false}
+{"pattern": "\\s(?<a>x)", "flags": "u", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "[\\u{1F600}-\\u{1F602}\\q{\\d}](?:(?i)\\c\\u{1F600}(?>\\p{}){2,3}?|\\P{Ll})?\\u{}{", "flags": "i", "valid": false}
+{"pattern": "a{2,3}\\uDE00(?=$\\p{Greek}(?i-m:(?!\\0|\\w\\a+?{2,3})+?[^\\q{}]))😀", "flags": "v", "valid": false}
+{"pattern": "[[a]\\uD83D[\\q{ab}\\!](?-:😀(?ii:[a-\\d\\c_]{0|a))[\\1]", "flags": "u", "valid": false}
+{"pattern": "(?i-m:[[](?i)[)\\q{ab}-]{(?<=(?>\\1[]😀a-z])[{]+|-{?))z??[^]]|", "flags": "i", "valid": false}
+{"pattern": "\\!{2,}[[a]]\\k{2,}[]*?|]{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\10[\\d+?[&\\-\\c1$$]{2,3}\\10", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "0|(?={1}{2,}(?i:(?ims-:[\\q{ab}\\w}][\\u{1F600}-\\u{1F602}\\P{Lu}$$&|z[[\\){2,}|(?-:\\x4{2,3}?|\\08|\\10)**)&)", "flags": "v", "valid": false}
+{"pattern": "\\x4[^\\q{\\d}&[]", "flags": "v", "valid": false}
+{"pattern": "\\k<\\u0061>\\p{RGI_Emoji}(?=[][^])}[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\u{1F600}-\\u{1F602}](?<a1>x)", "flags": "v", "valid": true, "captures": 1, "names": ["a1"]}
+{"pattern": "\\x4[][\\1$$!!|]\\cA**", "flags": "", "valid": false}
+{"pattern": "(?!\\08)[]\\P{RGI_Emoji}(?ii:(?ii:[^^[]\\1]?[!!]||[\\\\\\b\\q{\\d}][[a]]{3,2})){2,}", "flags": "", "valid": false}
+{"pattern": "b?[\\q{\\d}\\d-a]|[^!!\\q{a}--\\&]{2,3}?\\p{Script_Extensions=Latn}", "flags": "", "valid": false}
+{"pattern": "\\p{Script_Extensions=Latn}(?x:\\e*((?<![!!\\P{Lu}]|*?[\\c1za-\\d\\p{L}])[^\\cA&&[|\\p{RGI_Emoji}/\\&]{2,3}?|\\k<)\\p{L{3,2})", "flags": "v", "valid": false}
+{"pattern": "\\w(?![a-\\d]\\0$$](?=(?<=(?<$>x)|[--[\\q{\\d})]\\w[.\\s]**|)\\p{RGI_Emoji}(?x:\\10|[\\b]${)|{99999999999}{2,3})(?i)\\p{Basic_Emoji}[\\s[]|[\\]\\uD83D\\uDE00-\\uD83D\\uDE02]\\p{}|[|])", "flags": "", "valid": false}
+{"pattern": "$|[](?>[]{2,3}?(?<![--.]]|(?>\\q{ab})\\c_{2,3}))(?<!\\p{Basic_Emoji})(\\q{ab}{2}|[\\c1$$\\uD83D\\uDE00-\\uD83D\\uDE02](?ims-:(?x:[a-z][\\p{L}\\P{Lu}]\\P{RGI_Emoji}{2,}|\\d[--]*?)|(?<b>+*?|[\\q{ab}\\q{a}]{2,}[^a-\\d(a-z]|)+?[&\\q{a}z-a[\\q{ab}]]*?\\p{})", "flags": "v", "valid": false}
+{"pattern": "\\c😀", "flags": "v", "valid": false}
+{"pattern": "(?=_[$$]{[}😀-😂]{)*\\c_??[\\q{a}]{2}\\k\\k", "flags": "v", "valid": false}
+{"pattern": "[\\&[^\\q{ab}]\\q{a|bc}]", "flags": "u", "valid": false}
+{"pattern": "(?>\\k<a>)?}{2,3}|([]\\p{sc=Greek}{1}|[😀-😂(!!])😂", "flags": "", "valid": false}
+{"pattern": "\\!??[\\!\\p{L}][]\\uD83D\\uDE00-\\uD83D\\uDE02|][😀\\1&|]?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w\\w\\]**[^\\d-a\\u{1F600}-\\u{1F602}\\u{1F600}-\\u{1F602}]", "flags": "", "valid": false}
+{"pattern": "[|]a\\k<[^][\\!.\\d-a&]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "0\\a[]!", "flags": "v", "valid": false}
+{"pattern": "(?-i:[][a]\\08|[^\\d-a--\\1]{3,2}\\x41)", "flags": "v", "valid": false}
+{"pattern": ".(?i-m:[^\\-\\c1]\\k<+(?<b>(?<a>[--😂-😀\\![\\q{ab}])|\\-{,2}{|))[\\q{a}\\P{Lu}\\q{a|bc}|", "flags": "u", "valid": false}
+{"pattern": "(?<b>[\\b]_[]){1}{2,}\\uD83D+\\p{gc=Lu}|", "flags": "u", "valid": false}
+{"pattern": "[\\]*?[\\d](?<b>[[])?\\s", "flags": "v", "valid": false}
+{"pattern": "(?>\\2*(?:\\12))[😂-😀😂-😀\\p{RGI_Emoji}&]+\\cA", "flags": "i", "valid": false}
+{"pattern": "[^]{2}\\p{Basic_Emoji}{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\d[^]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:[}😂-😀\\B](?>\\k<b>(?<a>[&\\p{RGI_Emoji}[a]\\d]\\c1\\#)*(?ii:\\P{Ll}|\\k<\\b{2,})*?)(?<a>x){2,3}|[[a]😂-😀.]\\d)_[]😀", "flags": "v", "valid": false}
+{"pattern": "[^^\\1a-z]{(?i).[^[^a]]|(?i)[^\\d&&]|{\\B|(?:\\p{L|\\c_$)(?<b>[]?){|+\\-(?i-m:(?<=(?-:\\w[^z-a{z]])\\0[[😀]){2,}(?-i:[a-\\d))+?(?<!\\x41|(?i-m:[-\\p{L}!!$$]|[^]|\\p{Basic_Emoji}){)|", "flags": "", "valid": false}
+{"pattern": "(?ims-:[^[^a]]{2}[)\\w]|)[}-😂-😀\\u{1F600}-\\u{1F602}](?-:(?<\\u{61}>x)?[^[b\\q{a}^])|z", "flags": "", "valid": false}
+{"pattern": "(!|(?<![]|\\uD83D|[\\q{a|bc}]\\k<a>[--]_{", "flags": "", "valid": false}
+{"pattern": "[[!!]{2}|[\\d-a[a]](?<=(?<b>y)(?<=(?<a>\\B\\/|[^]{\\a)(?>[^/\\cA\\1][\\uD83D\\uDE00-\\uD83D\\uDE02[]\\p{Greek}+|\\0\\P{RGI_Emoji}|[😀-😂--}$$])))", "flags": "v", "valid": false}
+{"pattern": "\\/[^\\]\\p{RGI_Emoji}]\\x4[\\c_\\q{a}]|", "flags": "v", "valid": false}
+{"pattern": "(?>\\p{ASCII})(?ii:{1}+?)\\p{Lu}(?i)(?:(?>[\\w\\q{}]\\q{\\d}]**|)|\\u{41}\\12|\\k<b>|", "flags": "v", "valid": false}
+{"pattern": "\\p{gc=Lu}{2}(?=\\p{Basic_Emoji}\\c**(?ims-:(?i-m:\\w[a^@]{3,2}+){2,3}?(?i:[&\\s$$\\uD83D\\uDE00-\\uD83D\\uDE02]\\00)(?<b>(?<a>x)||)+?|(?<b>\\10)[[^\\q{ab}]])*", "flags": "i", "valid": false}
+{"pattern": "[^\\d\\s.\\q{a}][!!|\\-a-z](?i-m:[{}a-\\d]|\\uDE00\\0){", "flags": "v", "valid": false}
+{"pattern": "(?i-m:(?!(?ims-:|[](?<a>x){2}**(?<!\\p{}[\\-\\p{RGI_Emoji}]**))\\u{1F600}[@\\P{Lu}a-\\da-z]+?)*?\\q{ab}", "flags": "v", "valid": false}
+{"pattern": "[&\\q{a}\\q{a}]", "flags": "u", "valid": false}
+{"pattern": "[[^\\q{ab}]\\&&]??[\\q{\\d}\\s][^\\p{RGI_Emoji}]\\3", "flags": "v", "valid": false}
+{"pattern": "}\\b*?\\P{Ll}(?-i:😂^{1}|(?ims-:{*(?-:[^\\d-a&&b\\c1]{99999999999}\\c1))(?<=[^]{2,}\\!**)[$$])\\P{Ll}*", "flags": "", "valid": false}
+{"pattern": "\\u{1F600}(?ims-:(?i-m:\\p{gc=Lu}(?i:[\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a}]|[{]})[]|(?>😀\\p{L)*?))\\p{Basic_Emoji}|\\p{}", "flags": "v", "valid": false}
+{"pattern": "\\p{sc=Greek}b\\p{gc=Lu}\\3{", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^a-z[\\q{ab}]\\q{}[\\q{ab}]]", "flags": "v", "valid": false}
+{"pattern": "\\P{RGI_Emoji}\\k<\\u0061>\\uD83D\\uDE00", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{41}[\\s&]*?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!(?-:[-][\\&\\p{RGI_Emoji}\\-]{2,3}?[))?\\p{Basic_Emoji}((?<=[]*|)|(?<a>\\p{Basic_Emoji}{2}|\\a)(?ims-:\\x4??(?i-m:\\d\\u{}||)(?ims-:*.)){2,3}|[.]*?(?x:(?i)|\\k??|\\c_(?<=))\\u{})", "flags": "v", "valid": false}
+{"pattern": "0*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x:(?i:[\\c_]{2,}[)])\\00{2,3}?(?-:(?-:\\0\\08\\k<a>?(?ii:|)[\\uD83D\\uDE00-\\uD83D\\uDE02]))\\uD83D(?-:\\3\\p{Greek})*|]\\/{|", "flags": "i", "valid": false}
+{"pattern": "-[/&&\\c_][\\!]|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "((?-i:\\p{L}|![][^😀\\b](?-i:(?>(?i:\\2+[^[^a]]??|![])z|\\uDE00|\\uDE00)😂)", "flags": "v", "valid": false}
+{"pattern": "\\p{RGI_Emoji}{2,}\\-|", "flags": "v", "valid": false}
+{"pattern": "\\k<(?![{😀-😂b\\P{Lu}]{2,3}?|)|[]\\q{}\\p{L}😂-😀]*", "flags": "", "valid": false}
+{"pattern": "\\d[\\q{})\\p{L}@]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=\\c_{2,}(?<b>(?-:[a-zz-a[\\q{ab}]\\c_]|[[^\\q{ab}]/])(?>*|)(?=\\&{3,2}\\1{)))[!/\\]|]|", "flags": "u", "valid": false}
+{"pattern": "\\x41[\\cA[^a]\\q{ab}]0z{2,3}", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[!}](?-:(?i-m:\\p{sc=Greek}[!!\\P{Lu})]|\\q{ab}|[\\1\\u{1F600}-\\u{1F602}\\&|]))[^\\!!]\\1*a", "flags": "i", "valid": false}
+{"pattern": "(?ims-:(?<b>[^--]\\p{L}(?-i:[^[^a].]))|(?-:[^]{3,2}!|\\b[]?)[&&]{3,2})]{2,3}?\\10", "flags": "v", "valid": false}
+{"pattern": "[|&\\]\\c_][^[a]b\\q{ab}]", "flags": "u", "valid": false}
+{"pattern": "[^]\\q{ab}\\-$${2,3}|\\-[^\\b]\\c1((?<a>x)[]\\uDE00)", "flags": "v", "valid": false}
+{"pattern": "[^😀](?-:(?i-m:[\\p{L}](?<a>[^\\x41\\q{a}][\\P{Lu}\\[^a]$$][[a]\\u{1F600}-\\u{1F602}]||\\0(?<a1>x)\\p{Greek}|)|\\p{})(?<b>\\00(?<a>x)\\P{RGI_Emoji}+?)|(?>(?<$>x)(?i-m:\\a\\s|)\\x41){2,3}?|\\&", "flags": "v", "valid": false}
+{"pattern": "(?<b>y)(?-i:[\\|]\\u{41}|\\8)|", "flags": "v", "valid": false}
+{"pattern": "\\12|[\\u{1F600}-\\u{1F602}{a-\\d]\\uD83D", "flags": "v", "valid": false}
+{"pattern": "{2,1}[\\q{a|bc}]|(?![-\\b](?i-m:(?<\\u{61}>x)[^\\q{\\d}\\cA[^\\q{ab}]]|(?!*?|[^\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a|bc}]*?(?x:😀{2,}[^$$]))", "flags": "v", "valid": false}
+{"pattern": "😀[\\d-a]{2}😂(?:[\\\\!\\b]])+[[^a]]*?", "flags": "v", "valid": false}
+{"pattern": "\\p{}^(?i:[[^a]z-a](?:[^\\q{a|bc}]\\uD83D\\uDE00-\\uD83D\\uDE02\\&]|(?i-m:{\\uD83D*?)){2,3}?|\\w(?ii:\\c\\k<b>**[^(])", "flags": "i", "valid": false}
+{"pattern": "(?x:\\u{41}(?<!\\08(?-:\\u{})(?<\\u{61}>x))|[)\\&]){2}[@\\&]", "flags": "", "valid": false}
+{"pattern": "[[^\\q{ab}]\\q{a}\\1]\\k<\\u0061>\\p{}|(?:0\\p{RGI_Emoji}|[]\\x4[^)])*[b!]**", "flags": "", "valid": false}
+{"pattern": "\\&{[\\uD83D\\uDE00-\\uD83D\\uDE02\\q{a|bc}\\c1\\d-a]**\\8", "flags": "u", "valid": false}
+{"pattern": "\\P{RGI_Emoji}(?i-m:((?x:[\\w\\q{a|bc}\\q{}\\])*?[^-\\uD83D\\uDE00-\\uD83D\\uDE02\\u{1F600}-\\u{1F602}\\q{a}]){2}(?ims-:(?>[\\p{RGI_Emoji}]\\k<{3,2}|\\b||[\\&])(?<\\u{61}>x)|\\#))|", "flags": "v", "valid": false}
+{"pattern": "(?i:}(?<\\u{61}>x)\\u{41})[](?<a1>x)\\p{gc=Lu}", "flags": "v", "valid": false}
+{"pattern": "\\c_(?<b>[^])", "flags": "v", "valid": false}
+{"pattern": "(?ims-:\\B)[][\\P{Lu}](?=\\-[--])(?:\\#{2,3})?", "flags": "v", "valid": false}
+{"pattern": "[😀-😂]**(?!\\#)\\10", "flags": "i", "valid": false}
+{"pattern": "(?ii:[^\\q{a|bc}a](?<![])?){2,3}?\\s+|", "flags": "v", "valid": false}
+{"pattern": "[[a]\\x41\\p{L}]{2,3}?[\\s&&a-\\d](?<a1>x)\\p{L}\\s", "flags": "v", "valid": false}
+{"pattern": "[\\&]{{2,3}?[\\&]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[\\d-a\\q{\\d}]?[^($$\\q{a|bc}](?>0|\\#[😀-😂!!\\1\\0]**)\\k", "flags": "v", "valid": false}
+{"pattern": "(?<b>(?:[a-z\\]][^😀-😂]*?[^]+?)\\p{Script_Extensions=Latn}??(?x:\\uDE00?[\\x41!][]**))[a-z[a][\\c_]{2,}|[\\s\\1]", "flags": "v", "valid": false}
+{"pattern": "(?<b>y)*\\#\\!{3,2}|(?ii:[^\\-][^]{|[^\\d-a][]\\q{a}](?<=\\k<\\u0061>(?!\\p{RGI_Emoji}{3,2}|{2}😂??)[\\1)]|))", "flags": "v", "valid": false}
+{"pattern": "[\\!\\p{RGI_Emoji}]{(?i-m:(?i-m:[]{2,}|[^|&&😂-😀\\-]))[^\\u{1F600}-\\u{1F602}[\\q{ab}]]+\\p{L{3,2}", "flags": "v", "valid": false}
+{"pattern": "[!\\w[^\\q{ab}]@]{2}\\a+😂^?", "flags": "u", "valid": false}
+{"pattern": "[&&[\\q{ab}]]\\k<a>|[b&&^\\p{L}]\\uD83D\\uDE00*?", "flags": "u", "valid": false}
+{"pattern": "[\\cA\\q{\\d}](?i:([[^a]@\\q{a}][^\\d-a\\c1\\b\\B]*?(?<!][^|\\-&\\p{L}]\\e))?😂[^]){2,3}?\\08", "flags": "v", "valid": false}
+{"pattern": "[😂-😀😂-😀|][&\\!.]|", "flags": "v", "valid": false}
+{"pattern": "[\\1]!]{3,2}(?![^\\u{1F600}-\\u{1F602}]]])?[})]*(?ims-:(?!(?i-m:\\u{})|(?-i:\\p{Lu}|\\#\\p{L}|[\\0\\cA😀-😂--]|\\&)[b])|[^\\c_[a(]", "flags": "", "valid": false}
+{"pattern": "[^[^a]\\b](?i-m:(?ii:!\\0[^]\\1\\!\\x41]|[😀-😂b(][\\x41\\\\d-a\\b]\\k<\\u0061>)&{2,1})|(?:(?<a>(?<a>[\\w]{2,3})\\u{41})[\\-😂-😀](?ii:[\\\\!]|})\\uD83D\\uDE00", "flags": "v", "valid": false}
+{"pattern": "(?i)[^{\\P{Lu}😂-😀\\](?ii:[\\B\\cA\\q{a|bc}(]|(?>\\e\\k<a>+||_){3,2})^|", "flags": "v", "valid": false}
+{"pattern": "\\s+[^][@\\c_]\\!", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:z|[\\B])", "flags": "u", "valid": false}
+{"pattern": "\\p{Script=Greek}{1,2}+\\b{3,2}", "flags": "u", "valid": false}
+{"pattern": "\"[^^\\8!!\\q{ab}]\\.*?[\\-\\!!\\8]<", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[&=&a-zA]{2,}[)\\p{L}]\\c1**", "flags": "v", "valid": false}
+{"pattern": "\\k<a>[][\\c1]{2,}[^\\p{L}--[:alpha:]]*?", "flags": "", "valid": false}
+{"pattern": "\\0\\f+{\\10", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n??\\n??a{2,3}?[\\w.][^\\q{ab}\\q{ab}\\q{ab}\\q{ab}]?\\z{2,3}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "#[]{2}\\k\\v[^a-z[\\s]??", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "{,2}(?'a'\\2\\k<b>[a-\\d\\x41\\]A]**|(?(a)\\k<a>\\k<a>|[\\\\}])|)(?<a>\\A\\p{Script=Greek}|/{)\\k<a>+? ", "flags": "u", "valid": false}
+{"pattern": "(?<a>\\8)<\\k<b>", "flags": "i", "valid": false}
+{"pattern": "[..z)\\-]+?[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\10*?", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[.A😀*+(?<=\\z(?|\\x41|[\\s\\cA*?\\v++\\A)|)(?i)[^.]]*?\\3??|(?(?=a){1,2}[^[\\c1]|)\\B*?\\3\\t", "flags": "", "valid": false}
+{"pattern": "\\x4[\\p{L}]*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#[^])", "flags": "v", "valid": false}
+{"pattern": "(?<=:\\1|)\\0\\d{\\k{2,1}\\x4??|", "flags": "v", "valid": false}
+{"pattern": "\\w*&+\\x411}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(a)é{3,2})[]((<a>),{2,3}?)*", "flags": "", "valid": false}
+{"pattern": "(?P<a>{1}*=\\s{)(?<a-b>[](?<a-b>\\a{2}#(?'a'[{{\\d]\\e{{|\\s?))(?<b>\\v\\v))\\w\\8?", "flags": "", "valid": false}
+{"pattern": "(?:\\12\\3)>\\-{2,1}?\\/", "flags": "i", "valid": false}
+{"pattern": "\\.\\2", "flags": "v", "valid": false}
+{"pattern": "^{[)\\D??&\\w", "flags": "", "valid": false}
+{"pattern": "(?<a><[\\w.]|)\\x40{3,2}(?(a)[]\\Z*?😀)", "flags": "i", "valid": false}
+{"pattern": "(-|[\\d\\]{2}a{2,})(?<b>[^Az|a-z][]|(?-i:a(?P<a>\\w|\\8**)<):)'\\cA{\\P{Lu}", "flags": "", "valid": false}
+{"pattern": "\\10{3,2}", "flags": "", "valid": false}
+{"pattern": "\\x4:", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[A\\q{ab}-]\\D\\c1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>>++\\q|(?<=\\x41(?<a-b>A))[(?)${3,2}[\\0]{2,}\\3(?<a>\\0{2,}\\D)*?(?:\\n|:*+\\p{L})", "flags": "i", "valid": false}
+{"pattern": "[[:alpha:]\\\\-&&]\\s(?|\\x4+(?##(?<=[\\q{ab}]{2,}:[^||])|(?i)\\G:[[\\8&&]|\\v)\\pL??)\\e*+]{2,3}?\\0", "flags": "i", "valid": false}
+{"pattern": "(?(?=a)(?i:\\G))\\v\\G(?i)\\k<b>|+?A", "flags": "v", "valid": false}
+{"pattern": "_?'**^(?<b>(?<a-b>\\10[.}]|\\10))]", "flags": "", "valid": false}
+{"pattern": "[&&\\cA--](?(1):{2})a\\8}|", "flags": "", "valid": false}
+{"pattern": "(\\k<b>)\\k[a]*?é(?i)<[$!!", "flags": "", "valid": false}
+{"pattern": " *+", "flags": "i", "valid": false}
+{"pattern": "[^\\-.a-z](?(a)[({[]*?-{2}(?>[😀\\cA\\p{L}*\\t.)**)++[\\\\\\q{ab}]9??é|", "flags": "", "valid": false}
+{"pattern": "[]{1,2}\\pL*+-?(?(<a>)#*+\\c1\\1|)[^\\p{L}z|]**", "flags": "u", "valid": false}
+{"pattern": "(?=(?<!\\w+\\v??[\\p{L}??!)\\p{Script=Greek}", "flags": "v", "valid": false}
+{"pattern": "\\s{,2}\\^n-😀[z-a\\b{)]{2,3}", "flags": "", "valid": false}
+{"pattern": "(?<a-b>(?<b>]\\D*? +?)){,3}[=][^{z]", "flags": "i", "valid": false}
+{"pattern": "[!!][\\cA\\](?<!(?(a)\\/(?<!b[^]*+[]**))\")=\\k<b>\\x41", "flags": "", "valid": false}
+{"pattern": "\\p{Script=Greek}>", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?|{2,1}(?(a)\\n{,3}\\\\))\\]k{2,}|_b=)++\\Z\\-&\\x41*+", "flags": "u", "valid": false}
+{"pattern": "\\.+?[^}{\\s]*\\u{41}[{&*&\\k|", "flags": "i", "valid": false}
+{"pattern": "[\\s-\\\\]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#\\c1){\\k<a>(?!\\x41?(?:(?i)[^a-z\\a]<\\P{Lu}\\G))", "flags": "", "valid": false}
+{"pattern": "\\x41+\\A[](?|(?i)\\pL😀|[a]&*?0++é\\f|(!)(?(a)'[}--)]<)([!!(])", "flags": "i", "valid": false}
+{"pattern": ",+?(?x){2,1}(?<a>\\n\\p{Script=Greek}\\1|)", "flags": "i", "valid": false}
+{"pattern": "[😀z-a]*+\\8[^😀\\sA\\q", "flags": "", "valid": false}
+{"pattern": "0*\\v\\10", "flags": "u", "valid": false}
+{"pattern": "\\d|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\G(?=[]&(?i).|:**é\\w)\\u{41}", "flags": "i", "valid": false}
+{"pattern": "\\tb-++\\p{L}", "flags": "", "valid": false}
+{"pattern": "\\pL", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n[a-\\d][)]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "^*?\\a+[\\1]*+", "flags": "i", "valid": false}
+{"pattern": "\\t{2,}.{2,}0", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "{1}{2,3}?\\/??\\d}$?", "flags": "v", "valid": false}
+{"pattern": "+\\D>", "flags": "i", "valid": false}
+{"pattern": "\\f{3,2}\\a{2,}\\k{2,3}?", "flags": "v", "valid": false}
+{"pattern": "\\k<b>(?i:<*?\\f{1,2}++|\\x4*|)\\q(?!$*?[^.\\c1\\d\\d]|[\\bz--]:\\t)\\u{41}", "flags": "u", "valid": false}
+{"pattern": "\\k<b>{3,2}(\\d{3,2}0{3,2}(?:\\3)*?]++\\12{2,3}?", "flags": "v", "valid": false}
+{"pattern": "}{1,2}}{2,}\\12?(?'a'[\\x41--\\]\\1][a-zzA])++", "flags": "i", "valid": false}
+{"pattern": "\\b*><", "flags": "v", "valid": false}
+{"pattern": "[|", "flags": "u", "valid": false}
+{"pattern": "\\e+? *?[^\\s|\\c1$]\\k<b>{,3}[--z-aa/](?|\\n{2,3}\\0\\\\|[a-z\\0a-z[^--{[:alpha:]]|){3,2}", "flags": "u", "valid": false}
+{"pattern": "😀\\v(?x)(?=\\k)(?P<a>[\\p{L}.\\\\.]*?,||(#\\^w{2})*+\"*?=**)||\\t\\3>{,3}[]+$", "flags": "", "valid": false}
+{"pattern": ">{,+3}(?x)\\-{2,3}?a\\k{,3}", "flags": "", "valid": false}
+{"pattern": "\\D\\A*😀+?\\3(?#[\\b][\\\\a-z}.])", "flags": "", "valid": false}
+{"pattern": "[\\w][--z]&(?<b> {2,3}?(?'a'\\x4{2,}))", "flags": "", "valid": false}
+{"pattern": "\\k<>|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "#*|?\\B,\\x41+", "flags": "u", "valid": false}
+{"pattern": "[\\cA(\\8[:alpha:]](?:[]{2,3}\\k<a>\\p{Script=Greek}|\\\\{(?(<a>)[](?<=,\\2??)+\\k<a>)){\\k<a>é\"", "flags": "i", "valid": false}
+{"pattern": "\\q\\s{2,}\\v+\\x41{2,}'{[\\p{L}\\b]", "flags": "v", "valid": false}
+{"pattern": "(?x)\\v[z-aa[:alpha:][]|9{,3}??\\x4\\d\\n[^\\cAA]\\-", "flags": "u", "valid": false}
+{"pattern": "(?'a'[^]{,3},[^&&])[^a-\\d])??a[\\8\\]]", "flags": "v", "valid": false}
+{"pattern": "\\-[][&&}\\w]\\D{(?<=[!!|&&😀]++\\w\\1){'", "flags": "u", "valid": false}
+{"pattern": "(?(1){2,1})[\\q{ab}\\0\\b]\\p{L}\\t+|", "flags": "i", "valid": false}
+{"pattern": "[][^\\8&]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!{1}|\\k<b>(?!\\0*+|0\\2{2,}\\P{Lu})(?>\\c1[^--]]))|", "flags": "", "valid": false}
+{"pattern": "/^", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<b>\\a\\G[\\s]", "flags": "v", "valid": false}
+{"pattern": "[-]*+(?(<a>)[\\p{>L}A\\c1[[:alpha:]])[A]{\\p{Script=Greek}^", "flags": "", "valid": false}
+{"pattern": "\\c1*+[][]/z-a]*(?(<a>)0{,3}\\12|/\\c1\\3)\\u{41}\\v", "flags": "u", "valid": false}
+{"pattern": ",{23}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "9[^|]😀?\\k", "flags": "v", "valid": false}
+{"pattern": "\\cA{2}(?(a)(?'a'(?(1)]\\1*+*\\k++{,2}[\\cA]??))\\k<a>\\b |", "flags": "v", "valid": false}
+{"pattern": "\\P{Lu}}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(<a>)\\f??[\\wa-z]|[\\\\!!^]\\z+?\\x41)\\x41{2,3}?^", "flags": "i", "valid": false}
+{"pattern": "\\p{S>cript=Greek}-b++[]'**{1}", "flags": "i", "valid": false}
+{"pattern": "{1}[]=??\\3+:", "flags": "u", "valid": false}
+{"pattern": ",", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\3\\.\\pL(?(<a>){)*+(?=({?:(?i:[z-a{\\8a]{,2}\\P{Lu}|)(?=\\B\\2[😀!!]{2,3}?)??),\\\\+?)[)[]", "flags": "u", "valid": false}
+{"pattern": "(?-i:[&&]*+\\2??){2}", "flags": "i", "valid": false}
+{"pattern": "[][-)]\\A(?-i:/)(?i:\\Z)\\q", "flags": "v", "valid": false}
+{"pattern": ">[a\\x41\\]\\q{ab}]{2,3}(?(1)=|){\\w", "flags": "i", "valid": false}
+{"pattern": "(?x):{2}[][|^a-za-z][^\\]\\w][!!\\s&&](?(?=a)(\\u{41}++(?'a'\\G|\\A)(?(a)^)??)*?|\\1)", "flags": "v", "valid": false}
+{"pattern": "(?'a'A)\\n|", "flags": "", "valid": false}
+{"pattern": "{,2}😀\\-{2,3}?\\s{1}**\\f", "flags": "", "valid": false}
+{"pattern": ",2}\\e++[-!!", "flags": "u", "valid": false}
+{"pattern": "!\\0'>", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^](?|(?=(?+<!&\\a|\\f*?)\\1)++(?##+[^\\\\\\x41[\\b]{,3}[]*+)\\0{2,3}|(?<!\\qA)??\\k<a>\\B)**{1}>+", "flags": "", "valid": false}
+{"pattern": "\\f(?<=(?'a'(?(?=a)\\pL}*?\\1|[/\\p{Script=Greek}\\c1))([]\\x41|\\q&)|(?:(?<!😀\\p{Script=Greek}).|){2})(?P<a>\\1\\cA\\k\\f(\")", "flags": "", "valid": false}
+{"pattern": "[]+$[A\\p{L}]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^&&\\c1z-a](?-i:?<??)(?-i:\\x4[z-a)\\q{ab}\\](?(a)\\Z.|[|]\\c1\\q{ab}]\"*\\x4)?|(?|\\x4??\"\\c1)]\\12{2,3})*\\t\\10(?<=\\t)", "flags": "i", "valid": false}
+{"pattern": ">[\\c1$\\\\\\x41]!(?=(?i:_)|)\\c1", "flags": "v", "valid": false}
+{"pattern": "(?<a>(?x)(?<b>{{2,3}?|)}<**[{{\\]]|0\\w\\8)(?=b[\\cA\\1[:alpha:]\\bb])\\G😀\\v", "flags": "u", "valid": false}
+{"pattern": "(?P<a>\\pL{2}(?<a>](?i)\\A*?[])(?<a>\\k<b>){)(?x)(?(a)\\t)**[]\\B|\\w|++", "flags": "v", "valid": false}
+{"pattern": "[\\cA-\\s](?!{1}{2,3})9(?P<a>[\\0]^\\0][^z]\\s)(?=#{2}\\8{2,3}('|[\\8\\\\[]_){2,})", "flags": "u", "valid": false}
+{"pattern": "", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "{1,2}++[a-\\da]", "flags": "v", "valid": false}
+{"pattern": ".+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "]&b\"", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12\\\\1\\s[\\s]$]]?[]**[\\c1)\\-\\]", "flags": "", "valid": false}
+{"pattern": "\\s++\\s(?>\\D?\\x4é||(?x)>{2}/{,2}[]{,3})\\pL", "flags": "v", "valid": false}
+{"pattern": "\\P{Lu}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]*?[\\x41]{2}\\e{,3}[]{,3}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "A?[{\\w]]{2}(?-i:\\e|([][\\s--\\p{L})(?(1)\\12|\\w^**\\a)\\b**\\u{41}??0", "flags": "u", "valid": false}
+{"pattern": "\\t\\.+?_<{3,2}", "flags": "", "valid": false}
+{"pattern": "(?>(?<=\\/{3,2} =??)(?(<a>)[](?-i:\\D[^\\8--]++{1}?|[a)][{]{3,2}\\s)\\k'+?)[\\8\\0]\\a(?<!\\8[!!]|[-\\]a$]?)++|", "flags": "v", "valid": false}
+{"pattern": "\\t*?&\\cA{2,3}?", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA?\\2+(?>(?i:[\\](?|0?#+?)|[\\wa\\]][.(]++(?<b>\\G\\s\\2+))):", "flags": "v", "valid": false}
+{"pattern": "\\q{2,3}{\\e(?!\\pL}{2,3}\\.)[]/+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|\\p{Script=Greek}(?:_)\\t{3,2})[]\\e??[{\\q{ab}]*+\\v{2,3}([z-a](?(?=a)a[]+))", "flags": "", "valid": false}
+{"pattern": "\\/(?x)(?(<a)^|\\A{,2}(?:$_))", "flags": "v", "valid": false}
+{"pattern": "9|", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": ":{[}--][a-z[:alpha:]](?P<a>[a\\x41\\\\])[((z\\w(]{2,3}?", "flags": "i", "valid": false}
+{"pattern": "\\A?\\w", "flags": "u", "valid": false}
+{"pattern": "[a\\s$--]{2,1}", "flags": "", "valid": false}
+{"pattern": "{\\s", "flags": "v", "valid": false}
+{"pattern": "😀(?|[$\\c1]|)\\t$??\\w", "flags": "i", "valid": false}
+{"pattern": "(?<a>(?|a>[^\\sz-a{]{3,2}\\A|A{2,})\\v]+?[]]*?", "flags": "u", "valid": false}
+{"pattern": "(?i){2,1}**\\-[\\1]+?[a-\\d](?'a'9)|", "flags": "v", "valid": false}
+{"pattern": "[\\da-\\d\\cA]\\p{L}{1,2}{2,3}", "flags": "u", "valid": false}
+{"pattern": "=+(?<=\\B{2})+?[]\\f&(?<!\\x41+-??.*+", "flags": "v", "valid": false}
+{"pattern": "\\Z*$+?(?(<a>)(?(1)[]\\z[\\q{ab}.]|(?<![.a&&|]\\cA.|a))**!(?:!)|)*?[)\\cA[]**", "flags": "", "valid": false}
+{"pattern": "(?>}\\]\\)", "flags": "", "valid": false}
+{"pattern": "(?<<={,2}\\k<b>\\0+|-**)??", "flags": "", "valid": false}
+{"pattern": ".\\B+\\x4", "flags": "", "valid": false}
+{"pattern": "A(?<b>[\\]\\cA\\b😀]_[^\\8&&])_\\cA", "flags": "", "valid": true, "captures": 1, "names": ["b"]}
+{"pattern": "\\G{2,}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(a)$[\\p{LA]=*?|(?!(?(?=a)\\\\{2}))*+)*+\\3(?i:\\-\\\\{2}[&&zz|_\\1😀*?)[{\\0a]*\\k<b>?(?x)\\e:?", "flags": "", "valid": false}
+{"pattern": "\\x4{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": " ^[^]*+", "flags": "v", "valid": false}
+{"pattern": "\\2\\q++(?!{1,2})-(?=<)[\\]", "flags": "i", "valid": false}
+{"pattern": "z]|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B(?-i:(?-i:(?>\\z+?|)\\2)+|A+(?#{1,2}*+[\\w&&][\\w.z|]{2,}))[\\0\\p{L}\\p{L}]", "flags": "u", "valid": false}
+{"pattern": "\\k{2,3}?(?<a>\\A)+\\/{2,}](?<b> (?<!\\w**/)){2}\\0:", "flags": "u", "valid": false}
+{"pattern": "\\p{Script=Greek}0b", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a-b>0[^\\p{L}]\\e)[[.{\\d]", "flags": "", "valid": false}
+{"pattern": "\\-{32}\\t|", "flags": "v", "valid": false}
+{"pattern": "[^]??(?(a).\\2(?=[^a]*{)*+\\pL\\10?[\\d&&]'", "flags": "i", "valid": false}
+{"pattern": "\\G{2,3}?(?:\\u{41})??|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{??(?i:[}]{2,}(?#(?x)A(?(<a>)-)]++)|9{2,3}?=*?\\8)*+", "flags": "i", "valid": false}
+{"pattern": "[]?{2,1}[--]", "flags": "u", "valid": false}
+{"pattern": "}{2,}\\B{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{2,3}?.(?(?=a)😀{*+|(?!\"\\b){2,1}[\\b])(?|(?<=😀[^--\\c1\\s])| )(?<b>\\k<a>[]#+|&??\\x41)", "flags": "i", "valid": false}
+{"pattern": "\\v\\s\\pL\\p{Script=Greek}{3,2}}(?x)(?(a)\\/(?<a>\\b[\\1>]\\A|)|\\s{,3}(?(?=a)\\z[^a-\\d]+)){2,}\\p{L}[|\\d\\d😀]**", "flags": "i", "valid": false}
+{"pattern": "(?x)(?>\\pL|😀\\t*-){\\P{Lu}", "flags": "", "valid": false}
+{"pattern": "[\\p{L}]+$+:{,2}<>", "flags": "i", "valid": false}
+{"pattern": "[]{2}[[\\😀/]", "flags": "v", "valid": false}
+{"pattern": "\\/[$A({]{2,1}", "flags": "v", "valid": false}
+{"pattern": "'$", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": " {3,2}|", "flags": "v", "valid": false}
+{"pattern": "\\\\{2,}\\-é(?#!?(?<!3[a-z$])*+)++", "flags": "", "valid": false}
+{"pattern": "b\\q{,3}(?!\\)t*?){", "flags": "v", "valid": false}
+{"pattern": "(?x)[^/\\1\\s\\q{ab}]{,3}|(?(?=a)\\A(?x){\\cA{2}\\A$)+?\\cA{2,3}\\Z||", "flags": "v", "valid": false}
+{"pattern": "[]|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)\\x44<\\cA|", "flags": "", "valid": false}
+{"pattern": "(?-i:[z-aa--\\cA| )**\\x41{3,2}(?>\\e\\q:)[]", "flags": "", "valid": false}
+{"pattern": "[-\\p{L}a\\s]++^\\P{Lu}(?P<a>(?<a-b>#{,3}😀\\12||\"*{2,1}){,3}*\\x41\")😀a{2}|", "flags": "", "valid": false}
+{"pattern": "Aé", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w]*(?!(\\12(?#&|a{,3}|)){2,3})[^\\w--]*?", "flags": "", "valid": false}
+{"pattern": "\\a[]\\1", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a\\c1!){(?'a'[\\w\\-\\cA.]{1,2}\\b|)(?=[a-z])>\\Z\\k<a>", "flags": "u", "valid": false}
+{"pattern": "[(a-\\d\\cA--]}+(?:!\\x41)*+(?i)\\\\x41?[]\\n{", "flags": "i", "valid": false}
+{"pattern": "(?<=(?i)\\x41(?#[]|\\p{L}\\B{2,3}?[^\\8[:alpha:]--])[/\\\\]a_)**[a-z]*+[|]", "flags": "", "valid": false}
+{"pattern": "(?|[\\p{L}\\1a-\\d\\cA*+|\\x4{2}\\k{2,3}?)\\Z]", "flags": "", "valid": false}
+{"pattern": "(?#[\\wA]++|[\\0]<++\\e{2,3}|)+?[\\]\\cA\\c1\\k<a>**", "flags": "", "valid": false}
+{"pattern": "[]#\\D(?i:(?|(?:\\pL[a-\\da-z]??|)+[]|\\3)*+9", "flags": "i", "valid": false}
+{"pattern": "[(],", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "/\\10++\\k}]*|", "flags": "i", "valid": false}
+{"pattern": "\\$.?\\a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\1]\\s\"\"(?(<a>),(?P<a>[](?x)\\\\||\\p{Script=Greek}{2}&'b+|(?:\\t)\\d){<\\zb", "flags": "u", "valid": false}
+{"pattern": "\\u{41}??(P<a>>[{2,3}){2,}[.]", "flags": "i", "valid": false}
+{"pattern": "^\\b\\x4[\\s&&^]{2,3}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(=?<=\\G[\\-){2} [$A]", "flags": "", "valid": false}
+{"pattern": "(?x)\\2|**\\c1(?'a'\"(?#(?<a>[\\p{L}-\\c1]\\P{Lu}\\A)[\\-\\8]++))A<\\8", "flags": "", "valid": false}
+{"pattern": "\\8^\\x41[A\\q{ab}&&[](?![^\\d\\8\\cA\\]#{,3,2}(?>\\10\\c1){2,}){1}", "flags": "i", "valid": false}
+{"pattern": "=!(?|{1}??)", "flags": "v", "valid": false}
+{"pattern": "ab(?<=[\\b][\\c1a\\x41])(?(1)[a-\\da/\\1])[]{,3}\\2", "flags": "", "valid": false}
+{"pattern": "(?#[$\\0[:alpha:]/(?\\k<a>[A]{2}|\\pL^){)\\v\\p{L}'[--$", "flags": "u", "valid": false}
+{"pattern": "\\/", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{1,2}{2,3}?|", "flags": "u", "valid": false}
+{"pattern": "\\1(?-i:\\8{2,3}?<{|)é(?(1)(?<![a-\\d](?|[[][)]\\D?)[a]| =)*?A){,3}(?<!# ++(?-i:\\/)).", "flags": "v", "valid": false}
+{"pattern": "(?i)\\A(?<=\\cA{2}|[a\\q{ab}]]+?\\k<a>)[\\]a| {,3}\\.0+\\q{1,2}\\k<a>?a\\a", "flags": "", "valid": false}
+{"pattern": "{1,2}[<\\q{ab}]](?x){1}b++\\u{41}", "flags": "", "valid": false}
+{"pattern": "(?i:\\Z\\x4{2,3})|", "flags": "v", "valid": false}
+{"pattern": "[^[-][\\8][{\\-", "flags": "v", "valid": false}
+{"pattern": "[!!!!\\1&&](?=/|\\P{Lu}[^Az-a]{)++|", "flags": "v", "valid": false}
+{"pattern": "\\a{a[$]*\\x41*?\\k<a>{,3}", "flags": "v", "valid": false}
+{"pattern": "[\\xx41\\cA--]\\10+?[/]+?\\e", "flags": "u", "valid": false}
+{"pattern": "[zz\\\\8]{2,3}?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p-{L}\\\\.[]{,3}\\n", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?'a'(?>(?(a)\\Z[\\b\\0a-z]?!?\\k<a>)[]\\/|\\p{L}{2,3}[]|[\\8]a-z&&])\\v**(?#\\e|)(?!\\B)**", "flags": "", "valid": false}
+{"pattern": "\\3\\2", "flags": "u", "valid": false}
+{"pattern": " [][.!!{\\w][\\p{L}^{,3}😀*?", "flags": "u", "valid": false}
+{"pattern": "\\Z{2,3}[--\\-\\--\\s**|", "flags": "v", "valid": false}
+{"pattern": " +=", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:}{(?=(?!+\\k<b>**|\\b_)??\\2*?|)(?<!\\.[^]*?\\P{Lu}){)", "flags": "i", "valid": false}
+{"pattern": "[]\\f[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA{2,}\\p{L}?[zza-za-\\d]{,3}&", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[][}z😀]**", "flags": "i", "valid": false}
+{"pattern": "0[^\\]", "flags": "u", "valid": false}
+{"pattern": "[]?[\\]][(?<!(\\z)\\q\\b|[/[](?<=[a-z\\x41](?<b>\\a){2,}|\\u{41}{3,2})\\e{2,})", "flags": "", "valid": false}
+{"pattern": "{2,1}(?i)}|'++", "flags": "i", "valid": false}
+{"pattern": "[\\c1/(\\0]?(?#[\\x41^|#{{(?-i::[]]{3,2}))[]/]\\]]", "flags": "", "valid": false}
+{"pattern": "A(?<!(?-ii:\\D))(?'a'<{=)*+[\\1{\\1]é\\-|", "flags": "i", "valid": false}
+{"pattern": "{2,1}{2}[]]}+?(?-i:(?:(?-i:\\x41)[\\p{L}\\x41])+?)\\n", "flags": "u", "valid": false}
+{"pattern": "(?x)={,2}|[]}/++\\G(\\p{L})", "flags": "", "valid": false}
+{"pattern": "\\10[^\\8\\c1]\\u{41}+?", "flags": "u", "valid": false}
+{"pattern": "\\\\d:+?![\\d.[.\\1-]\\d", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": ".[z\\b\\x41](?P<a>\\v|\"\\q{)(?x)[](?<a-b><)(?(<a>)[-][^[]{2,3}?(?(?=a)({{3,2}[\\-\\d)]#)\\q))", "flags": "u", "valid": false}
+{"pattern": "\\a[a\\\\[:alpha:]]>{2,3}?&|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4{[\\d\\d😀a]\\d[^|]\\.{", "flags": "u", "valid": false}
+{"pattern": "{1}{,3}=(?<!(?<!\\k)+\\2*?){(?(a)(?<!\\t[\\\\]*)\\12[\\q{ab}++)[](?=\\2\\qa)", "flags": "", "valid": false}
+{"pattern": "\\e\\Z**\\x41<*?0{2}{,2}", "flags": "i", "valid": false}
+{"pattern": "\\f[/\\b][\\-😀a)]\\12?\\/\\A", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "a", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[z-a]!", "flags": "u", "valid": false}
+{"pattern": "\\z\\t|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "_=+?", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[.$\\c", "flags": "", "valid": false}
+{"pattern": "{\\12(?-i:(?!\\p{Script=Greek}\\z{2})++\\k{2,3}\\x41|[\\8\\s\\d]*?)[Aa-z\\d]{2,3}?,é", "flags": "", "valid": false}
+{"pattern": "[--][]\\f[\\c1\\\\]+?", "flags": "v", "valid": false}
+{"pattern": "(?:\\G[]{2,3}|[-z]\\8)é[[:alpha:]&&{][^\\-&&]\\e", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\10*+(?'a\\-*[^]).++{2,1}$?>+?|", "flags": "", "valid": false}
+{"pattern": "[^--]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!-|(?(?=a),)[\\w|😀{]**\\cA|)\\G+?\\b", "flags": "v", "valid": false}
+{"pattern": "\\=f'??", "flags": "u", "valid": false}
+{"pattern": "(?<=[\\w\\][\\cA])&+A\\.==", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s\\.{2,3}<?\\da+/", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "['*+&", "flags": "u", "valid": false}
+{"pattern": "[z\\q${ab}\\dA]", "flags": "v", "valid": false}
+{"pattern": "[]\\-[\\q{ab}a]++\\D\"?|", "flags": "u", "valid": false}
+{"pattern": ">9{2,3}?<=]\\d\\z", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(a)[\\8)/](?:[\\cA|][😀\\s😀])|\\G|)(?|\\1*+\\u{41}|)b", "flags": "i", "valid": false}
+{"pattern": "\\c1\\n", "flags": "u", "valid": false}
+{"pattern": "[b", "flags": "v", "valid": false}
+{"pattern": "(?-i:[-(\\]\\c1\\{2}(?i:[^zA]\\0|)++/+?|)", "flags": "u", "valid": false}
+{"pattern": "[😀\\]😀^]\\v??<", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]\\](?:(?P<a><!\\e*?|[(\\cA)(]{,3}\\b??)\\u{41}(?<=\\A(?(?=a)]+&0*|{1}))){3,2}\"\\p{Script=Greek}++(?:[-a-\\d\\8$](\\a(?'a'\\e++[|]|[z-az]]){2,3})|)", "flags": "", "valid": false}
+{"pattern": "[\\d\\x41]\\p{Script=Greek}\\8+.\\B[!!😀]*?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k(?(?=a)/|^+(?=[^]\\8\\8", "flags": "", "valid": false}
+{"pattern": "\\e*?\\\\(?-i:(?<=[\\-aa-\\d]+\\8{2,3}?(\\c1\\a\\\\)) ){2,}>(?<a>(?:\"+?(?<a>[&&/{(]$+\\u{41}))*[--]|\\c1*+(?:})){(?(?=a)\\k<b>|\\2{,3}", "flags": "v", "valid": false}
+{"pattern": "[|\\1(a]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]](?<=(?'a'-)[]|\\f)😀\\/", "flags": "u", "valid": false}
+{"pattern": "[..](?'a'[[:alpha:][:alpha:]a-\\d(]*+[^\\p{L}]**|(?<b>\\x41\\10|[^[\\q{ab}😀][^])$^{2,3}?{2,1}|)\\G\\u{41}?[][z\\x41\\])]*?", "flags": "", "valid": false}
+{"pattern": "\\P{Lu}*$\\c1|", "flags": "v", "valid": false}
+{"pattern": "<{,3}\\q}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\a", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v\\1{2+}_\\s", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "é\\3[]]\\w]", "flags": "v", "valid": false}
+{"pattern": "[]{,3}(?<a>\\x4)(?|\\\\){2,}(?(<a>)(?<=\\10*?&\\10)\\a\\w|\\\\{2,3}?)", "flags": "u", "valid": false}
+{"pattern": "[[\\8-\\d][^](?'a'(?#(?=/\\G[\\a-\\d-\\\\]*+)\\a)\\}a(?'a'[]A{2})(?x)[\\w\\q{ab}^]??", "flags": "", "valid": false}
+{"pattern": "(?>9|\\\\).0\\3", "flags": "", "valid": false}
+{"pattern": "\\p{L}{2,3}[\\w\\-\\\\]b**{,2}\\e.", "flags": "v", "valid": false}
+{"pattern": "\\-v(?x)\\v|", "flags": "", "valid": false}
+{"pattern": "\\-#&\\x41?\\B\\b|", "flags": "v", "valid": false}
+{"pattern": "\\1d{2,3}?\\t", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": ":{,3}[[]\\n*+", "flags": "v", "valid": false}
+{"pattern": "\\k<a>\\t\\]c1", "flags": "u", "valid": false}
+{"pattern": "(?(a)\\\\f{2}[}(|]{[z\\x41z]{,3}[^^-\\s]{,3}(?'a'!{3,2}\\B*)?[^\\0[:alpha:]]\\3{2,3}?\\12", "flags": "", "valid": false}
+{"pattern": "(?!\\u{41}{2,3}?)\\z", "flags": "v", "valid": false}
+{"pattern": "$k\\P{Lu}[\\x41]+\\n{", "flags": "v", "valid": false}
+{"pattern": "(?<a-b>[z[$\\q{ab}]**[\\p{L}z\\])(?'a'\\A{2,}(|?|9\\e|\\q[^\\[\\0][]{,3})[(a-\\d\\sz]||-\\d[\\])", "flags": "", "valid": false}
+{"pattern": "\\>z{>+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pL(?P<a><){2,3}?\\P{Lu}{2,}\\A", "flags": "", "valid": false}
+{"pattern": "\\12*+\\.\\10\\0", "flags": "", "valid": false}
+{"pattern": "9[😀A\\cA\\0](?i:\\q|😀\\z", "flags": "", "valid": false}
+{"pattern": "[\\w[:alpha:]]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\D{2,3}?b[\\]z]](?(1)A\\c1\\b)(?(a)\\G]++(?<b>(?'a'[^]{2,1}??|&\\p{L}\\\\){2,1}))(?<a>\\u{41}]\\0{|(?|\\-**[^z]\\\\|(?>\\n++{,2}|[^^\\w\\b]\\G+?\\G)??\\.)++\\q{2,1}){2}", "flags": "i", "valid": false}
+{"pattern": "_\\x4*[\\\\\\|\\cA]**", "flags": "v", "valid": false}
+{"pattern": "[\\[)]++[][:alpha:]!!|", "flags": "", "valid": false}
+{"pattern": "éé", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|\\p{Script=Greek})(?|[&&z](?P<a>\\D)\\/+?)*+(?-i:(?(<a>)[\\p{L}!!]**\\x41{){2,3}(?:(?!\\10||[*\\Z)\\10*+\\G)\\10|[z-aa])]\\x41*?", "flags": "i", "valid": false}
+{"pattern": "\\-\\p{L}(?<a-b>\\d\\e\\e{{,2}?\\B\\D", "flags": "v", "valid": false}
+{"pattern": "(?!\\3[\\8]\\\\)*?,{2,}>\\f", "flags": "u", "valid": false}
+{"pattern": "[^.$[:alpha:]\\]{2,}{,2}[]*\\x4{2,1}", "flags": "", "valid": false}
+{"pattern": "\\Z{2}(?i)\\x41|", "flags": "i", "valid": false}
+{"pattern": "[\\s\\b\\A]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a-b>{[\\p{L}z](?|\\1))", "flags": "", "valid": false}
+{"pattern": "(?<b>\\8{3,2}$\\a|)(?:-)+(?x)(?(1)/(?<a-b>\\cA{3,2}\\-{2}|{1,2}|)[^]|{1,2}(?:\\.|\\{x41+?\"*?)\\k<a>)[.(\\d\\c1]|(?=[.z-a]){2,3}?\\x4++??(?<a>[]|{,2})|", "flags": "", "valid": false}
+{"pattern": "(?<b>\\Z)(?i:\\A{2,3}?\\d|[😀{)]{2,}(?P<a>{1}))+\\cA:", "flags": "", "valid": false}
+{"pattern": "(?(?=a)[\\w][\\\\\\d]|(?<a>[|]\\s?? |\\-\\c1)**}**)", "flags": "", "valid": false}
+{"pattern": "\\P{Lu}\\c1\\/{,2}[{/]|", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "{1}[}|\\\\[\\q{ab}{]\\10b{2,}", "flags": "", "valid": false}
+{"pattern": "(?![^a-z^.][^\\x41\\w\\d--]\\k<a>*+|[\\b😀)a-\\d]é<)é**=", "flags": "v", "valid": false}
+{"pattern": "\\8\\Z(\\p{L},(?'a'\\0{2,}|}\\\\*))", "flags": "", "valid": false}
+{"pattern": "\\G}{3,2}</!", "flags": "", "valid": false}
+{"pattern": "&|", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s(?<a-b>^{2,3}(?x)(?<!,?#??|\\10\\P{Lu}{,3}[\\x41\\c1\\b])++\\c1+?9{2,3}[\\x41]++|\\1(?<b>[}\\-+|[\\-a&&&&]???)\\v_{[]\\p{L}", "flags": "", "valid": false}
+{"pattern": "\\.\\B++(?(?=a)(?>😀))\\q\\k<b>a", "flags": "u", "valid": false}
+{"pattern": "[[[\\s]\"", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(1)[\\[:alpha:]])(?i:\\Z)\\*+", "flags": "", "valid": false}
+{"pattern": "(?x)\\cA{1}**[\\w\\b^]{2,}[],{", "flags": "i", "valid": false}
+{"pattern": "\\w\\Z*?\\D", "flags": "u", "valid": false}
+{"pattern": "\\.{\\B(?>\\B(?x)[*+(?(1)\\12){,3}(?<=\\u{41}{2,1})|(?<!\\w\\c1{2})\\cA(?<b>[]a\\.++)|[\\0]?,){2,3}9\\A*?", "flags": "u", "valid": false}
+{"pattern": "[^$-]\\D_(?:\\D[a-\\d]0)[!![\\x41/]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "a{,3}(?!(?!(?=\\12[^\\bz-aA$]\\A)*>*+(?(a)[^]^])|-{2,3}\\v[])|(?>}(?<a-b>[^\\x41.[:alpha:]{]*?\\p{Script=Greek}\\G)){3,2}[^(\\]a-z}{2,3}?)??((?<b>\\cA[^)]{2}\\1|[^a-\\d\\\\]??|)*+(?>\\1{2}|\\-)9){^", "flags": "v", "valid": false}
+{"pattern": "&\\A[\\w\\8]-\\u{41}\\A*+", "flags": "", "valid": false}
+{"pattern": "\\.(?:\"**(?(1)\\a<\\cA{)??){2,3}(?-i:=é+|(?#{,2}{2,3}(?i){1}|\\0*+\\d[A]{3,2}|**)?)?{2,}", "flags": "u", "valid": false}
+{"pattern": "\\u{41}\\d*+\\pL??}(?(?=a)[)z-a]8*+\\1)++|", "flags": "v", "valid": false}
+{"pattern": "\\10+", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[A][[:alpha:]]**\\k(?#[.])[😀--\\cA&&]", "flags": "i", "valid": false}
+{"pattern": "\\10 (?>\\P{Lu}[)\\c1[:alpha:]]*😀", "flags": "v", "valid": false}
+{"pattern": "\\v", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(-[\\c1]", "flags": "", "valid": false}
+{"pattern": "(?(<a>)-|)\\-[\\8\\0\\0]", "flags": "i", "valid": false}
+{"pattern": "\"\\x4{2,}(?<!(?-i:(?=>\\Z[^&&\\ba-\\d\\p{L}])|(?={2,1}\\w?é||[^.\\sa-\\d]a?[\\b]))|\\k<a>\\w*+b|)??\\e\\cA+?[^]{2,3}?", "flags": "", "valid": false}
+{"pattern": "\\\\{2}\\pL", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)a\\0\\-){,3}\\G[/][](?:(?=/{1,2}?|){(?(a)(?<a>(?#:+|){))", "flags": "i", "valid": false}
+{"pattern": "[][A&&!!/]\\v{2,}\\p(L[z]*?/", "flags": "", "valid": false}
+{"pattern": "[^z-az-a-]\\cA*+A{2,3}", "flags": "v", "valid": false}
+{"pattern": "\\G{2,3}(?'a'[z-a\\p{L}-])\\d(?i:(?|(?=[^{2}})\\P{Lu}')[-😀]{2,3}?[]^😀)]{2,3}?)", "flags": "", "valid": false}
+{"pattern": "<\\1=", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<b>\\s\\A[\\p{L}\\1]]\\B", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\1]\\cA{22,3}?", "flags": "", "valid": false}
+{"pattern": "'", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(1)(?(?=a)9\\a[[\\x41(z]))", "flags": "", "valid": false}
+{"pattern": "\\x41]|", "flags": "v", "valid": false}
+{"pattern": "\\w{2,3}*?9+?", "flags": "i", "valid": false}
+{"pattern": "([😀]-][|\\w\\c1}][a\\\\\\]|)*+", "flags": "", "valid": false}
+{"pattern": "(?P<a>[])[\\8z})]*", "flags": "i", "valid": false}
+{"pattern": "\\1\\v{1,2}{{2,}|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]😀|]\\pL:\\P{Lu}*+", "flags": "u", "valid": false}
+{"pattern": "\\p{L}(?i)\\k\\w(?(<a>)]{2}[/\\cA\\0])|\\B(?|(?-i:b|)){2,3}😀\\t,([\\bz-a\\\\}]|/", "flags": "i", "valid": false}
+{"pattern": "\\u{41}[\\q{ab}/(]\\1\\w", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]{(?<a>#{2,})[^\\d--]{2,}\\k(?P<a>[^\\0}\\x4\\f|)", "flags": "i", "valid": false}
+{"pattern": "\\<\\", "flags": "v", "valid": false}
+{"pattern": ":{2,3}$+?\\D-\\3{2}", "flags": "", "valid": false}
+{"pattern": "(?(a)\\A+(?P<a>😀{|)[z-a\\0*?|\\x4\\A{32}:)|", "flags": "i", "valid": false}
+{"pattern": "[\\]**.", "flags": "", "valid": false}
+{"pattern": "{1,2}(?<b>\\3\\-|[\\-\\d](?!#\\k<b>😀){2,3})(?<\\u{41}|\\p{Script=Greek}\\e**", "flags": "", "valid": false}
+{"pattern": "\\b\\c1??[z-a}[:alpha:](][^{1,2}{2}[\\q{ab}]|", "flags": "u", "valid": false}
+{"pattern": "\\10\\x4{\"(?(<a>)(?-i:(?x)[\\\\}]\\]{2}{2,1}*?||&^**#[😀z-a\\1]*?)[^\\b\\p{L}]+|:?(?![]|)\\D*?|)|", "flags": "", "valid": false}
+{"pattern": "0[]-{,2}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b]{]*(?:>)(?<a>\\/\\3 )\\s{,3}{", "flags": "i", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\w*+[\\b\\-a-z[\\0\\],", "flags": "v", "valid": false}
+{"pattern": "\\d{\\.??\\/\\A[{]??^^{2,3}?", "flags": "i", "valid": false}
+{"pattern": "/++\\Z[^\\]a-z]][]+", "flags": "", "valid": false}
+{"pattern": "[\\x41.(\\d]\\v(?<=\\D)[\\b$a-\\d--]\\1*[\\]\\q{ab}z\\cA]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)[^\\s]+?|(?<a-b>\\.*)(\\u{441}|\\D|){,3}*+!", "flags": "v", "valid": false}
+{"pattern": "(?#_)[a\\x41\\cA}](?(<a>)<)^", "flags": "u", "valid": false}
+{"pattern": "b\\d*", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(1)\\a\\G??&)[\\\\$\\b\\x41]\\pL{,3}(?:(?(<a>)(?(<a>)\\e)(?(a)_{){,3}){2,3}?é)", "flags": "i", "valid": false}
+{"pattern": "\\d[^[:alpha:]][\\8]\\b}]A[^]\\cA", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "!2,3}", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[}\\-a-z]'|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:\\a)(?P<a>[^}][z-a[:alpha:]😀[]++\\D){2,3}[\\c1--a-z]\\u}{41}[z-az-aa\\]{2,}", "flags": "u", "valid": false}
+{"pattern": "A[z-a\\\\[:alpha:]**\\a|", "flags": "v", "valid": false}
+{"pattern": "A{2,}\\D[!!a--z][a-za-z\\s\\s\\d{2,3}=", "flags": "i", "valid": false}
+{"pattern": "\\3\\u{41}(?|\\z{2,3}-\\d{2}|#)\\k", "flags": "i", "valid": false}
+{"pattern": "\\3{3,2}\\pL", "flags": "v", "valid": false}
+{"pattern": "a\\e^\\q", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1[--!!(]\\k", "flags": "", "valid": false}
+{"pattern": "(?<b>-|(?x)-{3,2}|{3,2}[\\]])>9{\\k<a>", "flags": "i", "valid": false}
+{"pattern": "{,{2,3}\\A++|", "flags": "u", "valid": false}
+{"pattern": "\\x41é+=\\u{41}(?i)[^\\][:alpha:]a-\\d[:alpha:]]?(?(?=a)\\c1{,2})\\p{Script=Greek}?", "flags": "i", "valid": false}
+{"pattern": ">{\\8*+(?'a'(?(<a>)(?|\\p{Script=Greek})|(?:\\f|\\p{Script=Greek}\\-)+|){2,3}?|[\\1$^]\\1?)", "flags": "", "valid": false}
+{"pattern": "\\t{2,}{,2}\\1+\\2\\\\.(?i:\\x41*|\\/{2,3}?|)", "flags": "v", "valid": false}
+{"pattern": "\\x4[^^\\\\.a-z", "flags": "", "valid": false}
+{"pattern": "'(?>-)\\D++", "flags": "v", "valid": false}
+{"pattern": ":\\q{,3}]\\pL|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B(?<!(?<={,3}[](?'a'[^\\]a.\\d]++)|)){(?<=[\\d\\\\\\d\\-])", "flags": "v", "valid": false}
+{"pattern": "_(?={1,2}\\n{,3}", "flags": "v", "valid": false}
+{"pattern": "{1,2}", "flags": "u", "valid": false}
+{"pattern": "[|]\\\\**}\\k<a>{2}\"+[$\\d\\]\\q{ab}", "flags": "", "valid": false}
+{"pattern": "\\.>{2,3}?[\\cAa-z\\d](?-i:\\10)[^]*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n(?(a)(?(1)(?'a'\\12>!)|\\-\\3<)**\\d)(?i:]\\x41[\\cA]|).{2,}\\0{3,2}", "flags": "v", "valid": false}
+{"pattern": "\\B{2,}\\D{2,3}\\e++(?:\\10||{,2}[\\ba](?i)-\\2*+\\.|)!_", "flags": "", "valid": false}
+{"pattern": "&!{.+?\\n", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "'{2,3[/^[\\t", "flags": "u", "valid": false}
+{"pattern": "\\\\\\d", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\"\\Z_{[\\c1\\0", "flags": "u", "valid": false}
+{"pattern": "\\t\\v{2}[]\\w", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1?(?(a)\\w(?i)0{2}\\u{41}+|\\k<a>**[&&z-a][/😀](?<a>[|a-za/{|\\k<a>{2,}(?<b>\\c1\\x4^)?){3,2}{,2}", "flags": "", "valid": false}
+{"pattern": "[]-\\k", "flags": "v", "valid": false}
+{"pattern": "9{3,2}\\.\\f(?=(?:\\12{2,3}}*?\\p{L}|){2}'\\p{Script=Greek}){2,3}?", "flags": "", "valid": false}
+{"pattern": "\\c1?)?", "flags": "", "valid": false}
+{"pattern": "\"-(?#[}/a-z]{2}\\8|}{1,2}$)(?(?=a)[^]++(?<!{,2}\\cA|{,2}[\\q{ab}\\1[:alpha:]\\q{ab}]+|).", "flags": "v", "valid": false}
+{"pattern": "(?i)(?#(?<b>\\c1)*+){2,3}?\\n*[\\\\]", "flags": "v", "valid": false}
+{"pattern": "{(?'a'\\q{2,}[\\]]\\z+?)(?:(?<a-b><\\pL|){2,}\\pL+?)a*?\\pL{2,}", "flags": "", "valid": false}
+{"pattern": "\\pL[]{2,3}{\\2[\\s\\s\\bA]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q++", "flags": "", "valid": false}
+{"pattern": "\\0\\k<a>", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "9[\\\\a-\\d|$]\\x4", "flags": "v", "valid": false}
+{"pattern": "", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\**:\\u{41}+\\x4(?<b>[z-a\\\\]{){", "flags": "v", "valid": false}
+{"pattern": "][(a-z\\cA\\]][](?<=\\G+?[a-\\dz\\p{L}&&]{2,3}?|\\s|)\\/", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pL\\3[|z-a\\]z-a]+?[A\\\\]\\w[]&&{]**", "flags": "u", "valid": false}
+{"pattern": "[\\8]{2,}(?<a>(?-i:(?(a)A+?\\k<b>'|\\cA\\p{Script=Greek}){,2}\\b*|\\p{L})(?(?=a)>{3,2}=)|(\\109\\B)++)+?[\\]]", "flags": "u", "valid": false}
+{"pattern": "(?{i:[(\\x41\\s]\\x4*+\\.{2,3}?|\\cA+)\\d++<#(?<a-b>\\c1[.]\\n)??\\f+?", "flags": "", "valid": false}
+{"pattern": ":(?i)[!!\\8][^a-z😀]|\\d[|a-\\d😀]**\\0\\10\\2{", "flags": "", "valid": false}
+{"pattern": "0[][!!]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=[^----&&😀]\\s\\k|\\d|)", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": " ?\\k<b>{,3}", "flags": "v", "valid": false}
+{"pattern": "(?<![[:alpha:]){\\cA[[|", "flags": "v", "valid": false}
+{"pattern": "\\cA(?-i:\\1&{2,1})(?|(?:\\12)é)(\\cA(?<!(?(a)\\/\\k{2,3}[\\8])[a-\\d.](?x)A>[\\8]))*\\10*?", "flags": "", "valid": false}
+{"pattern": "\\k<a>(?(1)[]??|(?-i:[[:alpha:]&&])\\b)", "flags": "v", "valid": false}
+{"pattern": "(?<=$)\\p{Script=Greek}(?|\\n{\\b[a--\\c1\\\\]{2,}|0*+(?P<a>\\z&{2,3}?|)\\k)[|\\q{ab}](?##*-{3,2}\\B{2,3}?)!(?i)(?<a>\\10[()]>|)[[/]", "flags": "u", "valid": false}
+{"pattern": "\\z\\k<a>(?i:\\10)[^\\w){[]{2,1}", "flags": "i", "valid": false}
+{"pattern": "😀++", "flags": "i", "valid": false}
+{"pattern": "-{", "flags": "u", "valid": false}
+{"pattern": "(?(<a>)\\q)\\x4(?x)(?>é)}[\\c1\\w.[]++[]+?", "flags": "i", "valid": false}
+{"pattern": "\\c1<\\c1??(?(1)[]{2,3,}|{1})\\z\\x4", "flags": "", "valid": false}
+{"pattern": "(?!(?|\\.+?)++\\G)[az]\\k[\\-]*", "flags": "", "valid": false}
+{"pattern": "(?(?=a)\\x41|,){2,}\\k<b>[\\0\\8\\0]{1,2}{\\d+_|", "flags": "", "valid": false}
+{"pattern": "[\\x41$)][|-\\wa-z](?(1)(?x)(?'a'[[:alpha:]\\c1(]{,2})):", "flags": "", "valid": false}
+{"pattern": "\\wé[^:]{,3}|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:b)(?<=\\A\\2{3,2}\\e),**[\\q{ab}\\cA!!\\|1]", "flags": "u", "valid": false}
+{"pattern": "[]\\Z+?(?=(?<!(?x).|\\d)(?>(?<b>\\1{2,3}?)){\\d){,3}", "flags": "u", "valid": false}
+{"pattern": "\\k(?<>\\c1)\\3\\d\\P{Lu}", "flags": "", "valid": false}
+{"pattern": "[!!!😀\\\\][]\\z*", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[.[]?\\c1{2,1}", "flags": "", "valid": false}
+{"pattern": "\\/cA\\1,", "flags": "v", "valid": false}
+{"pattern": "\\t{2,3}\\.", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": ">>", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{Lu}[(}|][^\\b!!\\]]??[a-z/z-a]", "flags": "", "valid": false}
+{"pattern": "(?i){1}+{1}(?-i:\\Z|{(?>\\1\\A\\x4){2,3}{2}[[a!!\\s]++}\\k+(?<a-b>(?(a)\\w)|[^\\\\\\]\\n😀*)[/$]", "flags": "i", "valid": false}
+{"pattern": "[\\0)^a-\\d]^\"*+(?|\\1(?:[^-\\0]\\12{2,}\\B**)|\\k+?)*?[](?i:(?(1)(?x) \\P{Lu}??[-z-a/a-zz]){2,3}?|_)", "flags": "i", "valid": false}
+{"pattern": "\\G", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t\\8[}]\\10", "flags": "v", "valid": false}
+{"pattern": "[\\\\😀-](?=\\-(?-i:(?<![\\p{L}$-])\\b{3,2}\\n|\")(?i:-{2,3}?\\k<a>{3,2}[]*?(?=:*+[^\\d[:alpha:]]??)\\pL++\\.+(?=\"+?[\\s|\\x41](\\w\\b(?#b|\\A)))", "flags": "u", "valid": false}
+{"pattern": "[a]{2,3}\\3{2,3}?\\a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "^{2,}", "flags": "u", "valid": false}
+{"pattern": "=[\\--/]^+?\\/\\v**", "flags": "", "valid": false}
+{"pattern": "A(?(1)[\\8\\p{L}]{[\\p{L}](?i:\\Z\\x4-1)[[]|", "flags": "", "valid": false}
+{"pattern": "$[z$a-z\\\\][\\(?'a'\\b*|:\\x41", "flags": "v", "valid": false}
+{"pattern": "(?'a'é**|\\3\\a|)\\B**", "flags": "", "valid": false}
+{"pattern": "\\G[^\\8z\\&&{", "flags": "u", "valid": false}
+{"pattern": "[\\x41|]\\pL_\\2\\k<b*>\\pL", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=(?|(?x)A+?[^\\]😀z-a\\-]||(?#\\p{Script=Greek}\\2\\k<b>{3,2}))*+(?(?=a)\"|{1,2}\\pL|)😀[^]", "flags": "", "valid": false}
+{"pattern": "\\2\\w?\\8}{[^--\\x41&&\\](?i){1,2}\\x4{2,}", "flags": "u", "valid": false}
+{"pattern": "[[\\8\\b]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x41\\\\bé", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": ".{2,3}?(?i)\\f\\a\\b{2,3}?\\b", "flags": "", "valid": false}
+{"pattern": "\\k<b>]{\\B{2,}[]\\cA[\\\\A]", "flags": "", "valid": false}
+{"pattern": "(?>(?=}(?x)<|[z-aa-\\d\\]{2-,3}?[^A^](?|[^\\b][\\w]\\c1){,3})*)[^&&\\b]+?\"{,2}\\-+", "flags": "u", "valid": false}
+{"pattern": "\\D??", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "<\\d{,2},{2,3}^?\\8??", "flags": "v", "valid": false}
+{"pattern": "[^][/\\1--|??(?>[[--\\x41\\x41]^{2}(?(1)a)|\\.)b", "flags": "u", "valid": false}
+{"pattern": "\\\\(?(?=a)(?#\\e{3,2}[^-😀\\cA]++)+?{2,<1}\\k<a>?)'{3,2}", "flags": "i", "valid": false}
+{"pattern": "(?i)[]\\G|\\s\\v{2,}:<??\\b", "flags": "v", "valid": false}
+{"pattern": "\\P{Lu}/++d&++>[&&\\-z-a--]++", "flags": "u", "valid": false}
+{"pattern": "\\G(?<b>[^||😀]{2,3}?)\\p{Script=Greek}(?-i:[]\\t){2,}}*?(?P<a>=\\.", "flags": "i", "valid": false}
+{"pattern": "\\cA\\k<b>{_[\\c1(?<a>(?<a>\\p{Script=Greek}!\\/))", "flags": "", "valid": false}
+{"pattern": "$0[(\\\\-]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!(?#^(?(a)\\\\|[\\s]9{,3}|)(?>\\0}*+))*?^{3,2})*(?>(?<a>[\\0a]'))\\k<a>(?=[|-/]$:){,3}({,2}A)", "flags": "i", "valid": false}
+{"pattern": "$\\q++={3,2}\\0{3,2}", "flags": "", "valid": false}
+{"pattern": "{2,1}(?(?=a)\\p{L}[\\z(]|A\\k<b>*+ {2,3}?|)(?'a' (?<b>(?<! |{1}**'.|))\\d**){2,}\\1", "flags": "", "valid": false}
+{"pattern": "[^\\q{ab})&&^]?:\\2+\\w?", "flags": "u", "valid": false}
+{"pattern": "\\3{2}[^\\q{ab}\\cA]\\a(?(1)(?'a'\\cA'){2,3})+\\D*+\\P{Lu}+?|", "flags": "", "valid": false}
+{"pattern": "[\\b]\\k<a>+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "](\\w\\v=??{2,}(?=(?'a'[)\\q{ab}],|)\\k\\k+?|[--[\\8])(?(<a>)[\\w]+(?:[]{\\.[-A])\\t)[😀[\\cA\\]]*+", "flags": "", "valid": false}
+{"pattern": "\\-**\\z'(?!(?>[\\s]\\b))😀++", "flags": "u", "valid": false}
+{"pattern": "((?i:\\.*+{1,2}|\\k<a>??\"{(?>:\\x41\\x41)\\cA\\k", "flags": "u", "valid": false}
+{"pattern": "\\2(?i:[][]**(?<=(?<a>\\x41>é{2,}|{2,1}{,2}\\A{)|)", "flags": "i", "valid": false}
+{"pattern": "[\\A]>\\G++", "flags": "", "valid": false}
+{"pattern": "\\\\{2,}(?<![^}&&|]++[)][}a-.][|{1}[^{a|])<+?{1}", "flags": "u", "valid": false}
+{"pattern": "(?(<a>)\\u{41}'(?![\\q{ab}\\b]|))*+(?:\"**|[])++", "flags": "v", "valid": false}
+{"pattern": ",+[\\1\\x41]\"{(?![|]]&&]}[--]||\\D{,3}\\k(?-i:}\\12(?<![\\\\\\s|\\w]\\P{Lu})))\\u{41}(?:[-.]?\\u{41}|)", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\--😀\\s](?|é[a-\\da])(?i)(?x)[a-z\\]]{,3}[\\s.\\w**\\s|{1,2}\\v{,3}\\\\\\k<b>|", "flags": "", "valid": false}
+{"pattern": "\\Z(?(?=a)(?<a>(?<!\\\\**\\k\\s)||[^\\1--.\\d]*?(?i)\\z\\x4\\u{441}{2}|é)|)[^\\1A]<**", "flags": "u", "valid": false}
+{"pattern": "#[^}a-\\d\\d\\s][😀]{2,3}+?\\x4{2}(?:a)", "flags": "u", "valid": false}
+{"pattern": "(?<!\"|[&&&&w\\cA]{,2}{2,})", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[]{2,3}\\0\\3\\\\", "flags": "u", "valid": false}
+{"pattern": "\\3,(?<a-b>\\x4\\p{Script=Greek}|[^]++\\e)[}\\\\-]:", "flags": "", "valid": false}
+{"pattern": "[]?*+\\v[\\])]", "flags": "", "valid": false}
+{"pattern": "_=(?(1)^\\/|(?!😀)((\\12b\\k|[.a\\cAz-a]{2,1})|\\/{3,2}\\\\{2,}[\\sA]))", "flags": "", "valid": false}
+{"pattern": "\\B", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\", "flags": "i", "valid": false}
+{"pattern": "\\p{L}*?[|]\\a[\\q{ab}|]\\8", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)(?i)>?$*?)\"$\\s{,3}&", "flags": "i", "valid": false}
+{"pattern": "\\-{,3}(?'a'!{2,3}?-{2,})[a-z]{:,3}", "flags": "v", "valid": false}
+{"pattern": "\"{\\8_{,3}(?i:\\e*+)", "flags": "", "valid": false}
+{"pattern": ":(?'a'\\s||(?<a>\\pL)||)\\a+", "flags": "v", "valid": false}
+{"pattern": " {2,}}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>\\P{Lu})\\3{,3}\\v[A\\q{ab}\\p{L}][^)]", "flags": "v", "valid": false}
+{"pattern": "[a-z\\p{L}0]{3,2}\\c1{2,3}(?:\\0(?-i:[^\\wa-\\d\\cA\\1]))", "flags": "v", "valid": false}
+{"pattern": "é\\b+?[\\1A{]{,3}\\z(?(a)(?(?=a)}*|\\B[^][])'){2}!", "flags": "i", "valid": false}
+{"pattern": "][^z\\1^]", "flags": "v", "valid": false}
+{"pattern": "[^]++9\\A[]]|", "flags": "i", "valid": false}
+{"pattern": "[\\d[[:alpha:]\\]]/>*?", "flags": "u", "valid": false}
+{"pattern": "\\k<aa>??", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\z{2,3}?[\\w-{](?(1)(?-i:=)+\\0b)|", "flags": "", "valid": false}
+{"pattern": "(?=: [])'{[^\\d\\-)A]\\c1+", "flags": "u", "valid": false}
+{"pattern": "[--(?(1)[^\\c1\\0a]\\D{2,3})<+?(?(<>)\\k<a>(?<![^][\\-/]{2,})|[]+|)\\1\\\\", "flags": "", "valid": false}
+{"pattern": "!](?<=\\f[^}.]**)[))\\p{L}\\x41](?<a>\\/**#*+0||\\cA\\k<a>)\\n{2}", "flags": "", "valid": false}
+{"pattern": "\\cA![A\\x4", "flags": "v", "valid": false}
+{"pattern": "{1,2}{2,}[]-\\c1+?\\a", "flags": "u", "valid": false}
+{"pattern": "\\P{Lu}/[](?#(?i\\s>\\t){\\s)", "flags": "", "valid": false}
+{"pattern": "[{]{2,3}.\\k<^a>:{", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!'-|[--]{2,3}$)", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[][\\]\\q{ab}-]^a|", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "P{Lu}", "flags": "u", "valid": false}
+{"pattern": "\\p{Script=Greek}*?(?(<a>)0{[[:alpha:]]\\x4|[\\w][:alpha:]]?(?P<a>\\p{Script=Greek}\\0\\B|$){\\10,", "flags": "v", "valid": false}
+{"pattern": "\\.**(?(a){2,1}(?x)[]\\2(?#\\.\"|&A{2,1}|)(?-i:\\s[a-z\\dz-a](?'a'^[&&\\-\\1z]|é)*?){,3}\\2{2,}A", "flags": "", "valid": false}
+{"pattern": "<", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "😀(?x)[😀a-\\d]{2}|#+?[\\cA[alpha:]\\q{ab}]'$", "flags": "", "valid": false}
+{"pattern": "[😀z-a]", "flags": "v", "valid": false}
+{"pattern": "{,2}\\e", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\x41-\\-][/]{2,}[\\x41\\p{L}]{2}\\u{41}\\z**", "flags": "u", "valid": false}
+{"pattern": "=+}\\10[\\-\\1a-z\\b]", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)(?<b>{2,1}\\v(\\10{3,2}|[^]{[&&\\p{L}(\\d]{,2}))'\\a*|[\\--[:alpha:]])??\\.\\pL+9??\\t[\\x41\\8!!z]", "flags": "", "valid": false}
+{"pattern": "{,2}][\\b\\8a--\\d\\d]*\\u{41}++", "flags": "u", "valid": false}
+{"pattern": "[\\0](?!:*?[-\\u{41}**[^a-z(?!(?i)(?(a)]\\z|^#)?[]*?|\\-{|)(?!A){.{,3}", "flags": "", "valid": false}
+{"pattern": "(?(a):?|[-]*+)\\p{L}\\t(\\x41++{2,1}|\\A😀??\\A", "flags": "v", "valid": false}
+{"pattern": "[^]\\d{2}\\f*?(?x)[$|\\0]\\/|", "flags": "", "valid": false}
+{"pattern": "[]**9\\x41{,3}\\p{L}", "flags": "u", "valid": false}
+{"pattern": "\\f{2,3}?[\\w(}]\"[]\\a(?'a'(?(1)(?-i:\\G)-{2,3}?')*\\cA\\B)", "flags": "v", "valid": false}
+{"pattern": "(?i)(?<b>[^|)\\b]{2,3}[\\1\\cA])++\\q", "flags": "", "valid": false}
+{"pattern": "(?<a-b>\\3)(?=$(?(?=a)\\x41**\\q*+\\p{Script=Greek}){||\\b[\\1]|){?[}]*?[[\\8z-az]/{2}", "flags": "u", "valid": false}
+{"pattern": "(?<=\\A*+)\\:b{2,1}'+", "flags": "u", "valid": false}
+{"pattern": "\\8(?P<a>[^z]){,2}<{[^[:alpha:]\\8-}](?(a)[}])*?|", "flags": "u", "valid": false}
+{"pattern": "é", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": ":[^\\s]{2,}{1,2}\\x41😀\\D", "flags": "u", "valid": false}
+{"pattern": "(?<=[^]**.)\\1(?=[.]**(?<=\\P{Lu}\\s😀)?[^$\\]])(?-i:[\\b]++){\\Z[\\\\\\p{L}\\c1}]", "flags": "", "valid": false}
+{"pattern": "\\A\\qq\\v", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "_(?(1)#(?'a'(?<b>!\\8?-*||[^][]+[])\\Z+))(?(a)>[\\w\\p{L}\\0[])*?", "flags": "u", "valid": false}
+{"pattern": "(?(a)\\d0)+?*\\eb", "flags": "", "valid": false}
+{"pattern": "-[\\d\\p{L}]", "flags": "u", "valid": true, "captures": 0, "names": []}
+{"pattern": "{\"\\pL\\p{L}\\q ", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.++", "flags": "", "valid": false}
+{"pattern": "😀\\x41\\{41}", "flags": "u", "valid": false}
+{"pattern": "é{3,2}#**\\d{3,2}(?a'\\1(?i:(?<!$\\12[\\z.])(?(a)\\.{,3}a\\A|){[--z-a[\\\\]+?|\\u{41}(?i:}{2,3}?)\\x4|)A?-++", "flags": "v", "valid": false}
+{"pattern": "[^]*[$$a]\\k<b>??[!!!!^]{2,3}?", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(<a>)[](?:(?-i:<+|\\10\\Z?😀)[]))[\\\\!!][][^", "flags": "v", "valid": false}
+{"pattern": "(?'a'<{,3}(?<b>{1}|[]?)[\\0]){2}('?x)(?#.{2}\\P{Lu}😀*?|\\2++é^)[\\]\\p{L}]++|\\p{L}*\\n[]", "flags": "u", "valid": false}
+{"pattern": "[[(][^[:alpha:]a]{2,3}?[^]{2,1}", "flags": "i", "valid": false}
+{"pattern": "0\\/\\A&[z\\0]\\a", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA\\-]{$2}", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "{*+[^]{,3}", "flags": "i", "valid": false}
+{"pattern": "\\f\\x41*?=(?:\\B(?'a'(?<=\\1||=\")){,3}[[:alpha:]\\w]{1}*", "flags": "", "valid": false}
+{"pattern": "\\k<a>**?", "flags": "", "valid": false}
+{"pattern": "-=?\\s+?\\A\\z*?[^!!$\\x41]]{2,3}(?(a)[\\8A]++[\\w^])", "flags": "u", "valid": false}
+{"pattern": "((?'a'[]\\Z|[^.+[]??)", "flags": "", "valid": false}
+{"pattern": "\\w*?(?-i:\\D&?([}A]|[(?(?=a)\\k<a>?|)[])#?>{2,}0|", "flags": "", "valid": false}
+{"pattern": "[^?\\0\\s]", "flags": "v", "valid": true, "captures": 0, "names": []}
+{"pattern": "{??\\c1", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ww[]+", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1-\\\\]", "flags": "v", "valid": false}
+{"pattern": "\\.*+|", "flags": "", "valid": false}
+{"pattern": "[---]\\A*[]", "flags": "u", "valid": false}
+{"pattern": "[^\\w]{2,3}\\z*", "flags": "u", "valid": false}
+{"pattern": "é[].\\B\\D", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{41}\\12#[^(^^!!][(A]*+0", "flags": "", "valid": false}
+{"pattern": "=(?>\\P{Lu}{,2}(?i:}(?|\\x41{[^\\]\\b[:alpha:]&&]{){2,3}?a++))\\P{Lu}a??", "flags": "i", "valid": false}
+{"pattern": "^", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)(?P<a>[]??\\dd\\A{2,3}\\w[$]]", "flags": "", "valid": false}
+{"pattern": "(?(<a>)\\pL|>|{1,2}(?<! {{,2}|){2,}3}?\\b**[|/|", "flags": "i", "valid": false}
+{"pattern": "(?<b>^0||[{\\8\\w$[)]<{3,2}=)", "flags": "v", "valid": false}
+{"pattern": "{,2}_+(?(a)(\\z|[\\]\\-\\b])\\Z?\\e", "flags": "u", "valid": false}
+{"pattern": "(?:\\u{41}*?}**){3,2}[\\b][^\\c1]\\12\"", "flags": "v", "valid": false}
+{"pattern": ",[Aa-z\\x41--]{2,3}\\k<b>/\\b\\.", "flags": "u", "valid": false}
+{"pattern": "(?i:[][\\s\\-][!!\\8\\p{L}])*+(?P<a>\\-{1,2}||\\B\\k<a>)\\pL", "flags": "i", "valid": false}
+{"pattern": "[^\\]a-z]\\c1][^😀}\\8]a?!(?<a>\\/)", "flags": "", "valid": true, "captures": 1, "names": ["a"]}
+{"pattern": "\\c1](?![{-]\\k<b>)\\1\\A+\\k<b>", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|[]](?'a'\\.(?<a-b>\\/{2,3}?||\\3??\\n)\\A)(?:>)|\\p{L}[.a-d{.?)=[a]{3,2}{1,2}{3,2}\\GA{2,3}?", "flags": "i", "valid": false}
+{"pattern": "(?!\\A9)+?[^[^\\]]=", "flags": "v", "valid": false}
+{"pattern": "(?=\\Z?\\1*|^{2,3}?\\e{1,2}*)\\p{Script=Greek}??\\k<a>(?=\\q{2,3}?\\q\\G){2,3}(?'a'\\Z{2,3}?|\\2{,3}[^a-z\\0]+-)[a]", "flags": "i", "valid": false}
+{"pattern": "[a-z/](?<a-b>[\\b)\\0][^]--}])", "flags": "", "valid": false}
+{"pattern": "{1}{2,}\\n{2,}<\\B9+?", "flags": "i", "valid": false}
+{"pattern": "\\e\\2[^\\q{ab}\\\\1][]<", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "b[\\\\\\x41-]?(?-i:(?(<a>)\\a😀{2,1})\\10", "flags": "i", "valid": false}
+{"pattern": "\\e{\\0}[]", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Z", "flags": "i", "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)\\B||\\x41+?", "flags": "", "valid": false}
+{"pattern": "[|\\](?i:[A](?<=\\12a+\\D+?)]{2,3}\\Z{2}é", "flags": "", "valid": true, "captures": 0, "names": []}
+{"pattern": "\\a**\\p{Script=Greek}(?(a)[(\\\\]\\1]|}){2,3}", "flags": "", "valid": false}
+{"pattern": "[]$*\\12**", "flags": "", "valid": false}

--- a/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/PcreConformance.jsonl
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/PcreConformance.jsonl
@@ -1,0 +1,3910 @@
+{"pattern": "a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a", "extended": false, "valid": false}
+{"pattern": "(a", "extended": true, "valid": false}
+{"pattern": "a)", "extended": false, "valid": false}
+{"pattern": "a)", "extended": true, "valid": false}
+{"pattern": "()", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "()", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?:)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?", "extended": false, "valid": false}
+{"pattern": "(?", "extended": true, "valid": false}
+{"pattern": "(?)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[", "extended": false, "valid": false}
+{"pattern": "[", "extended": true, "valid": false}
+{"pattern": "]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]", "extended": false, "valid": false}
+{"pattern": "[]", "extended": true, "valid": false}
+{"pattern": "[^]", "extended": false, "valid": false}
+{"pattern": "[^]", "extended": true, "valid": false}
+{"pattern": "[]a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^]a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^]a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[z-a]", "extended": false, "valid": false}
+{"pattern": "[z-a]", "extended": true, "valid": false}
+{"pattern": "[a-a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-z]", "extended": false, "valid": false}
+{"pattern": "[\\d-z]", "extended": true, "valid": false}
+{"pattern": "[z-\\d]", "extended": false, "valid": false}
+{"pattern": "[z-\\d]", "extended": true, "valid": false}
+{"pattern": "[\\w-\\d]", "extended": false, "valid": false}
+{"pattern": "[\\w-\\d]", "extended": true, "valid": false}
+{"pattern": "[a-\\w]", "extended": false, "valid": false}
+{"pattern": "[a-\\w]", "extended": true, "valid": false}
+{"pattern": "[\\b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\B]", "extended": false, "valid": false}
+{"pattern": "[\\B]", "extended": true, "valid": false}
+{"pattern": "[.]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[.]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "{}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "{1}", "extended": false, "valid": false}
+{"pattern": "{1}", "extended": true, "valid": false}
+{"pattern": "a{1}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{,1}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{,1}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2,1}", "extended": false, "valid": false}
+{"pattern": "a{2,1}", "extended": true, "valid": false}
+{"pattern": "a{ 1}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ 1}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1 }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1 }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1, 2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1, 2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1,2", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65535}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65535}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{65536}", "extended": false, "valid": false}
+{"pattern": "a{65536}", "extended": true, "valid": false}
+{"pattern": "a{2147483647}", "extended": false, "valid": false}
+{"pattern": "a{2147483647}", "extended": true, "valid": false}
+{"pattern": "a{2147483648}", "extended": false, "valid": false}
+{"pattern": "a{2147483648}", "extended": true, "valid": false}
+{"pattern": "a{99999999999}", "extended": false, "valid": false}
+{"pattern": "a{99999999999}", "extended": true, "valid": false}
+{"pattern": "a{1}{2}", "extended": false, "valid": false}
+{"pattern": "a{1}{2}", "extended": true, "valid": false}
+{"pattern": "a{1}?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{1}+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a**", "extended": false, "valid": false}
+{"pattern": "a**", "extended": true, "valid": false}
+{"pattern": "a*?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a*?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a*+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a*+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a+?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a+?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a++", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a++", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a?+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a?+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a???", "extended": false, "valid": false}
+{"pattern": "a???", "extended": true, "valid": false}
+{"pattern": "*", "extended": false, "valid": false}
+{"pattern": "*", "extended": true, "valid": false}
+{"pattern": "+", "extended": false, "valid": false}
+{"pattern": "+", "extended": true, "valid": false}
+{"pattern": "?", "extended": false, "valid": false}
+{"pattern": "?", "extended": true, "valid": false}
+{"pattern": "a|*", "extended": false, "valid": false}
+{"pattern": "a|*", "extended": true, "valid": false}
+{"pattern": "(*)", "extended": false, "valid": false}
+{"pattern": "(*)", "extended": true, "valid": false}
+{"pattern": "(+)", "extended": false, "valid": false}
+{"pattern": "(+)", "extended": true, "valid": false}
+{"pattern": "(|*)", "extended": false, "valid": false}
+{"pattern": "(|*)", "extended": true, "valid": false}
+{"pattern": "^*", "extended": false, "valid": false}
+{"pattern": "^*", "extended": true, "valid": false}
+{"pattern": "$*", "extended": false, "valid": false}
+{"pattern": "$*", "extended": true, "valid": false}
+{"pattern": "\\b*", "extended": false, "valid": false}
+{"pattern": "\\b*", "extended": true, "valid": false}
+{"pattern": "\\B+", "extended": false, "valid": false}
+{"pattern": "\\B+", "extended": true, "valid": false}
+{"pattern": "a|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "|a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "|a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "||", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "||", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(|)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(|)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "\\", "extended": false, "valid": false}
+{"pattern": "\\", "extended": true, "valid": false}
+{"pattern": "a\\", "extended": false, "valid": false}
+{"pattern": "a\\", "extended": true, "valid": false}
+{"pattern": "[\\", "extended": false, "valid": false}
+{"pattern": "[\\", "extended": true, "valid": false}
+{"pattern": "[a\\", "extended": false, "valid": false}
+{"pattern": "[a\\", "extended": true, "valid": false}
+{"pattern": "\\0", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\00", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\00", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\000", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\000", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\01", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\01", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\07", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\07", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\08", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\08", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1", "extended": false, "valid": false}
+{"pattern": "\\1", "extended": true, "valid": false}
+{"pattern": "\\2", "extended": false, "valid": false}
+{"pattern": "\\2", "extended": true, "valid": false}
+{"pattern": "\\8", "extended": false, "valid": false}
+{"pattern": "\\8", "extended": true, "valid": false}
+{"pattern": "\\9", "extended": false, "valid": false}
+{"pattern": "\\9", "extended": true, "valid": false}
+{"pattern": "\\10", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\10", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\11", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\11", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\18", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\18", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\19", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\19", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\99", "extended": false, "valid": false}
+{"pattern": "\\99", "extended": true, "valid": false}
+{"pattern": "\\377", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\377", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\400", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\400", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\777", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\777", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(a)\\1", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\1", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\2", "extended": false, "valid": false}
+{"pattern": "(a)\\2", "extended": true, "valid": false}
+{"pattern": "(a)\\10", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\10", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "extended": false, "valid": true, "captures": 10, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "extended": true, "valid": true, "captures": 10, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "extended": false, "valid": true, "captures": 9, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "extended": true, "valid": true, "captures": 9, "names": []}
+{"pattern": "\\1(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "\\1(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "\\2(a)(b)", "extended": false, "valid": true, "captures": 2, "names": []}
+{"pattern": "\\2(a)(b)", "extended": true, "valid": true, "captures": 2, "names": []}
+{"pattern": "(a\\1)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a\\1)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "[\\1]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\1]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\8]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\8]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x", "extended": false, "valid": false}
+{"pattern": "\\x", "extended": true, "valid": false}
+{"pattern": "\\x4", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x41", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x41", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4g", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4g", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\xg", "extended": false, "valid": false}
+{"pattern": "\\xg", "extended": true, "valid": false}
+{"pattern": "\\x{41}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{41}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{}", "extended": false, "valid": false}
+{"pattern": "\\x{}", "extended": true, "valid": false}
+{"pattern": "\\x{110000}", "extended": false, "valid": false}
+{"pattern": "\\x{110000}", "extended": true, "valid": false}
+{"pattern": "\\x{D800}", "extended": false, "valid": false}
+{"pattern": "\\x{D800}", "extended": true, "valid": false}
+{"pattern": "\\u", "extended": false, "valid": false}
+{"pattern": "\\u", "extended": true, "valid": false}
+{"pattern": "\\u4", "extended": false, "valid": false}
+{"pattern": "\\u4", "extended": true, "valid": false}
+{"pattern": "\\u004", "extended": false, "valid": false}
+{"pattern": "\\u004", "extended": true, "valid": false}
+{"pattern": "A", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "A", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u{41}", "extended": false, "valid": false}
+{"pattern": "\\u{41}", "extended": true, "valid": false}
+{"pattern": "\\u{}", "extended": false, "valid": false}
+{"pattern": "\\u{}", "extended": true, "valid": false}
+{"pattern": "\\u{110000}", "extended": false, "valid": false}
+{"pattern": "\\u{110000}", "extended": true, "valid": false}
+{"pattern": "\\u{10FFFF}", "extended": false, "valid": false}
+{"pattern": "\\u{10FFFF}", "extended": true, "valid": false}
+{"pattern": "😀", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "😀", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀-😂]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[😀-😂]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[😂-😀]", "extended": false, "valid": false}
+{"pattern": "[😂-😀]", "extended": true, "valid": false}
+{"pattern": "😀+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "😀+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "extended": false, "valid": false}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "extended": true, "valid": false}
+{"pattern": "\\c", "extended": false, "valid": false}
+{"pattern": "\\c", "extended": true, "valid": false}
+{"pattern": "\\cA", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ca", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ca", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cz", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cz", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c_", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c_", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c@", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c@", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c[", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c[", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c]", "extended": false, "valid": false}
+{"pattern": "[\\c]", "extended": true, "valid": false}
+{"pattern": "[\\cA]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c1]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c_]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c_]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c@]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\c@]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\e", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\e", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Z", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Z", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\z", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\z", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\G", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\G", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\K", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\K", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qa\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qa\\E", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qab", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qab", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q\\E", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q]\\E]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q]\\E]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Qa-z\\E]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Qa-z\\E]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\h", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\h", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\H", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\H", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\R", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\R", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\X", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\X", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\C", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\C", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g", "extended": false, "valid": false}
+{"pattern": "\\g", "extended": true, "valid": false}
+{"pattern": "\\g1", "extended": false, "valid": false}
+{"pattern": "\\g1", "extended": true, "valid": false}
+{"pattern": "\\g{1}", "extended": false, "valid": false}
+{"pattern": "\\g{1}", "extended": true, "valid": false}
+{"pattern": "\\g-1", "extended": false, "valid": false}
+{"pattern": "\\g-1", "extended": true, "valid": false}
+{"pattern": "(a)\\g-1", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g-1", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g{-1}", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g{-1}", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g{+1}", "extended": false, "valid": false}
+{"pattern": "(a)\\g{+1}", "extended": true, "valid": false}
+{"pattern": "\\g<1>", "extended": false, "valid": false}
+{"pattern": "\\g<1>", "extended": true, "valid": false}
+{"pattern": "\\L", "extended": false, "valid": false}
+{"pattern": "\\L", "extended": true, "valid": false}
+{"pattern": "\\l", "extended": false, "valid": false}
+{"pattern": "\\l", "extended": true, "valid": false}
+{"pattern": "\\U", "extended": false, "valid": false}
+{"pattern": "\\U", "extended": true, "valid": false}
+{"pattern": "\\i", "extended": false, "valid": false}
+{"pattern": "\\i", "extended": true, "valid": false}
+{"pattern": "\\I", "extended": false, "valid": false}
+{"pattern": "\\I", "extended": true, "valid": false}
+{"pattern": "\\j", "extended": false, "valid": false}
+{"pattern": "\\j", "extended": true, "valid": false}
+{"pattern": "\\m", "extended": false, "valid": false}
+{"pattern": "\\m", "extended": true, "valid": false}
+{"pattern": "\\o", "extended": false, "valid": false}
+{"pattern": "\\o", "extended": true, "valid": false}
+{"pattern": "\\o{101}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{101}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{}", "extended": false, "valid": false}
+{"pattern": "\\o{}", "extended": true, "valid": false}
+{"pattern": "\\o{8}", "extended": false, "valid": false}
+{"pattern": "\\o{8}", "extended": true, "valid": false}
+{"pattern": "\\N{U+41}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{U+41}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{U+}", "extended": false, "valid": false}
+{"pattern": "\\N{U+}", "extended": true, "valid": false}
+{"pattern": "\\N{LATIN}", "extended": false, "valid": false}
+{"pattern": "\\N{LATIN}", "extended": true, "valid": false}
+{"pattern": "\\y", "extended": false, "valid": false}
+{"pattern": "\\y", "extended": true, "valid": false}
+{"pattern": "\\-", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\-", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\:", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\:", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\=", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\=", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\!", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\!", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\>", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\>", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\#", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\#", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\`", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\`", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\"", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\"", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\'", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\'", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p", "extended": false, "valid": false}
+{"pattern": "\\p", "extended": true, "valid": false}
+{"pattern": "\\pL", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pL", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pLu", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pLu", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lu}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L", "extended": false, "valid": false}
+{"pattern": "\\p{L", "extended": true, "valid": false}
+{"pattern": "\\p{}", "extended": false, "valid": false}
+{"pattern": "\\p{}", "extended": true, "valid": false}
+{"pattern": "\\p{^L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{^L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{^L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{^L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Letter}", "extended": false, "valid": false}
+{"pattern": "\\p{Letter}", "extended": true, "valid": false}
+{"pattern": "\\p{Uppercase_Letter}", "extended": false, "valid": false}
+{"pattern": "\\p{Uppercase_Letter}", "extended": true, "valid": false}
+{"pattern": "\\p{gc=L}", "extended": false, "valid": false}
+{"pattern": "\\p{gc=L}", "extended": true, "valid": false}
+{"pattern": "\\p{General_Category=Letter}", "extended": false, "valid": false}
+{"pattern": "\\p{General_Category=Letter}", "extended": true, "valid": false}
+{"pattern": "\\p{sc=Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx=Grek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx=Grek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script_Extensions=Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script_Extensions=Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{IsGreek}", "extended": false, "valid": false}
+{"pattern": "\\p{IsGreek}", "extended": true, "valid": false}
+{"pattern": "\\p{InGreek}", "extended": false, "valid": false}
+{"pattern": "\\p{InGreek}", "extended": true, "valid": false}
+{"pattern": "\\p{Bogus}", "extended": false, "valid": false}
+{"pattern": "\\p{Bogus}", "extended": true, "valid": false}
+{"pattern": "\\p{Any}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Any}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ASCII}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ASCII}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Assigned}", "extended": false, "valid": false}
+{"pattern": "\\p{Assigned}", "extended": true, "valid": false}
+{"pattern": "\\p{Alphabetic}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alphabetic}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alpha}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Alpha}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L&}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L&}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xan}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xan}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xwd}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xwd}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Emoji}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Emoji}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{RGI_Emoji}", "extended": false, "valid": false}
+{"pattern": "\\p{RGI_Emoji}", "extended": true, "valid": false}
+{"pattern": "\\p{Basic_Emoji}", "extended": false, "valid": false}
+{"pattern": "\\p{Basic_Emoji}", "extended": true, "valid": false}
+{"pattern": "\\p{lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{lu}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=}", "extended": false, "valid": false}
+{"pattern": "\\p{Script=}", "extended": true, "valid": false}
+{"pattern": "\\p{=Greek}", "extended": false, "valid": false}
+{"pattern": "\\p{=Greek}", "extended": true, "valid": false}
+{"pattern": "\\p{sc=Bogus}", "extended": false, "valid": false}
+{"pattern": "\\p{sc=Bogus}", "extended": true, "valid": false}
+{"pattern": "\\P{RGI_Emoji}", "extended": false, "valid": false}
+{"pattern": "\\P{RGI_Emoji}", "extended": true, "valid": false}
+{"pattern": "[\\p{RGI_Emoji}]", "extended": false, "valid": false}
+{"pattern": "[\\p{RGI_Emoji}]", "extended": true, "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}]", "extended": false, "valid": false}
+{"pattern": "[^\\p{RGI_Emoji}]", "extended": true, "valid": false}
+{"pattern": "\\k", "extended": false, "valid": false}
+{"pattern": "\\k", "extended": true, "valid": false}
+{"pattern": "\\k<", "extended": false, "valid": false}
+{"pattern": "\\k<", "extended": true, "valid": false}
+{"pattern": "\\k<a", "extended": false, "valid": false}
+{"pattern": "\\k<a", "extended": true, "valid": false}
+{"pattern": "\\k<a>", "extended": false, "valid": false}
+{"pattern": "\\k<a>", "extended": true, "valid": false}
+{"pattern": "\\k<1>", "extended": false, "valid": false}
+{"pattern": "\\k<1>", "extended": true, "valid": false}
+{"pattern": "\\k'a'", "extended": false, "valid": false}
+{"pattern": "\\k'a'", "extended": true, "valid": false}
+{"pattern": "\\k{a}", "extended": false, "valid": false}
+{"pattern": "\\k{a}", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k<a>", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)\\k<a>", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)\\k<b>", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\k<b>", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\k", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k<a", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\k<a", "extended": true, "valid": false}
+{"pattern": "\\k<a>(?<a>x)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "\\k<a>(?<a>x)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?<a>y)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)(?<a>y)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)", "extended": true, "valid": false}
+{"pattern": "((?<a>x)|(?<a>y))", "extended": false, "valid": false}
+{"pattern": "((?<a>x)|(?<a>y))", "extended": true, "valid": false}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "extended": false, "valid": false}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "extended": true, "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)((?<a>y)|z)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)((?<a>y)|z)", "extended": true, "valid": false}
+{"pattern": "(?<a>", "extended": false, "valid": false}
+{"pattern": "(?<a>", "extended": true, "valid": false}
+{"pattern": "(?<a", "extended": false, "valid": false}
+{"pattern": "(?<a", "extended": true, "valid": false}
+{"pattern": "(?<>x)", "extended": false, "valid": false}
+{"pattern": "(?<>x)", "extended": true, "valid": false}
+{"pattern": "(?<1a>x)", "extended": false, "valid": false}
+{"pattern": "(?<1a>x)", "extended": true, "valid": false}
+{"pattern": "(?<a1>x)", "extended": false, "valid": true, "captures": 1, "names": [["a1", 1]]}
+{"pattern": "(?<a1>x)", "extended": true, "valid": true, "captures": 1, "names": [["a1", 1]]}
+{"pattern": "(?<_>x)", "extended": false, "valid": true, "captures": 1, "names": [["_", 1]]}
+{"pattern": "(?<_>x)", "extended": true, "valid": true, "captures": 1, "names": [["_", 1]]}
+{"pattern": "(?<$>x)", "extended": false, "valid": false}
+{"pattern": "(?<$>x)", "extended": true, "valid": false}
+{"pattern": "(?<a$>x)", "extended": false, "valid": false}
+{"pattern": "(?<a$>x)", "extended": true, "valid": false}
+{"pattern": "(?<é>x)", "extended": false, "valid": true, "captures": 1, "names": [["é", 1]]}
+{"pattern": "(?<é>x)", "extended": true, "valid": true, "captures": 1, "names": [["é", 1]]}
+{"pattern": "(?<𝒜>x)", "extended": false, "valid": true, "captures": 1, "names": [["𝒜", 1]]}
+{"pattern": "(?<𝒜>x)", "extended": true, "valid": true, "captures": 1, "names": [["𝒜", 1]]}
+{"pattern": "(?<a-b>x)", "extended": false, "valid": false}
+{"pattern": "(?<a-b>x)", "extended": true, "valid": false}
+{"pattern": "(?<a b>x)", "extended": false, "valid": false}
+{"pattern": "(?<a b>x)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<\\u{61}>x)", "extended": false, "valid": false}
+{"pattern": "(?<\\u{61}>x)", "extended": true, "valid": false}
+{"pattern": "(?'a'x)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?'a'x)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P<a>x)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P<a>x)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P<a>x)(?P=a)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P<a>x)(?P=a)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P>a)", "extended": false, "valid": false}
+{"pattern": "(?P>a)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)(?P>a)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?P>a)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?&a)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?&a)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?&a)", "extended": false, "valid": false}
+{"pattern": "(?&a)", "extended": true, "valid": false}
+{"pattern": "(?R)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?R)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?0)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?0)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?1)", "extended": false, "valid": false}
+{"pattern": "(?1)", "extended": true, "valid": false}
+{"pattern": "(a)(?1)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)(?1)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)(?-1)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)(?-1)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)(?+1)", "extended": false, "valid": false}
+{"pattern": "(a)(?+1)", "extended": true, "valid": false}
+{"pattern": "(?+1)(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?+1)(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?-1)", "extended": false, "valid": false}
+{"pattern": "(?-1)", "extended": true, "valid": false}
+{"pattern": "(a)(?-2)", "extended": false, "valid": false}
+{"pattern": "(a)(?-2)", "extended": true, "valid": false}
+{"pattern": "(?C)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C1)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C1)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C255)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C255)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C256)", "extended": false, "valid": false}
+{"pattern": "(?C256)", "extended": true, "valid": false}
+{"pattern": "(?C\"a\")", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C\"a\")", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C{a})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C{a})", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?Ca)", "extended": false, "valid": false}
+{"pattern": "(?Ca)", "extended": true, "valid": false}
+{"pattern": "(*FAIL)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*FAIL)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*F)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*F)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ACCEPT)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ACCEPT)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*COMMIT)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*COMMIT)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*PRUNE)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*PRUNE)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*SKIP)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*SKIP)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*THEN)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*THEN)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*MARK:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*MARK:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*MARK)", "extended": false, "valid": false}
+{"pattern": "(*MARK)", "extended": true, "valid": false}
+{"pattern": "(*BOGUS)", "extended": false, "valid": false}
+{"pattern": "(*BOGUS)", "extended": true, "valid": false}
+{"pattern": "(*UTF)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UTF)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UCP)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UCP)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*CR)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*CR)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a(*UTF)", "extended": false, "valid": false}
+{"pattern": "a(*UTF)", "extended": true, "valid": false}
+{"pattern": "(*", "extended": false, "valid": false}
+{"pattern": "(*", "extended": true, "valid": false}
+{"pattern": "(*a", "extended": false, "valid": false}
+{"pattern": "(*a", "extended": true, "valid": false}
+{"pattern": "(?=a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=a)*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!a)+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a)?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a){2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!a){2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a+)", "extended": false, "valid": false}
+{"pattern": "(?<=a+)", "extended": true, "valid": false}
+{"pattern": "(?<=a*)", "extended": false, "valid": false}
+{"pattern": "(?<=a*)", "extended": true, "valid": false}
+{"pattern": "(?<=a|bc)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a|bc)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(a)\\1)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(a)\\1)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?>a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>a)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>a)*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|(a)|(b))", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?|(a)|(b))", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?|(a)|(b)(c))\\3", "extended": false, "valid": false}
+{"pattern": "(?|(a)|(b)(c))\\3", "extended": true, "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "extended": false, "valid": false}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "extended": true, "valid": false}
+{"pattern": "(?i)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i)a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-m:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?im-s:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?im-s:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?ii:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-i:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-i:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?s:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?s:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?m:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?m:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?n:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?n:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?n)(a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?n)(a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?q)", "extended": false, "valid": false}
+{"pattern": "(?q)", "extended": true, "valid": false}
+{"pattern": "(?^)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^i)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^i)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^i:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^i:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?xx)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?xx)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?J)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?J)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?U)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?U)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?u)", "extended": false, "valid": false}
+{"pattern": "(?u)", "extended": true, "valid": false}
+{"pattern": "(?aD)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aD)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?r)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?r)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i", "extended": false, "valid": false}
+{"pattern": "(?i", "extended": true, "valid": false}
+{"pattern": "(?i:a", "extended": false, "valid": false}
+{"pattern": "(?i:a", "extended": true, "valid": false}
+{"pattern": "a(?i)*", "extended": false, "valid": false}
+{"pattern": "a(?i)*", "extended": true, "valid": false}
+{"pattern": "(?i)*", "extended": false, "valid": false}
+{"pattern": "(?i)*", "extended": true, "valid": false}
+{"pattern": "(?#comment)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#comment)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#comment", "extended": false, "valid": false}
+{"pattern": "(?#comment", "extended": true, "valid": false}
+{"pattern": "(?#)a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#)a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a(?#x)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a(?#x)*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a(?#x){2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a(?#x){2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(1)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(1)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(1)a|b)(x)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(1)a|b)(x)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(1)a|b|c)(x)", "extended": false, "valid": false}
+{"pattern": "(?(1)a|b|c)(x)", "extended": true, "valid": false}
+{"pattern": "(?(a)x|y)", "extended": false, "valid": false}
+{"pattern": "(?(a)x|y)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)(?(a)x|y)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?(a)x|y)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?('a')x|y)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)(?('a')x|y)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(<a>)x|y)", "extended": false, "valid": false}
+{"pattern": "(?(<a>)x|y)", "extended": true, "valid": false}
+{"pattern": "(?(R)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(R)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(R1)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(R1)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(R&a)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(R&a)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x))", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(DEFINE)(?<a>x))", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(DEFINE)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(+1)a|b)(x)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(+1)a|b)(x)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(-1)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(-1)a|b)", "extended": true, "valid": false}
+{"pattern": "(x)(?(-1)a|b)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(x)(?(-1)a|b)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(VERSION>=10.0)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION>=10.0)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?!a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?!a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?<=a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?<=a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?:a)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(?:a)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(a)", "extended": false, "valid": false}
+{"pattern": "(?(a)", "extended": true, "valid": false}
+{"pattern": "(?(", "extended": false, "valid": false}
+{"pattern": "(?(", "extended": true, "valid": false}
+{"pattern": "(?()a)", "extended": false, "valid": false}
+{"pattern": "(?()a)", "extended": true, "valid": false}
+{"pattern": "(?(1a)x)", "extended": false, "valid": false}
+{"pattern": "(?(1a)x)", "extended": true, "valid": false}
+{"pattern": "(?(?#c)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(?#c)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(?<n>x)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(?<n>x)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(?'n'x)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(?'n'x)a|b)", "extended": true, "valid": false}
+{"pattern": "[[:alpha:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:bogus:]]", "extended": false, "valid": false}
+{"pattern": "[[:bogus:]]", "extended": true, "valid": false}
+{"pattern": "[[:alpha:]", "extended": false, "valid": false}
+{"pattern": "[[:alpha:]", "extended": true, "valid": false}
+{"pattern": "[[:alpha]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.a.]]", "extended": false, "valid": false}
+{"pattern": "[[.a.]]", "extended": true, "valid": false}
+{"pattern": "[[.hyphen.]]", "extended": false, "valid": false}
+{"pattern": "[[.hyphen.]]", "extended": true, "valid": false}
+{"pattern": "[[.-.]]", "extended": false, "valid": false}
+{"pattern": "[[.-.]]", "extended": true, "valid": false}
+{"pattern": "[[=a=]]", "extended": false, "valid": false}
+{"pattern": "[[=a=]]", "extended": true, "valid": false}
+{"pattern": "[[=ab=]]", "extended": false, "valid": false}
+{"pattern": "[[=ab=]]", "extended": true, "valid": false}
+{"pattern": "[[:alpha:]-z]", "extended": false, "valid": false}
+{"pattern": "[[:alpha:]-z]", "extended": true, "valid": false}
+{"pattern": "[a-[:alpha:]]", "extended": false, "valid": false}
+{"pattern": "[a-[:alpha:]]", "extended": true, "valid": false}
+{"pattern": "[[.a.]-z]", "extended": false, "valid": false}
+{"pattern": "[[.a.]-z]", "extended": true, "valid": false}
+{"pattern": "[[:ALPHA:]]", "extended": false, "valid": false}
+{"pattern": "[[:ALPHA:]]", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:^alpha:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:word:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:word:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:blank:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:blank:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[:alpha:]", "extended": false, "valid": false}
+{"pattern": "[:alpha:]", "extended": true, "valid": false}
+{"pattern": "[[a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[b]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[b]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[aeiou]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[aeiou]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[b]c]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z-[b]c]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-[b]]", "extended": false, "valid": false}
+{"pattern": "[a-[b]]", "extended": true, "valid": false}
+{"pattern": "[[a]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a--b]", "extended": false, "valid": false}
+{"pattern": "[a--b]", "extended": true, "valid": false}
+{"pattern": "[a--]", "extended": false, "valid": false}
+{"pattern": "[a--]", "extended": true, "valid": false}
+{"pattern": "[--a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[--a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]&&[b]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]&&[b]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]--[b]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a]--[b]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w&&\\d]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w&&\\d]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w--\\d]", "extended": false, "valid": false}
+{"pattern": "[\\w--\\d]", "extended": true, "valid": false}
+{"pattern": "[a&&b&&c]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a&&b&&c]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a--b--c]", "extended": false, "valid": false}
+{"pattern": "[a--b--c]", "extended": true, "valid": false}
+{"pattern": "[a&&b--c]", "extended": false, "valid": false}
+{"pattern": "[a&&b--c]", "extended": true, "valid": false}
+{"pattern": "[ab&&c]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[ab&&c]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z&&[aeiou]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z&&[aeiou]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a-z]&&[aeiou]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[a-z]&&[aeiou]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\q{abc}]", "extended": false, "valid": false}
+{"pattern": "[\\q{abc}]", "extended": true, "valid": false}
+{"pattern": "[\\q{abc|d}]", "extended": false, "valid": false}
+{"pattern": "[\\q{abc|d}]", "extended": true, "valid": false}
+{"pattern": "[^\\q{abc}]", "extended": false, "valid": false}
+{"pattern": "[^\\q{abc}]", "extended": true, "valid": false}
+{"pattern": "[^\\q{a}]", "extended": false, "valid": false}
+{"pattern": "[^\\q{a}]", "extended": true, "valid": false}
+{"pattern": "[\\q{}]", "extended": false, "valid": false}
+{"pattern": "[\\q{}]", "extended": true, "valid": false}
+{"pattern": "\\q{a}", "extended": false, "valid": false}
+{"pattern": "\\q{a}", "extended": true, "valid": false}
+{"pattern": "[|]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[|]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[(]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[(]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[)]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[)]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[{]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[{]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[}]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[/]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[/]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\&]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\&]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\!]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\!]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\#]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\#]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\%]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\%]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\,]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\,]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\:]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\:]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\;]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\;]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\<]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\<]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\=]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\=]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\>]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\>]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\@]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\@]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\`]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\`]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\~]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\~]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\$]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\$]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\^]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\^]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[!!]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[!!]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[##]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[##]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[$$]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[$$]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[%%]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[%%]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[**]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[**]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[++]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[++]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[,,]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[,,]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[..]", "extended": false, "valid": false}
+{"pattern": "[..]", "extended": true, "valid": false}
+{"pattern": "[::]", "extended": false, "valid": false}
+{"pattern": "[::]", "extended": true, "valid": false}
+{"pattern": "[;;]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[;;]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[<<]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[<<]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[==]", "extended": false, "valid": false}
+{"pattern": "[==]", "extended": true, "valid": false}
+{"pattern": "[>>]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[>>]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[??]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[??]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[@@]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[@@]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^^]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^^^]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[``]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[``]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[~~]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[~~]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^^]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^^]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[&]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[&]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&&]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[&&&]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d-]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-\\d]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-\\d]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\d]", "extended": false, "valid": false}
+{"pattern": "[a-\\d]", "extended": true, "valid": false}
+{"pattern": "[\\s-\\S]", "extended": false, "valid": false}
+{"pattern": "[\\s-\\S]", "extended": true, "valid": false}
+{"pattern": "[\\p{L}-z]", "extended": false, "valid": false}
+{"pattern": "[\\p{L}-z]", "extended": true, "valid": false}
+{"pattern": "[a-\\p{L}]", "extended": false, "valid": false}
+{"pattern": "[a-\\p{L}]", "extended": true, "valid": false}
+{"pattern": "[\\x41-\\x5A]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x41-\\x5A]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x5A-\\x41]", "extended": false, "valid": false}
+{"pattern": "[\\x5A-\\x41]", "extended": true, "valid": false}
+{"pattern": "[A-Z]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[A-Z]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA-\\cZ]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA-\\cZ]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0-\\x20]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\0-\\x20]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b-\\n]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b-\\n]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\n-\\b]", "extended": false, "valid": false}
+{"pattern": "[\\n-\\b]", "extended": true, "valid": false}
+{"pattern": "[\\--a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\--a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\-]", "extended": false, "valid": false}
+{"pattern": "[a-\\-]", "extended": true, "valid": false}
+{"pattern": "[%--]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[%--]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[+--]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[+--]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a^]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[$]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[$]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\]a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\\]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\]", "extended": false, "valid": false}
+{"pattern": "[a\\]", "extended": true, "valid": false}
+{"pattern": "[a\\]b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\]b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[#]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[#]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[ ]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[ ]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{a}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{a}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1,a}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1,a}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{,}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{,}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{,5}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{,5}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ ,5}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ ,5}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{5, }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{5, }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1,2}{3}", "extended": false, "valid": false}
+{"pattern": "x{1,2}{3}", "extended": true, "valid": false}
+{"pattern": "x{1}*", "extended": false, "valid": false}
+{"pattern": "x{1}*", "extended": true, "valid": false}
+{"pattern": "x{0}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0,0}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{0,0}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{00001}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{00001}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{1}{1}", "extended": false, "valid": false}
+{"pattern": "x{1}{1}", "extended": true, "valid": false}
+{"pattern": "(?:a){1}{2}", "extended": false, "valid": false}
+{"pattern": "(?:a){1}{2}", "extended": true, "valid": false}
+{"pattern": "^", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "^", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "$", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "$", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "^^", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "^^", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "$$", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "$$", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a^", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a^", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "$a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "$a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a^b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a^b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a$b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a$b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(^a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(^a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a$)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a$)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "a|^b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a|^b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a$|b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a$|b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "^*a", "extended": false, "valid": false}
+{"pattern": "^*a", "extended": true, "valid": false}
+{"pattern": "\\(a\\)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(\\)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(\\)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{1\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{1\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,2\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1,2\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{,2\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{,2\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{2,1\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{2,1\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "*a", "extended": false, "valid": false}
+{"pattern": "*a", "extended": true, "valid": false}
+{"pattern": "**", "extended": false, "valid": false}
+{"pattern": "**", "extended": true, "valid": false}
+{"pattern": "\\(*a\\)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*a\\)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(^a\\)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(^a\\)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|*b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|*b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}\\{2\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}\\{2\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a*\\{2\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a*\\{2\\}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(a\\)\\1", "extended": false, "valid": false}
+{"pattern": "\\(a\\)\\1", "extended": true, "valid": false}
+{"pattern": "\\1\\(a\\)", "extended": false, "valid": false}
+{"pattern": "\\1\\(a\\)", "extended": true, "valid": false}
+{"pattern": "\\(a\\)\\2", "extended": false, "valid": false}
+{"pattern": "\\(a\\)\\2", "extended": true, "valid": false}
+{"pattern": "\\w", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\{1\\}*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(a)*", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)*", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)+?", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)+?", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a){2}{3}", "extended": false, "valid": false}
+{"pattern": "(a){2}{3}", "extended": true, "valid": false}
+{"pattern": "a+*", "extended": false, "valid": false}
+{"pattern": "a+*", "extended": true, "valid": false}
+{"pattern": "a?*", "extended": false, "valid": false}
+{"pattern": "a?*", "extended": true, "valid": false}
+{"pattern": "a*{2}", "extended": false, "valid": false}
+{"pattern": "a*{2}", "extended": true, "valid": false}
+{"pattern": "a{2}*", "extended": false, "valid": false}
+{"pattern": "a{2}*", "extended": true, "valid": false}
+{"pattern": "a{2}+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2}+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:", "extended": false, "valid": false}
+{"pattern": "(?:", "extended": true, "valid": false}
+{"pattern": "(?=", "extended": false, "valid": false}
+{"pattern": "(?=", "extended": true, "valid": false}
+{"pattern": "(?<", "extended": false, "valid": false}
+{"pattern": "(?<", "extended": true, "valid": false}
+{"pattern": "(?<=", "extended": false, "valid": false}
+{"pattern": "(?<=", "extended": true, "valid": false}
+{"pattern": "(?'", "extended": false, "valid": false}
+{"pattern": "(?'", "extended": true, "valid": false}
+{"pattern": "(?P", "extended": false, "valid": false}
+{"pattern": "(?P", "extended": true, "valid": false}
+{"pattern": "(?P=", "extended": false, "valid": false}
+{"pattern": "(?P=", "extended": true, "valid": false}
+{"pattern": "(?P>", "extended": false, "valid": false}
+{"pattern": "(?P>", "extended": true, "valid": false}
+{"pattern": "(?P<", "extended": false, "valid": false}
+{"pattern": "(?P<", "extended": true, "valid": false}
+{"pattern": "(?&", "extended": false, "valid": false}
+{"pattern": "(?&", "extended": true, "valid": false}
+{"pattern": "(?R", "extended": false, "valid": false}
+{"pattern": "(?R", "extended": true, "valid": false}
+{"pattern": "(?1", "extended": false, "valid": false}
+{"pattern": "(?1", "extended": true, "valid": false}
+{"pattern": "(?C", "extended": false, "valid": false}
+{"pattern": "(?C", "extended": true, "valid": false}
+{"pattern": "(?(1)", "extended": false, "valid": false}
+{"pattern": "(?(1)", "extended": true, "valid": false}
+{"pattern": "(?#", "extended": false, "valid": false}
+{"pattern": "(?#", "extended": true, "valid": false}
+{"pattern": "\\Q(\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q(\\E", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q[\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q[\\E", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(\\Qa)\\E)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(\\Qa)\\E)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "[\\Qa\\E]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Qa\\E]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q\\E]", "extended": false, "valid": false}
+{"pattern": "[\\Q\\E]", "extended": true, "valid": false}
+{"pattern": "[\\E]", "extended": false, "valid": false}
+{"pattern": "[\\E]", "extended": true, "valid": false}
+{"pattern": "[a\\Q]\\E]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Q]\\E]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E\\E", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a#b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a#b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "c", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "c", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)[a b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)[a b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)[ ]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)[ ]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a {2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a {2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a{2} ?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a{2} ?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a\\ b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a\\ b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)\\", "extended": false, "valid": false}
+{"pattern": "(?x)\\", "extended": true, "valid": false}
+{"pattern": "(?x)(? :a)", "extended": false, "valid": false}
+{"pattern": "(?x)(? :a)", "extended": true, "valid": false}
+{"pattern": "(?x)( ?:a)", "extended": false, "valid": false}
+{"pattern": "(?x)( ?:a)", "extended": true, "valid": false}
+{"pattern": "(?x)(?#)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)(?#)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a#(", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a#(", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)\\p{ L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)\\p{ L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)\\k< a>", "extended": false, "valid": false}
+{"pattern": "(?x)\\k< a>", "extended": true, "valid": false}
+{"pattern": "(?x)a+ +", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)a+ +", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?xx)[a b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?xx)[a b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aT)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aT)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aP)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aP)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aS)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aS)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aX)", "extended": false, "valid": false}
+{"pattern": "(?aX)", "extended": true, "valid": false}
+{"pattern": "(?xxx)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?xxx)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^-i)", "extended": false, "valid": false}
+{"pattern": "(?^-i)", "extended": true, "valid": false}
+{"pattern": "(?i^)", "extended": false, "valid": false}
+{"pattern": "(?i^)", "extended": true, "valid": false}
+{"pattern": "(?-^)", "extended": false, "valid": false}
+{"pattern": "(?-^)", "extended": true, "valid": false}
+{"pattern": "(?--i)", "extended": false, "valid": false}
+{"pattern": "(?--i)", "extended": true, "valid": false}
+{"pattern": "(?i-)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?+i)", "extended": false, "valid": false}
+{"pattern": "(?+i)", "extended": true, "valid": false}
+{"pattern": "(?+)", "extended": false, "valid": false}
+{"pattern": "(?+)", "extended": true, "valid": false}
+{"pattern": "(?I)", "extended": false, "valid": false}
+{"pattern": "(?I)", "extended": true, "valid": false}
+{"pattern": "(*:)", "extended": false, "valid": false}
+{"pattern": "(*:)", "extended": true, "valid": false}
+{"pattern": "(*MARK:)", "extended": false, "valid": false}
+{"pattern": "(*MARK:)", "extended": true, "valid": false}
+{"pattern": "(*PRUNE:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*PRUNE:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*SKIP:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*SKIP:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*THEN:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*THEN:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*COMMIT:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*COMMIT:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ACCEPT:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ACCEPT:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*FAIL:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*FAIL:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*F:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*F:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*skip)", "extended": false, "valid": false}
+{"pattern": "(*skip)", "extended": true, "valid": false}
+{"pattern": "(* SKIP)", "extended": false, "valid": false}
+{"pattern": "(* SKIP)", "extended": true, "valid": false}
+{"pattern": "(*UTF)a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UTF)a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UTF)(*UCP)a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UTF)(*UCP)a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LF)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LF)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*CRLF)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*CRLF)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ANYCRLF)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ANYCRLF)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ANY)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ANY)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NUL)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NUL)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*BSR_ANYCRLF)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*BSR_ANYCRLF)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*BSR_UNICODE)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*BSR_UNICODE)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_MATCH=10)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_MATCH=10)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_DEPTH=10)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_DEPTH=10)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_HEAP=10)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_HEAP=10)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NOTEMPTY)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NOTEMPTY)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NOTEMPTY_ATSTART)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NOTEMPTY_ATSTART)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_AUTO_POSSESS)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_AUTO_POSSESS)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_DOTSTAR_ANCHOR)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_DOTSTAR_ANCHOR)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_JIT)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_JIT)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_START_OPT)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*NO_START_OPT)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_MATCH=)", "extended": false, "valid": false}
+{"pattern": "(*LIMIT_MATCH=)", "extended": true, "valid": false}
+{"pattern": "(*LIMIT_MATCH)", "extended": false, "valid": false}
+{"pattern": "(*LIMIT_MATCH)", "extended": true, "valid": false}
+{"pattern": "(*MARK:a)b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*MARK:a)b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*positive_lookahead:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*positive_lookahead:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*plb:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*plb:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*nla:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*nla:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*nlb:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*nlb:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*napla:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*napla:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*naplb:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*naplb:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*sr:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*sr:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*non_atomic_positive_lookahead:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*non_atomic_positive_lookahead:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*script_run:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*script_run:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*asr:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*asr:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic_script_run:a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic_script_run:a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic)", "extended": false, "valid": false}
+{"pattern": "(*atomic)", "extended": true, "valid": false}
+{"pattern": "(*MARK:a)*", "extended": false, "valid": false}
+{"pattern": "(*MARK:a)*", "extended": true, "valid": false}
+{"pattern": "(*FAIL)*", "extended": false, "valid": false}
+{"pattern": "(*FAIL)*", "extended": true, "valid": false}
+{"pattern": "(*ACCEPT)+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*ACCEPT)+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*:a)?", "extended": false, "valid": false}
+{"pattern": "(*:a)?", "extended": true, "valid": false}
+{"pattern": "(*UTF8)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UTF8)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*UTF32)", "extended": false, "valid": false}
+{"pattern": "(*UTF32)", "extended": true, "valid": false}
+{"pattern": "(*LIMIT_RECURSION=1)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*LIMIT_RECURSION=1)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*CASELESS_RESTRICT)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*CASELESS_RESTRICT)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*TURKISH_CASING)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*TURKISH_CASING)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:(*CR))", "extended": false, "valid": false}
+{"pattern": "(?:(*CR))", "extended": true, "valid": false}
+{"pattern": "(*LIMIT_MATCH=99999999999)", "extended": false, "valid": false}
+{"pattern": "(*LIMIT_MATCH=99999999999)", "extended": true, "valid": false}
+{"pattern": "(*MARK:a)(*UTF)", "extended": false, "valid": false}
+{"pattern": "(*MARK:a)(*UTF)", "extended": true, "valid": false}
+{"pattern": "(?=a\\K)", "extended": false, "valid": false}
+{"pattern": "(?=a\\K)", "extended": true, "valid": false}
+{"pattern": "(?<=a\\K)", "extended": false, "valid": false}
+{"pattern": "(?<=a\\K)", "extended": true, "valid": false}
+{"pattern": "(?>a\\K)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>a\\K)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:a\\K)", "extended": false, "valid": false}
+{"pattern": "(*pla:a\\K)", "extended": true, "valid": false}
+{"pattern": "(*pla:a)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:a)*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic:a)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic:a)*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*sr:a)+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*sr:a)+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*plb:a+)", "extended": false, "valid": false}
+{"pattern": "(*plb:a+)", "extended": true, "valid": false}
+{"pattern": "(*nlb:a+)", "extended": false, "valid": false}
+{"pattern": "(*nlb:a+)", "extended": true, "valid": false}
+{"pattern": "(*naplb:a+)", "extended": false, "valid": false}
+{"pattern": "(*naplb:a+)", "extended": true, "valid": false}
+{"pattern": "(*pla:)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla)", "extended": false, "valid": false}
+{"pattern": "(*pla)", "extended": true, "valid": false}
+{"pattern": "(*PLA:a)", "extended": false, "valid": false}
+{"pattern": "(*PLA:a)", "extended": true, "valid": false}
+{"pattern": "(?<=a\\Qbc\\E)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a\\Qbc\\E)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a{0,255})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a{0,255})", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?:ab){128})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?:ab){128})", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?:ab|c){1,128})", "extended": false, "valid": false}
+{"pattern": "(?<=(?:ab|c){1,128})", "extended": true, "valid": false}
+{"pattern": "(?<=(?:ab|c){1,127})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?:ab|c){1,127})", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a|b{300})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a|b{300})", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?:a|b{300}))", "extended": false, "valid": false}
+{"pattern": "(?<=(?:a|b{300}))", "extended": true, "valid": false}
+{"pattern": "(?<=\\C)", "extended": false, "valid": false}
+{"pattern": "(?<=\\C)", "extended": true, "valid": false}
+{"pattern": "(?<=[a-z]{3})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=[a-z]{3})", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=\\p{L}+)", "extended": false, "valid": false}
+{"pattern": "(?<=\\p{L}+)", "extended": true, "valid": false}
+{"pattern": "(?<=(?=a+))b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?=a+))b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?<=a+))b", "extended": false, "valid": false}
+{"pattern": "(?<=(?<=a+))b", "extended": true, "valid": false}
+{"pattern": "(?<=(a)\\1{300})", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(a)\\1{300})", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(a+)\\1)", "extended": false, "valid": false}
+{"pattern": "(?<=(a+)\\1)", "extended": true, "valid": false}
+{"pattern": "(?<=(?1))(a+)", "extended": false, "valid": false}
+{"pattern": "(?<=(?1))(a+)", "extended": true, "valid": false}
+{"pattern": "(?<=\\g{1})(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=\\g{1})(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(?(1)a|bb))(x)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(?(1)a|bb))(x)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?<=(?(1)a|b{300}))(x)", "extended": false, "valid": false}
+{"pattern": "(?<=(?(1)a|b{300}))(x)", "extended": true, "valid": false}
+{"pattern": "(?<=a{2}+)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a{2}+)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a?+)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a?+)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a*+)", "extended": false, "valid": false}
+{"pattern": "(?<=a*+)", "extended": true, "valid": false}
+{"pattern": "(?<=(*ACCEPT))", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(*ACCEPT))", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=\\X)", "extended": false, "valid": false}
+{"pattern": "(?<=\\X)", "extended": true, "valid": false}
+{"pattern": "(?<=\\R{200})", "extended": false, "valid": false}
+{"pattern": "(?<=\\R{200})", "extended": true, "valid": false}
+{"pattern": "(?<=.{255}|a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=.{255}|a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a{300})b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a{300})b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=a{1,256})b", "extended": false, "valid": false}
+{"pattern": "(?<=a{1,256})b", "extended": true, "valid": false}
+{"pattern": "(?<=\\d+?)c", "extended": false, "valid": false}
+{"pattern": "(?<=\\d+?)c", "extended": true, "valid": false}
+{"pattern": "(?|(?<a>x)|(y))", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?|(?<a>x)|(y))", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?|(x)|(?<a>y))", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?|(x)|(?<a>y))", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?|(?<a>x)|(?<a>y)(?<b>z))", "extended": false, "valid": true, "captures": 2, "names": [["a", 1], ["b", 2]]}
+{"pattern": "(?|(?<a>x)|(?<a>y)(?<b>z))", "extended": true, "valid": true, "captures": 2, "names": [["a", 1], ["b", 2]]}
+{"pattern": "(?J)(?<a>x)(?<a>y)", "extended": false, "valid": true, "captures": 2, "names": [["a", 1], ["a", 2]]}
+{"pattern": "(?J)(?<a>x)(?<a>y)", "extended": true, "valid": true, "captures": 2, "names": [["a", 1], ["a", 2]]}
+{"pattern": "(?J:(?<a>x))(?<a>y)", "extended": false, "valid": false}
+{"pattern": "(?J:(?<a>x))(?<a>y)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)(?J)(?<a>y)", "extended": false, "valid": true, "captures": 2, "names": [["a", 1], ["a", 2]]}
+{"pattern": "(?<a>x)(?J)(?<a>y)", "extended": true, "valid": true, "captures": 2, "names": [["a", 1], ["a", 2]]}
+{"pattern": "(?<a>x)(?J:(?<a>y))", "extended": false, "valid": true, "captures": 2, "names": [["a", 1], ["a", 2]]}
+{"pattern": "(?<a>x)(?J:(?<a>y))", "extended": true, "valid": true, "captures": 2, "names": [["a", 1], ["a", 2]]}
+{"pattern": "(?J)(?<a>x)(?-J)(?<a>y)", "extended": false, "valid": false}
+{"pattern": "(?J)(?<a>x)(?-J)(?<a>y)", "extended": true, "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))(?<a>z)", "extended": false, "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))(?<a>z)", "extended": true, "valid": false}
+{"pattern": "(?|(a)|(b))(c)\\2", "extended": false, "valid": true, "captures": 2, "names": []}
+{"pattern": "(?|(a)|(b))(c)\\2", "extended": true, "valid": true, "captures": 2, "names": []}
+{"pattern": "(a)(?<x>b)(c)", "extended": false, "valid": true, "captures": 3, "names": [["x", 2]]}
+{"pattern": "(a)(?<x>b)(c)", "extended": true, "valid": true, "captures": 3, "names": [["x", 2]]}
+{"pattern": "\\81(a)", "extended": false, "valid": false}
+{"pattern": "\\81(a)", "extended": true, "valid": false}
+{"pattern": "\\8(a)(b)(c)(d)(e)(f)(g)(h)", "extended": false, "valid": true, "captures": 8, "names": []}
+{"pattern": "\\8(a)(b)(c)(d)(e)(f)(g)(h)", "extended": true, "valid": true, "captures": 8, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\9", "extended": false, "valid": true, "captures": 9, "names": []}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\9", "extended": true, "valid": true, "captures": 9, "names": []}
+{"pattern": "\\cé", "extended": false, "valid": false}
+{"pattern": "\\cé", "extended": true, "valid": false}
+{"pattern": "\\c\u001f", "extended": false, "valid": false}
+{"pattern": "\\c\u001f", "extended": true, "valid": false}
+{"pattern": "\\c ", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c ", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c~", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c~", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cé]", "extended": false, "valid": false}
+{"pattern": "[\\cé]", "extended": true, "valid": false}
+{"pattern": "[\\--$]", "extended": false, "valid": false}
+{"pattern": "[\\--$]", "extended": true, "valid": false}
+{"pattern": "[\\--\\x40]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\--\\x40]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\é", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\é", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\é]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\é]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ ", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ ", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Ca", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Ca", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\C]", "extended": false, "valid": false}
+{"pattern": "[\\C]", "extended": true, "valid": false}
+{"pattern": "(?i-J)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i-J)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?J-J)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?J-J)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^J)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^J)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^n)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^n)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-n)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-n)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?n:(a))\\1", "extended": false, "valid": false}
+{"pattern": "(?n:(a))\\1", "extended": true, "valid": false}
+{"pattern": "(?n)(?<a>x)\\1", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?n)(?<a>x)\\1", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(R&)a)", "extended": false, "valid": false}
+{"pattern": "(?(R&)a)", "extended": true, "valid": false}
+{"pattern": "(?(R&1)a)", "extended": false, "valid": false}
+{"pattern": "(?(R&1)a)", "extended": true, "valid": false}
+{"pattern": "(?(R0)a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(R0)a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(R)a|b|c)", "extended": false, "valid": false}
+{"pattern": "(?(R)a|b|c)", "extended": true, "valid": false}
+{"pattern": "(?(<a)x)(?<a>y)", "extended": false, "valid": false}
+{"pattern": "(?(<a)x)(?<a>y)", "extended": true, "valid": false}
+{"pattern": "(?(<>)x)", "extended": false, "valid": false}
+{"pattern": "(?(<>)x)", "extended": true, "valid": false}
+{"pattern": "(?('a)x)", "extended": false, "valid": false}
+{"pattern": "(?('a)x)", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x)|)", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x)|)", "extended": true, "valid": false}
+{"pattern": "(?(DEFINEX)a)", "extended": false, "valid": false}
+{"pattern": "(?(DEFINEX)a)", "extended": true, "valid": false}
+{"pattern": "(?(VERSION>=10)a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION>=10)a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION>=10.)a)", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.)a)", "extended": true, "valid": false}
+{"pattern": "(?(VERSION>=10.4.7)a)", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4.7)a)", "extended": true, "valid": false}
+{"pattern": "(?(VERSION=10.123)a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION=10.123)a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION>=100)a)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION>=100)a)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(VERSION>10)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>10)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(VERSION)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(VERSION)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(?C1)(?!a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C1)(?!a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C\"x\")(?<=a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C\"x\")(?<=a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C1)(*pla:a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C1)(*pla:a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?#x)(?=a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?#x)(?=a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?((?=a))a|b)", "extended": false, "valid": false}
+{"pattern": "(?((?=a))a|b)", "extended": true, "valid": false}
+{"pattern": "(?(*sr:a)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(*sr:a)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(?C1)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(?C1)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(?>a)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(?>a)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(*pla:a)a|b)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(*pla:a)a|b)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(1))(x)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(1))(x)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(0)a)", "extended": false, "valid": false}
+{"pattern": "(?(0)a)", "extended": true, "valid": false}
+{"pattern": "(?(01)a)(x)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?(01)a)(x)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?( 1)a)(x)", "extended": false, "valid": false}
+{"pattern": "(?( 1)a)(x)", "extended": true, "valid": false}
+{"pattern": "(?(1 )a)(x)", "extended": false, "valid": false}
+{"pattern": "(?(1 )a)(x)", "extended": true, "valid": false}
+{"pattern": "(?(a b)x)(?<a>y)", "extended": false, "valid": false}
+{"pattern": "(?(a b)x)(?<a>y)", "extended": true, "valid": false}
+{"pattern": "(?(R2)a|b)(x)", "extended": false, "valid": false}
+{"pattern": "(?(R2)a|b)(x)", "extended": true, "valid": false}
+{"pattern": "(?(Rx)a|b)", "extended": false, "valid": false}
+{"pattern": "(?(Rx)a|b)", "extended": true, "valid": false}
+{"pattern": "(?(a)x|y)(?<a>z)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(a)x|y)(?<a>z)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(x)(?(-2)a|b)", "extended": false, "valid": false}
+{"pattern": "(x)(?(-2)a|b)", "extended": true, "valid": false}
+{"pattern": "(?-1)(a)", "extended": false, "valid": false}
+{"pattern": "(?-1)(a)", "extended": true, "valid": false}
+{"pattern": "(a)(?+2)(b)", "extended": false, "valid": false}
+{"pattern": "(a)(?+2)(b)", "extended": true, "valid": false}
+{"pattern": "(a)(?+2)", "extended": false, "valid": false}
+{"pattern": "(a)(?+2)", "extended": true, "valid": false}
+{"pattern": "(?+1)", "extended": false, "valid": false}
+{"pattern": "(?+1)", "extended": true, "valid": false}
+{"pattern": "(?-2)(a)(b)", "extended": false, "valid": false}
+{"pattern": "(?-2)(a)(b)", "extended": true, "valid": false}
+{"pattern": "(a)\\g{-2}", "extended": false, "valid": false}
+{"pattern": "(a)\\g{-2}", "extended": true, "valid": false}
+{"pattern": "(a)\\g-2", "extended": false, "valid": false}
+{"pattern": "(a)\\g-2", "extended": true, "valid": false}
+{"pattern": "(a)(b)\\g{-2}", "extended": false, "valid": true, "captures": 2, "names": []}
+{"pattern": "(a)(b)\\g{-2}", "extended": true, "valid": true, "captures": 2, "names": []}
+{"pattern": "\\g{+1}(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "\\g{+1}(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g<-2>", "extended": false, "valid": false}
+{"pattern": "(a)\\g<-2>", "extended": true, "valid": false}
+{"pattern": "(a)\\g'-1'", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g'-1'", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?&a)(?<a>x)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?&a)(?<a>x)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P>a)(?<a>x)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?P>a)(?<a>x)", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(a)(?-0)", "extended": false, "valid": false}
+{"pattern": "(a)(?-0)", "extended": true, "valid": false}
+{"pattern": "(a)(?+0)", "extended": false, "valid": false}
+{"pattern": "(a)(?+0)", "extended": true, "valid": false}
+{"pattern": "(?00)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?00)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?01)(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?01)(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(?R1)", "extended": false, "valid": false}
+{"pattern": "(?R1)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k<1>", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\k<1>", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k<1a>", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\k<1a>", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\g{1a}", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\g{1a}", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\g{a b}", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\g{a b}", "extended": true, "valid": false}
+{"pattern": "(?<a>x)(?&a1)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)(?&a1)", "extended": true, "valid": false}
+{"pattern": "(?<a1>x)(?&a1)", "extended": false, "valid": true, "captures": 1, "names": [["a1", 1]]}
+{"pattern": "(?<a1>x)(?&a1)", "extended": true, "valid": true, "captures": 1, "names": [["a1", 1]]}
+{"pattern": "(?<a>x)(?&a b)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)(?&a b)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)(?&1)", "extended": false, "valid": false}
+{"pattern": "(?<a>x)(?&1)", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k a", "extended": false, "valid": false}
+{"pattern": "(?<a>x)\\k a", "extended": true, "valid": false}
+{"pattern": "(?<a>x)\\k{ a }", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)\\k{ a }", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)\\k{a}", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<a>x)\\k{a}", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(a)\\g{ 1 }", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g{ 1 }", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "(a)\\g+1", "extended": false, "valid": false}
+{"pattern": "(a)\\g+1", "extended": true, "valid": false}
+{"pattern": "(a)\\g<+1>", "extended": false, "valid": false}
+{"pattern": "(a)\\g<+1>", "extended": true, "valid": false}
+{"pattern": "\\g<+1>(a)", "extended": false, "valid": true, "captures": 1, "names": []}
+{"pattern": "\\g<+1>(a)", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "a{,}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{,}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ ,}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ ,}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ 3 , 2 }", "extended": false, "valid": false}
+{"pattern": "a{ 3 , 2 }", "extended": true, "valid": false}
+{"pattern": "a{,65536}", "extended": false, "valid": false}
+{"pattern": "a{,65536}", "extended": true, "valid": false}
+{"pattern": "a{0065535}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{0065535}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ 2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{ 2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2 }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2 }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2 , 3}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2 , 3}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ ,2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ ,2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ 2 , }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "x{ 2 , }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "a{2}{3}", "extended": false, "valid": false}
+{"pattern": "a{2}{3}", "extended": true, "valid": false}
+{"pattern": "\\x{ }", "extended": false, "valid": false}
+{"pattern": "\\x{ }", "extended": true, "valid": false}
+{"pattern": "\\x{4 1}", "extended": false, "valid": false}
+{"pattern": "\\x{4 1}", "extended": true, "valid": false}
+{"pattern": "\\o{ 1 0 }", "extended": false, "valid": false}
+{"pattern": "\\o{ 1 0 }", "extended": true, "valid": false}
+{"pattern": "\\x{0041}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{0041}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{000000041}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{000000041}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{ 41 }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{ 41 }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{ 101 }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\o{ 101 }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{U+ 41}", "extended": false, "valid": false}
+{"pattern": "\\N{U+ 41}", "extended": true, "valid": false}
+{"pattern": "\\N{u+41}", "extended": false, "valid": false}
+{"pattern": "\\N{u+41}", "extended": true, "valid": false}
+{"pattern": "\\x{g}", "extended": false, "valid": false}
+{"pattern": "\\x{g}", "extended": true, "valid": false}
+{"pattern": "\\o{77777777}", "extended": false, "valid": false}
+{"pattern": "\\o{77777777}", "extended": true, "valid": false}
+{"pattern": "\\N{U+D800}", "extended": false, "valid": false}
+{"pattern": "\\N{U+D800}", "extended": true, "valid": false}
+{"pattern": "[\\x{41}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x{41}]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\o{101}-\\x{5A}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\o{101}-\\x{5A}]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\N{U+41}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\N{U+41}]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{2,3}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{2,3}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:][:digit:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:][:digit:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[::]]", "extended": false, "valid": false}
+{"pattern": "[[::]]", "extended": true, "valid": false}
+{"pattern": "[[:a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[:b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[:b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[:a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[:a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[.a.]", "extended": false, "valid": false}
+{"pattern": "[.a.]", "extended": true, "valid": false}
+{"pattern": "[=a=]", "extended": false, "valid": false}
+{"pattern": "[=a=]", "extended": true, "valid": false}
+{"pattern": "[a[:alpha:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a[:alpha:]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q\\E]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q\\E]]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Q\\E-z]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Q\\E-z]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\E]a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\E]a]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\x{100}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\x{100}]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x{100}-a]", "extended": false, "valid": false}
+{"pattern": "[\\x{100}-a]", "extended": true, "valid": false}
+{"pattern": "[\\N]", "extended": false, "valid": false}
+{"pattern": "[\\N]", "extended": true, "valid": false}
+{"pattern": "[\\R]", "extended": false, "valid": false}
+{"pattern": "[\\R]", "extended": true, "valid": false}
+{"pattern": "[\\X]", "extended": false, "valid": false}
+{"pattern": "[\\X]", "extended": true, "valid": false}
+{"pattern": "[\\h-z]", "extended": false, "valid": false}
+{"pattern": "[\\h-z]", "extended": true, "valid": false}
+{"pattern": "[a-\\h]", "extended": false, "valid": false}
+{"pattern": "[a-\\h]", "extended": true, "valid": false}
+{"pattern": "[\\b-z]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\b-z]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p{L}-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\p{L}-]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pl", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pl", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{LU}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{LU}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ L u }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ L u }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L_u}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L_u}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L-u}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L-u}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{^ Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{^ Lu}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ ^Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ ^Lu}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{^Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{^Lu}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lc}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lc}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{LC}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{LC}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{any}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{any}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xps}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xps}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xsp}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xsp}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xuc}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Xuc}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Grek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Grek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc:Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc:Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{script=Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{script=Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script:Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script:Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx:Grek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{scx:Grek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=Alpha}", "extended": false, "valid": false}
+{"pattern": "\\p{sc=Alpha}", "extended": true, "valid": false}
+{"pattern": "\\p{bc:L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{bc:L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{bidiclass:AL}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{bidiclass:AL}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Bidi_Class=AL}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Bidi_Class=AL}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{bc=Left_To_Right}", "extended": false, "valid": false}
+{"pattern": "\\p{bc=Left_To_Right}", "extended": true, "valid": false}
+{"pattern": "\\p{Bidi_C}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Bidi_C}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{BidiControl}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{BidiControl}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Cn}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Cn}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Zzzz}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Zzzz}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Unknown}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Unknown}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Zinh}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Zinh}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Qaai}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Qaai}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Katakana_Or_Hiragana}", "extended": false, "valid": false}
+{"pattern": "\\p{Katakana_Or_Hiragana}", "extended": true, "valid": false}
+{"pattern": "\\p{Hrkt}", "extended": false, "valid": false}
+{"pattern": "\\p{Hrkt}", "extended": true, "valid": false}
+{"pattern": "\\p{Latn}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Latn}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{incb}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{incb}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc=}", "extended": false, "valid": false}
+{"pattern": "\\p{sc=}", "extended": true, "valid": false}
+{"pattern": "\\p{=L}", "extended": false, "valid": false}
+{"pattern": "\\p{=L}", "extended": true, "valid": false}
+{"pattern": "\\p{^}", "extended": false, "valid": false}
+{"pattern": "\\p{^}", "extended": true, "valid": false}
+{"pattern": "\\p{L}}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Lu", "extended": false, "valid": false}
+{"pattern": "\\p{Lu", "extended": true, "valid": false}
+{"pattern": "\\pb", "extended": false, "valid": false}
+{"pattern": "\\pb", "extended": true, "valid": false}
+{"pattern": "[\\pb]", "extended": false, "valid": false}
+{"pattern": "[\\pb]", "extended": true, "valid": false}
+{"pattern": "\\p{SC = Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{SC = Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{^sc:Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{^sc:Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{sc:^Greek}", "extended": false, "valid": false}
+{"pattern": "\\p{sc:^Greek}", "extended": true, "valid": false}
+{"pattern": "\\p{bidi class : al}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{bidi class : al}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script Extensions:Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script Extensions:Greek}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{ }", "extended": false, "valid": false}
+{"pattern": "\\p{ }", "extended": true, "valid": false}
+{"pattern": "\\p{:}", "extended": false, "valid": false}
+{"pattern": "\\p{:}", "extended": true, "valid": false}
+{"pattern": "\\p{:Greek}", "extended": false, "valid": false}
+{"pattern": "\\p{:Greek}", "extended": true, "valid": false}
+{"pattern": "\\p{Is Greek}", "extended": false, "valid": false}
+{"pattern": "\\p{Is Greek}", "extended": true, "valid": false}
+{"pattern": "\\p{^^L}", "extended": false, "valid": false}
+{"pattern": "\\p{^^L}", "extended": true, "valid": false}
+{"pattern": "\\p{sc::Greek}", "extended": false, "valid": false}
+{"pattern": "\\p{sc::Greek}", "extended": true, "valid": false}
+{"pattern": "\\u0041", "extended": false, "valid": false}
+{"pattern": "\\u0041", "extended": true, "valid": false}
+{"pattern": "(?C0)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C0)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C\"a\"\"b\")", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C\"a\"\"b\")", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C`a`)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C`a`)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C'a')", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C'a')", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C^a^)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C^a^)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C%a%)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C%a%)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C#a#)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C#a#)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C$a$)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C$a$)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C{a)", "extended": false, "valid": false}
+{"pattern": "(?C{a)", "extended": true, "valid": false}
+{"pattern": "(?C\"a)", "extended": false, "valid": false}
+{"pattern": "(?C\"a)", "extended": true, "valid": false}
+{"pattern": "(?C 1)", "extended": false, "valid": false}
+{"pattern": "(?C 1)", "extended": true, "valid": false}
+{"pattern": "(?C1 )", "extended": false, "valid": false}
+{"pattern": "(?C1 )", "extended": true, "valid": false}
+{"pattern": "(?C)a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C)a", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C1)*", "extended": false, "valid": false}
+{"pattern": "(?C1)*", "extended": true, "valid": false}
+{"pattern": "(?#x)*", "extended": false, "valid": false}
+{"pattern": "(?#x)*", "extended": true, "valid": false}
+{"pattern": "(?:)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:)*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Q\\E*", "extended": false, "valid": false}
+{"pattern": "\\Q\\E*", "extended": true, "valid": false}
+{"pattern": "\\K+", "extended": false, "valid": false}
+{"pattern": "\\K+", "extended": true, "valid": false}
+{"pattern": "a\\K+", "extended": false, "valid": false}
+{"pattern": "a\\K+", "extended": true, "valid": false}
+{"pattern": "\\A?", "extended": false, "valid": false}
+{"pattern": "\\A?", "extended": true, "valid": false}
+{"pattern": "{,2}", "extended": false, "valid": false}
+{"pattern": "{,2}", "extended": true, "valid": false}
+{"pattern": "^{2,}", "extended": false, "valid": false}
+{"pattern": "^{2,}", "extended": true, "valid": false}
+{"pattern": "\\G{2,}", "extended": false, "valid": false}
+{"pattern": "\\G{2,}", "extended": true, "valid": false}
+{"pattern": "[\\ ]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ *", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\ ", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\!*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\!", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\!b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\\"]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\"*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\\"", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\\"b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\#*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\#", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\#b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\$", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\$b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\%*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\%", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\%b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\&*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\&", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\&b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\']", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\'*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\'", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\'b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\(]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\(*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\(", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\(b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\)]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\)*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\)b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\*]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\**", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\*b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\+]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\+*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\+b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\,*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\,", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\,b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\-*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\-", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\-b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\.]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\.*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\.", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\.b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\/]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\/", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\/b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\0*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\0", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\0b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1*", "extended": false, "valid": false}
+{"pattern": "a\\1", "extended": false, "valid": false}
+{"pattern": "[a\\1b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\2]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\2*", "extended": false, "valid": false}
+{"pattern": "a\\2", "extended": false, "valid": false}
+{"pattern": "[a\\2b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\3", "extended": false, "valid": false}
+{"pattern": "[\\3]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\3*", "extended": false, "valid": false}
+{"pattern": "a\\3", "extended": false, "valid": false}
+{"pattern": "[a\\3b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\4", "extended": false, "valid": false}
+{"pattern": "[\\4]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\4*", "extended": false, "valid": false}
+{"pattern": "a\\4", "extended": false, "valid": false}
+{"pattern": "[a\\4b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\5", "extended": false, "valid": false}
+{"pattern": "[\\5]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\5*", "extended": false, "valid": false}
+{"pattern": "a\\5", "extended": false, "valid": false}
+{"pattern": "[a\\5b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\6", "extended": false, "valid": false}
+{"pattern": "[\\6]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\6*", "extended": false, "valid": false}
+{"pattern": "a\\6", "extended": false, "valid": false}
+{"pattern": "[a\\6b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\7", "extended": false, "valid": false}
+{"pattern": "[\\7]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\7*", "extended": false, "valid": false}
+{"pattern": "a\\7", "extended": false, "valid": false}
+{"pattern": "[a\\7b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\8*", "extended": false, "valid": false}
+{"pattern": "a\\8", "extended": false, "valid": false}
+{"pattern": "[a\\8b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\9]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\9*", "extended": false, "valid": false}
+{"pattern": "a\\9", "extended": false, "valid": false}
+{"pattern": "[a\\9b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\:*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\:", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\:b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\;", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\;*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\;", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\;b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\<", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\<b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\=*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\=", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\=b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\>*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\>", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\>b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\?]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\?*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\?b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\@*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\@", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\@b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\A]", "extended": false, "valid": false}
+{"pattern": "\\A*", "extended": false, "valid": false}
+{"pattern": "a\\A", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Ab]", "extended": false, "valid": false}
+{"pattern": "\\B", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B*", "extended": false, "valid": false}
+{"pattern": "a\\B", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Bb]", "extended": false, "valid": false}
+{"pattern": "\\C*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\C", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Cb]", "extended": false, "valid": false}
+{"pattern": "\\D", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\D]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\D*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\D", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Db]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\E*", "extended": false, "valid": false}
+{"pattern": "a\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Eb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\F", "extended": false, "valid": false}
+{"pattern": "[\\F]", "extended": false, "valid": false}
+{"pattern": "\\F*", "extended": false, "valid": false}
+{"pattern": "a\\F", "extended": false, "valid": false}
+{"pattern": "[a\\Fb]", "extended": false, "valid": false}
+{"pattern": "[\\G]", "extended": false, "valid": false}
+{"pattern": "\\G*", "extended": false, "valid": false}
+{"pattern": "a\\G", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Gb]", "extended": false, "valid": false}
+{"pattern": "[\\H]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\H*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\H", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Hb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\I]", "extended": false, "valid": false}
+{"pattern": "\\I*", "extended": false, "valid": false}
+{"pattern": "a\\I", "extended": false, "valid": false}
+{"pattern": "[a\\Ib]", "extended": false, "valid": false}
+{"pattern": "\\J", "extended": false, "valid": false}
+{"pattern": "[\\J]", "extended": false, "valid": false}
+{"pattern": "\\J*", "extended": false, "valid": false}
+{"pattern": "a\\J", "extended": false, "valid": false}
+{"pattern": "[a\\Jb]", "extended": false, "valid": false}
+{"pattern": "[\\K]", "extended": false, "valid": false}
+{"pattern": "\\K*", "extended": false, "valid": false}
+{"pattern": "a\\K", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Kb]", "extended": false, "valid": false}
+{"pattern": "[\\L]", "extended": false, "valid": false}
+{"pattern": "\\L*", "extended": false, "valid": false}
+{"pattern": "a\\L", "extended": false, "valid": false}
+{"pattern": "[a\\Lb]", "extended": false, "valid": false}
+{"pattern": "\\M", "extended": false, "valid": false}
+{"pattern": "[\\M]", "extended": false, "valid": false}
+{"pattern": "\\M*", "extended": false, "valid": false}
+{"pattern": "a\\M", "extended": false, "valid": false}
+{"pattern": "[a\\Mb]", "extended": false, "valid": false}
+{"pattern": "\\N*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\N", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Nb]", "extended": false, "valid": false}
+{"pattern": "\\O", "extended": false, "valid": false}
+{"pattern": "[\\O]", "extended": false, "valid": false}
+{"pattern": "\\O*", "extended": false, "valid": false}
+{"pattern": "a\\O", "extended": false, "valid": false}
+{"pattern": "[a\\Ob]", "extended": false, "valid": false}
+{"pattern": "\\P", "extended": false, "valid": false}
+{"pattern": "[\\P]", "extended": false, "valid": false}
+{"pattern": "\\P*", "extended": false, "valid": false}
+{"pattern": "a\\P", "extended": false, "valid": false}
+{"pattern": "[a\\Pb]", "extended": false, "valid": false}
+{"pattern": "[\\Q]", "extended": false, "valid": false}
+{"pattern": "\\Q*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\Q", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Qb]", "extended": false, "valid": false}
+{"pattern": "\\R*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\R", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Rb]", "extended": false, "valid": false}
+{"pattern": "[\\S]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\S*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\S", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Sb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\T", "extended": false, "valid": false}
+{"pattern": "[\\T]", "extended": false, "valid": false}
+{"pattern": "\\T*", "extended": false, "valid": false}
+{"pattern": "a\\T", "extended": false, "valid": false}
+{"pattern": "[a\\Tb]", "extended": false, "valid": false}
+{"pattern": "[\\U]", "extended": false, "valid": false}
+{"pattern": "\\U*", "extended": false, "valid": false}
+{"pattern": "a\\U", "extended": false, "valid": false}
+{"pattern": "[a\\Ub]", "extended": false, "valid": false}
+{"pattern": "\\V", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\V]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\V*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\V", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Vb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\W]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\W*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\W", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Wb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\X*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\X", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Xb]", "extended": false, "valid": false}
+{"pattern": "\\Y", "extended": false, "valid": false}
+{"pattern": "[\\Y]", "extended": false, "valid": false}
+{"pattern": "\\Y*", "extended": false, "valid": false}
+{"pattern": "a\\Y", "extended": false, "valid": false}
+{"pattern": "[a\\Yb]", "extended": false, "valid": false}
+{"pattern": "[\\Z]", "extended": false, "valid": false}
+{"pattern": "\\Z*", "extended": false, "valid": false}
+{"pattern": "a\\Z", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\Zb]", "extended": false, "valid": false}
+{"pattern": "[\\[]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\[*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\[", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\[b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\\\*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\\\", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\\\b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\]*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\^*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\^", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\^b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\_]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\_", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\_b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\`*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\`", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\`b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\a*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\ab]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\bb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\c", "extended": false, "valid": false}
+{"pattern": "[a\\cb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\d", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\db]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\e]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\e*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\e", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\eb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\f]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\f", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\fb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\g]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g*", "extended": false, "valid": false}
+{"pattern": "a\\g", "extended": false, "valid": false}
+{"pattern": "[a\\gb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\h]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\h*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\h", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\hb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\i]", "extended": false, "valid": false}
+{"pattern": "\\i*", "extended": false, "valid": false}
+{"pattern": "a\\i", "extended": false, "valid": false}
+{"pattern": "[a\\ib]", "extended": false, "valid": false}
+{"pattern": "[\\j]", "extended": false, "valid": false}
+{"pattern": "\\j*", "extended": false, "valid": false}
+{"pattern": "a\\j", "extended": false, "valid": false}
+{"pattern": "[a\\jb]", "extended": false, "valid": false}
+{"pattern": "[\\k]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k*", "extended": false, "valid": false}
+{"pattern": "a\\k", "extended": false, "valid": false}
+{"pattern": "[a\\kb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\l]", "extended": false, "valid": false}
+{"pattern": "\\l*", "extended": false, "valid": false}
+{"pattern": "a\\l", "extended": false, "valid": false}
+{"pattern": "[a\\lb]", "extended": false, "valid": false}
+{"pattern": "[\\m]", "extended": false, "valid": false}
+{"pattern": "\\m*", "extended": false, "valid": false}
+{"pattern": "a\\m", "extended": false, "valid": false}
+{"pattern": "[a\\mb]", "extended": false, "valid": false}
+{"pattern": "[\\n]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\n", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\nb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\o]", "extended": false, "valid": false}
+{"pattern": "\\o*", "extended": false, "valid": false}
+{"pattern": "a\\o", "extended": false, "valid": false}
+{"pattern": "[a\\ob]", "extended": false, "valid": false}
+{"pattern": "[\\p]", "extended": false, "valid": false}
+{"pattern": "\\p*", "extended": false, "valid": false}
+{"pattern": "a\\p", "extended": false, "valid": false}
+{"pattern": "[a\\pb]", "extended": false, "valid": false}
+{"pattern": "\\q", "extended": false, "valid": false}
+{"pattern": "[\\q]", "extended": false, "valid": false}
+{"pattern": "\\q*", "extended": false, "valid": false}
+{"pattern": "a\\q", "extended": false, "valid": false}
+{"pattern": "[a\\qb]", "extended": false, "valid": false}
+{"pattern": "[\\r]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\r*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\r", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\rb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\s]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\s", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\sb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\t]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\t*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\t", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\tb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\u]", "extended": false, "valid": false}
+{"pattern": "\\u*", "extended": false, "valid": false}
+{"pattern": "a\\u", "extended": false, "valid": false}
+{"pattern": "[a\\ub]", "extended": false, "valid": false}
+{"pattern": "[\\v]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\v", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\vb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\w*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\w", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\wb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x]", "extended": false, "valid": false}
+{"pattern": "\\x*", "extended": false, "valid": false}
+{"pattern": "a\\x", "extended": false, "valid": false}
+{"pattern": "[a\\xb]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\y]", "extended": false, "valid": false}
+{"pattern": "\\y*", "extended": false, "valid": false}
+{"pattern": "a\\y", "extended": false, "valid": false}
+{"pattern": "[a\\yb]", "extended": false, "valid": false}
+{"pattern": "[\\z]", "extended": false, "valid": false}
+{"pattern": "\\z*", "extended": false, "valid": false}
+{"pattern": "a\\z", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\zb]", "extended": false, "valid": false}
+{"pattern": "[\\{]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\{*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\{b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\|]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\|*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\|b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\}*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\}b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\~*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "a\\~", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a\\~b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\-\\-a-\\d]|[\\E](?>\\pb(?(<a>)(?(1)*?||\\B+?)|\\g-1(?<b>(?J)|\\g<a>{3,2}\\g{-1})(?P=a)))**[]", "extended": false, "valid": false}
+{"pattern": "(?(R)(?(a)(?<b>\\p{L&}[^{,3}))\\b**)(?(?=a)[]\\u0041){65536}(?(VERSION>=10.4)[[]\\B**|\\k<a>|(*atomic:&\\X))\\b", "extended": false, "valid": false}
+{"pattern": "(*atomic:[\\x{41}]\\E)[\\cA\\-](?|(?i:\\é?(?(?C1)(?=a))$|(?(?C1)(?=a)\\p{ L }){)(?P>a)|[[:bogus:]])\\k", "extended": false, "valid": false}
+{"pattern": "[]++", "extended": true, "valid": false}
+{"pattern": "(?(1)(*pla:\\G(?(VERSION>=10.4){(?C))\\1])\\1\\h{3,2}\\2", "extended": false, "valid": false}
+{"pattern": "[^a-\\da-z[=a=]\\w]😀[]|\\g1**", "extended": false, "valid": false}
+{"pattern": "^\\g<-1>(*nlb:(?<=(*pla:[\\h][](*sr:\\x41|){ 2 , 3 }|(?(?=a)[\\hza]\\_)*\\k{a}\\E|[a-z\\b]\\K{3,2}\\g1|)+|", "extended": true, "valid": false}
+{"pattern": "\\g-1(?P>a){2,3}(*sr:(?n){2,}(?&a)[])", "extended": false, "valid": false}
+{"pattern": "[^-[:word:][:word:]z-ab(*FAIL)", "extended": true, "valid": false}
+{"pattern": "(*pla:(?(1)(?^){3,2})){|", "extended": false, "valid": false}
+{"pattern": "(?|[[.a.]]++)\\012", "extended": true, "valid": false}
+{"pattern": "(?^)(?'a'(*UTF)(\\N{U+41}|[^😀-😂aa-\\d][a\\Q-]\\E\\8\\p{L}]|\\k{2}[\\x{41}z]*+)\\b)++(*nlb:(?&a)\\o{101}|(?!(?(VERSION>=10.4)\\g{a}[]){2,3}-){2})|{ 2 }", "extended": true, "valid": false}
+{"pattern": "(?|[])(?<a>\\N*+\\U(?:\\B[\\R\\d-a](?(DEFINE)(?&a)(*nlb:[]\\é(?C256)){2,}\\k<a>)|(?Cx)|[\\p{L}]|", "extended": false, "valid": false}
+{"pattern": "(?C){2}\\E(?Cx)(?(R)[\\pL[=a=]]|(*plb:(?<=[\\E\\x{41}\\d][^\\x{41}])(?(R)**\\b)(?(R1)\\p{L&}|{,3})|\\g{+1}{))", "extended": false, "valid": false}
+{"pattern": "\\g1[[=a=]]", "extended": false, "valid": false}
+{"pattern": "\\E(?:[\\d-aa-z-]|(?<b>\\u0041a\\cA*+)(?>(?P<a>[z-a])+\\p{L&}*+|[]*|(*BOGUS)+?[[.a.]\\x{41}\\-][\\p{L}\\x{41}a-z]){2})(?<![[\\h[:alpha:]]|[^^[:bogus:]\\b](?(R1)\\pb)|)(?:[\\C\\cA]**\\R\\g{-1}|)\\p{ L }{2}", "extended": false, "valid": false}
+{"pattern": "(*UTF)(?i:(?(?C1)(?=a)[^][^^\\Ca-z]\\k{a})?(?x)|0[z-aa-\\d[:word:][])?{.", "extended": true, "valid": false}
+{"pattern": "(?aD)(*nlb:(?>[\\g\\w][](?(VERSION>=10.4)(?R)\\pb|\\o{101}))[[:word:]\\-😀]+)(?(1)[[[.a.]]*+|[a[:bogus:]\\w[:bogus:]]{2})(?!(?<=(?<!\\p{^Lu})|[]|)[\\]\\]])", "extended": true, "valid": false}
+{"pattern": "(?(?C1)(?=a)(?C\"x\")**(?(R)b0#+|\\2(?<b>){2,}[\\b]))(*atomic:\\p{Greek}\\81*+)(*plb:(?i:\\b(?<a>[\\dz-a\\h\\C]{\\8|)(?i:\\g{+1}-+?{ 2 , 3 }))**(?i)|(?|[^\\C[:^alpha:]\\g]*)*|\\012(?<=(?P<a>|)||a(?P<a>\\u0041\\g<1>[^[\\8]){ 2 })\\g-1+?\\X(?<=(?(R)\\p{L&}+?[-\\p{L}]|(?(a)?(*FAIL)**|[\\Q-]\\Ea-z\\][^\\^]))(?<a>(*plb:{ 2 , 3 }{+|[][😀]\\P{Xan})))", "extended": false, "valid": false}
+{"pattern": "\\k\\k<a>*|\\b(?+1)", "extended": false, "valid": false}
+{"pattern": "(?(R)[\\N\\Q-]\\E]([[:^alpha:]\\b[:bogus:]😀-😂]😀|\\012(?:\\x{41}{3,2}\\x{110000}**)\\k{a}|))\\z[\\h\\pL[:^alpha:][:bogus:]", "extended": false, "valid": false}
+{"pattern": "(?(1)\\2\\p{Greek}(?:(?P<a>0|[[:^alpha:]-]))?)[\\8a-\\d]*?\\N(?(-1)[\\g\\pL]]+?|0[^[]++(?<b>\\x{41}[\\h\\cA]))[\\Q-]\\E]", "extended": false, "valid": false}
+{"pattern": "(?<=(?(a)[[:word:]\\cAz-a\\x{41}]){,3}|](?<!a{3,2}[](?(-1)\\w*+|[\\N😀-😂]|)))\\p{^Lu}\\Q\\E(?<=(?P=a)(*atomic:(*MARK:m)|\\u0041|)(?=(?<a>[^]*+)(?<b>[\\cA\\cA||){3,2}))**", "extended": false, "valid": false}
+{"pattern": "[[.a.]\\C]", "extended": true, "valid": false}
+{"pattern": "(?(<a>)(?J:[][\\p{L}[:word:]][^\\]\\cA\\x{41}])(?<=\\cé(?<a>\\p{Bogus}+[^\\Q-]\\E[.a.]]|\\p{sc:Latn})\\k<a>{ 2 , 3 })+?|\\p{Bogus}(*ACCEPT))[\\g](?(<a>)0|\\g<1>)|", "extended": false, "valid": false}
+{"pattern": "(*MARK:m)(?(?=a)((?J:|)|)(?(?C1)(?=a)(*MARK)[^[:word:]\\E\\pL]|\\c)*+|(?P<a>[^\\C\\d\\C]))(?i:\\é**(?C\"x\")\\x{ 41 }(?P>a){3,2}[\\-", "extended": false, "valid": false}
+{"pattern": "(?Cx)", "extended": true, "valid": false}
+{"pattern": "(?^)(?(?C1)(?=a)(?<!{,2}(?(VERSION>=10.4)[^\\x{41}😀-😂][]){65536}[^\\]\\x{41}\\-]{65536})**[\\cA\\-\\pL]|)++", "extended": true, "valid": false}
+{"pattern": "(?<a>\\Qa)\\E(?!(?(DEFINE))+[]|[\\Ca](?(VERSION>=10.4)\\k<a>+|\\g{+1})(?<=$*+|\\N\\k))\\u0041|0", "extended": false, "valid": false}
+{"pattern": "(*MARK)*(?C1)(*sr:(*atomic:\\N(?i:(?C\"x\")|*)|(?^))|(?i)^{ 2 , 3 })", "extended": false, "valid": false}
+{"pattern": "[^😀][[:bogus:][:^alpha:]\\cA^]*+", "extended": true, "valid": false}
+{"pattern": "[^[\\Q-]\\E-\\h]*{+?(?-1)", "extended": false, "valid": false}
+{"pattern": "[[.a.][=a=]a-\\d\\]]{2,3}|\\X", "extended": false, "valid": false}
+{"pattern": "\\b\\8{2,}(?!(?<a>\\012)[](?(?C1)(?=a)[^\\pL\\-\\p{L}\\pL](?(?C1)(?=a)\\g{+1}|\\g<1>{65536}[^\\cA\\cA\\cA\\d])?))", "extended": false, "valid": false}
+{"pattern": "(?<a>(*atomic:\\U\\R*+(?u)+?|(*atomic:[]{3,2}\\pb\\P{Xan}){65536}\\pL)|[\\b]){2} {3,2}[\\E\\g\\E\\Q-]\\E]\\cA*+", "extended": true, "valid": false}
+{"pattern": "\\k{ 2 , 3 }\\x41{2,3}[^\\p{L}]\\p{Greek}(?i)", "extended": false, "valid": false}
+{"pattern": "[\\8\\R](?(R1)\\U[^])|", "extended": false, "valid": false}
+{"pattern": "(?'a'[]){1}{|(*sr:(?(R)(*atomic:\\cé{|\\012(?C1))+?(?u))|", "extended": false, "valid": false}
+{"pattern": "[[:bogus:]\\h[:bogus:]z-a]", "extended": false, "valid": false}
+{"pattern": "(?>[z😀\\Na]*)\\p{ L }\\cé{2,}", "extended": false, "valid": false}
+{"pattern": "(?C)\\h[^]", "extended": false, "valid": false}
+{"pattern": "\\p{ L }(?|(?(R1)(?P<a>\\x41{\\g{-1}[[])?(*SKIP)(?P>a))\\K(*plb:[\\-\\cA]|_)", "extended": true, "valid": false}
+{"pattern": "(?(R)(b(*pla:|\\p{sc:Latn})\\_|\\z\\d(?R))\\p{sc:Latn}", "extended": false, "valid": false}
+{"pattern": "(*sr:\\g-1)**", "extended": false, "valid": false}
+{"pattern": "(?J:\\Qa)\\E[^\\E\\Ea-z]{,3}[\\w]|)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\é|\\_(?n)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[-\\-](?(-1)(?(1)(?J:\\012|(?x){3,2}[][=a=][:bogus:]]|)(?(R)(?Cx)(?J)|[]?|)(?Cx){3,2}|(*SKIP)))[\\w\\w]{2,3}\\b|[^\\C[:^alpha:]]", "extended": false, "valid": false}
+{"pattern": "(*plb:(?<a>(?<b>[^\\ha-\\d\\8]{65536}){,3}(?=)(?(?=a)0))|(?!\\cA{3,2}(?i:\\x{41}(*MARK:m){,3}\\U)\\z{2,}|(?(DEFINE)*+|){2}){\\B)", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]\\cA\\d-a[:^alpha:]]{ 2 , 3 }\\g<1>(?|(?+1))", "extended": false, "valid": false}
+{"pattern": "(?P>a)+(?'a'\\C(?aD)|(?(R1)(?(?C1)(?=a)(?P=a){ 2 , 3 }{,3})))(?<a>(?(R)(?1){2,}[\\Na-z\\](?C1)?)[^\\-z\\d-a\\R]|\\P{Xan})", "extended": false, "valid": false}
+{"pattern": "(?P>a)*(?i)\\012(?u)+?|", "extended": false, "valid": false}
+{"pattern": "(?C)(?:(*plb:\\2(?(R)[^-](?#c)*?[^-]z-a])|[\\E\\h]0)\\g-1(?|\\p{L&}[\\x{41}[:alpha:]]|\\012)**){,3}(?(-1)(*plb:(*ACCEPT)[^\\pL[]|(?<b>\\x{41}|+?){65536})0)*", "extended": true, "valid": false}
+{"pattern": "[\\d-a]*?\\pL*?", "extended": false, "valid": false}
+{"pattern": "\\1(*plb:(?C1)\\o{101}{2}[])**\\w\\8\\b", "extended": false, "valid": false}
+{"pattern": "(?|(?^)|(?'a'(?(<a>)[^😀z-a[\\8][^\\N]|\\X[^\\])(?R))|(*FAIL)?(?i))", "extended": false, "valid": false}
+{"pattern": "-[](?R)|(?&a)\\g1?|", "extended": true, "valid": false}
+{"pattern": "[]++[z-a\\b😀](*pla:(?|[\\]\\R]\\-[[](?(a)\\p{L&}|\\x41(*MARK:m)|[a-\\d[a-zz]))|[\\]\\b](?'a'(?(R)++|\\R{65536}\\012*){,3}(*UTF){2,}[\\d\\p{L}]))", "extended": false, "valid": false}
+{"pattern": "(*sr:(?C\"x\")-)(?(R)[[:word:]]+ (?>(?(-1)[^^\\-\\N]*|(?n))\\k)", "extended": true, "valid": false}
+{"pattern": "\\u0041[\\]\\d-a][\\R]", "extended": false, "valid": false}
+{"pattern": "\\g{a}\\N{U+41}{2,}\\p{ L }{2}(*sr:(?|\\_|\\Qa)\\E(?!(?J))(*pla:(?-1)[\\g\\[]**\\g-1|\\k{a})))", "extended": false, "valid": false}
+{"pattern": "\\N(?i:(?aD)*+\\g<1>|)[^\\Q-]\\E]", "extended": false, "valid": false}
+{"pattern": "(?P<a>(*SKIP))0(?(a)\\z{3,2}|)[\\b[.a.]\\a-\\d]*?[^][\\Q-]\\E]", "extended": false, "valid": false}
+{"pattern": "(?(R)\\k'b')(?(<a>)(?P=a)(?P<a>\\10){,3})[[.a.]]{2,3}", "extended": false, "valid": false}
+{"pattern": "\\p{Bogus}(?:(?J)(?=(*SKIP)\\kb)|[\\h\\Q-]\\E]{2,3}[\\])(*UTF)[\\g^\\w]|", "extended": false, "valid": false}
+{"pattern": "\\p{sc:Latn}++|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\C(*UTF)\\p{ L }{65536}", "extended": false, "valid": false}
+{"pattern": "(?P=a){2}(?<![]{65536})+(?C)(*pla:(*plb:(*FAIL))\\X)*a", "extended": false, "valid": false}
+{"pattern": "[\\h😀-😂\\w](?J:\\8[^[:^alpha:]]){2,3}(?(<a>)\\Q\\E(?(1)(*atomic:\\2{2,}))**)\\dé{,3}", "extended": true, "valid": false}
+{"pattern": "[^[=a=][:bogus:][:^alpha:]]*?\\p{^Lu}(?(R1)._||(?J){3,2}(?n)+)(?=\\k<a>\\g{-1}?0)", "extended": false, "valid": false}
+{"pattern": "(?i:[[=a=]](?(?=a)\\K[\\x{41}[:^alpha:][:word:][=a=]]{,3}){(?<a>(?(?C1)(?=a)]|[[:alpha:]][^\\g\\C](*BOGUS))\\g{a} |(*MARK)**\\g-1\\p{sc:Latn})){2}(?u)(?<b>\\1\\Qa)\\E)[^😀]", "extended": false, "valid": false}
+{"pattern": "\\k'b'+?\\pb", "extended": false, "valid": false}
+{"pattern": "(?P<a>(?Cx)(?i))(?(-1)(*atomic:(?(?=a)[^a-zz\\E\\h]{2}é{2})){3,2}[^][\\N\\b\\8😀]|", "extended": true, "valid": false}
+{"pattern": "(?u)[\\d-a]{2,3}", "extended": true, "valid": false}
+{"pattern": "(?(a)(?(?=a)[\\b[=a=]](?(-1)[\\b])|(?i){3,2})-|(?^)){2,}(*atomic:\\1{2,3}(*UTF)*+\\x{110000})\\K*+(?'a'(?<=(*sr:(?-1))(?(a)(?^){3,2}\\w|(?C)|(*MARK)|))|\\x{ 41 }|)", "extended": false, "valid": false}
+{"pattern": "(?(-1)(?![]](?P=a))[a-z]|(?x)){3,2}(?:\\A)\\cé\\g<a>[\\g]{2,3}", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]😀-😂\\-](*atomic:(?P<a>[^\\R[:alpha:]]|(?(?=a)(*ACCEPT){,3}|(?+1){2})*?)(?i:[\\cA]|)[\\]\\E[:^alpha:]\\b]|[^a-\\d\\-]{2,}[😀[:alpha:]\\d\\8]*+)*?(?C)*?", "extended": false, "valid": false}
+{"pattern": "(?P=a)(*MARK)(?P<a>\\1){", "extended": false, "valid": false}
+{"pattern": "}\\pb[\\x{41}\\p{L}a-z]", "extended": false, "valid": false}
+{"pattern": "(?<b>(?i:\\p{Bogus}(?(?C1)(?=a)+|[\\]]*+[[:alpha:]\\R]{[[:word:][:alpha:]])(?(a)[]{,3}[^[=a=]\\x{41}]z]+?+))(?(DEFINE)[\\p{L}😀\\8]+?\\z{,3}(*FAIL)))", "extended": false, "valid": false}
+{"pattern": "[]*+[\\pLa^\\pL](*BOGUS){,3}", "extended": true, "valid": false}
+{"pattern": "(*nlb:(?(R1)\\p{L}|[\\x{41}\\cA\\N]])a(?J))[\\8[:alpha:]\\cA😀](?1)(?1)(*UTF)", "extended": false, "valid": false}
+{"pattern": "(?(R1)\\c[\\x{41}\\8\\d])\\x{ 41 }+(?(?=a)(?R))", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(?(VERSION>=10.4)\\pb-|\\g<1>*+(*pla:-|))\\g1)*+[\\d\\w[:word:]\\]]", "extended": true, "valid": false}
+{"pattern": "[z-a[:^alpha:][:bogus:]]]", "extended": false, "valid": false}
+{"pattern": "[^😀-]+?(*atomic:(?![\\bz-a\\h\\-]\\10++(?i:**\\c*?)){2}[\\Ca-])*(*nlb:\\g<a>{2,3}(?+1)+)(?!(?u)**){2,3}|", "extended": true, "valid": false}
+{"pattern": "[\\d-a](*MARK)[^\\Q-]\\E]\\g<-1>", "extended": true, "valid": false}
+{"pattern": "(?J:\\o{101}\\81[\\b\\cA😀-😂\\cA]|(?P>a)(?&a){2,3}[\\pL\\g[\\C]{2,}|)(?(<a>)\\_[\\b](?(a)(?C1){65536}[z[[.a.]]{3,2}||){2}\\g<-1>0**", "extended": false, "valid": false}
+{"pattern": "[^\\Q-]\\Ez]\\1", "extended": false, "valid": false}
+{"pattern": "(?=(?(?=a)\\x41|[\\R]|\\é)(*pla:(?(DEFINE)\\pb\\k)(*plb:[😀]||\\p{ L })\\x{ 41 })[a\\dz]|\\g<a>(?J:\\U|[^\\x{41}](*pla:|)))(*sr:(?!(?i:[^\\C^][^[:alpha:][=a=][:bogus:]\\E]){65536}(?<b>\\g{+1}{2,1}#)?(?(-1)[-[=a=][:alpha:]^]){|\\81[\\w\\-](?-1))*+)(?=\\c\\x{ 41 }(?1))", "extended": true, "valid": false}
+{"pattern": "\\d[a-z\\]|\\b(?:(?n)(?<![])[😀-😂[\\]]|(?(?=a)[^😀]\\B|[a-z[:^alpha:][:^alpha:]](*SKIP))[(?>\\g-1(?(DEFINE)){3,2})|)\\p{^Lu}{65536}", "extended": false, "valid": false}
+{"pattern": "(?(1)}\\x{110000})\\g<-1>\\pL", "extended": false, "valid": false}
+{"pattern": "(*UTF)(?(a)(?(R)[\\b[:bogus:]]||\\u0041*+(?(R)\\R*+)\\h)(?={,2}{,2}|(*MARK){2}[^\\E]{2}|[]|)|[\\h])(?<a>(?<=(?<b>*+)(?(?C1)(?=a)+?|-[^a]+)+?)|\\X)(?x)", "extended": true, "valid": false}
+{"pattern": "[^]\\x{41}{2,}(?'a'[\\p{L}]+(?(<a>)[\\d-a[:word:]\\g]))(*plb:\\x{41})\\cé", "extended": false, "valid": false}
+{"pattern": "(?<a>\\Qa)\\E{3,2}(?(<a>)[]\\h|\\z\\p{^Lu}){2,}[\\C][=a=][:word:]](?|(?=(?(a)[\\]z-a\\cA\\h])\\z(?(1)[]\\w[:alpha:]\\8]\\g<-1>+))((?J:(*BOGUS)\\P{Xan}*?\\c|[^z]*[]{2,})(?P=a))**|((?<=\\pL{2,1}){2}(?:]|\\g{a}{65536})\\g{-1}{,3})+(?&a))[\\Q-]\\E\\-😀", "extended": false, "valid": false}
+{"pattern": "(*plb:(?C1)[\\N]\\pL{ 2 , 3 })(?i:(?P<a>{,2}(*pla:++*{2,3}|\\pL)){[^](?J)|(?<b>(?i)[\\-a](?(1)[z-a\\cAa-][\\gz\\]z]))\\pb\\k'b')(*pla:(?(R)é{65536}[[:word:]z\\C])(*plb:(?P>a)\\k{a}{2,3}[\\b]*+|\\P{Xan}+?[[.a.]])**[\\E[:alpha:][.a.]]){2,}\\k{a}*+\\A", "extended": false, "valid": false}
+{"pattern": "(?|(*atomic:\\E?(?<![\\g[=a=]\\d-a]{{ 2 , 3 }|[^[.a.]])))\\b{2,}[-]", "extended": true, "valid": false}
+{"pattern": "[]\\X(*MARK)*", "extended": false, "valid": false}
+{"pattern": "[-\\p{L}][^\\d-a]](?J:[][[:word:]\\]]{ 2 }|)\\p{ L }+?", "extended": true, "valid": false}
+{"pattern": "\\p{^Lu}(?<!(\\g<a>(?(R)[😀-\\wz-a]\\g<a>\\N{U+41}++){3,2}(?'a'(?-1)+)|(?n)\\N\\B)|{[\\R\\p{L}\\8])(?>\\C)[^\\w\\w]", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)(?(R1)\\81(?'a'[]])[])(?(?=a)(?J:[] |\\b++){,3}(?P<a>\\U\\U|**\\p{Bogus})*+(?C\"x\")))(?'a'\\N\\N){(?<b>{1}|(?(DEFINE)[^]\\g{+1})\\g-1(?<!\\R[^\\-\\N\\x{41}\\p{L}]?|(*pla:\\x41{|[^[:bogus:]\\pL\\d\\E])[^^^\\g]))(?(-1)\\g{-1})", "extended": false, "valid": false}
+{"pattern": "{2,1}{3,2}\\_", "extended": true, "valid": false}
+{"pattern": "(?P<a>é(?n)[^]|(?(?=a)_|\\U)(?(1)[]|)\\c*+)(*ACCEPT)", "extended": false, "valid": false}
+{"pattern": "{2,1}{ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "[[[^[]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<a>(?(1)\\z(*nlb:\\8([z-a\\w][]|\\p{Greek}{,3}(?>(?1)\\K|[a-\\d-]+?\\cé)?|)+|(?J:\\p{L}++\\R{ 2 , 3 }(0|\\x41é)|[-\\h](?(DEFINE)[\\C[.a.][:word:]\\C]*+)*?)", "extended": true, "valid": false}
+{"pattern": "(?(R)[\\b\\R[:word:]\\R][\\pL\\-]{ 2 }){ 2 , 3 }|(?J:[]{2,3}(?|(?!*+)+?(?(<a>)[^-]||\\d\\G|)|)(*sr:(?C\"x\")(?(-1)[](?aD)|{2}\\p{L})]{65536}))(?<![](?P<a>[])[-\\N]|(?R)(?(-1)(?(a)(*SKIP)+(*SKIP)**|)(?(-1){ 2 , 3 }|😀|)(?J))[[:word:]])|", "extended": false, "valid": false}
+{"pattern": "\\A\\h\\N", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C\"x\")\\k{a}[]{", "extended": false, "valid": false}
+{"pattern": "\\P{Xan}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|(*nlb:(?P<a>{,3}[[:bogus:]\\pLa-z\\][^a\\pL]|)(?|\\8[^\\w]|[[=a=]\\d[:^alpha:]]^))*+(?(VERSION>=10.4)(?(R)(*FAIL)\\K)[\\d]){2,3})*[\\R\\h\\][:alpha:]]\\k'b'(*sr:(*UTF)(?(R)(?R)){ 2 , 3 }|){2,1}", "extended": false, "valid": false}
+{"pattern": "(*nlb:(?'a'(?(<a>)é)){2,3}|)|\\h", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "\\k'b'[[:alpha:]]](?C256)++(*nlb:[]|(?(a)\\x{41}+?|(?!|)[\\N\\Q-]\\E])|(?=\\A|(?(-1)\\u0041|\\é|\\cé{,3}\\U))", "extended": false, "valid": false}
+{"pattern": "(?>[]\\d-a\\R\\pL]\\g<a>|(?=(?(R)(*SKIP))|\\Qa)\\E|)\\K(?1))", "extended": true, "valid": false}
+{"pattern": ".+(?i:\\é{3,2})(?(1)\\p{Greek}[[:alpha:]\\h\\cA][^a]*[a\\8\\w[*?", "extended": false, "valid": false}
+{"pattern": "(?<a>(?J:[^[:^alpha:]^\\dz-a](*sr:)(?'a'[^]|&|\\g1[^\\d])**|\\z[\\C\\[:word:]](?n))\\G(?P<a>(?|[]|(?=[\\E]))\\C|(?#c)0(?=\\012|(*nlb:(*MARK:m){)**[])?){2,}(?(VERSION>=10.4)(?<b>a(*atomic:(?P>a)))|a\\o{101}\\C)", "extended": false, "valid": false}
+{"pattern": "\\Qa)\\E{2,3}\\K", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{\\x{ 41 }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:(*atomic:(?^)+)(*pla:\\cé\\p{ L }|(*pla:\\g<1>)b(?u)|)|[])(*MARK:m)+?\\k", "extended": true, "valid": false}
+{"pattern": "(?x)(?C1)(?Cx)", "extended": false, "valid": false}
+{"pattern": "(?(R1)[[:alpha:]z-a\\C]\\g{-1}[-\\-\\cA]+?|(?(R1)([]|\\g{-1})|(?(-1)}[\\][:^alpha:]]😀-😂]|))(?>(*nlb:{ 2 }*+){2,3}[^\\d[=a=][.a.]]+))\\g<1>[\\8^]", "extended": false, "valid": false}
+{"pattern": "(?P>a)[^]*?", "extended": true, "valid": false}
+{"pattern": "[^\\cA\\R\\C\\x{41}]", "extended": false, "valid": false}
+{"pattern": "\\p{Greek}{2,1}(*atomic:(?=(*plb:[^\\h\\x{41}z\\d-a]|(?1))[]|(?'a'[\\d]+(?J)*+)|\\B(?(-1)\\g<a>\\N{U+41}{2,}|(?C1){2,})++(?P<a>a{2,1}\\pb|[]*\\p{^Lu}))(*sr:(?|[\\cA[=a=]\\d-a\\x{41}][\\Q-]\\E[:alpha:]\\8]{3,2}(*MARK:m))[\\w\\Ea\\d-a])(?|[^]\\K(?(?C1)(?=a)[]?))|\\p{sc:Latn}*|){ 2 , 3 }(?(a)(?:\\p{L&}(?(-1)||\\p{L&}[^]){2,}|(?!(*SKIP)\\cA{ 2 , 3 }|(?aD){2}\\cé{2,3}[\\g\\b\\cA\\x{41}]){ 2 , 3 }|)|😀", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)\\g<-1>\\g<1>)\\b{2,3}[^[:bogus:]\\d-a[:^alpha:]]?", "extended": true, "valid": false}
+{"pattern": "(*nlb:(?!(*plb:\\x{41}\\p{ L }[]|\\p{ L }{2,})*+)(?P=a)*?)\\g<-1>{2,3}", "extended": false, "valid": false}
+{"pattern": "\\P{Xan}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^a-\\da-\\d^](?(R1)\\g{-1})|", "extended": true, "valid": false}
+{"pattern": "(?(-1)(?(?C1)(?=a)0)$|\\g<1>+|(*nlb:(?(?C1)(?=a)}[[:^alpha:]^\\b]{,3}|(?+1)0{ 2 , 3 }|){,3}\\1{ 2 , 3 }|\\c{2,1}|#{)|[^a-z](?(<a>)(?<b>||*?[])))+(?<b>(?(a)(?C256)|(?(?C1)(?=a)**|(?&a){2,3})(?:{,3}\\_)){2}(?|😀?(?=.|[^\\]\\pL\\Ra-\\d](?i)))(?(DEFINE)[][^\\N^\\g\\C]|(*sr:\\x{41})*(?(1))*?(?i:(?#c)))*?|\\g<1>\\x{ 41 }[^\\-])(*pla:\\cé{2,3}(*MARK)**)(*atomic:(*plb:{1}{2,3}(?#c)(?'a'[\\]^]|\\B(*MARK)+?){2,})(*pla:\\g{+1}\\p{L&}**(?:){ 2 , 3 })+?|[[.a.]][^\\8]|(?(?=a)\\P{Xan}|\\E{2,3}|))++|\\U*+", "extended": true, "valid": false}
+{"pattern": "(?!$\\E|\\U|(?(?=a)[](*atomic:\\2{2})(?(<a>)?[\\d-a\\R😀\\E]{3,2})))\\g{+1}", "extended": false, "valid": false}
+{"pattern": "(?'a'[]\\Q\\E&|[[:alpha:]\\cA[=a=]](*nlb:(?|[^][\\Ca-z]|[]])(?|[\\w]\\h](?|\\pL)*?)*){ 2 , 3 }\\Q\\E*?(?(DEFINE)(?(-1)[^\\-a-z\\C\\w]{3,2}){3,2}).", "extended": true, "valid": false}
+{"pattern": "(*MARK){|", "extended": false, "valid": false}
+{"pattern": "(?J)|[[\\\\-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[.a.]😀-😂a-z][\\d](?<!\\p{L&}[]{ 2 , 3 }[^[:^alpha:]\\-]+?)", "extended": true, "valid": false}
+{"pattern": "(?n)(?u)(?J)(*plb:(?i:(*plb:[z\\b\\8]|[a\\Ra]\\c)|{ 2 }+?\\c\\c){2,3}-(?!(?'a'\\8{3,2})?(?J:[\\C](?P>a)|\\k'b'){2,}(*sr:[^z\\p{L&}{2,3}|\\k'b'|})|\\Q\\E)|[]]+?)?\\d**", "extended": true, "valid": false}
+{"pattern": "\\k'b'*+|[\\E[:bogus:]\\h[:alpha:]](?<a>(?(?=a)[\\p{L}z😀-😂]\\k(?<!)){65536}|(?<a>-(?|)(?<b>}{2,3}|(?R)*?\\X{2})|[\\d]\\p{L}*(*plb:[[:alpha:]]?[\\E\\-\\h😀-😂]|))(?(a)\\p{Bogus}\\A{,3}){2,3}(?<a>(?|[z[:bogus:][.a.]]+?)|\\z(?P<a>[]|(?C256){,3}|(?P>a)\\k'b'\\G))", "extended": false, "valid": false}
+{"pattern": "[^\\E\\-\\p{L}\\p{L}](?(VERSION>=10.4)(?i:(?(DEFINE)[a-z]{)|){2}})(?(-1)[\\]\\b\\N\\N][[]|\\U+?$)[^]{65536}|", "extended": true, "valid": false}
+{"pattern": "[z😀😀\\d](?C\"x\")a{65536}[]?|", "extended": false, "valid": false}
+{"pattern": "[\\ba-\\d\\x{41}\\d-a][a-z\\8[=a=]\\p{L}]{2}[\\d-a\\w\\d-a]**", "extended": false, "valid": false}
+{"pattern": "\\g<-1>*?", "extended": false, "valid": false}
+{"pattern": "#\\g1{2,}|", "extended": false, "valid": false}
+{"pattern": "[\\d-a](?!(?=(\\81|)*?(?'a'\\K))(?(1)[[.a.]😀\\d-a\\b](?i))*?)(?C256){3,2}(?![^]*?(?:[^[:^alpha:]]{1}(?J)|)\\cA+?|((*UTF){,3}\\E)_[\\a-\\d[:bogus:]^]{){65536}", "extended": false, "valid": false}
+{"pattern": "0(?'a'(?<![^\\p{L}\\N[]|)(?|\\N{U+41}{3,2}(?(?=a){2,1}\\x41)*|#([\\pL][^\\-z-\\])**(?(-1)[]\\b\\u0041){65536}){2,3}|)", "extended": true, "valid": false}
+{"pattern": "\\p{ L }\\K\\x{110000}[\\]\\8\\d-a]{(*SKIP)", "extended": false, "valid": false}
+{"pattern": "(?:\\P{Xan})(?C)[^\\h[]|\\x41", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:\\U(?(VERSION>=10.4)(?P<a>|[😀]?)\\p{L})){3,2}[a-\\d\\](?(VERSION>=10.4)[[:^alpha:]]{1}\\2{,3})\\G*?", "extended": false, "valid": false}
+{"pattern": "[\\E[:alpha:]](?J:b*+\\8|[]+[]|)(?!(?P=a)|\\81{65536})", "extended": false, "valid": false}
+{"pattern": "(*pla:(?|[]+(?(R){,3}|[[:^alpha:]\\b]))*[\\d\\pL\\-\\p{L}]+?[\\C\\]]{65536})(?(?C1)(?=a)\\p{sc:Latn}(?(DEFINE)[^\\Q-]\\E]{2}))+[\\Q-]\\E\\N[[:^alpha:]][]+", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]](?i)[-[:^alpha:]]**(?|(?P=a)++)[a-\\d\\8\\C[.a.]]", "extended": false, "valid": false}
+{"pattern": "[\\g]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)(?(VERSION>=10.4)(?i:|[\\]\\[.a.]^])||[^\\-\\-]][^a[:^alpha:]]))*{,2}{65536}(?'a'[\\8\\])", "extended": false, "valid": false}
+{"pattern": "[\\h[[\\g\\Ea]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i){3,2}{,2}\\x{41}\\x41(*BOGUS)", "extended": true, "valid": false}
+{"pattern": "(?>(?(VERSION>=10.4)\\U)])\\Qa)\\E_(?^)", "extended": false, "valid": false}
+{"pattern": "(*nlb:(?(-1)(?(R1)\\p{Bogus}{2,3}){3,2}(?<b>[z\\d])(*plb:*+\\pb[\\E[:bogus:]\\b[.a.]]{,3}|+))|a{,3}|){65536}\\g<a>|(?(<a>)(?i:\\x{ 41 }(?<b>{,3}\\k<a>\\C(?J:\\p{L&}))[\\E\\x{41}a😀]*(*BOGUS))", "extended": false, "valid": false}
+{"pattern": "(?P<a>(?P<a>(?<=|)|(?-1))|(?(?=a)\\w(?u)|(?(VERSION>=10.4)(*SKIP)[😀-😂[:bogus:]z]|{(?#c))*?\\10(?:[\\Ez^]||[[]|))(?(VERSION>=10.4)(?<=\\w|\\_)|))[-]", "extended": false, "valid": false}
+{"pattern": "(?P<a>[]](?>(*MARK)\\p{^Lu}|é|\\p{^Lu}(?!*||[^\\d-aa-\\d\\cA]\\p{ L }|){2}))|\\012{2,1}", "extended": false, "valid": false}
+{"pattern": "[[:alpha:]\\x{41}[.a.]]", "extended": false, "valid": false}
+{"pattern": "\\p{Bogus}(?(?C1)(?=a)\\h(*plb:[^[:alpha:][.a.][:bogus:]]\\u0041|(?(DEFINE)\\pbé[\\N\\8\\h[=a=]]))){2,1}", "extended": false, "valid": false}
+{"pattern": "}(?(?C1)(?=a)(?=(*nlb:(*ACCEPT){(?P=a))||(?&a)(?|[\\Q-]\\E]&{2}))(?=\\R?(?>)|(?J:(*BOGUS)|(?<a>{ 2 }{3,2})(?i))|\\cé*+)(*MARK)}", "extended": false, "valid": false}
+{"pattern": "\\8(?(R)(?(R1)[^]\\b]{2,3})\\w|\\k'b')(?(R1)[\\Ca-\\d\\N^]*(?Cx)*?(?i:(*MARK)\\2(?x)|[\\C\\Q-]\\E[=a=]\\pL](?(R1)\\N{U+41}\\w|[^😀\\C\\])(*pla:?))|\\g<1>(?(DEFINE)(?>{65536}|0\\pb)))", "extended": false, "valid": false}
+{"pattern": "(?C1)[\\C[=a=][]+(?<b>(?(-1)(?n)[^a-\\d](?(DEFINE)\\k<a>)){65536}\\g{+1}++|(?(R)[[:^alpha:][:^alpha:]\\-]|\\é[^\\Q-]\\E\\E\\cA\\8][\\w])+(?#c)++", "extended": false, "valid": false}
+{"pattern": "\\Qa)\\E{++(?x){2,3}", "extended": true, "valid": false}
+{"pattern": "(?(?=a)\\pb\\012{65536}(?(a)(?^)\\c|(*atomic:(*MARK)?|\\z)\\8(*nlb:|[\\x{41}][]))|(?|é(?'a'[\\w\\cA]++(?u))[a-z]||\\p{sc:Latn}(*FAIL)*?(?P<a>\\x{41}*?[^]))(?<a>(*plb:[^\\x{41}\\C[.a.]\\-]\\b{3,2})**{(?(a)(?n){65536})\\pb{(*sr:(?n){,3}|(?(<a>)\\o{101}(*nlb:(?i)+?|\\k<a>\\Qa)\\E)-)(?x)(?(R1)(*sr:+)))*?(?=(?(?C1)(?=a)(?n)+?\\R(?(<a>)))|(?aD)\\81){ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "\\g1[]a(?C1)++{,2}", "extended": false, "valid": false}
+{"pattern": "[\\C]\\c{,3}", "extended": false, "valid": false}
+{"pattern": "\\B\\g{-1}|(?<![a-\\d])|(?:\\k{65536}(*nlb:(?P<a>(?&a)+?\\x41+)(?(R)[[=a=]\\pL\\h]|)|\\b)(?>(*nlb:{3,2}{3,2}|\\x{41}\\p{Greek}\\x{110000})*?|))", "extended": false, "valid": false}
+{"pattern": "\\k'b'{3,2}\\x41(?J:[\\]\\]\\R\\d-a](?+1)\\N{U+41})", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(?(<a>)(?<!*)\\x41|(?(a)$|{[^\\R[:^alpha:]]|[\\x{41}])){2,}|\\U[\\-\\pL]{2,}(?P<a>(?(?C1)(?=a)(?(VERSION>=10.4)_*?b)&(?<a>\\p{sc:Latn}||))*?\\pb[😀-😂😀-😂\\cA]", "extended": false, "valid": false}
+{"pattern": "[\\][:bogus:]a-z]\\81+?(?=\\Q\\E\\w){2}{2,1}", "extended": true, "valid": false}
+{"pattern": "(*plb:(?(?=a)(?(a)|)\\d(?(<a>)\\p{^Lu}\\x{41}[a[=a=]\\b\\cA]|(?Cx)))\\k<a>{65536}(?<a>[]{65536})|)", "extended": true, "valid": false}
+{"pattern": "(*atomic:(_)(?:(?:[\\8[]{65536}\\p{^Lu}|\\c?))|(?|(?(-1)[z[.a.]z-a]*)|\\p{ L }|\\k{a}++|(?(R1)\\p{Greek}(?+1)|)(?(DEFINE)[]|(?x))|))|", "extended": false, "valid": false}
+{"pattern": "[\\b\\d-a-😀][\\w]*?[^[:word:][=a=]\\C](*atomic:(?(<a>)(?(DEFINE)[\\h]\\x41|)(?(VERSION>=10.4)(*FAIL)|\\X)**|(*sr:[]*\\cé))**)", "extended": false, "valid": false}
+{"pattern": "(?u)[^]\\pb((*atomic:\\p{L}(*sr:[])))+?", "extended": false, "valid": false}
+{"pattern": "(?<a>(?C)**[--]){3,2}|", "extended": false, "valid": false}
+{"pattern": ".(?i:(?(R)\\z\\8**|(?P<a>\\g-1|)\\p{Bogus}){ 2 , 3 })\\p{Greek}", "extended": false, "valid": false}
+{"pattern": "\\A*(?u)((?C\"x\")(?(DEFINE)a)|\\u0041\\x41)+(?>\\C*+|(?J:(?i:|){ 2 , 3 }\\Qa)\\E*+(?<=\\b){2}|[^-])(*MARK:m)[\\h]{3,2})]", "extended": false, "valid": false}
+{"pattern": "(?<a>(?:(?:[\\]\\d-a]|\\2{3,2}😀{)(?(<a>)[😀-😂\\d[:^alpha:][:^alpha:]][^\\x{41}]{2}|)+\\U{2})|\\8{65536}[])(*SKIP)(?(<a>)[^\\R\\x{41}\\d\\w]*?[[:bogus:]a-\\d\\pL[:bogus:]]|)[]", "extended": false, "valid": false}
+{"pattern": "(*pla:\\Qa)\\E(*pla:[😀](?(VERSION>=10.4)(*ACCEPT)\\d)|(?(?=a)\\p{L&}|))|\\g<1>(?P<a>(*FAIL){2}|))[\\b(?C)^{2}", "extended": true, "valid": false}
+{"pattern": "(*sr:[^\\d-az-a]|\\p{^Lu}*?){3,2}\\U(?:(?C\"x\")|_\\x{110000}|\\Qa)\\E)", "extended": false, "valid": false}
+{"pattern": "[\\]]\\1", "extended": false, "valid": false}
+{"pattern": "\\w|(?:(?(1)(?<a>[[.a.]\\cA\\]😀-😂]|[^\\8\\h\\b\\d-a]\\81[[:alpha:]a]+)(?(?C1)(?=a)(?C)*?|\\C))\\_{3,2}_){2}😀", "extended": true, "valid": false}
+{"pattern": "[[=a=]\\d[:bogus:]-]\\P{Xan}(?P>a)", "extended": false, "valid": false}
+{"pattern": "[^\\h-^][\\8]?", "extended": false, "valid": false}
+{"pattern": "(?<!(?=(?<=\\k)|(?!(?x)(?Cx)|\\Qa)\\E[[:^alpha:]\\]\\😀-😂]+\\p{L}))|a(?(VERSION>=10.4)(*sr:[😀\\pL]\\é)\\R(?(-1)[^]{))\\Q\\E", "extended": false, "valid": false}
+{"pattern": "(?C256)[^\\E].(?u)\\E", "extended": false, "valid": false}
+{"pattern": "{ 2 }{3,2}(?<a>[\\\\](*SKIP))+?^+(?J:(?+1)+)", "extended": true, "valid": false}
+{"pattern": "(?P=a)(?>(?J:\\pb\\U)*?(?(DEFINE)[😀a](?(<a>)\\g{+1}[\\\\b]|\\k<a>|)|\\g{-1}?|(?<b>\\U[^\\x{41}\\-\\Q-]\\E[=a=]]\\A|)$)(?(?C1)(?=a)(?u)+(?(R)*?)(?(R1)))|(?(R)[\\]][a-z\\g[:bogus:]](?<b>){2}){){,3}\\g{-1}[^\\Ca-z]*?", "extended": false, "valid": false}
+{"pattern": "(?<a>(?i)|(*BOGUS)[\\w\\C\\g]{3,2}|_){\\Qa)\\E-(?(R)\\pL{3,2}\\p{L})[\\x{41}^]+?", "extended": true, "valid": false}
+{"pattern": "(?P=a)", "extended": false, "valid": false}
+{"pattern": "(?!(?(VERSION>=10.4)(?(DEFINE)(?^))++ [^\\N[:^alpha:][:word:]^])[😀[:word:][=a=]a-\\d]|{1}{,3}){65536}", "extended": false, "valid": false}
+{"pattern": "(?(R)(*sr:[\\Q-]\\Ea-\\d]{2,}(?(?=a)-(?C1)?)+?|[]){ 2 , 3 }|(?(VERSION>=10.4)(?J:[\\cA\\C]{3,2}){ 2 , 3 }(*pla:)|\\k**){,3}\\k|[\\d-a[=a=]\\C[.a.]]\\B|[\\Ea-\\d]]{2,})\\81\\p{Greek}]", "extended": false, "valid": false}
+{"pattern": "(?(1)(*pla:(?i:\\x{ 41 })(?i)*(?-1)+?\\x{110000}|(?(<a>)[])(?Cx)*+)&[^😀-😂]{2,}\\é", "extended": false, "valid": false}
+{"pattern": "é[]\\w]\\p{sc:Latn}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?C)[^\\]\\pL](?:[\\-a-z\\x{41}](?i:(?i:[a-z\\cA]|(?+1)+?[]||[^[:alpha:]a-z\\h]{2,}[^\\pL\\]\\p{L}){2}\\c\\g<a>))", "extended": true, "valid": false}
+{"pattern": "[az-aa-\\d\\C]\\p{Greek}[]\\p{Bogus}[^]", "extended": false, "valid": false}
+{"pattern": "(?C)\\k<a>", "extended": true, "valid": false}
+{"pattern": ".{2,3}(?C\"x\")[[](?-1)", "extended": false, "valid": false}
+{"pattern": "\\012\\k(?<b>(?i:[^\\g.(?(VERSION>=10.4)[\\d-a])){2}[]]\\A){,3}", "extended": false, "valid": false}
+{"pattern": "\\x{110000}*\\é-{3,2}|", "extended": true, "valid": false}
+{"pattern": "\\z(?(R)(?'a'[\\E[:alpha:]\\R]))(?(R)(?J:[😀-😂\\x{41}])(?&a)?[\\b\\d|\\G)\\2(?!(?C1)[^]\\g1{,3})?", "extended": false, "valid": false}
+{"pattern": "(*BOGUS)\\Q\\E{2}", "extended": true, "valid": false}
+{"pattern": "(?<b>(?'a'\\_\\k<a>{)(*ACCEPT)(?(DEFINE)(?P<a>[z-a\\Nz-a[:alpha:]]\\_{2})(?C256)++[^\\R[:word:]\\N]|😀))\\x{41}\\g{+1}", "extended": false, "valid": false}
+{"pattern": "\\2{2}(?<b>(*MARK:m)){ 2 , 3 }(?=[\\8]{,2}+?|[😀\\pL[.a.]\\p{L}]+(?(<a>)\\R+?(?n)[]))[^😀][^]", "extended": false, "valid": false}
+{"pattern": "(*BOGUS)(?(<a>)\\g-1(?i)\\1?|((*pla:(?i)){,3}|\\_(?i:\\p{Greek}|(*SKIP)[[]|)|(?<=\\K)(?P<a>{ 2 , 3 })*?))++[a\\-]?\\Q\\E|[[:word:]]", "extended": false, "valid": false}
+{"pattern": "\\R[\\R^]*", "extended": false, "valid": false}
+{"pattern": "\\N{U+41}{,3}(?(VERSION>=10.4)(?^)|(?C){2,3}(?&a))(?<!(?>(?:|.))|)\\p{sc:Latn}", "extended": true, "valid": false}
+{"pattern": "0\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*nlb:(?'a'[]|\\C[]|(?>\\g<a>\\g{-1}|[^\\d]\\012)\\x{ 41 }(?(-1))*+)(?:(?+1)*+(?(1))?)|)(?>[[=a=]\\w]|[^\\b\\]\\g]++(?(DEFINE)\\cA*[^a-z\\d-a]\\U{|(?J:\\P{Xan}])😀{2,}(?!(*SKIP)+?))(*BOGUS))(?P<a>(?&a)|(?R)+)|(?Cx){2}", "extended": true, "valid": false}
+{"pattern": "\\p{sc:Latn}|(*FAIL)[\\x{41}\\d-]{2,3}\\N{2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<!\\x{ 41 }{3,2}[^😀\\N]{,3}[a-z\\w😀\\w)+?[](*MARK)[]\\p{L}", "extended": false, "valid": false}
+{"pattern": "[^\\cA\\8]{,3}(?(1)(?=(?(R1)|\\g1\\E**\\pL{,3})(*sr:{2,3}|é){3,2}|[])(?=(?![\\g])(?(?C1)(?=a))**\\h|[[.a.]-[:bogus:]\\w]{2,}\\N{U+41}*?)|(*MARK:m){ 2 , 3 }\\k)+(?aD){2}[", "extended": true, "valid": false}
+{"pattern": "(?'a'\\k'b'(?(?=a)(?P<a>{3,2}|(*UTF))*?)+?[\\g]{2})(*FAIL)[\\\\]\\d]{\\pb", "extended": false, "valid": false}
+{"pattern": "[^\\E]{2}\\Q\\E", "extended": false, "valid": false}
+{"pattern": "[^]*é(?(R)(?(-1)[[.a.]]\\\\cA][^\\w]){2}(?P<a>\\012\\C*?|(?+1)))**", "extended": true, "valid": false}
+{"pattern": "{ 2 }[[:bogus:]]", "extended": false, "valid": false}
+{"pattern": "{2,1}|(?(R)(?(R)(?u){)(?+1))[^](?(R1)\\é(?<b>\\cé{,3}|\\pL|(?(R1)[^[.a.]\\])[^\\wz-a[:word:]😀-😂]))[^z-a\\8😀-😂]", "extended": false, "valid": false}
+{"pattern": "[😀-😂\\w](?(R)b)]{2}\\R*", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[][^\\8a-\\d\\w[:bogus:]]|\\P{Xan}+?(?^)^{2,}", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)[\\bz]**)(?(VERSION>=10.4)[^][\\d\\x{41}]\\g-1(?R)|\\2(?'a'\\g<1>){2,3}|\\pb)|[\\\\g\\-]{2}(?i)(?i: {2,})", "extended": false, "valid": false}
+{"pattern": "\\K(*UTF)[]", "extended": false, "valid": false}
+{"pattern": "(?=(*atomic:\\Q\\E(?1))|{2,1}|(*SKIP){ 2 , 3 }{,2})", "extended": false, "valid": false}
+{"pattern": "\\p{L}{,3}[\\\\z](?(a)(*SKIP){2,}| ?)[^\\d\\C\\p{L}(?=&|(*SKIP)(*MARK:m)(?(<a>)(*plb:{2,1})(?P=a)\\10)|)", "extended": false, "valid": false}
+{"pattern": "(?(?=a)(*nlb:(*BOGUS)|(?(1)[]😀-😂][]|(?1))(?R))**[^\\d\\b\\g]{ 2 }|(?(VERSION>=10.4)(*atomic:(?u)\\012)[^[:^alpha:]]\\u0041|\\x{ 41 }\\p{L}(*UTF))[](?-1)*)\\g<-1>\\h", "extended": false, "valid": false}
+{"pattern": "\\h+?(*pla:\\o{101}|)(?(a)[\\E\\p{L}][a[:alpha:]|\\k<a>[\\]\\Q-]\\E](?i:😀{3,2}[-++\\p{Greek}))|", "extended": false, "valid": false}
+{"pattern": "\\g<-1>(?(?C1)(?=a)\\p{Greek}(?J:(?(R)+))|(?x))[[]", "extended": true, "valid": false}
+{"pattern": "\\k[\\N.", "extended": false, "valid": false}
+{"pattern": "\\z|(?1)**", "extended": false, "valid": false}
+{"pattern": "(?J:(*sr:()|[])[\\d]\\C|\\g1++{[^\\N])", "extended": false, "valid": false}
+{"pattern": "](*atomic:(?<a>[^\\d-a\\E\\C](?(-1)]|[\\g\\w[:alpha:]]|(?C)\\k{3,2}(?-1)\\P{Xan})[^\\-[:bogus:][[=a=]{,3}\\g{a}|(?u){,3}(?<![^[:bogus:]^])(?>(?(1))(?J:[\\cA-]])|\\x{41}(?C))*|)[]", "extended": false, "valid": false}
+{"pattern": "[^\\E\\g](?<=(?(-1)\\E\\G\\k'b')\\C*(?![\\Q-]\\E\\]*+)|(?i:(?#c)[\\]]{ 2 , 3 }|[[.a.]\\-z]?|(?<=(?^))(?+1)** ))**\\u0041(?#c)+?", "extended": true, "valid": false}
+{"pattern": "(?(?=a)[[:alpha:]^a-\\d]\\g<a>(?J))\\o{101}(?'a'{2,1}(?J)\\pb)(?<a>\\g{a}(?(DEFINE)(?J:\\x{41}{2,}|[[]\\C{ 2 , 3 })|[z])|\\K*)(?i:((?i:\\N\\G?)|(*sr:[])\\x{ 41 }*+(?=[\\w]+?)(?=\\E))", "extended": true, "valid": false}
+{"pattern": "(?C1)(*nlb:\\Q\\E(?=[\\-](?|\\h{ 2 , 3 }|)){2,}(?(R)\\k<a>\\é{2,})+||\\p{Bogus}**)(?<!(?C\"x\")\\k<a>(?P<a>[-](?(-1)\\x41\\p{sc:Latn}|)[])|^){,2}.{2,}", "extended": false, "valid": false}
+{"pattern": "\\k'b'?", "extended": true, "valid": false}
+{"pattern": "(?x)\\pb", "extended": false, "valid": false}
+{"pattern": "(?C1)(?(?C1)(?=a){2,1}{3,2}){65536}[-]\\pb(?(a)&[\\Ez]|(?>[😀-😂[]|\\C))", "extended": true, "valid": false}
+{"pattern": "\\g<-1>\\d(?P<a>(?=(?<b>|\\pb{2,}|){2,3}(?!b)}|(?(-1)[\\E\\w\\8]*+|\\k{a}))(?<a>(*SKIP))*?\\K)(?n)**", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)(?&a)\\p{L&}(*nlb:(?(<a>)[\\-\\cA\\Q-]\\E\\p{L}][\\cA\\gz-a][\\d[:alpha:]]))*+)", "extended": false, "valid": false}
+{"pattern": "[^\\N\\pL\\]\\x{41}](*sr:\\g<-1>\\pb.){ 2 , 3 }", "extended": true, "valid": false}
+{"pattern": "\\b+?(?![-]|(?x){(?(<a>)(?(DEFINE)[\\\\Q-]\\E]){|(?(DEFINE){[\\x{41}\\p{L}\\a]|\\pb\\Qa)\\E|(?C\"x\")+)(?:#))+){3,2}|a(?(R1)\\B{ 2 })", "extended": false, "valid": false}
+{"pattern": "(*MARK)(*sr:\\p{ L }{2,})", "extended": false, "valid": false}
+{"pattern": "(*pla:[][😀-😂z-a😀[=a=]]\\p{Greek}++|{2,1}(?'a'(*atomic:*?&{3,2}|\\cé)(*MARK:m)|\\_|#(?'a'\\k\\p{ L }|(?J))|){ 2 , 3 }{ 2 , 3 }0[\\Q-]\\E]++(*plb:\\g-1)", "extended": false, "valid": false}
+{"pattern": "(?(1)\\g<-1>{3,2}(?(VERSION>=10.4)(?'a'a)0++){65536}|[😀-😂[:alpha:]z-a](?J:[\\g\\E\\E[]+?|(*pla:\\1)|))|\\w", "extended": true, "valid": false}
+{"pattern": "[]\\N{U+41}[^]**|\\p{L&}", "extended": false, "valid": false}
+{"pattern": "a(?(-1)(*sr:[^]\\w\\pL]|\\c)|){2,3}", "extended": false, "valid": false}
+{"pattern": "[]++", "extended": false, "valid": false}
+{"pattern": "(?<!(?(?=a){ 2 }é(?'a'\\p{ L }|\\N\\cé)){65536}#|[\\Q-]\\E{65536})", "extended": false, "valid": false}
+{"pattern": "(?-1){3,2}\\012\\z(*plb:[z-a\\x{41}\\d])", "extended": false, "valid": false}
+{"pattern": "(?(<a>)[\\\\R😀])", "extended": false, "valid": false}
+{"pattern": "[\\Ra\\N\\d](?<a>\\g{+1}+?[](?#c)|\\k(?(DEFINE)(*pla:)){ 2 , 3 })(?(?=a)(*FAIL)++|[\\g\\d\\w]$)", "extended": false, "valid": false}
+{"pattern": "(*sr:(?(1)(\\P{Xan}[])+?|{,2}\\é)(?<a>\\g{+1}(?-1)+|)(?(?C1)(?=a)\\cA{2}&))", "extended": true, "valid": false}
+{"pattern": "\\A|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_[^\\g]+?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\C+?(?'a'(?=\\d|[^a]\\N){2,3}[[:bogus:]](?+1){2,3})\\g{+1}", "extended": false, "valid": false}
+{"pattern": "\\p{Bogus}[^a-z\\d-a[:word:]][\\8[=a=]\\C][^\\-\\E]{ 2 , 3 }\\h", "extended": false, "valid": false}
+{"pattern": "[]|\\p{sc:Latn}+(?(DEFINE)$++\\pL|(?<b>[\\C](*nlb:[]^z-aa-\\d]|)**\\g<1>)", "extended": true, "valid": false}
+{"pattern": "(?C)+", "extended": false, "valid": false}
+{"pattern": "\\2|\\Qa)\\E", "extended": false, "valid": false}
+{"pattern": "0(?(VERSION>=10.4)[^-[:^alpha:]]\\o{101} {3,2}|(?(a)\\8|[[:alpha:]a-\\d😀-😂a-z])\\g<-1>(*plb:\\x{110000}))*?[[:word:]\\bz\\b][\\C-]](?<=[\\Nz-a\\R]*+\\g{+1}|(*MARK:m))", "extended": false, "valid": false}
+{"pattern": "a\\p{sc:Latn}\\E", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>\\pL[[a-\\d]\\k'b')}[[:alpha:][.a.]]|", "extended": true, "valid": false}
+{"pattern": "(?n)[]\\Q-]\\E]{65536}|", "extended": false, "valid": false}
+{"pattern": "(?1)*(?(DEFINE)\\Q\\E[\\pLz-a\\x{41}]{2})|{ 2 }\\g{+1}|(?(?=a)\\E]|(?#c))", "extended": false, "valid": false}
+{"pattern": "(?J:(?!(*pla:\\g{+1}|\\G)[^\\R\\ha-z\\g]|(?(?C1)(?=a){,3}{2,3}[\\pLa-z]]|)){65536}(?<=-|(?(a)}a){2}\\p{sc:Latn}|){65536}|(?P<a>[](?:(?P=a)|[^z-a\\8]|[\\-[]{2,3})){3,2}|)[[=a=]]*+\\z(?!(?<=(*FAIL)){2,}(?=(?(1)(?u){,3}\\N{U+41}**|[^[:^alpha:]])[\\w\\-][:^alpha:]]{2}|-)(?(1)(?C\"x\")+(*BOGUS)|(?=}{3,2}|)(?(R1)_&{3,2}|(?P>a)[^][:bogus:]\\8^]{ 2 , 3 }){65536}\\p{Bogus}))", "extended": true, "valid": false}
+{"pattern": "(?i:\\g<-1>(?:\\h|(?|(?-1)\\é|{|)(?C\"x\")*?|(?J:\\N|))\\g<a>|(*ACCEPT)\\k<a>(*SKIP)", "extended": false, "valid": false}
+{"pattern": "(?=\\g{a}{,3}{|(*FAIL)\\8?[😀\\]{65536})[-\\E]", "extended": false, "valid": false}
+{"pattern": "(?<!(?(DEFINE)(?(<a>)\\8?){2,}|[^\\Q-]\\E\\d]{3,2}(*atomic:{,3}|(?-1){ 2 , 3 }(?#c)*+[[:word:]])[^\\Ez[[:alpha:]*?)(?=\\u0041\\z){2}|[^]\\pL\\R])(?(DEFINE)\\x41**|(?P=a)(*pla:[\\8\\cA-\\E]{2,3}|(?J:😀\\k<a>+?|[😀-😂😀\\cA][\\C\\R]{3,2})+[^]]+?\\X{2}))\\B(?(VERSION>=10.4)(?<b>(?(<a>)\\Qa)\\E||(*SKIP)\\x{ 41 }|)(*nlb:(*MARK)||{,3}\\U|)(*atomic:\\N[\\h[.a.]\\[])){ 2 , 3 }\\k'b'|[^][:word:]\\pL]{2}[[:bogus:]])(?|[^😀z-a\\8]{2,3}(?R)", "extended": false, "valid": false}
+{"pattern": "[z-a^][]\\x{ 41 }", "extended": false, "valid": false}
+{"pattern": "(?<=_\\C\\k|)*+(?aD)*?\\p{L}(?<=(?C256)|(?P=a)(?x))", "extended": false, "valid": false}
+{"pattern": "(*MARK){,3}", "extended": false, "valid": false}
+{"pattern": "\\_\\g-1|", "extended": false, "valid": false}
+{"pattern": "[\\]\\x{41}\\R]", "extended": false, "valid": false}
+{"pattern": "(*pla:(?J:[^][]|\\k<a>(?P<a>\\w{2,}\\céb{2}))**)**", "extended": true, "valid": false}
+{"pattern": "\\x{ 41 }*+(?=[😀-😂\\gza-\\d]\\d{2,}|(?x)(?(<a>)\\k{a}|(?(1)\\8{65536}|\\b)\\Qa)\\E+?)(?x))[{2,3}(?(R1)(*atomic:(?>)[\\C\\d-a\\cA][^\\ga-z|(?![]{3,2})\\x41){ 2 , 3 }(?'a'\\1{65536}|(?'a'][^\\b\\Q-]\\Ea😀-😂]*?\\pb)+?(?C\"x\")|(*MARK:m)\\U){2,3}\\é){ 2 , 3 }", "extended": true, "valid": false}
+{"pattern": "\\p{ L }\\c", "extended": false, "valid": false}
+{"pattern": "[\\N\\E]\\E{2,}\\p{L}(?(R)[^[\\x{41}])", "extended": false, "valid": false}
+{"pattern": "\\1\\g-1[]{", "extended": false, "valid": false}
+{"pattern": "\\g<a>(?>(?<a>[\\h\\Na\\8]{.{2,})(*nlb:(?<=)){65536}", "extended": false, "valid": false}
+{"pattern": "(?(R1)(?C\"x\")|(?(VERSION>=10.4)[^\\g😀]{2})\\g<1>|\\p{Bogus}\\k)|", "extended": false, "valid": false}
+{"pattern": "[|{1}{65536}(?(<a>)[^a\\x{41}]\\k{a}\\g{+1}|(*SKIP)(?aD)(*pla:[]**[^[=a=]z-a]{3,2})|){2,3}(?P>a)", "extended": false, "valid": false}
+{"pattern": "(?|(*sr:(?<a>\\g-1(*SKIP)|)**|(?+1)(?J:(?x)(?R)[\\E]){2,})(?'a'[^](?(VERSION>=10.4)\\N{U+41})(?(a)\\x{41}{ 2 , 3 })+)[\\w[:alpha:]]*+{,3}😀(?(VERSION>=10.4)[[\\C[:bogus:]]|(?J:(?(R1)(?P>a){2}.+\\x{110000}|\\E*?{2}(*MARK)){(?>(?1){65536}|\\o{101})(*sr:))\\k'b'$){ 2 }(*atomic:\\p{ L }{3,2}){3,2}", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)[\\C\\R])", "extended": false, "valid": false}
+{"pattern": "(?'a'[^\\C]*(?<![^]{65536})\\1)++(?P<a>(*pla:\\8){2,3}|[[:^alpha:]\\pL]^|)(*FAIL){", "extended": false, "valid": false}
+{"pattern": "\\p{L}**(?:.(?<!\\N{U+41}b{,3}(?(VERSION>=10.4)\\p{ L }])|[]|[a-z\\d-a]{2,3})_)(?<a>(*MARK))\\x41", "extended": true, "valid": false}
+{"pattern": "[\\]😀\\](?<!{1})", "extended": true, "valid": false}
+{"pattern": "0[^😀-😂[=a=][=a=]](?<!&\\Qa)\\E*?\\k{a})[a-\\d[.a.]](?&a)", "extended": true, "valid": false}
+{"pattern": "(?R)+?[^]\\Q-]\\E](*nlb:(?Cx)){2,1}++\\_", "extended": false, "valid": false}
+{"pattern": "[^\\cA]**[]\\g<1>", "extended": true, "valid": false}
+{"pattern": "(?P<a>(*plb:(*nlb:\\x{ 41 }|[^z[:word:]](*FAIL))|[^\\[:bogus:]](?>[]a]\\u0041[^]*)|(?J:{1}\\E|(?>(*SKIP)**)(?P<a>||))[])", "extended": false, "valid": false}
+{"pattern": "\\10(?P>a)|", "extended": true, "valid": false}
+{"pattern": "\\cA[\\g[:bogus:]^{2,3}[\\wz-a]", "extended": false, "valid": false}
+{"pattern": "\\pL(?>[\\cA\\x{41}z\\cA]**[\\-]++)*+(?x){2}(?![^]\\w\\E][😀-😂])\\N", "extended": true, "valid": false}
+{"pattern": "(?i:(?(1)(?(a)\\p{^Lu}{2}|[\\pL\\p{L}]**)(*pla:\\p{sc:Latn}|(?C)){2}))(?(<a>)(?(DEFINE)(?C\"x\")\\p{sc:Latn}+?|[]a-z][]*+(?(R)[])))", "extended": false, "valid": false}
+{"pattern": "[\\N\\d-a\\E\\E](?J:(?P<a>\\012{3,2}|(?P>a)(?|(*FAIL)(*MARK:m))(*pla:\\cé{ 2 , 3 }|(?P=a)){3,2})|[😀-😂]){|(?>(?(-1)[^a-z[=a=]]*+|(*ACCEPT)(?#c)[\\\\-[:bogus:]]{65536}){2,}(?#c)(?C256))(?<!(?<a>(*UTF))[z-a]]?)", "extended": false, "valid": false}
+{"pattern": "\\x{ 41 }(?(a)[\\8\\d\\w]{3,2})", "extended": false, "valid": false}
+{"pattern": "(?>$**(?Cx)[]\\w]|\\A(?(?=a)é\\cA){,3}|)(*MARK){2,}", "extended": false, "valid": false}
+{"pattern": "(?i)\\p{Greek}[]é+[\\R\\C\\Q-]\\E\\E]", "extended": false, "valid": false}
+{"pattern": "(?i:\\cé{2,}(?|\\cA|(?>)))|(?'a'[^[:bogus:][=a=]]|[[])+?[^😀-😂[:alpha:]a-z\\R]", "extended": false, "valid": false}
+{"pattern": "[\\R^\\cA\\d-a]\\p{L}", "extended": false, "valid": false}
+{"pattern": "(?=\\p{ L }+?(?<b>[\\cA[.a.]](?<!\\P{Xan}{2}{2,1}(?Cx)|})))|(?<a>(?(a)[z[][](*pla:[]++|\\8[^a-\\d{2}))(*plb:(*atomic:.\\h*?|)(?x))**|{,2}(?(DEFINE)\\X{ 2 , 3 }\\p{Bogus}|(*FAIL){\\Q\\E|a)*?\\k<a>)[^\\pL😀-😂](*nlb:\\E(?(VERSION>=10.4)\\c(*atomic:[\\8\\p{L}\\cA\\E]|(*FAIL)){,3}(*sr:[])|\\p{Bogus}\\cA\\z)(*plb:(?(R)[\\b\\x{41}\\N])(?!\\p{ L }|\\g<-1>)|[z\\N-a-\\d]**))*?&**", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)[\\E\\h^😀])(*sr:[\\\\w][]+?(?(VERSION>=10.4)[\\C\\dz-a][][[:alpha:]])|(?J)(?<!\\2{3,2}(*MARK))(*ACCEPT)*)$", "extended": false, "valid": false}
+{"pattern": "\\p{Bogus}|(?J)", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)(*pla:[[:alpha:]]+?(?u){2,}}\\b{65536}(?+1)|[^]})[[:bogus:]z-a[:word:]]|(?J)+?(*nlb:\\p{sc:Latn})*(?:(?C)(*nlb:(?P<a>\\g{-1}\\k{2,1})(*sr:\\E{2}|\\B+\\g<1>){2,3}|(?'a')){,3}|)", "extended": false, "valid": false}
+{"pattern": "\\1[😀-😂\\b\\C]{2,}", "extended": false, "valid": false}
+{"pattern": "(?P<a>[\\p{L}](?<!\\x41)+?[\\N])(?C256)|(\\P{Xan}{,2}(?<!{,2}|]\\pL[^\\C\\h\\w])|[]\\U)", "extended": false, "valid": false}
+{"pattern": "\\b*+\\g-1[^\\b\\\\E](?>\\B(?>(?J:\\E(?R))+\\g1{3,2}(?=\\g{-1}{0|)+?\\k<a>*+|)[\\C[.a.]z-]", "extended": false, "valid": false}
+{"pattern": "(?(?=a)-++[\\-](?(-1)\\p{sc:Latn}{2}(*UTF)*|\\K(?>{,2}(*sr:|[^\\p{L}\\cA]^)|(*plb:(*BOGUS).)?)", "extended": true, "valid": false}
+{"pattern": "{2,1}\\U\\x41|\\2{ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "(?J:[a[.a.]az-a]\\k'b')++\\B*?|", "extended": false, "valid": false}
+{"pattern": "(?R)(?C\"x\"){ 2 , 3 }", "extended": true, "valid": false}
+{"pattern": "[+?[-z-a\\p{L}^]+?|(?(a)(?:\\d{,2}(?<=*?[]){2}(?P=a)|[[:alpha:]\\C\\g\\Q-]\\E]\\10", "extended": false, "valid": false}
+{"pattern": "\\N|\\g{-1}(?(a)(?>(?<=*{ 2 , 3 })(?(a)|\\N)|)\\p{^Lu}(?(VERSION>=10.4)(?P<a>[\\g\\\\R]{2})(?1)(?'a'(?R){2,})))\\z|[-[:alpha:]a-\\d]", "extended": false, "valid": false}
+{"pattern": ".^(?<a>(*sr:\\cé**)(*UTF)|(*sr:(?+1)))|(?(?C1)(?=a)\\N\\pb(?<a>[\\p{L}^]|\\U?|(?<=){2}|)|(?'a'(?1)|(?P=a)+&[^[:alpha:]😀-😂z-a]]{2})\\p{L}) ", "extended": false, "valid": false}
+{"pattern": "(?<=[-[:bogus:]](?J:(?(<a>)[^]*+)+?|(*nlb:\\p{ L }\\C\\B|[a[.a.]\\g\\d-a]){{(?=😀)?))", "extended": true, "valid": false}
+{"pattern": "[](?>(?(R)(?(-1)|\\R|\\P{Xan})){65536}\\k<a>++(?(1)(?(R1)\\_[]|[^😀-😂\\N\\p{L}]a\\10)(?J:(?P=a)&{65536}|\\x{110000}{2,}|)|(*plb:\\o{101}(*MARK:m))(?(?=a)[\\w\\E] )))(*sr:\\p{sc:Latn}[\\-a](?=$)|(?^){)**😀é", "extended": false, "valid": false}
+{"pattern": "(?>[[.a.]a-\\d]\\g<a>{2}\\p{ L }|\\N(?<!(?(?=a)(*UTF)*|(?x)++)))\\pL{ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "(?i:(?'a'\\k{a}|\\x{ 41 }[])\\10)(*FAIL){2,3}(*pla:(*FAIL){2,}\\x41(?<![\\Nz-a]{ 2 , 3 }\\g<a>|(?J))+?){65536}\\p{^Lu}?", "extended": false, "valid": false}
+{"pattern": "\\g<a>(*atomic:\\P{Xan}(?&a)\\g-1|\\8\\é)(*pla:\\p{sc:Latn}*(?P>a)\\k<a>{2,3})+(?(-1)(?(?=a)([^[:alpha:]\\d\\d]+? )|[^z\\p{L}](#|(?R)|[\\8])éb)[^\\g😀-😂]", "extended": false, "valid": false}
+{"pattern": "\\pb*?|", "extended": false, "valid": false}
+{"pattern": "-|(*ACCEPT)++|[^\\b\\C\\x{41}]*+\\1*?\\g{+1}", "extended": true, "valid": false}
+{"pattern": "a{2,}|\\x41(*pla:(?:\\_[\\g[:bogus:]]|))", "extended": true, "valid": false}
+{"pattern": "(?:\\x{110000}\\10+?(?(-1)(?i)(?(-1){,3}))|(?<a>[]\\10{,3}(?|?[])){2,3}(?#c)(?=0{,3}(?(?=a)\\cé*+|\\g<1>[[:alpha:][])\\2{,3}))\\B", "extended": false, "valid": false}
+{"pattern": "(?'a'(?(DEFINE)\\g{a}*+[\\Q-]\\E])|[])[a-\\d]\\E\\b]", "extended": false, "valid": false}
+{"pattern": "[\\C😀-😂\\E](?(1)(?u){\\g1)(?(-1)[[:alpha:]](?(-1)(?<a>)|(?(a)\\g<-1>\\g{+1}{65536}[]{65536})[😀[.a.]a-z\\h]*)*?(?-1)", "extended": false, "valid": false}
+{"pattern": "(?(<a>)[^a](*nlb:\\g1)|(?=\\c(?:\\G[^a-z[:^alpha:]\\pL]{3,2}){3,2}){2,3}|\\8\\A[]{2,})(?i:(\\012)**)(?(<a>)\\cA[^a-\\d[:alpha:]])++(?(a)\\g<1>[\\pL\\R](?&a))", "extended": false, "valid": false}
+{"pattern": "\\x41(*pla:(?!(?'a'(*BOGUS)[\\d]|)(?P=a)|\\p{Bogus}\\w*?\\pL)(?(R1)(?C1)(?'a' ?\\G++)+?(?(?=a)[\\d-a^a]{2,3}|{1})|\\d+(?#c)[\\-z\\cA]|){,3})(?:(?C\"x\")\\x41*[😀\\h\\d-a\\g]*+(?(?C1)(?=a)\\2*+{,2}[\\8]{2,3})", "extended": true, "valid": false}
+{"pattern": "(?1)+{{3,2}", "extended": true, "valid": false}
+{"pattern": "\\R|{2,1}*", "extended": true, "valid": false}
+{"pattern": "(?(-1){1}{2,3}[[.a.])", "extended": false, "valid": false}
+{"pattern": "(?<a>[^^\\x{41}]])[a-z[.a.]]{\\cA", "extended": false, "valid": false}
+{"pattern": "(?<a>(?<=[z-a\\wz\\]](?i:(?P=a))[\\E\\-\\w^])+?(*nlb:[a-\\d😀😀-😂](?C1)[]|(*plb:+|)++\\u0041*+)\\P{Xan}(?i:\\g<-1>(?#c)){ 2 , 3 }", "extended": true, "valid": false}
+{"pattern": "(?P=a)(?![^]|(?!(?(1)\\g1[\\p{L}^]\\p{^Lu}||{2,3}|\\h{65536}[])|(*SKIP){,3}(?P>a)))(?(R)(?(1)[\\E]\\d-a])|(?(DEFINE)é*+(*MARK)[😀-😂\\-])\\u0041)[^\\8]", "extended": false, "valid": false}
+{"pattern": "(?<![[:^alpha:]\\d?\\X){ 2 , 3 }(?|(?'a'\\k<a>|(?(DEFINE)(?P>a){2,}(?P>a)|\\p{L&}{2,1}{|{,3})\\p{L&})|\\R)+", "extended": false, "valid": false}
+{"pattern": "[\\z\\p{L}]", "extended": false, "valid": false}
+{"pattern": "[a-\\da-\\d]++", "extended": true, "valid": false}
+{"pattern": "-[^++(*plb:[\\😀\\w-]){2,1}", "extended": false, "valid": false}
+{"pattern": "(*nlb:(?#c)*+-\\x{ 41 }{2,3}|)*?\\k<a>[^z]*+(?(?C1)(?=a)[^\\w\\h\\h\\d-a]**|[^[:^alpha:]\\]\\E{2})", "extended": true, "valid": false}
+{"pattern": "(?i:[[]++(?J:[]*?)(?!(*atomic:[^\\C\\h\\-\\pL]|)(?(1)[\\8[:word:]\\pL]\\pb\\k{a}|😀[^[:bogus:]\\N-[:bogus:]]){2,3}\\8|[^]))", "extended": true, "valid": false}
+{"pattern": "[[:bogus:]]\\A\\Q\\E(?(-1)(*nlb:\\N(?<b>^||))|\\2)|\\pb", "extended": true, "valid": false}
+{"pattern": "\\G{,3}\\o{101}(?(R)[\\h\\E]\\h](?(<a>)(?(DEFINE)}{2,}|))|)(?(?=a)\\g{+1}?(*plb:(?(R1)\\012\\z{2}|\\N)))", "extended": false, "valid": false}
+{"pattern": "[](?1)\\cA\\K", "extended": false, "valid": false}
+{"pattern": "(?J:(*atomic:(?={\\x{41}){3,2})**|){2,3}(?|(?>\\k<a>)(?|(?(R1)(*FAIL)+\\81**)*+|^)){65536}\\K(?<!\\pL|)", "extended": false, "valid": false}
+{"pattern": "[\\x{41}](*MARK)\\X", "extended": false, "valid": false}
+{"pattern": "[](?(1)[]^{2,3})(*pla:(?(a)\\p{Greek}|\\p{sc:Latn}{ 2 , 3 }\\C**|)[^\\p{L}[:word:]]) { 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "[^\\Q-]\\Ez-a\\E](?(R)(?(DEFINE)(?(1)))(?R)*(?<=(?!|)?|){,3})[^😀a-z\\C\\R]", "extended": false, "valid": false}
+{"pattern": "\\k{a}[]{ 2 }", "extended": false, "valid": false}
+{"pattern": "\\w{,3}[\\C][\\R]*[z-a[:^alpha:]]", "extended": false, "valid": false}
+{"pattern": "[\\p{L}[:bogus:]\\pL[:^alpha:]]\\Qa)\\E(?|[😀-😂^]\\b\\p{L&})(?:(?(?=a)[\\E\\p{L}](?u)|(?(VERSION>=10.4)b*?[-]){3,2})(?^))(*atomic:[]{2,3}|[^[=a=]^\\a-\\d++)", "extended": true, "valid": false}
+{"pattern": "(?=\\p{Bogus}(?(1)\\p{^Lu}\\k<a>{65536}(?'a'\\p{Bogus}[[:^alpha:]]))|(?1){,3})", "extended": false, "valid": false}
+{"pattern": "(?P<a>\\10(?C1)[^]{,3}){", "extended": false, "valid": false}
+{"pattern": "\\b{ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "[]{2,3}", "extended": false, "valid": false}
+{"pattern": "\\1++(?(1)(?(1)\\é|(?(R1)*))|\\x{ 41 }+?)\\cé[\\d-a\\h^\\E]|", "extended": false, "valid": false}
+{"pattern": "[^[:^alpha:]{2}", "extended": true, "valid": false}
+{"pattern": "#", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?>[]\\u0041**\\g<-1>", "extended": false, "valid": false}
+{"pattern": "[\\h\\N[:word:]\\cA]\\p{L}|\\p{Bogus}*?(?<b>(?<!(*atomic:\\g<a>)|(?J){)[^]{,3})+?(?i)", "extended": false, "valid": false}
+{"pattern": "\\Q\\E[^-[\\x{41}]\\N+(?(<a>)\\w\\b\\g<1>", "extended": false, "valid": false}
+{"pattern": "\\pb0{,3}\\g<a>(?<b>[][\\g\\p{L}\\x{41}]\\w*?)\\pL", "extended": false, "valid": false}
+{"pattern": "(?<b>(*sr:(?<=[z-a[\\cAz-a]-|))(?<!(?u)\\p{^Lu})+){2,1}{2,3}|(*nlb:(?(?=a)\\10){2,3})", "extended": false, "valid": false}
+{"pattern": "\\2(?(1)[\\-[:alpha:]]{65536}[][\\Na]])", "extended": true, "valid": false}
+{"pattern": "\\p{ L }{2}(?^)}(?J:\\81){2,}(?-1)", "extended": false, "valid": false}
+{"pattern": "(?x)[^😀[:word:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^😀-😂a-z\\N][\\E]", "extended": false, "valid": false}
+{"pattern": "(*nlb:(?C\"x\")(?<!(*nlb:(*ACCEPT){ 2 , 3 }||[^\\8[:alpha:][(?u)$))\\g<-1>|(?C\"x\")*?){2}", "extended": false, "valid": false}
+{"pattern": "\\E(?i)|(?(R1)\\x41{,3}[z-a[\\cA])\\2", "extended": false, "valid": false}
+{"pattern": "\\x{110000}{2,3}", "extended": false, "valid": false}
+{"pattern": "(?<b>[\\N[[=a=]\\N]++(?(DEFINE)\\81\\pL(?'a'\\g-1)))**\\C|(*sr:(?'a'(*atomic:(?i)++\\x{110000}|{3,2})(?i:[\\Ez-aa-z\\N]+?(?i)|[[=a=][=a=]\\d-a]\\g{a}\\E{2,}){2,}[[:alpha:]😀-]*|(?(-1)(?1)**)[]{3,2})+?)[^[:word:]][^-\\R]|", "extended": false, "valid": false}
+{"pattern": "(?'a'{1}|(?(?C1)(?=a)(?(?=a)){65536}|[\\p{L}a]|(*sr:(*FAIL)*?[\\N^])+?\\p{Bogus}-)", "extended": false, "valid": false}
+{"pattern": ".", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*plb:\\p{L})(?C\"x\")+?(?i)[^]**(?'a'_)**", "extended": true, "valid": false}
+{"pattern": "[z-a[=a=][=a=]\\][^\\8\\pL]*?(?<!{2,1}|[^\\x{41}]\\b]|[]*?", "extended": false, "valid": false}
+{"pattern": "\\k\\x41[z-a\\h]", "extended": false, "valid": false}
+{"pattern": "(*atomic:[[.a.]\\Rz]*?[)(?<=\\g<1>(?i:([[\\8\\N**(?P>a)**)(*plb:\\g<a>a{2})*?)\\k+|)", "extended": false, "valid": false}
+{"pattern": "(\\p{sc:Latn}\\g{-1}[\\C\\b]{|)", "extended": false, "valid": false}
+{"pattern": "(?^)(?=[\\d-a])(*SKIP)[\\b[:bogus:]\\R\\N]", "extended": true, "valid": false}
+{"pattern": "(?!\\x{ 41 }*+{)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\h\\-\\pL\\N]{2}", "extended": false, "valid": false}
+{"pattern": "(*plb:\\é[]{3,2})\\p{L&}+\\p{ L }+?(?^)", "extended": false, "valid": false}
+{"pattern": "(?(?=a)[[:word:]](*sr:[\\\\w]*?)", "extended": true, "valid": false}
+{"pattern": "(?<a>(?<b>(?<b>[az][^]|\\k{a}|)\\k<a>{,3}(?'a'{2,}|[]*?|\\g<a>)?){ 2 , 3 }(?C){(?(R)(?'a'(*sr:)(?P=a)[])|[\\w-😀\\E]b[]", "extended": false, "valid": false}
+{"pattern": "(?<a>(*ACCEPT)&^|{{2,3})(?i:(*plb:(?(<a>)\\d\\012?[^[:bogus:]^^\\x{41}]|))|{ 2 }(?Cx)*?)*?(?i:(?(?C1)(?=a)(?(<a>)|\\Q\\E)(?|\\P{Xan}|){[][.a.]a])[^]**||(*atomic:(?(VERSION>=10.4)\\B{3,2}(?C1)|\\g{-1})(?<b>&\\pL|)*+(?(VERSION>=10.4)[\\d-a\\x{41}\\8]++(?aD)é|\\p{sc:Latn}#){3,2})*+(*nlb:(?-1)[^\\w])+?|", "extended": false, "valid": false}
+{"pattern": "[\\d-a\\E[:alpha:][:bogus:](?P<a>(?i)\\c)(?Cx)(*sr:[^[:alpha:][=a=](?(1)\\10(?<!**0(?i){,3}||[^[.a.]]\\012))\\p{Bogus}{2,3}|-(*pla:(*sr:\\g{-1})(?(?C1)(?=a)(?1)|\\h\\k'b')((?n)*){ 2 , 3 }){)(?P<a>(?<![^-][a-z](?J:(?C\"x\")(*SKIP){3,2}|){,3}|(?(a)|[z-a]|[])*?[a-z\\E](*nlb:[\\h\\x{41}][[:alpha:][:bogus:]]))|(*sr:(?+1)(?(<a>)\\g{+1}|{ 2 }\\g{a}{2,3}[\\d-a\\dz\\p{L}]){ 2 , 3 }|(?P<a>(*UTF)**)$(?(R1)#|[^\\b😀\\Q-]\\E++|\\g{+1}\\g<-1>)){65536}(*nlb:[😀-😂][^a\\😀]{,3}(?P=a))|[]*+(?|[]))", "extended": true, "valid": false}
+{"pattern": "(?(R1)[\\C]{2,}][\\w^\\Ez]){|\\x{ 41 }", "extended": false, "valid": false}
+{"pattern": "(?P<a>[a-z\\C\\cA\\b]|){2,3}[\\]\\d-a(?J)", "extended": false, "valid": false}
+{"pattern": "\\g<a>", "extended": false, "valid": false}
+{"pattern": "}+?(?P=a){,3}[-\\w\\g[.a.]](*sr:(?<!&(?<=?)😀|\\d(?<a>(*BOGUS))(?(a)\\8))\\2*?\\é)", "extended": false, "valid": false}
+{"pattern": "[\\Ca^]{,3}(*plb:\\X[-\\da]{|[^[:alpha:]\\C](?(DEFINE)(?<a>[a\\E])?){ 2 }{ 2 , 3 })\\B", "extended": false, "valid": false}
+{"pattern": "\\2*(?C\"x\")*", "extended": true, "valid": false}
+{"pattern": "}[😀]|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\N\\d-aa-\\d]", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)\\g-1(?<=(*nlb:[a\\pL\\Ez-a]|[]*)\\pb*(?u)|(?'a'(?R)?\\k'b'{2,3}|(?aD){2,3})\\w++(?=[][:^alpha:][=a=]\\cA][\\--\\b\\w]\\X))|\\pL(*ACCEPT)(?(?C1)(?=a)\\N{U+41}\\p{sc:Latn}))(*MARK:m){,3}\\h+?(?>(?(R)(*ACCEPT){3,2})+$*|b0+)(?i)", "extended": false, "valid": false}
+{"pattern": "(*sr:#(*SKIP))(?<=(?^)(?C1))(?:(?aD)){ 2 , 3 }\\K(?'a'[\\pL\\]\\d](*plb:(?(R)[\\Q-]\\E\\C]\\z|)(?P<a>{3,2}[])[\\d])", "extended": true, "valid": false}
+{"pattern": "\\z|(?<b>(?(a)b{2,3})(?(a)(?<=\\u0041\\k|(?n))+?\\X\\k{a}{2,3}))(?J)", "extended": false, "valid": false}
+{"pattern": "(?(1)[\\8a-z\\]][\\g[:^alpha:][:alpha:]])(?(1)(?u)|[^\\[:word:]\\g][😀-😂]++)|", "extended": false, "valid": false}
+{"pattern": "(*nlb:[\\cA😀-😂]+?\\B{)(?(<a>)(?(R1)(?(?C1)(?=a)(?#c)*|\\é|)&{([z\\wz]++))[^z-a](?P<a>(?>_|0[\\d-a\\Q-]\\E\\w])))\\pb", "extended": false, "valid": false}
+{"pattern": "b{1}\\_", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?'a'(?:(?(DEFINE){2}\\P{Xan}\\c)\\pL)|[[.a.]\\b\\R](?(?C1)(?=a).{2,}[\\8\\C]))\\c(*FAIL)", "extended": true, "valid": false}
+{"pattern": "\\x{41}{,3}[^\\E](\\Q\\E\\g<1>(?:(?i:)\\E{,3}))\\cA[\\R\\d]", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)\\h(?^)[])", "extended": false, "valid": false}
+{"pattern": "(?C\"x\"){(?(a)(?<a>\\d|(?(a)(?&a))*(?<a>(?C)\\p{ L }|(?-1)){65536}\\pL{2})(*MARK){2,3}|(?<=[\\-a-z])){65536}", "extended": false, "valid": false}
+{"pattern": "\\pb |(?n)(?(?=a)[[:word:]])+[]]]{2}", "extended": true, "valid": false}
+{"pattern": "(?i:\\g<1>{2,}(?(?=a)\\2{ 2 , 3 }(*nlb:[\\]|[z-a]{3,2})|(*atomic:(?C1)))++|(?<!(*sr:{ 2 , 3 }\\2**){ 2 , 3 }\\N){){[]", "extended": false, "valid": false}
+{"pattern": "a(?>(?&a)[^a\\d-a\\-][])(?!\\x41)(*FAIL)\\g1++", "extended": true, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(*MARK:m){65536}|(?'a'(?:a{ 2 , 3 })))(?>(?>(?C1)[^]?[[:alpha:]-])[^[:word:]][\\C])", "extended": false, "valid": false}
+{"pattern": "\\K[]{ 2 }(?>\\_|\\p{ L }(?+1){2,3}(?n){3,2}|\\k'b'{2,3}", "extended": false, "valid": false}
+{"pattern": "]{ 2 , 3 }(?(R)(?aD))*+\\_[😀](?(?C1)(?=a)(?i:[\\-[=a=]]))", "extended": false, "valid": false}
+{"pattern": "[z(?:\\Qa)\\E(*SKIP))|", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a).)\\2*", "extended": true, "valid": false}
+{"pattern": "(?>\\cA){65536}\\g{-1}(?(VERSION>=10.4)(?(?C1)(?=a)(*plb:?[^\\cA😀][\\d-a]){2}[][^\\Nz-a[z-a]++|[\\pL]||(?!\\p{Greek}(?(1)){))[[:alpha:]z]|[]", "extended": false, "valid": false}
+{"pattern": " (?<=\\p{L&}|\\g1{+){2}|", "extended": false, "valid": false}
+{"pattern": "[\\]\\h]|(?<=(?|[^\\][.a.]]?(?<a>[^a-\\d\\]]|{,3})(*atomic:\\cé)|(*plb:[[a])){)", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)[\\Q-]\\E](?(?=a)(?(1)[\\x{41}a]**\\Qa)\\E){65536}[\\h\\E\\N^]])**|\\N{U+41}(?<!\\E+?|\\2|)(?'a'\\p{L&}||\\U(?<=[\\w\\pL\\h]*|(?(R)?\\E|))+|)", "extended": true, "valid": false}
+{"pattern": "$*(?i:$(?(R)\\B(?'a'?)|(?(a)\\k(*SKIP)|{{2,1}*(*SKIP))\\d(?i:[^\\hz-a\\C]))|(?C256)(*plb:(?(a)]|\\c)**}**\\8){,3})\\d**\\g<a>[[=a=]\\a-\\d]", "extended": true, "valid": false}
+{"pattern": "\\012{2}[[:bogus:]]\\x41[\\Ea\\p{L}\\h](?<a>(?!(?i:\\_\\X)(?J:)\\R)(?<=\\g{+1}|{1}\\k'b'){3,2})++", "extended": false, "valid": false}
+{"pattern": "(*atomic:0{|[[:^alpha:]\\]{,2})(?(a)-][\\p{L}[:bogus:]]|(*pla:(?!(?Cx){\\g1)[\\\\b[:bogus:][:^alpha:]]}|)(?(?=a)(?=[[:alpha:]]|)[\\8][^])?[]){ 2 , 3 }\\cA*", "extended": true, "valid": false}
+{"pattern": "(*BOGUS)|-[\\cA]", "extended": true, "valid": false}
+{"pattern": "(?|\\p{sc:Latn})(?>[]\\012**\\pb)", "extended": false, "valid": false}
+{"pattern": "(?'a'\\g<1>(?(1)\\o{101}|\\b)*?_|\\d|[\\-z-a-](?i:\\A|))", "extended": false, "valid": false}
+{"pattern": "\\é(?<!-\\pL\\N)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[](?(R1)[\\]a][[=a=]]{2}\\o{101}|){65536}", "extended": false, "valid": false}
+{"pattern": "(?Cx)(*MARK)(*sr:]{,3}-&){2,3}", "extended": false, "valid": false}
+{"pattern": "\\x41{2}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g{+1}(?:}\\8)(*BOGUS)+\\u0041(?(?C1)(?=a)(?(a)[\\R\\]a-z\\d-a]{ 2 }|[\\b]\\g<-1>{3,2})*?)", "extended": false, "valid": false}
+{"pattern": "(?P>a)+?", "extended": false, "valid": false}
+{"pattern": "\\E[\\cA\\N[:word:]](?(1)(?(<a>)(?(<a>)[^]|\\k{a}||[\\E]){2,3}[^\\R][^]){65536}\\pb(?J:(?(R)?)))\\g<-1>", "extended": false, "valid": false}
+{"pattern": "(?<!(*nlb:b([^\\R\\d-a\\x{41}[:alpha:][\\pL[:alpha:]-]| ))*(?:(?(?C1)(?=a)^\\N{U+41}|(?|(?R)\\k{a}\\pb|*)+|[\\]]|\\p{sc:Latn}{3,2}|{ 2 , 3 }[[=a=]\\-]\\E]|\\R\\X**b)++(*pla:{|[\\cA\\h\\N-\\012{3,2})\\p{sc:Latn}|(?aD)?\\g{+1}", "extended": false, "valid": false}
+{"pattern": "\\G(*nlb:{1}_{ 2 , 3 }|(?(?C1)(?=a)(?(R)[a-z\\-\\Nz]+?)(?(<a>)){){3,2}\\R{3,2}){65536}", "extended": false, "valid": false}
+{"pattern": "[\\g[:word:]\\8]+?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\_[[:alpha:]\\x{41}\\pL][[=a=]\\g[:bogus:]😀]\\Qa)\\E{,3}(?#c)", "extended": false, "valid": false}
+{"pattern": "\\p{sc:Latn}{,3}(?1){[\\g\\w\\h]\\p{^Lu}(?J:\\Q\\E**\\A", "extended": false, "valid": false}
+{"pattern": "\\p{sc:Latn}|(?C1)|(*nlb:(?:[z-a\\g](?i:(?#c){ 2 , 3 })|\\g1{65536}|[\\N[=a=]](?(<a>)\\k'b'\\p{Greek}(?(?C1)(?=a)-)|(?u)*+{2,1}){ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "(*pla:\\é\\G|(?(?C1)(?=a)[😀-😂\\8😀-😂]])\\A)[\\N\\-]\\k<a>}\\8?", "extended": false, "valid": false}
+{"pattern": "(?<a>(?J)++(?C1)|[^][[:alpha:]-\\h]|(?!\\Qa)\\E[z-a\\R[:alpha:]]{65536}){2,})\\2", "extended": false, "valid": false}
+{"pattern": "[]{,3}(*nlb:\\k{2}(?<![])**)\\p{ L }(?<!(*FAIL)+?(?:(?J){(*ACCEPT)*\\E{))[\\Nz\\]]**|", "extended": false, "valid": false}
+{"pattern": "\\g{-1}{3,2}(?<a>(?n)|(?(<a>)(*plb:\\g<1>){65536}(?i:)(?R))\\012)|(?(<a>)(?(?C1)(?=a)\\g{a}(?(?C1)(?=a)[^😀-😂😀-😂\\w]))**\\pb*(?(<a>)[^-a-\\d\\cA\\cA]|&**)", "extended": false, "valid": false}
+{"pattern": "(?(<a>)(?>[[:bogus:]\\]\\pL[:word:]]{2}[[:word:]](?<a>[^a](?aD)){,3}|(?#c)\\B)(?<b>(?<![\\d\\N])\\B\\B)++)*+(*atomic:(?J:[][z-a]{,3}){[a-\\d\\N^])(?<=(?(1)(?(R)^|a**){,3}[\\E\\E]){2,}){65536}|(?(R)\\x{41}(?P=a)(?<=(?C)[\\g]{3,2})|\\P{Xan}[]\\pL++)", "extended": true, "valid": false}
+{"pattern": "[-\\C\\R](?aD){ 2 , 3 }|(?'a'a){2,3}{ 2 }(?(<a>)(?P>a))**", "extended": true, "valid": false}
+{"pattern": "-(?(<a>)[\\d[.a.]\\C]|)", "extended": true, "valid": false}
+{"pattern": "[\\x{41}\\d-a\\N][^]]#?\\g-1", "extended": false, "valid": false}
+{"pattern": "[[=a=](?<=(?(a)\\E(?(<a>)[]))(?|\\c[\\Q-]\\Eaa-z\\pL]\\p{Greek}))](?(DEFINE)([\\h[.a.]z[.a.]]+\\x41(?<b>(?n)))\\c)(?-1){65536}", "extended": false, "valid": false}
+{"pattern": "\\B|(?![\\cA\\b[:alpha:]\\R][^\\x{41}[:word:]](?(DEFINE)[^]*?)(?i)", "extended": false, "valid": false}
+{"pattern": "[]*?|\\012(?|(?(-1)\\b(*nlb:+))(?(R1)(*atomic:[z-a]|){ 2 , 3 }\\Q\\E||\\o{101}){2,3}|(?-1))", "extended": false, "valid": false}
+{"pattern": "\\N+?(?C){2,3}(?C256)", "extended": false, "valid": false}
+{"pattern": "(?<=(?(-1)([\\-]{2})*?\\N{U+41}\\10)a\\R) ", "extended": true, "valid": false}
+{"pattern": "\\é*+|(?(VERSION>=10.4)(?(a)(?<b>\\cA++\\h){[az\\C]|\\g<-1>{,3})?||\\b\\Q\\E(?i)){2}\\g<-1>(?<b>[[=a=]\\pL[:word:][]**(*pla:_)[^\\wa-z]|(?=\\81|))", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]\\C-\\b?", "extended": false, "valid": false}
+{"pattern": "[]\\k<a>|", "extended": false, "valid": false}
+{"pattern": "(?(-1)[[:word:]\\Q-]\\E[:bogus:]\\d-a]{2,3}|(?x)\\c+?|[\\C\\h\\x{41}\\Q-]\\E]*+(?(R)\\pb|\\N\\81{,3}){2,3})(?(R1)\\k+?\\N{U+41}|[[:alpha:][:^alpha:][])(?(VERSION>=10.4)[^[:^alpha:]\\]]*0){", "extended": false, "valid": false}
+{"pattern": "(?P=a)|(?>(*sr:(?(?=a)\\c?\\z|\\K{65536}\\P{Xan}**){[^]++\\pb)|[\\g])", "extended": false, "valid": false}
+{"pattern": "\\p{Greek}{65536}(\\g<-1>)+(*MARK)", "extended": false, "valid": false}
+{"pattern": "[^\\-z-a\\w]", "extended": false, "valid": false}
+{"pattern": "\\10\\x{41}++", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?P<a>(?|[]\\g{a}\\_)*?[]{2}|", "extended": true, "valid": false}
+{"pattern": "\\pL{3,2}{,2}+\\h", "extended": false, "valid": false}
+{"pattern": "[^\\b\\w]|}[\\d\\d-a]", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)😀)[[:alpha:]]{3,2}\\k*?[\\]z-a](?J:(*plb:[a😀-😂\\-]\\b\\p{Bogus}{,3})(*SKIP))|", "extended": false, "valid": false}
+{"pattern": "(?(1)(?>[](?(?C1)(?=a)\\N+(?&a)\\2|(?n)\\g1)|[^z-a[\\][:bogus:]]))\\_{2,1}", "extended": false, "valid": false}
+{"pattern": "(?C256)(?(VERSION>=10.4)(*MARK)|\\10|((?i)[\\-\\]\\pL\\E](?|[])|(?(?C1)(?=a)\\g<a>*?\\h**|\\p{^Lu}[\\p{L}\\R]+)(?(R)|\\cA|\\C{2,1})(?P<a>\\p{^Lu}|(*BOGUS)))[^]\\h[:^alpha:]-]*?)#", "extended": false, "valid": false}
+{"pattern": "(?(-1)(*atomic:(?'a'(?n)++\\C)[]\\cé|(?(a)\\g1{2}(?aD)[]|)|)(?C256))(?<=\\p{Greek})\\2[\\d\\-[:alpha:]]|", "extended": true, "valid": false}
+{"pattern": "\\X{2,}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{L}[]\\g{-1}[^\\d[.a.]]", "extended": true, "valid": false}
+{"pattern": "(?(?=a)[a-z\\cA]\\p{L}(?:\\h+)||\\h[^\\g])[^]z-a[:bogus:]]+?|(?x)|", "extended": false, "valid": false}
+{"pattern": "(?<![\\cA\\w\\b\\][a-\\d\\Q-]\\E\\E](?<!(?'a'[\\C[.a.]\\pL]^{)[\\-]|(?'a'\\g{-1}{65536}|){,3})|]*+(?<=(?>{,2}\\k{a}[^-\\b\\R\\8]|\\k'b'\\k'b')\\z(?(-1)(?P=a))){3,2}(?J:(?<a>)0)){2}\\p{Greek}(?(<a>)[[\\g\\d-a][]{65536}[\\E[=a=]a-\\d]|(?(R1)\\10?\\b?\\g{a}{2}\\g-1*", "extended": false, "valid": false}
+{"pattern": "(?:(?|\\Q\\E{65536})){3,2}\\P{Xan}++\\p{^Lu}(?(R)(?aD)*(?(R)[\\p{L}z-a\\d[:word:]](?J:(?n))(?(1)[^][^]{2})+?)*?[^\\w]]|[]{(?i: *))", "extended": true, "valid": false}
+{"pattern": "\\x{110000}{3,2}", "extended": true, "valid": false}
+{"pattern": "[[=a=]\\d]{2,}\\B+(?i)#[\\x{41}]{2,3}", "extended": true, "valid": false}
+{"pattern": "[][a\\d[:bogus:]]*+", "extended": false, "valid": false}
+{"pattern": "(*UTF){.\\pL\\g{+1}|[\\p{L}😀-😂]", "extended": false, "valid": false}
+{"pattern": "\\x{110000}[😀]{(?![\\g😀\\x{41}]{2,3}[aa-\\d[:bogus:]😀-😂]\\x{41}+|\\p{ L }{\\p{Greek}{,3}[[\\\\Ca-\\d])+?|[^\\C[=a=]^]", "extended": false, "valid": false}
+{"pattern": "\\dé", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(DEFINE)(?>[[.a.][]\\d(?(1)\\A(?+1)|))0\\1|)[\\pLa-zz\\x{41}]+?\\g<-1>(?(DEFINE)[\\x{41}]|)*+", "extended": true, "valid": false}
+{"pattern": "\\g<a>(*nlb:(?C1)*?\\g{+1}(*pla:\\o{101}|\\k<a>\\G)||[^\\b[])(?n){2}", "extended": false, "valid": false}
+{"pattern": "[[:alpha:]\\Q-]\\Ea-z](?<b>[^a[:bogus:][:word:]]{2,3}(?<!(?=))|\\d(?x)+)[\\cA(?>0{ 2 , 3 }[[:bogus:][=a=][=a=]a(*plb:(?:**+?(?C\"x\")++)\\p{L}{65536}.)**|(*atomic:(?(R1)[\\E\\cA\\b]){1}?(?>[^\\pL\\h]|]{*))(?C1)|)*?", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)(?C)*?(?&a)||(?(?=a)(?i:)++(?(DEFINE)\\k{{1}|\\U{,3}{2,3})[\\b\\pL\\N😀-😂]))(?=\\x41|(?(R)(*atomic:[\\C{65536})(*MARK)|[]|\\p{ L })+? ", "extended": false, "valid": false}
+{"pattern": "[](?(-1)\\cé|(?(<a>)[]|))(?=$\\1+)", "extended": true, "valid": false}
+{"pattern": "&\\2[[:bogus:]😀-😂]*(?(-1)[z-aa\\R]_(*FAIL))*+|", "extended": false, "valid": false}
+{"pattern": "(?i)(?!(?<b>(*sr:|[]{ 2 , 3 })|[\\8^]{2})|\\p{Bogus})", "extended": false, "valid": false}
+{"pattern": "(?>(?R)(?:a[]\\])|(?(VERSION>=10.4)\\p{L}{2}|😀(?(R1)[\\h\\d-a😀]|)\\g{-1}{,3})[^😀-😂\\[\\](?|\\1++[\\b]))(*nlb:$(?<=(?<![^]|[\\g])(){2,3}|(?<a>){2})+\\R?|[z]\\012(?R))(?&a)(?|[\\b\\N[=a=]]\\p{sc:Latn}|(?i:[]{ 2 , 3 }|(?<a>{2,})))", "extended": false, "valid": false}
+{"pattern": "\\x41\\pL|(?(R)[^\\-++|[\\pL\\d-aé)(?P<a>(?i:(*pla:{)\\pL\\cA|[z-a\\ha]{65536}\\p{L}|)\\p{Greek})(?(VERSION>=10.4){[^a😀-😂\\d](?+1))++", "extended": false, "valid": false}
+{"pattern": "(*atomic:(*pla:}(?=[a])*))*{(?!(?J)#{2})", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(<a>)(?(DEFINE)\\p{Greek}(*nlb:[^\\p{L}][\\bz-a]|(?>(?C256)|{3,2}[\\p{L}]|)\\g<1>)){ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "[\\cA\\b😀-😂](?=[a-\\d-\\N\\N]{2})(?(1)(?n)(*plb:\\o{101}*(?aD)?(?i))?(?(?C1)(?=a)\\h[]|))|", "extended": false, "valid": false}
+{"pattern": "\\p{sc:Latn}\\cA", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[=a=]]\\g\\d](?x)", "extended": false, "valid": false}
+{"pattern": "\\g<a>(?>[^])?(?(?C1)(?=a)(?!(*pla:{ 2 , 3 }\\g<1>.))+?)", "extended": true, "valid": false}
+{"pattern": "(?n)+?", "extended": false, "valid": false}
+{"pattern": "[\\pL[[:^alpha:]]++", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:[\\Q-]\\E😀\\p{L}\\d]*)|(*nlb:\\B|[^\\Q-]\\Ea])*?\\N{U+41}|(?aD)(?R)*|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "((*atomic:(?:[]\\8\\Ra]|)[\\g]++[^\\][:word:][.a.]\\w||(?:[[=a=]\\C[:alpha:]](?1))(*sr:_|[\\d-a]){)(?<b>(?(a)\\012|)\\_(?Cx))|)[z-a😀-😂\\](?<!\\d|[-[](?i:#)(?<a>\\Q\\E){2,3})(?(1)(?(<a>)(?i:{,2}{2,})\\012))**", "extended": false, "valid": false}
+{"pattern": "\\cA(?<b>(?<a>\\p{ L }{{2}(*SKIP){|)|[\\N[\\p{L}](?(VERSION>=10.4)[[:word:]\\h](?(1)|^)|\\pb)*?", "extended": true, "valid": false}
+{"pattern": "[[:bogus:]](?i:\\é(?(1)\\E&[^]|(?<![a-z\\E]|\\p{ L })\\p{L&}*?))*+[\\]]", "extended": true, "valid": false}
+{"pattern": "(?<=\\k<a>{2,3}(?P<a>(?(-1){2,3}(*MARK:m))(*atomic:[z\\h](*ACCEPT)++|)(?=[\\h😀-😂\\8]|\\cA)))(*atomic:(?(a)(?J:(?n)[\\d]|[^[.a.]\\]\\x{41}[:alpha:]])[\\C[:^alpha:]]**[^]++){2,}(?=(?<!)(*nlb:.\\g{a}^)(?|(*UTF)[-]_))😀+?)(?(R)[](?u){,3}|(*nlb:(?<!))){65536}(?(?C1)(?=a)é)", "extended": false, "valid": false}
+{"pattern": "\\P{Xan}[\\R](?#c)", "extended": false, "valid": false}
+{"pattern": "(*pla:\\81(?(R)(?(VERSION>=10.4))[😀-😂😀-😂-\\h])|)\\pL", "extended": false, "valid": false}
+{"pattern": "}*\\c(?(R)(?P>a)\\p{L&}{2,}|(*sr:[?)|)", "extended": false, "valid": false}
+{"pattern": "(?(R)\\Qa)\\E|[^\\w](*atomic:(*SKIP)(?P>a)[^\\-\\d-a]*){)\\Qa)\\E\\8", "extended": false, "valid": false}
+{"pattern": "(?R)(?(VERSION>=10.4){,2}{,3}\\cé|[aa-z[:word:]-])\\R", "extended": false, "valid": false}
+{"pattern": "(?=\\1{|[]{3,2}\\b*+|\\g{a}", "extended": false, "valid": false}
+{"pattern": "(?^)(*atomic:[\\-]\\N){,3}(?R)*+(?(R1)[^a])?(?<!\\p{sc:Latn}(?<![](?i:[\\Ca-z\\p{L}😀-😂]|{2})*+\\81)*)|", "extended": false, "valid": false}
+{"pattern": "(?|\\C\\E|[](*nlb:[](?P=a){65536}(?C256))\\R{3,2}(?=\\k<a>|){,3}|(?<=(?(?C1)(?=a)(?x)++(*MARK:m)\\x{41})(?C\"x\")|[\\wa-z])", "extended": false, "valid": false}
+{"pattern": "\\g{-1}{2}(*MARK){65536}[]", "extended": false, "valid": false}
+{"pattern": "(?(?=a)\\Q\\E?(*plb:\\1)\\R*)(?<b>\\g{a}?(?<a>(?(?C1)(?=a)[a-z]|\\z\\k'b'*?)**(?n)(?(DEFINE)(?aD))[\\E[=a=]\\p{L}])|", "extended": false, "valid": false}
+{"pattern": "(?n){(*MARK:m)[^]\\d-a[:bogus:]\\Q-]\\E](?=(?(<a>)\\p{^Lu}(?(<a>)||)))", "extended": false, "valid": false}
+{"pattern": "\\p{Greek}\\cA", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*plb:\\p{^Lu}[\\pL😀😀{,3}|[[:bogus:]\\d]{)\\cé", "extended": false, "valid": false}
+{"pattern": "(?J:(?<=(?<b>[😀-😂\\cA]*|++){2,}|\\p{sc:Latn}\\w\\p{Bogus})+(*nlb:(?<a>[]|\\B)*[\\R[=a=]\\N]{2,3})0)[]{65536}(?aD)[^]", "extended": false, "valid": false}
+{"pattern": "(?(1)[-\\cA\\cAz]*+(?+1))++{1}((?R))", "extended": false, "valid": false}
+{"pattern": "((?|(?P=a).)*+(?|(?'a'[a-z^]|(?-1)|[^[.a.]]++))(?<a>(*nlb:|\\g<a>){,3}|\\N(?(<a>)\\u0041){2})|\\R*+)|[^\\-z-a]*?(?-1){2}", "extended": false, "valid": false}
+{"pattern": "^(*SKIP)(?<=&0|(?<=\\x{110000}\\k{a}{2}))|\\p{L&}(?|(*plb:[[:word:]](?i:(?+1))|\\c{2,})(?![\\x{41}\\g\\Q-]\\E\\Q-]\\E]*+)++(*ACCEPT)?)", "extended": false, "valid": false}
+{"pattern": "(?#c)(*UTF)(?#c)", "extended": false, "valid": false}
+{"pattern": "(?J:\\pL[^^\\]a\\Q-]\\E]\\x41)\\x{110000}", "extended": false, "valid": false}
+{"pattern": "(*atomic:[^[.a.]]\\g{+1}(*pla:(?(-1)\\A|{,3}\\k'b'+?é)\\k'b'{,2}|\\p{L&}+?){65536})(?J:\\b\\é{,3})(?P>a)", "extended": false, "valid": false}
+{"pattern": "(?i)\\p{^Lu}(?(DEFINE)\\B|(*UTF)(?+1){1})", "extended": true, "valid": false}
+{"pattern": "(?!(?!(?(DEFINE)\\8\\2|)[\\]]\\X)(?C)(*UTF))[-\\pL\\p{L}]\\2{", "extended": false, "valid": false}
+{"pattern": "(?<b>[]*(?(VERSION>=10.4)[[:alpha:]]*?)[a-z]{,3}|(?|\\A[^\\x{41}\\](?P<a>)){65536}\\p{^Lu})(?P<a>(?(R1)(*atomic:-\\P{Xan}\\x{41}(?<a>\\81)*+){2,}\\10|(?+1)(*SKIP))?(?(a)(?(<a>)\\g{a}[\\x{41}aa-\\d]{65536})[^\\cAa-z[:bogus:]](?(a)\\A$(?(?=a)|\\P{Xan}[^]{||\\g<1>)|(?(VERSION>=10.4)-{,3}|[^\\d-a]))(?<a>(?<!\\A(*nlb:(*MARK)|\\pb\\w))(?J:(*sr:[^]]_\\Q\\E))|\\g{+1}(?(1)[[\\h]{ 2 , 3 }(?(?=a)\\x{ 41 }+?|(?aD)))(*atomic:[\\x{41}-]))++(*plb:(*SKIP)(?<a>\\2[\\b-[.a.]]|(?(<a>){,3})*?_*+){2,}|[\\d\\R\\\\R]{65536}|\\p{ L }(?i:[\\N\\\\h\\-][\\g\\d[=a=]]{65536}|\\k))", "extended": false, "valid": false}
+{"pattern": "\\N{U+41}[\\cA](*nlb:(?J:[\\p{L}\\cA\\h\\cA](?i)|(?i:[\\p{L}\\cA\\]]**[^[\\\\N]\\g{a}+?){,3}\\x{ 41 })|(?>{1}[[:bogus:]\\w]|(?<b>\\p{Greek}**|\\g{+1}))(?P<a>[[](?&a)\\o{101}{2})|(*SKIP)\\d[\\d-a\\(?<=\\z|)", "extended": false, "valid": false}
+{"pattern": "(?<=\\2(?aD))|\\k{a}\\p{L}{65536}(?'a'\\h{65536}|[\\ga-\\d]{65536})", "extended": true, "valid": false}
+{"pattern": "(?i:{|\\k'b')\\8(*pla:(?i:\\K|))++(?n){2,}\\w", "extended": false, "valid": false}
+{"pattern": "(?>{,2})(*nlb:\\p{^Lu}{2}(?C256)(?J:(?<=*\\x{ 41 }|[[=a=][](*MARK)*+)\\10[))|(*atomic:\\u0041|\\é(?R)(?(?C1)(?=a)(?<a>(*MARK)+?)|(?(-1)(*SKIP)\\N?\\Qa)\\E|)|[^😀-😂[:word:]-[]){65536})*?(?1)", "extended": false, "valid": false}
+{"pattern": "\\X*?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(DEFINE)\\g<a>?[\\cA]?(?-1)+)(*SKIP)", "extended": true, "valid": false}
+{"pattern": "-{ 2 , 3 }}{65536}(?(a)(?(-1)\\g<a>|\\cé(*MARK)|\\g1(?'a'[^\\]]\\d\\012|[z\\ga-\\d\\](*SKIP)|(*UTF)))*[^\\]\\N\\w]\\g{a}){3,2}", "extended": false, "valid": false}
+{"pattern": "😀[\\b*+(?<=(?>(?^)){2,}[a-z😀-😂\\d-az-a]{65536})*+}", "extended": false, "valid": false}
+{"pattern": "[\\N]a-za](?(DEFINE)(?C\"x\"){|\\u0041{,3}\\N|)\\w(?(DEFINE)[\\C\\p{L}]?|(?:(?i:[]{,3}{2,})(*MARK))", "extended": false, "valid": false}
+{"pattern": "(*MARK:m)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x{ 41 }(?(VERSION>=10.4)[\\pL\\Rz-aa-\\d](*sr:[])(?!(?n))|(*pla:\\g-1(?(a)\\c**[z-a[:bogus:]]){65536}|é[]{65536}$+?)(?|[\\g\\p{L}^[:bogus:]]|\\g{+1}))[](?>\\10|(?P<a>(*atomic:{{2,}[^😀\\E])|[z-a])|\\g-1(?(1)[]))?", "extended": true, "valid": false}
+{"pattern": "(?<a>(?Cx)*?|\\p{sc:Latn}(?'a'(?(R)\\k{ 2 , 3 }(?'a')*+)|$)[\\d\\x{41}\\p{L}\\C]\\Qa)\\E|", "extended": true, "valid": false}
+{"pattern": "b", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\8\\C(?J:(?(DEFINE)\\K|(*sr:\\x{ 41 }?-(?(<a>)\\u0041))(?<b>\\k<a>[\\]é)(?(R1)[-\\d\\]])|[]|)++", "extended": false, "valid": false}
+{"pattern": "(?<![\\w[=a=]\\g\\pL](?J:(?P<a>)\\10{2,1})(?&a)|(?(R1)(?(DEFINE)\\g{a}\\g-1\\U{65536}))(?J))\\N{U+41}\\p{Bogus}#|\\p{^Lu}", "extended": false, "valid": false}
+{"pattern": "\\k[\\N\\R[:word:]]+?[\\d-a]-]", "extended": false, "valid": false}
+{"pattern": "(?<a>[]|)", "extended": true, "valid": false}
+{"pattern": "(?<b>(?(<a>)\\x{41}|)\\x{110000})[[😀\\x{41}\\w]\\1[[.a.]]*?(?^)", "extended": true, "valid": false}
+{"pattern": "(?<a>(*UTF)(?#c)\\x{ 41 }|(?'a'\\C|(?x))\\N{U+41}&|(?P=a)|(?'a'(?R)*+)\\G|", "extended": false, "valid": false}
+{"pattern": "[\\\\]^](?i:(?i)+?\\x41 )(?J){ 2 , 3 }\\K\\g<a>+", "extended": true, "valid": false}
+{"pattern": "(?+1)+|\\g<-1>\\K", "extended": false, "valid": false}
+{"pattern": "(?<b>\\B\\g{+1})[\\d-a^\\d-a]]{,3}(?R)\\8{,3}\\pL", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)(?J:[](*ACCEPT){2,3}(?![\\x{41}a]+\\g<1>\\K){))|", "extended": false, "valid": false}
+{"pattern": "}(*sr:(?(1)(*FAIL))[\\E\\pL]{2,1})(*UTF)[\\p{L}\\cA\\p{L}😀]\\B", "extended": false, "valid": false}
+{"pattern": "(?![^[:bogus:]\\h](?(VERSION>=10.4)(?P<a>[\\😀[:^alpha:]]|))[\\N\\Q-]\\E]*|(?&a)\\k{a}\\10){ 2 , 3 }", "extended": false, "valid": false}
+{"pattern": "[^\\d-a]{65536}", "extended": false, "valid": false}
+{"pattern": "(?J:\\N{U+41}\\Q\\E|(?=(?>[^][^-\\cA]]|[])|(?<=(?-1)\\Qa)\\E||\\p{sc:Latn}**)[^]){2,3}){2,3}(?'a'(*plb:\\A[]))\\k", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)&[-\\C\\Q-]\\E]\\k|(?P<a>[\\p{L}\\x{41}]]|[[:bogus:]]){ 2 , 3 })", "extended": false, "valid": false}
+{"pattern": "(?C)[]😀[.a.]][^]", "extended": true, "valid": false}
+{"pattern": "{ 2 }|(?n){2,}", "extended": false, "valid": false}
+{"pattern": "\\x41[][=a=]\\g]+?", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)\\b{2})?(?x)|\\p{Greek}(?J)", "extended": false, "valid": false}
+{"pattern": "[\\-\\[:word:][:^alpha:]]", "extended": false, "valid": false}
+{"pattern": "(?<a>[\\E\\h\\E]|\\Qa)\\E\\g-1)(?C1)++(?<=\\b\\p{ L }{,3})(?Cx)[\\pLa\\]]*+", "extended": false, "valid": false}
+{"pattern": "\\U?(?<=\\012*+|\\x41(?<=\\p{Bogus}(?(R1)\\cé)(?!\\o{101}\\x{ 41 }+?)))\\p{sc:Latn}(?<!\\R*?[\\pL😀\\g])\\p{Greek}", "extended": true, "valid": false}
+{"pattern": "[]\\R\\pb", "extended": false, "valid": false}
+{"pattern": "\\x{ 41 }|{ 2 }+? ", "extended": false, "valid": false}
+{"pattern": "[\\d-a\\cA]&{3,2}", "extended": false, "valid": false}
+{"pattern": "[\\N😀-😂]{65536}\\k{65536}(*MARK:m)(?<a>#[a-\\d\\g]\\Q\\E\\E+", "extended": true, "valid": false}
+{"pattern": "(?!(?J:(?J)(?(<a>)*|{2,3})*?\\Qa)\\E)?(*plb:(?C\"x\")(?P=a)[😀]|[a]++){3,2}|){2,}(?P<a>(?i:(*MARK){,3}|)[\\b]\\g{a}{ 2 , 3 })(?:[[:word:]-]+?|(?<b>{(?1)){2,3}-|)", "extended": true, "valid": false}
+{"pattern": "\\Qa)\\E[[:word:]]\\p{L&}(*FAIL)|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[z]|(*ACCEPT)\\g{a}{ 2 , 3 }|", "extended": true, "valid": false}
+{"pattern": "(*nlb:_\\_)[[=a=]\\w\\]]&[\\d\\C😀]", "extended": false, "valid": false}
+{"pattern": "[\\pL[](?(R1)[])*", "extended": true, "valid": false}
+{"pattern": "(?P=a)|(*plb:(*pla:(*sr:[a-z[.a.])\\x41|(?J:\\1.))+|(?P<a>(?x)||[](?<=0\\x41{65536}|\\cA)[])?[]|\\u0041)(?(?=a)(*BOGUS)[😀-😂-]|)(*nlb:(?<a>})\\k<a>{2,1})", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(?i:(?!{2}]{\\p{L&})(?(a)\\x{ 41 })|\\g<1>*?[\\R^\\-]*?", "extended": false, "valid": false}
+{"pattern": "(?+1)+(?Cx){2}{2,1}[^a\\d", "extended": false, "valid": false}
+{"pattern": "(?i:[\\p{L}](*nlb:(?!\\g-1\\k){2}\\Qa)\\E|\\A)|[)\\g1(*plb:[\\ba-z\\Q-]\\E](?P<a>(?<=){2}(*pla:[]{,3}*+[\\g\\h\\p{L}[]|))", "extended": true, "valid": false}
+{"pattern": "\\x{41}(*pla:{(?<b>(?<!.)😀{65536}|(?(1)\\o{101})|(?<=\\G{1}{,3}| \\81{,3})\\k)(?C256))[[=a=]\\d-a]\\p{^Lu}", "extended": false, "valid": false}
+{"pattern": "[\\Nz\\N]?", "extended": false, "valid": false}
+{"pattern": "[^\\b][*", "extended": false, "valid": false}
+{"pattern": "\\k{2}[\\w][:bogus:]]]", "extended": true, "valid": false}
+{"pattern": "\\x{ 41 }\\k(?|(?i:[]|^|)\\G|_\\g<-1>)(?:[]{ 2 , 3 }|)", "extended": false, "valid": false}
+{"pattern": "(?<a>(?(?C1)(?=a)[\\p{L}][^\\])[\\gz-a[.a.]](*sr:[\\p{L}\\Rz-a][[=a=]\\]+){65536})\\é(?1)-(?:\\x{110000}{3,2}|\\U(*ACCEPT){3,2}){ 2 , 3 }", "extended": true, "valid": false}
+{"pattern": "[\\d\\p{L}\\*(?P<a>(*sr:\\p{sc:Latn}😀|\\k<a>{ 2 , 3 }(?aD)(*SKIP))|[](?#c))*+\\z++(?P<a>\\k{a}\\C|)", "extended": false, "valid": false}
+{"pattern": "(?&a)(?!#+?\\E|)(?i:(?(<a>)0)|\\p{Greek}(?u))*(*nlb:&\\x{ 41 }{2,}[\\pL[.a.]\\Q-]\\E[]{3,2})", "extended": false, "valid": false}
+{"pattern": "\\p{L&}\\é(?|\\x41\\1)", "extended": false, "valid": false}
+{"pattern": "\\pb(*ACCEPT)[^[:bogus:]\\h-\\8](?<=[\\hz]?é{1}|[a][a]){", "extended": false, "valid": false}
+{"pattern": "\\k{a}?(?(?=a)(?(a)(?P>a)\\012\\c){65536})[[:word:]]&", "extended": true, "valid": false}
+{"pattern": "\\B?\\k{a}(?>\\81[^😀-😂](*plb:(*SKIP){65536}\\g{+1}**[[])|(?(?=a)(?-1)|(?(?C1)(?=a))|(?Cx)){2}(?(?=a)\\c{2,3}|)[[:word:]\\8])(?:\\012😀*?|\\2\\2){3,2}(?C256)", "extended": false, "valid": false}
+{"pattern": "(?(R)(?(-1)\\A|\\g{-1}||[[.a.]😀😀a-\\d][😀-😂\\N[:bogus:]\\x{41}(?<b>\\8|\\p{ L }\\B)*?)(?P<a>[\\-]\\é|[\\][=a=]\\](*pla:+|[😀-😂a-z\\cA\\d])(*FAIL)){2,3}\\10|(?P<a>\\cA)(?(R)(?i:(*MARK:m)[\\b\\8\\p{L}])))|\\A{65536}", "extended": false, "valid": false}
+{"pattern": "\\X(?P=a){|(?P>a){2,3}", "extended": true, "valid": false}
+{"pattern": "(?(?C1)(?=a)[\\w\\E\\x{41}\\]](*nlb:[\\g😀]{ 2 , 3 }^\\cé|(*MARK)(?:\\Q\\E{,2}{ 2 , 3 }|#\\x{ 41 }\\cé?)))[]", "extended": false, "valid": false}
+{"pattern": "[[]++", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-\\d]|(?(?C1)(?=a)(?>[😀[:word:]\\\\x{41}]|\\é(?(<a>)+?*?\\81))\\d{2,3}-|\\B(*nlb:(*plb:\\2{3,2}*|[\\pL]|)(?>++|)-)(?(1)\\k{a}){2})\\x41**", "extended": false, "valid": false}
+{"pattern": "[^", "extended": false, "valid": false}
+{"pattern": "[[.a.]\\N\\-][\\w\\C](*plb:[^z\\E[:^alpha:]]{2,3}||([[\\-][^]+[\\N[:^alpha:]-]))", "extended": false, "valid": false}
+{"pattern": "[](?!\\g1[^\\-[:word:][=a=]])\\Q\\E{ 2 }(?C)*?", "extended": true, "valid": false}
+{"pattern": "\\g<-1>\\pb(?<b>[\\Q-]\\E\\N\\E^])\\b[]{2,3}", "extended": true, "valid": false}
+{"pattern": "\\p{Bogus}\\o{101}", "extended": false, "valid": false}
+{"pattern": "\\E[^\\C\\x{41}\\d-a[:bogus:]](?:(?x)|(?+1)(?i)(?(-1)b\\b$|{1}[\\Ez-a[]))(?(VERSION>=10.4)[^[:^alpha:]]|[-\\b]*+|#\\x{110000}{,3}-{3,2})++", "extended": false, "valid": false}
+{"pattern": "(?<={1}\\c\\g<1>)[^[:bogus:]\\R\\C😀]\\N(*ACCEPT)|\\cé*?", "extended": false, "valid": false}
+{"pattern": "(?(R1)\\p{L&}+?\\p{sc:Latn}\\N|\\g{a}{2,1})\\k'b'{3,2}[^-]", "extended": false, "valid": false}
+{"pattern": "(?P<a>\\é|(?aD)\\N{U+41})(*nlb:(?C\"x\"){2}\\P{Xan}|(?=[\\g]](?(DEFINE)(?R)|)))(?(R)[\\pL]){ 2 , 3 }(?'a'(?>[z-a[:alpha:](?>\\h)|[^[.a.]\\]]{\\u0041\\g<-1>)\\w)*+", "extended": false, "valid": false}
+{"pattern": "#*(?(a)(*pla:(?(-1)\\z\\b[^\\b\\-\\b]|+)é{ 2 , 3 }|\\cé|\\U)]{,3}#)(?(VERSION>=10.4)(?<!(?Cx))?(*MARK)\\x{ 41 })(*sr:(?aD)(?(R1)(?'a'[\\h]|?(?J)|)(?<![^\\N\\Na\\-])|)(?aD)|)", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\]\\cA] { 2 , 3 }(\\g<a>-{(?(DEFINE)\\g<1>))", "extended": false, "valid": false}
+{"pattern": "(?<b>(*MARK){3,2}\\Qa)\\E[[:alpha:]\\w\\]+?)\\g<-1>\\cé*", "extended": false, "valid": false}
+{"pattern": "(?P<a>(?i:(?|{3,2}|)(?<=[[=a=]\\Q-]\\Ea][\\R[:word:]\\x{41})\\R)*?[\\Nz]*?)(?C256)\\1\\é{\\Q\\E", "extended": false, "valid": false}
+{"pattern": "(?Cx)(?'a'(?C1)(*pla:}{3,2}\\X{2,}))", "extended": false, "valid": false}
+{"pattern": "[^]*(?(VERSION>=10.4)[[](?>[^[[=a=]\\Q-]\\E\\pL](?|[[:word:]]))(*FAIL)|(?|(?C\"x\")(*sr:\\k<a>|)|(?!(?+1)*?[😀\\b😀])\\B(?P>a)*?))+[😀-😂[.a.]\\b\\]]\\g{-1}", "extended": false, "valid": false}
+{"pattern": "\\N[a[:word:]\\g]\\g{+1}(?P=a)", "extended": false, "valid": false}
+{"pattern": "(?=(?(VERSION>=10.4)\\pL(?>\\b)+?|[[:^alpha:]\\z\\Q-]\\E][z-a😀\\8\\x{41}]|)**){2,1}", "extended": false, "valid": false}
+{"pattern": "(?u)\\C*+|(\\c{1}[]|(?(-1)(?<=][]|(?Cx))){2})-", "extended": true, "valid": false}
+{"pattern": "(?aD)\\p{sc:Latn}\\g-1", "extended": false, "valid": false}
+{"pattern": "(*atomic:(?J:[\\h]++(?<!{65536}|\\B*?|)*[\\Q-]\\E😀\\h])\\p{Bogus}(?(VERSION>=10.4)\\d(*nlb:#_|\\p{Greek}){|[^]{^{)(?:(?<!(?(?=a)*?)a{,3}|(*plb:}{3,2}\\Qa)\\E+|[\\x{41}[][[:^alpha:][\\p{L}])(*ACCEPT))(?1)\\R++){3,2}(?(VERSION>=10.4)\\z(?![\\w]+[](?(-1)[\\p{L}]{2,3}[\\cA]{,3}{65536})|(*UTF)(?P<a>b[^])){2,3}\\x{ 41 }\\p{ L }", "extended": false, "valid": false}
+{"pattern": "(?(a)(?J:\\x{41}\\g<1>)**})[^\\E\\cA](*pla:(?(?C1)(?=a)\\8(*ACCEPT)|\\b)[]*+(*sr:(*BOGUS)(*FAIL)|(?'a'\\x{ 41 }\\8[a-z]+)(?<b>|\\B){)){2,}[a]\\R", "extended": false, "valid": false}
+{"pattern": "[*?[\\x{41}z-a\\R]^+", "extended": false, "valid": false}
+{"pattern": ".{3,2}\\g{+1}(*SKIP)[^\\[:^alpha:]]", "extended": false, "valid": false}
+{"pattern": "[\\pL\\E\\b]{2,}\\p{L&}[^\\d-aa-\\d]?", "extended": false, "valid": false}
+{"pattern": "[a-z\\g\\b\\p{L}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(R1)(?&a)_*\\R)\\k'b'[][]**", "extended": false, "valid": false}
+{"pattern": "(?(1)(?|(?J:(?#c)[^a-\\d^😀-😂😀-😂]{3,2}[[.a.]\\E]|\\k{a})?[\\pL[:word:]]\\R]\\E)\\k<a>(*atomic:(?J:)[^-[:alpha:]]**)|(?(R1)(?(R1)\\g{-1}+?\\p{Greek}\\G)\\P{Xan}{2,3}[\\-])*+)*+}\\2(?J:(?i:(*plb:\\p{ L })😀|\\012**)", "extended": false, "valid": false}
+{"pattern": "[\\x{41}[:^alpha:]\\8]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?P<a>[^\\Q-]\\E\\g]*+|[^])**\\P{Xan}++(?<a>(?'a'(?(?C1)(?=a)\\81*+[^😀-😂\\x{41}\\R\\pL]|)|(?<b>))|(?(R1)(?:+?)[[=a=][=a=][-]|(?(R)||)(?<![^[:^alpha:]😀-😂\\cA\\d-a][^-]{65536}|*?(*sr:{2,3}|\\h|)|)(?1)[\\8😀-😂]**", "extended": false, "valid": false}
+{"pattern": "\\p{L&}\\g1", "extended": false, "valid": false}
+{"pattern": "\\k<a>+(?(?=a)[\\pL\\pL][](?!(?(?C1)(?=a)\\p{^Lu}*+?||#\\k<a>+?))*?)", "extended": true, "valid": false}
+{"pattern": "\\p{sc:Latn}|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{Xan}\\x{110000}**", "extended": true, "valid": false}
+{"pattern": "(?<b>[[:bogus:]])", "extended": false, "valid": false}
+{"pattern": "(?-1)[][:bogus:]a](?aD)[]\\N{2}", "extended": false, "valid": false}
+{"pattern": " ", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\U(?(?C1)(?=a)[^\\8])é|", "extended": false, "valid": false}
+{"pattern": " (?+1)(?x)", "extended": false, "valid": false}
+{"pattern": "(?i:\\w\\g<-1>{3,2}\\g<a>|(*pla:[[:bogus:]\\R\\d\\b](?+1)|[[.a.]😀\\Q-]\\E[:^alpha:]]))|[-][\\x{41}]{2,3}(?<=\\K\\pb\\b{,3}|[^\\R[=a=]])\\x{110000}*?", "extended": true, "valid": false}
+{"pattern": "\\p{^Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aD)(?(a)(?<!(?:\\B*||[a-\\d])(*plb:\\k'b'{,3}|[-\\g[:word:][:alpha:]])(?(?=a)[\\d-a\\R\\d]\\b))\\Qa)\\E?(?C\"x\"))", "extended": true, "valid": false}
+{"pattern": "(?<b>\\g<-1>{,3}|(?<b>\\d)|(?(-1)(?'a'|[[=a=][:alpha:]\\h^*?){,2}{3,2}[^[:word:]\\x{41}\\w[.a.]]|-{65536}(?aD)(?<b>[^a-\\d\\R\\d-a[\\N\\cA\\h]*?(?P>a)|(*ACCEPT))))(?>[^\\d-a\\E\\E])[^][\\b\\d\\][:word:]]{3,2}(?Cx)|", "extended": false, "valid": false}
+{"pattern": "(?>(?-1)[^](?P=a)*?)|(?(-1)\\P{Xan}\\p{Greek}\\10)", "extended": true, "valid": false}
+{"pattern": "[\\-[:alpha:]]\\p{L}\\k<a>", "extended": false, "valid": false}
+{"pattern": "(?R)?\\K{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[](?(DEFINE)(?(VERSION>=10.4)(*sr:[]|{ 2 , 3 }|){ 2 })(?1){2,}[^])[[:word:]]&]", "extended": true, "valid": false}
+{"pattern": "(*sr:\\N[^[.a.][.a.]\\E]\\p{^Lu}*|(?(?=a)(?(?=a){3,2}{2,})*?[\\b[]\\p{^Lu}+|[^[:word:]\\d[:bogus:]]\\pb)*+)(?(DEFINE)[z\\d\\Q-]\\E]{ 2 , 3 }){65536}[😀-😂\\d-a]]\\w", "extended": false, "valid": false}
+{"pattern": "[^][^]\\K(?C)(?(?=a)[a-z^\\]])", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "((?i:(?=[\\-\\p{L}😀-😂\\cA](*MARK)\\p{L}{,3})**[^[:bogus:][.a.][:word:][]|(?J:[-\\d]|){3,2}\\x{41}[\\w]])(?(VERSION>=10.4)\\G)){2}", "extended": false, "valid": false}
+{"pattern": "(?n)(*pla:\\k{2,3}(?-1)\\p{Greek}|(*atomic:\\cé|(?(?C1)(?=a)(?i)|[]\\g{-1}|)\\x41[a\\hz])(?:-\\U)[z-a[:^alpha:]z])|(?>[\\b[=a=]]|(?+1)(?<=\\g-1[z\\w\\p{L}]][\\cAa[:word:]]|\\g<a>[](?(R)(*UTF){2,3})){ 2 , 3 })\\p{^Lu}[\\x{41}[:word:]]", "extended": false, "valid": false}
+{"pattern": "[[:bogus:]\\Q-]\\E\\R-][]\\p{L}?(?(R){,2}|[]{2,}^?)(?=[a-\\d]\\p{sc:Latn}[\\N\\]]|(?(a)(?:\\G\\p{Bogus})|[😀-😂])|[[=a=]a-\\d]{,3}|(*plb:(?(R)*?(*MARK){2,}[a[]+|\\_\\pL)?(?=[[:word:]z-z])))", "extended": false, "valid": false}
+{"pattern": "[\\-]\\p{L}(?<b>\\_(?J)\\10){65536}", "extended": true, "valid": false}
+{"pattern": "([😀]\\C){2}\\p{ L }[^\\d-a[\\w\\]\\p{Bogus}(*BOGUS)", "extended": false, "valid": false}
+{"pattern": "\\g{a}(?(R)(*nlb:\\g{a}\\p{^Lu}[😀\\g])(?(?C1)(?=a)\\g<a>(?(VERSION>=10.4)\\U|[\\C\\E\\8a-z]{(*BOGUS){2}_)|{)[\\N]|(*SKIP)|😀++){65536}\\x{ 41 }(?<!(?=\\8|\\k{a}\\z(?=\\p{L&})){[\\][:bogus:]](?(1)\\p{Bogus}[][:word:]]*+\\_*?)|(?=(*BOGUS))(?C1){,3}(?(-1)[\\pL\\p{L}a-z]|[\\d😀-😂^]|))", "extended": false, "valid": false}
+{"pattern": "\\b\\g-1[[:bogus:]😀[][[:alpha:]\\C\\w\\d]", "extended": true, "valid": false}
+{"pattern": "(?(-1)[a\\C[:word:]]\\w|\\E)\\10#(?&a)\\N{U+41}", "extended": false, "valid": false}
+{"pattern": "(*atomic:\\Q\\E(?C\"x\")(?(?C1)(?=a){2,1}[\\Q-]\\E]||[\\R](?i:\\E+?[\\Q-]\\E[:alpha:]]{3,2}))|[\\x{41}]|", "extended": false, "valid": false}
+{"pattern": "(?'a'\\8{3,2}(*nlb:[\\C\\d😀-😂]|[]){2,}\\A)\\b(*nlb:(?|(|(*SKIP))\\k'b'(?#c))*?[]a\\d[]\\x{41}){2}(?(R1)[[=a=][=a=]a-\\da-z])", "extended": true, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(*atomic:\\p{Bogus}\\10\\g<1>*+){ 2 , 3 }[😀-😂\\p{L}]\\d0", "extended": false, "valid": false}
+{"pattern": "\\p{L&}?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "_*?[\\x{41}\\C](?=\\k<a>\\K)|[a-\\d\\g\\pL]*+\\81", "extended": true, "valid": false}
+{"pattern": "(?(?=a)[[:alpha:]\\h](?|[\\w\\pL])||(?J)|)\\A", "extended": false, "valid": false}
+{"pattern": "[[:bogus:]\\x{41}]", "extended": false, "valid": false}
+{"pattern": "(?P=a)(?<b>(?(DEFINE)(?^)+(?+1){|)[z[.a.]]\\8]{3,2}-)\\A\\u0041", "extended": false, "valid": false}
+{"pattern": "(?-1)[^]][😀[:word:]\\N]+?", "extended": false, "valid": false}
+{"pattern": "(?Cx)[^😀-😂]?_{2}[]", "extended": false, "valid": false}
+{"pattern": "(?&a)|\\g1(*pla:(*pla:{1}|(?(<a>){?|(?R){2,}(?-1))*+(*atomic:\\Q\\E|[\\C\\pL])|(*nlb:-|\\pL){ 2 , 3 }|(?J:)|]+)*|\\g-1+?[\\8])", "extended": false, "valid": false}
+{"pattern": "(\\K|[\\p{L}\\w\\Q-]\\E\\C|((?(VERSION>=10.4)[]-[]\\h)[^][\\p{L}-\\Q-]\\E\\Q-]\\E])\\p{L}){[]", "extended": true, "valid": false}
+{"pattern": "(?<=(?(<a>)a(?(R){,2}|[\\][:word:][:word:]\\pL]|(?^))(?C256)|(?J:(?J)|[^\\R[.a.]][\\cA])++))\\N", "extended": false, "valid": false}
+{"pattern": "(*pla:(?n){2,}|(*plb:[😀-😂zz-a[]{3,2})+?)(?-1)(?(-1)(?P>a))|", "extended": false, "valid": false}
+{"pattern": "(?J:}\\c(*MARK)|\\R(*pla:(?i:[\\d-a]\\C))*+", "extended": false, "valid": false}
+{"pattern": "😀(?J:\\cA\\g<1>)(?Cx)[-a-z]", "extended": false, "valid": false}
+{"pattern": "(?(1)(?>\\8(?<a>(?P=a)||)(?|)++)?\\X(?(?C1)(?=a)\\g<a>([[:bogus:]\\pL\\pL]||)[^\\w\\x{41}\\N\\b]){65536}|(?<=(?-1))(?(DEFINE)\\8(?#c){,3}|(?:\\c||\\k'b'[^\\]]+?(?|\\g<1>?)(*atomic:[^\\Na-z))++)(?(?=a)\\g1(?<a>(?<=\\g{+1}+|[\\Q-]\\E\\d^[=a=]]++{2,})*|\\x{41})[])[^😀-😂\\R\\R\\]]{ 2 }", "extended": false, "valid": false}
+{"pattern": "(?!(?(R)\\p{^Lu}{65536}](*pla:[^😀-\\a][^]*\\p{Bogus}{2,}|[^]){ 2 , 3 }){3,2}){ 2 , 3 }\\p{sc:Latn}\\k|[\\h[:^alpha:]]", "extended": false, "valid": false}
+{"pattern": "(?#c){,3}|\\x{41}+(?=\\p{Greek}|\\Q\\E\\8*+)(?(-1)(?+1){65536}|(?(R1)\\g-1\\2)[[:word:]\\]😀-😂]{2})", "extended": false, "valid": false}
+{"pattern": "(?'a'(*nlb:(?P=a){65536}(?'a'[\\8]|)+\\é)(?+1))(?#c)[^😀\\p{L}\\E][]+?", "extended": false, "valid": false}
+{"pattern": "(?(1)_)\\N{U+41}|{{\\é(?:(?(R1)(*sr:||\\A(?<a>[\\p{L}[:bogus:][=a=]]\\p{ L }{|))|\\cé|)", "extended": false, "valid": false}
+{"pattern": "{,2}{65536}\\G{\\w{,3}([](?>(*MARK:m)\\cA*\\_|(*ACCEPT)(?'a'[\\R\\8]|{3,2}$*\\g{-1}))", "extended": true, "valid": false}
+{"pattern": "\\p{Bogus}(?<=(?(-1)[](?(R1)^(?Cx))(?(DEFINE)\\c?\\g-1))[^\\g😀-])", "extended": false, "valid": false}
+{"pattern": "(?(?=a)\\x{41}|(?![a\\Q-]\\E\\w])**(?<=[\\p{L}]|[\\-\\Q-]\\E]{2,3}).)[^\\C]{65536}(?(VERSION>=10.4)[😀])${", "extended": true, "valid": false}
+{"pattern": "(?(VERSION>=10.4)\\A|(?<a>\\u0041(?(?=a)\\u0041[^^z-a]|\\g{-1})|(?(-1){2,3})\\B(*nlb:)++))(?<a>(?i:\\N{65536}\\pb|){65536}[\\]\\]\\N]|(?(<a>)(?<=[\\Q-]\\E]\\p{Greek}\\z|(?x)|\\x{110000}\\10)\\Qa)\\E(*MARK:m)))**&(?(DEFINE)\\N{U+41}\\A|^)[^]*?", "extended": false, "valid": false}
+{"pattern": "(?(?=a)[\\p{L}\\h\\d](*pla:[[:alpha:]\\pL\\]][^[\\8\\bz-a]|)*(*pla:[\\d-a[:word:]]|(?C)|(?<b>\\C))|^(*nlb:(?(?=a)(*MARK)(?aD){,3})(?(R1)\\k<a>[\\d-a\\Ea-z\\-][]|\\g{+1}*\\U{)*|#)*+)((?(<a>)&|[^[:bogus:]](?(1)#){(*atomic:))(?J:[^\\b][:word:]\\h])(*sr:(?:[\\N\\d])|)){[\\Q-]\\Ez][]+?", "extended": true, "valid": false}
+{"pattern": "\\1+", "extended": false, "valid": false}
+{"pattern": "[^^]*+(?(R1)(?<=[](?^)|\\g<a>\\g{-1})[^\\-\\b^😀](?(?=a)(?>(*FAIL)*+))|&)[[:bogus:]]]", "extended": true, "valid": false}
+{"pattern": "(?&a){,3}(?(1)(?u)(*atomic:[](?(R1){ 2 , 3 }\\10)**\\c)*(?'a'[\\]\\g\\C](?<a>{,2}|\\U{2}\\Qa)\\E*?)?\\k{a}))(?>[😀](?(R1)(?(DEFINE)[\\R^^]}\\012*|😀**)\\p{L&}{2,})\\pL)[]", "extended": true, "valid": false}
+{"pattern": "\\g1[]?${2}(*sr:(*plb:(*ACCEPT)(*pla:\\p{^Lu}))\\u0041)|[^\\-]*?", "extended": true, "valid": false}
+{"pattern": "[[.a.]\\w\\h\\-]", "extended": true, "valid": false}
+{"pattern": "\\E_\\b[\\d-a😀](?n)|", "extended": true, "valid": false}
+{"pattern": "(?!(?(a)(?C\"x\")+(?(<a>)|\\R{|)|[^\\-😀a-z[=a=]](?'a'++)|)(*BOGUS))\\C[[\\Na-z\\]", "extended": false, "valid": false}
+{"pattern": "(*MARK:m)**{ 2 }😀(?^)", "extended": false, "valid": false}
+{"pattern": "(?<b>(?(R)\\b)(?>(?P<a>(?C256){a\\g1|\\P{Xan}|)*+(?(R1)\\g<a>{ 2 }\\o{101})|[za-\\d]*|(*pla:0[^\\N-]\\x{41})[^a-z\\pL[])||(*pla:(?P<a>a(?n)|)[\\wa\\x{41}]|[a-\\d[=a=]\\w]|(*atomic:*?[]\\d][]a-\\d\\E]){,3})|)", "extended": false, "valid": false}
+{"pattern": "(?(<a>)[^😀]|(?(VERSION>=10.4)[^\\C](*plb:[\\g\\cA]{65536})|[^\\pL[=a=][:bogus:]\\d]{ 2 , 3 }(?=(?Cx)😀[\\x{41}]))_(?Cx))(?i)(?&a)\\c*?", "extended": true, "valid": false}
+{"pattern": "(?!(?i:[\\p{L}]{,3}(?(R1)|\\g<-1>{,3})😀){2,3}|(?(VERSION>=10.4)(?(?C1)(?=a)\\p{L}|)(?i:[][\\d-a]|{++))\\p{^Lu})[a-z\\C][](?J)", "extended": false, "valid": false}
+{"pattern": "\\o{101}{|[]{,2}*+ [^\\x{41}\\h[.a.]\\x{41}]**", "extended": false, "valid": false}
+{"pattern": "[^\\8😀-😂[:^alpha:]][^]{ 2 , 3 }0(?:(?(R)\\g{-1}\\g<-1>|(?(-1))))|(?(DEFINE)(?|\\Q\\E\\pL){ 2 }{3,2}\\p{Bogus}|\\x{110000}(?Cx){2,3}|(?![😀-😂[=a=]a-\\d]|(?(1)\\_|{,3}))+){2}", "extended": false, "valid": false}
+{"pattern": "[z]\\g]\\cé\\Q\\E[]|", "extended": true, "valid": false}
+{"pattern": "_*+(?(-1)[]*?(*SKIP){[]|}(?C))(?(VERSION>=10.4)[[=a=]])", "extended": false, "valid": false}
+{"pattern": "[]|[a-z](?:[\\\\Q-]\\E[:word:]](?(?=a)(*pla:😀)\\g{-1}(?C\"x\")|)++(?=b*+|\\k<a>){65536})[]", "extended": false, "valid": false}
+{"pattern": "(?<a>\\x{ 41 })(?C1)*\\pb", "extended": false, "valid": false}
+{"pattern": "(?!(?![\\b])(?<a>(?P=a)(?|#))(?i:\\cé\\p{L}|{ 2 }))(?<=😀)(*pla:(?(a)(?(<a>)(*SKIP)?)[^\\h\\b][\\x{41}\\-\\R😀]|[[=a=]\\d-a]*?)\\x{110000}", "extended": false, "valid": false}
+{"pattern": "{,2}{2,3}\\k'b'", "extended": true, "valid": false}
+{"pattern": "\\g-1\\dé|", "extended": false, "valid": false}
+{"pattern": "\\g{+1}\\g{a}{ 2 , 3 }\\é", "extended": true, "valid": false}
+{"pattern": "(?(<a>)(*pla:\\g1a\\p{Bogus}+?)|(*UTF)+)(?i:[^\\d[:word:]]{65536})[]*+[]", "extended": false, "valid": false}
+{"pattern": "[\\b\\pL\\-]{3,2}(?<a>(?'a'(*atomic:)?\\U\\81|(?(a)(*atomic:\\Qa)\\E.){,3}|(?i:\\8++é)\\o{101}(?i:{,2}\\1?||))[^z-a\\d-a\\R])\\pL", "extended": false, "valid": false}
+{"pattern": "[^][\\a\\C\\E](*nlb:(?(VERSION>=10.4)\\p{^Lu}\\K|\\p{Greek}**|[^\\C](?(R1)(?C)*))é)", "extended": false, "valid": false}
+{"pattern": "\\x{ 41 }\\g-1*?\\w\\b[^|", "extended": true, "valid": false}
+{"pattern": "(?C1){,3}[]", "extended": false, "valid": false}
+{"pattern": "(*pla:}+)*\\p{sc:Latn}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*MARK:m)(?'a'((?>++(?n)|{65536}){65536}[--a-z\\x{41}]++[[.a.]\\p{L}]{65536})(?|(?(-1)\\10[😀-😂\\-[=a=]\\-]|\\8\\x{110000})))(?J:(*sr:[^a-\\da[=a=]]|(?=(?^)(?u){,3}|\\1(?Cx))(?>)|(?'a'{)?)*(?P<a>\\k|_\\p{sc:Latn}{,3})|\\p{sc:Latn}[😀[:bogus:]-][]*){2}", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(?(?=a)(?=a|\\P{Xan}(?u)\\pb{3,2})\\p{sc:Latn}\\p{Greek})(?P<a>(?<!\\g<-1>|\\c+)*+(*MARK:m)|[](*MARK)[[\\b]+){ 2 , 3 }[\\w\\E](?|\\g{-1}*+)\\8{2,}", "extended": true, "valid": false}
+{"pattern": "(?!\\p{L&}{3,2}|)(?'a'\\8*?[[:word:]\\p{L}\\g](?(DEFINE)(*atomic:\\K)++ (?(VERSION>=10.4)\\C\\10**||)||(?(-1)(?^)\\b)){2,}|\\p{^Lu}{3,2}|[^zz-a\\h)(?<={1}\\p{^Lu}(*MARK:m)|[](?(-1)[^\\p{L}\\p{L}\\d^]{|\\cA|]+?[z-a😀-😂]{2,3}))*+[\\C\\pLz-a]", "extended": true, "valid": false}
+{"pattern": "(?C\"x\")(?P=a){3,2}(?1)(*atomic:(?J:(?<=\\pL{65536}(?J)){,3}(?(-1))|)(*MARK:m)|(\\G]|\\N{U+41}\\p{Bogus})+?\\P{Xan}{ 2 , 3 }){3,2}[\\N", "extended": false, "valid": false}
+{"pattern": "#(?(VERSION>=10.4)\\w(*nlb:(?i))[\\p{L}[:alpha:]]|\\g{-1}){3,2}\\g<1>(?>(*pla:(?<!$*|\\b**|)|{2,1}**[\\cA-\\-\\p{L}]])", "extended": false, "valid": false}
+{"pattern": "(?P>a)(?(<a>)(?x)|(?<a>\\x{ 41 }{ 2 , 3 }[^[=a=]z-a[:word:]\\]]{2,3}[^]|(?={é|+[\\w^]])))(?(VERSION>=10.4)(?-1){2,}(?<=[a[:alpha:]\\R]|\\z?(*nlb:[]|(?J:[])(?(?C1)(?=a)(?1)\\d)))😀", "extended": false, "valid": false}
+{"pattern": "(?<b>(?<!(?J:\\o{101}\\g<a>^|)[^[\\d-a]+(?<=\\2)|(?^)(?J)*)\\8**\\b++|(*nlb:\\p{Bogus}(?:😀|\\Q\\E)) ){2}", "extended": false, "valid": false}
+{"pattern": "(?<!(*plb:(?!(?C)é)|[\\cA]\\G)(*MARK:m)++[^[:word:]\\Q-]\\Ea]{2,3})[[:^alpha:]\\d]\\k{2}(?(-1)(*UTF))[\\R[=a=][.a.]\\p{L}]", "extended": true, "valid": false}
+{"pattern": "(?<b>(?(R)(?(R)$(*SKIP)){,3}(?i:[^]|(?R)[]{,3})||(?aD)(*pla:{1}.{2,1}*?)[\\w[:word:]]|)(?<a>\\Q\\E){3,2}(?<=(?u)*[[:bogus:]a\\w😀]{ 2 , 3 }a+|(*SKIP)\\x{41}(*UTF))|\\x{110000}{2,})++\\X[^\\d-a[=a=]a\\N]{2,}[\\Na-z\\w\\cA]\\b", "extended": true, "valid": false}
+{"pattern": "\\g<-1>++(?<![^\\R]|\\012++\\p{L})(?(?=a)(?<a>(*MARK)(?(VERSION>=10.4)(?C1))|\\h))(?C)", "extended": false, "valid": false}
+{"pattern": "((?J:}(?C){ 2 }**|)|\\B😀)[\\g\\E](?(-1)(?i)|[a-\\d{2,})(*FAIL)", "extended": false, "valid": false}
+{"pattern": "(?C\"x\")\\X\\C(*plb:\\w|(*nlb:\\cé{3,2}(?R)(?(<a>)_😀{,3})*\\p{L})", "extended": false, "valid": false}
+{"pattern": "[^\\cA-]](?>[^[=a=]\\pL--])", "extended": false, "valid": false}
+{"pattern": "\\B[^](?J:(?!(*BOGUS){3,2}(*FAIL)[😀\\h[:alpha:]\\h])|\\G\\w(?<a>\\pb\\g<a>(?(<a>)[^\\cA\\cA\\Q-]\\E]]\\x{ 41 }[^])|(?={65536}|]{2,}\\p{Bogus}{3,2})[\\][:^alpha:]z-a](*UTF))){2,3}[\\]", "extended": false, "valid": false}
+{"pattern": "\\p{ L }{ 2 , 3 }\\x{41}|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C1)(?=a)(?(-1)😀?\\g<a>{3,2}|{2,1}?\\z{65536})|\\R(?C)|\\g{a}*?(?(R1){2,1})(?J:(*sr:(*BOGUS)|)+))\\k{a}][😀-😂z\\p{L}]\\N|", "extended": false, "valid": false}
+{"pattern": "0{3,2}(?:\\é(*sr:(?(VERSION>=10.4)++|)(?i:\\g<1>\\U))[^[:word:]😀-😂a-\\d]|[[.a.][=a=]a-\\d]\\X{2}){ 2 , 3 }(?(1)[a-\\d\\E\\C]]**[^😀]])", "extended": false, "valid": false}
+{"pattern": "{{2}\\h{ 2 , 3 }[\\Ra\\8]{,3}(?R)\\g<1>|", "extended": true, "valid": false}
+{"pattern": "\\x{ 41 }(?'a'\\pL{2,}(?1))(*BOGUS)\\10++(?u)", "extended": false, "valid": false}
+{"pattern": "[^\\-az\\]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:[\\d\\d-a\\h\\x{41}]\\G)*", "extended": false, "valid": false}
+{"pattern": "[^\\x{41}\\]]**", "extended": true, "valid": false}
+{"pattern": "😀(?(R1)(?|\\K{,3}|(?(?=a)\\b(?C\"x\"))\\K{65536}))[^z]{,3}", "extended": false, "valid": false}
+{"pattern": "(?Cx)|[[\\-\\8](*UTF)", "extended": false, "valid": false}
+{"pattern": "(?P<a>[\\p{L}\\C\\C]|[][😀-😂a].)*+(?<=(?=(?<a>(?u)[\\8\\d\\g^]+|)|{)", "extended": false, "valid": false}
+{"pattern": "[^]a(?u)(?J:(?(R)(?(?=a)(*MARK)))*?(?'a'[[:bogus:]a-\\d]{65536}|(*plb:[\\\\p{L}z-a]\\x{ 41 }(?1){ 2 , 3 }))[^[:word:][.a.]]|\\Qa)\\E{2}(?<=(?(a){1}[]|[\\Ca-\\d[:word:]😀-😂])*(?>[\\p{L}])))\\g<a>|", "extended": false, "valid": false}
+{"pattern": "(?&a)[\\Q-]\\E]\\2{2,}", "extended": false, "valid": false}
+{"pattern": "(*sr:(?(a)(?(DEFINE)\\d**|(?C)[^\\pL])[-]+(?!\\z\\x{ 41 }{2}|\\N{U+41}{2,3}|)**😀){65536}(*atomic:(?'a'\\é{2}\\d)|[\\C])\\X{(?!\\g<1>(?(R1)😀*|(?(VERSION>=10.4)(?^){0++|)é|\\012)*+", "extended": false, "valid": false}
+{"pattern": "[\\d-a\\Q-]\\E][[:word:]\\Q-]\\E\\g]?(?Cx)[]", "extended": false, "valid": false}
+{"pattern": "&{65536}(?(a).)[[\\b\\Q-]\\E[:bogus:]](*nlb:(?1)|(?(<a>)\\w*)(?Cx)|(?J:$\\N{U+41})){|(?<a>(?1)[-a-\\d[=a=]+?|\\p{^Lu}\\_)", "extended": true, "valid": false}
+{"pattern": "😀{,3}[\\d-a](?+1)(?:(*nlb:(?=?\\E(?n))?|[^]{2,3}", "extended": false, "valid": false}
+{"pattern": "[\\8-a-z\\pL]0\\cA*?[^][=a=]]++", "extended": true, "valid": false}
+{"pattern": "(?>(?(VERSION>=10.4)(?>\\g<a>*){ 2 , 3 }[😀\\cAz[:word:]]+(?={(?C256))){2,3}\\d|)|(?(1)(?P<a>[\\]|[\\R[[\\h][^\\p{L}[:word:]z-a][\\R😀z]*+)#[\\8\\w]++)", "extended": false, "valid": false}
+{"pattern": "a(?#c)(?>(?n)*+\\Q\\E+(?:(?|))||(?(-1)(*atomic:[^^\\d[=a=][]|)(?P<a>-|(?![😀-😂a]{ 2 , 3 }|[\\b\\b]|\\Qa)\\E)){65536}\\C)[\\E]", "extended": false, "valid": false}
+{"pattern": "\\p{ L }++}|(?:(*nlb:[\\-]\\Q-]\\E[:bogus:]](?'a'[a-\\d😀-😂\\]]\\cA\\p{ L }{2,3})?)**b)(?(<a>)\\R{3,2}(?(DEFINE)\\o{101}|(?(R)\\Q\\E{1}[[:alpha:]^]|){,3}){2,3}[]|\\z\\2++){65536}", "extended": true, "valid": false}
+{"pattern": "(\\h|[^\\w])(?C)\\p{Bogus}\\b{65536}\\k{a}", "extended": false, "valid": false}
+{"pattern": "\\d?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A(?(?C1)(?=a)(?(a)(?x))+\\d(?:[][az-a]))\\b(?i:\\x{41}(?<=\\U\\P{Xan}(?C){ 2 , 3 })|\\p{Greek}(*pla:[^[:word:]])(?(VERSION>=10.4)\\p{sc:Latn}(\\h{2,3}||\\N)(?(1)(*BOGUS)|[^])))#", "extended": false, "valid": false}
+{"pattern": "\\Q\\E[\\E]", "extended": false, "valid": false}
+{"pattern": "\\g<a>\\_[](?i)", "extended": false, "valid": false}
+{"pattern": "{1}(?C256)[[=a=]^a\\g]", "extended": false, "valid": false}
+{"pattern": "{|\\K{3,2}(?!(?(1)[a][^a-z[:bogus:]]*+|[\\]\\\\b]\\d*+\\x{41}))", "extended": false, "valid": false}
+{"pattern": "(*BOGUS)(?![^[:^alpha:]]**\\é_**\\N(?^){3,2}", "extended": true, "valid": false}
+{"pattern": "[\\ha-z](*BOGUS)(?n)(*sr:(?1)(*nlb:[]\\R\\E][\\w\\-](?<!\\p{L}\\81+\\p{^Lu})|[^a][^])(*pla:[^\\]\\R])*)", "extended": false, "valid": false}
+{"pattern": "^(?|(*BOGUS))", "extended": false, "valid": false}
+{"pattern": "((*sr:(*atomic:\\8[[\\8\\E\\E]😀{65536}){2}(?(DEFINE)[[:^alpha:]\\]{3,2}\\k\\10|[\\8\\Q-]\\E\\-[]){)**[[.a.]\\pL[.a.]\\h])[a-\\d]\\E]\\é[\\w[:alpha:]]\\g]", "extended": false, "valid": false}
+{"pattern": "(*UTF)(*SKIP)[a-z\\R\\d\\]]+?(*atomic:[[:word:]\\x{41}][]+?|(?#c)|(*MARK){,2})", "extended": false, "valid": false}
+{"pattern": "\\o{101}(?i:(?(1)(*sr:|)}|(?-1)))(?(VERSION>=10.4)(*sr:{\\N{U+41}(?<a>**|){3,2})[]*|(?C\"x\"){2}[^\\Q-]\\E])0", "extended": false, "valid": false}
+{"pattern": "(?x)\\012{2,}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#c)(?(R)&)|(?>(?(?C1)(?=a)\\R\\K(?<![\\b]){)[]||[^a-z\\E\\b\\C]{3,2}0)(?C256)(?&a)", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)(*plb:(?(a)++|[]){,3}|[^]a{2}|(?P<a>[\\E]+?\\w)[\\N\\cA[:alpha:]\\-])(?(DEFINE)\\E(?(R1))\\cA++)\\p{ L }(?(R1)]|\\B)?(?<b>\\8\\g{-1}|a)[\\N\\N[:^alpha:]]", "extended": true, "valid": false}
+{"pattern": "(?J)*?", "extended": false, "valid": false}
+{"pattern": "\\B[\\hz\\w]\\G(?(VERSION>=10.4)[^\\-a-z]**|[^\\x{41}\\E[:^alpha:]]||\\8)+?", "extended": false, "valid": false}
+{"pattern": "(?C1)\\x{41}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[(*FAIL){\\k", "extended": true, "valid": false}
+{"pattern": "[\\w]|(?(?C1)(?=a)(?(R)[\\R][[:^alpha:]😀[:alpha:]][\\[.a.]a\\cA]))+|(*pla:\\B\\10{2,}|[\\bz\\E\\N])", "extended": false, "valid": false}
+{"pattern": "(?:0|)+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\N{U+41}|(?(DEFINE)(?(R)(?(1)\\c\\81(?u)))\\p{ L }|)|", "extended": false, "valid": false}
+{"pattern": "[\\g[=a=]\\]\\cA](?(a)(?P=a)[\\w]|\\h{2,3})|", "extended": false, "valid": false}
+{"pattern": "[😀-😂\\Q-]\\E\\x{41}\\d-a][a-\\d]?|(?!([\\d-a](?<a>)(?&a)++|[](?!😀^))*+\\h|[^\\C\\p{L}]\\u0041(*SKIP))(?J:b|(?P<a>(?i:(?u)[[:word:][:bogus:]]*+){3,2}|(?<a>[\\b[:alpha:]a-\\d😀-😂]|))*?){2,}|(?:a[a\\d\\p{L}]|[[:alpha:]]\\cé)", "extended": true, "valid": false}
+{"pattern": "(?P<a>(?|{2,1}\\E||(*nlb:\\U*+)+?)*[\\d-a[:^alpha:]\\h|[^a-z😀-😂](?n))*?(*sr:^[^[=a=]])\\X+?(?!(?n)\\x41(?(a)[](*atomic:(?(a)(?C\"x\"){2,3}|\\p{L})|(?C)))", "extended": true, "valid": false}
+{"pattern": "(?(1)(?(-1)(?(a){2,1}|[^😀😀])(?(-1)\\cé{65536}|)|_*)){65536}\\p{L}+?(?(DEFINE)(?(1)[a\\d[:bogus:]](?i))?(?<=\\A(?&a)[\\g[\\cA\\g]{ 2 , 3 }))\\C{2,3}(?(R)\\x{ 41 }(?1)(?<=(*plb:(?-1)| \\pL*+|[^[.a.]a-\\d]*[😀[:alpha:]z]){3,2}(?(VERSION>=10.4)(*ACCEPT)){3,2}\\G)|(*atomic:(?:[]a[:bogus:]\\g]\\B|)\\h{3,2}|\\g<a>*+))", "extended": false, "valid": false}
+{"pattern": "#\\g-1{3,2}\\p{Greek}\\C**[\\cA]*", "extended": false, "valid": false}
+{"pattern": "(*plb:(?R)*+)\\g{a}\\k<a>{", "extended": true, "valid": false}
+{"pattern": "([]{65536}|[a-\\cAa-z] )(?(?C1)(?=a)(?>(?<=\\g{a}{,3}\\g{-1})(?=|\\g{-1}.)){2,3}|(?#c)**[^\\ga-z]|(?P<a>\\G**)\\g{-1}(?J:(*ACCEPT){,3}|a[])**){2,}\\10", "extended": false, "valid": false}
+{"pattern": "[\\-[:word:]\\N[:bogus:]]", "extended": true, "valid": false}
+{"pattern": "[\\]\\E]{ 2 , 3 }|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-1)|", "extended": false, "valid": false}
+{"pattern": "[\\p{L}]\\w]{65536}", "extended": true, "valid": false}
+{"pattern": "(?^)(?i)(*plb:(?Cx)(?(<a>)\\p{^Lu}(?(a)\\k{a}){|(*atomic:\\g1)){2,3})++(?C256)?|(?(?C1)(?=a)[\\p{L}](?|[]{,3}[\\d[.a.]]++[^]+)*+\\E{2,3}|[\\cA\\+ {65536})", "extended": false, "valid": false}
+{"pattern": "(?'a'(*MARK:m)&", "extended": true, "valid": false}
+{"pattern": "(?i)|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*plb:(?(VERSION>=10.4)(?P=a)\\cA(?C256)|(?P<a>\\B{2}|[^[\\]+(?(R1){2,}(?#c)|[[.a.]^\\]])+)?\\k{a}(*plb:(?J:\\g<a>[-\\p{L}]|\\pL{2,3}(?x))(?C)))(?:]|(?(R1)\\g{a}|(?(<a>)|[😀a-\\d\\-[.a.]])(*atomic:[]\\-[:word:]]{2,3}|(*MARK)||))\\k'b'){2,}\\g{-1}{,3}[😀\\h\\d\\g]", "extended": false, "valid": false}
+{"pattern": "[[:bogus:][:^alpha:][:alpha:]]\\1", "extended": true, "valid": false}
+{"pattern": "[\\81**(?<a>(?'a'(?<b>{ 2 })(?(1)\\k|\\p{L&}?|)?)(?(<a>)(?i)(?'a'\\U\\k'b')))$(\\K\\p{Bogus})**", "extended": false, "valid": false}
+{"pattern": "(?^)|\\pb(?&a)", "extended": false, "valid": false}
+{"pattern": "(?(1)[[:bogus:][:word:]\\cA\\]{2,}|\\2)\\U", "extended": true, "valid": false}
+{"pattern": "(?<!(*UTF)?[-^\\E]){,3}\\X", "extended": false, "valid": false}
+{"pattern": "[\\pL[.a.][:^alpha:]][\\]\\C[:bogus:]](?>(?|(?<!)(*MARK:m)|0{)\\g<-1>\\b|)\\8|", "extended": false, "valid": false}
+{"pattern": "(?(<a>)(?(?=a)(?<![a-z\\-😀^])|(\\K[^])\\g<1>(*nlb:{2,1})|(*atomic:(?:{2,}|\\p{sc:Latn}*+\\p{sc:Latn}\\p{L}{3,2})[\\E[:word:]]\\cA]{2,3}(?<!(*MARK:m))|[-])){2,}(?:[^\\d-a]{,3}(*ACCEPT))(*FAIL)*?", "extended": false, "valid": false}
+{"pattern": "(?(R)(?(R)\\w(?<b>[\\h\\E]#){2,})(?:[[=a=]-a-z](?^)(?(?=a)[a\\8]|\\u0041)|[^[:word:][\\Ez](?n){2,}(*atomic:{2,1}?){,3}))++(?-1)\\p{L&}[^\\[:^alpha:]a-za]", "extended": false, "valid": false}
+{"pattern": "(?'a'(?(<a>)(?|{3,2})(*pla:)){65536}\\U|a(?i:[\\R])(*plb:(?(R)(?'a'*?(?&a)){2,}((?(-1)(?&a)|(*FAIL)||)){2,}(?C\"x\"))", "extended": true, "valid": false}
+{"pattern": "(?(R1)[[=a=]\\8[=a=]](*MARK:m)*|(?'a'[\\d\\g[:^alpha:]\\R](*pla:[])|\\p{ L }|^{,3}[[=a=]\\p{L}\\h]+?(?C256))b)[\\E\\g\\R\\d-a]*?(*BOGUS){2,}\\g<1>{2,3}(?(DEFINE)\\k{a}(?&a))", "extended": false, "valid": false}
+{"pattern": "(*atomic:(?(a)[😀-😂]?|\\u0041\\Q\\E)|[^\\a][\\w\\C]])[\\h[\\cA]", "extended": true, "valid": false}
+{"pattern": "(*atomic:(*atomic:(?i:\\k'b'\\x41|[^za]{65536}[](?aD))|&{2,})(?P<a>(?C\"x\")*?|(?J:_(?Cx))(?|)\\p{^Lu}))(?1)|", "extended": false, "valid": false}
+{"pattern": "(?(<a>)(*nlb:\\g1|\\P{Xan}(?R))){,3}\\k<a>(*atomic:(?!\\012\\_){2}_(?(?=a)(*sr:)(?n)+?))(*plb:(?1)|.)", "extended": false, "valid": false}
+{"pattern": "\\é\\pb{2}(?|(?(R)\\k<a>[a\\Q-]\\E])(*atomic:\\C(?i:b\\k'b'*+|)*[\\w[]))|", "extended": false, "valid": false}
+{"pattern": " [[:word:]\\d-aa]a[\\d-a[:bogus:]](?J:.\\X*+)", "extended": false, "valid": false}
+{"pattern": "(?x)^{2,}|(?!{1}(?-1)&|\\g{a}[])", "extended": false, "valid": false}
+{"pattern": "\\Qa)\\E{2,3}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\G[]\\pb", "extended": false, "valid": false}
+{"pattern": "(?n)((*plb:(?(DEFINE)[\\x{41}[^\\C])[[:bogus:]\\b][😀-😂[:alpha:][:bogus:]]|(*FAIL)[^](?(R)\\x{ 41 }|\\Q\\E))(*pla:[\\E\\h\\h[:alpha:]]))+?\\pb", "extended": false, "valid": false}
+{"pattern": "[^]^{2,1}", "extended": false, "valid": false}
+{"pattern": "\\g-1(?<![a][:^alpha:]😀*|(?<b>\\o{101}#[^]|(?(DEFINE)\\g-1(*FAIL)\\h)){\\2[[:^alpha:]a[=a=]])(*sr:[[:alpha:]\\R\\]\\cA](?i:(*sr:|[^]\\-])\\h)||\\x{110000}(?P<a>(*atomic:\\g<1>)|)\\Q\\E)", "extended": false, "valid": false}
+{"pattern": "(?(R)(?aD)(?![](?C1)))(*FAIL)|\\g{+1}[]", "extended": false, "valid": false}
+{"pattern": "[[=a=]\\R]\\G?", "extended": false, "valid": false}
+{"pattern": "[[:^alpha:]\\h\\d-aa]**(?C){2,3}", "extended": false, "valid": false}
+{"pattern": "[\\[.a.]\\R]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\8\\E[](?P<a>(?(?=a)(?(?=a)[^a-\\d])*+(?(?=a)[])\\g{-1})(?'a'(?(VERSION>=10.4)\\h{65536}[^[:alpha:]\\C\\x{41}a-\\d]){ 2 , 3 }[a-z\\p{L}\\8](*nlb:?[\\d-a\\d\\R\\]])|(?:[\\E]){65536})[[:word:]])*+(?:\\p{^Lu}**(?(1)\\k){2}(?1))\\k<a>", "extended": true, "valid": false}
+{"pattern": "(?(VERSION>=10.4)\\_)\\_|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?(a)(?<![^\\Q-]\\E\\-\\g]+|)(?(a)\\x{110000}|[😀-😂](?-1)+?|){2,})(?^)(?P<a>\\012)|(*nlb:[a-z\\g].|(?(VERSION>=10.4))|\\cé)(?!\\81|\\g<a>\\p{Bogus}){2,3}[\\cA])[^z-a](?C1)(?'a'[])", "extended": false, "valid": false}
+{"pattern": "(*pla:(?(a)(?&a)|(?(VERSION>=10.4)😀[\\-[:^alpha:]z][z|)\\Qa)\\E)|\\81{65536}\\_)", "extended": false, "valid": false}
+{"pattern": "\\w\\N\\h*+\\g{-1}(?=(?#c){ 2 , 3 }(?<!\\B\\x41(?P<a>(?u)*+{1}(?Cx)))|(?(a)(*nlb:\\k<a>++\\X||\\E(?n))(?(1)[^](?x)|)(?:)))", "extended": false, "valid": false}
+{"pattern": "(*MARK)\\k{a}(?(?C1)(?=a)(?i)\\p{sc:Latn}*?_{65536}){3,2}", "extended": true, "valid": false}
+{"pattern": "(?(<a>)(?u)+?)++(?n){ 2 , 3 }\\U", "extended": false, "valid": false}
+{"pattern": "(?1)(?(R1)(?<=(?<b>(*UTF)}){65536}|[]{ 2 , 3 }[😀-😂\\8a-z]]\\Qa)\\E{2}){", "extended": true, "valid": false}
+{"pattern": "\\p{L}(?(a)\\g{a}", "extended": false, "valid": false}
+{"pattern": "(*UTF){3,2}(?n)\\g<-1>(?(R)(*sr:[😀-😂a-\\d]|(?J))\\p{L&})\\cA", "extended": false, "valid": false}
+{"pattern": "(*atomic:(?n)|(?aD)(?<=\\C|\\C|||(*MARK)[\\R[:alpha:]\\d](?(R1)\\p{L}#(?(<a>)\\p{^Lu}+?)|[^])|)\\1", "extended": true, "valid": false}
+{"pattern": "[\\pL\\Q-]\\E\\8\\R](?(1)(?(R1)(?|\\012)++)(?=][\\d\\w\\b\\])(?(VERSION>=10.4)0-(?(R)\\P{Xan}|(?C1){)))[", "extended": true, "valid": false}
+{"pattern": "[^😀-😂[:^alpha:]\\d\\b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?-1))(?<b>(?(?=a)(?J:|\\pb\\Qa)\\E++)[[:alpha:]\\b-\\k<a>)(*atomic:(\\p{sc:Latn}+||[\\E😀-😂^\\w][^\\]\\N]){3,2}\\2|(*sr:|[]{2})))", "extended": false, "valid": false}
+{"pattern": "\\g{-1}(?(DEFINE)(?(1)[\\x{41}[:alpha:]])[😀\\Q-]\\E\\g](?i:(*BOGUS)(?=(?x)(*BOGUS)||){ 2 , 3 }[^]))(?x)(?<!\\P{Xan}{2,}(?+1))", "extended": false, "valid": false}
+{"pattern": "(?(a)(?<=[^\\p{L}])(?(?C1)(?=a)[^\\-][[\\C](?R)|.(?(VERSION>=10.4)|{2,1}))}*){2}(?(R)\\p{ L }{2,}[]\\cA](*pla:\\g{-1}|[\\cA]+?)|[\\p{L}a[\\E])(?J)|\\cA(?P<a>[\\pL]|(?(R1)(?(?=a)[--😀]{2,}|{2,}){2,3}|)+\\X)", "extended": true, "valid": false}
+{"pattern": "\\81[a-z]|", "extended": false, "valid": false}
+{"pattern": "\\g<1>{2}(*ACCEPT)**", "extended": false, "valid": false}
+{"pattern": "(?'a'(?J){2,3}(?R)|[^[.a.][\\-])", "extended": false, "valid": false}
+{"pattern": "(?i:(?(?C1)(?=a)(*SKIP))([\\pL\\pL][-\\b\\x{41}]{2,3}))\\8", "extended": false, "valid": false}
+{"pattern": "\\10[^]{2,}(*UTF){3,2}(*plb:(?=[]{2}(?={,2}[])(?+1){3,2}||\\g{+1}*\\p{L&})(?i:(?:(*ACCEPT)\\c{|0)){", "extended": true, "valid": false}
+{"pattern": "[^😀-😂]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?P=a)\\g{+1}[]{", "extended": false, "valid": false}
+{"pattern": "(?<!\\G[\\ha-z](?=\\o{101}{2})|(?J)+)(?#c)\\p{^Lu}{(*ACCEPT)(*plb:\\p{sc:Latn}?\\C)", "extended": true, "valid": false}
+{"pattern": "(?x){ 2 , 3 }[\\][:bogus:]a-\\d\\R]*?(?&a)[\\w\\x{41}]?\\X", "extended": true, "valid": false}
+{"pattern": "(*sr:(?J:((?J)||\\k{a}(?-1))*(?(<a>)[\\pL\\g]))(?(<a>)(?|_\\k{a}{2})[\\d-a[]\\g<a>)", "extended": false, "valid": false}
+{"pattern": "[^[.a.]a-\\d\\p{L}z](*nlb:\\p{Greek}+)", "extended": false, "valid": false}
+{"pattern": "[^[:^alpha:]\\w\\d[:alpha:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-1)|\\z{", "extended": false, "valid": false}
+{"pattern": "(?!\\k'b'_[^z]+?|0\\G)(*BOGUS)(?J)|(?(R)(*FAIL)|(?(?C1)(?=a)(?(<a>)\\81|[\\?[^\\ha-\\d]{2,3}(*pla:[^[.a.]\\w\\E]|\\k)(?(a)[a\\C]\\N{U+41}|){ 2 , 3 })|(?&a))(*plb:\\z?\\R|(?=(*ACCEPT))){65536}", "extended": false, "valid": false}
+{"pattern": "(?(?=a)(?P>a){2,3}|(?C1))(?J:[[:bogus:]\\d\\E\\N\\P{Xan}*+[\\Q-]\\E]{ 2 , 3 }|0)(*SKIP)", "extended": false, "valid": false}
+{"pattern": "[\\C\\]]\\C]", "extended": true, "valid": false}
+{"pattern": "[\\p{L}\\Q-]\\E\\8][^[:^alpha:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!\\w\\d{2}){3,2}\\cé{2,3}{ 2 }**(?<=(*pla:😀|)|(*atomic:(?=\\p{L&}[]|\\pL\\p{L}[[.a.][\\]\\8]{2,})[^])(?=(*BOGUS)[\\cA[])(?(R)[\\C[.a.]]++))[\\d\\N\\x{41}^]", "extended": true, "valid": false}
+{"pattern": "b{2}[\\Q-]\\E\\Ca]{3,2}\\p{ L }(?C)|", "extended": false, "valid": false}
+{"pattern": "\\cA**", "extended": false, "valid": false}
+{"pattern": "\\k'b'[^]\\1*(?Cx)|(*sr:(?C256)+?)", "extended": false, "valid": false}
+{"pattern": "(?=#**(?(a)(?i:\\1{(*SKIP)(?=)|(?(-1)(?x)\\u0041|))\\o{101}{65536}(*sr:[a-z][:word:]][\\8\\]\\ga])+\\E{ 2 , 3 }(?<a>\\g{+1} ){3,2}(?i:(?x)(?<!(?:+?\\Qa)\\E|)\\E[]\\cA😀-😂\\8]|[\\N\\w])|", "extended": false, "valid": false}
+{"pattern": "\\g1** (*plb:[\\g\\8\\]](?<=(?>\\N[\\-])|(?(-1)\\d\\x41\\E*+|)\\A*?|)\\d||(?i){ 2 , 3 })|([\\C\\C]*?|[[=a=]]{2,}&||\\c|\\k<a>(*FAIL))", "extended": true, "valid": false}
+{"pattern": "\\k<a>|(?C\"x\")\\u0041", "extended": false, "valid": false}
+{"pattern": "(?(R1)(?<!(?(DEFINE)[])(?n)())){3,2}", "extended": false, "valid": false}
+{"pattern": "(?|[^\\Q-]\\E]😀?{,2}[a\\N])${65536}", "extended": true, "valid": false}
+{"pattern": "b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\8+?", "extended": true, "valid": false}
+{"pattern": "[\\cA[:bogus:]](?(?C1)(?=a)[^\\b\\w^\\]]|(?(R)(?>[^\\R\\Q\\E{2}*)**\\p{Greek}{,3}|[^[.a.][:alpha:]])(?C256)", "extended": false, "valid": false}
+{"pattern": "_{ 2 , 3 }", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic:(?<b>[^😀]|)*+{,2}*?){2}\\x{ 41 }{3,2}(*atomic:\\w{65536}(?(DEFINE)&\\B?(?i:[^\\N\\w]|(?<b>[z^\\-][a-\\d\\b])){65536})", "extended": false, "valid": false}
+{"pattern": "[a-\\d\\h[.a.]\\-]", "extended": false, "valid": false}
+{"pattern": "(*UTF){3,2}\\B[\\d-az](?(1)(?(?=a)0(*atomic:\\k<a>|[[:word:][:^alpha:]\\C[:bogus:]]*|[\\x{41}\\g]\\C))|(?1)(?<!\\z[\\x{41}[:^alpha:]+${ 2 , 3 }|){65536}|(?(a)0{2,}[\\C[.a.]a-\\d\\-]|\\p{L}(?<=\\N|[]{2,3})+(?<=\\_{ 2 , 3 }))*)(?i:(?P<a>[\\E[=a=]\\a](?i:|(*MARK:m){2,}\\X)?\\u0041|(?u)(?(R1)(?+1))[^[=a=]\\d-a])++{,2}|(*pla:{2,1}(?(?C1)(?=a)\\g<a>|)(?:(*UTF)+?[]|\\g<a>*){2,3}|(?(?C1)(?=a)\\E+(*UTF)|)))", "extended": false, "valid": false}
+{"pattern": "(?<=(?'a'(?<a>\\c).+|[\\pL])){65536}\\E(?(?C1)(?=a)\\g-1)|\\K\\k<a>", "extended": false, "valid": false}
+{"pattern": "(?(R1)(?Cx)(*plb:(?C\"x\")[\\N](?n)**))", "extended": false, "valid": false}
+{"pattern": "(*nlb:\\p{sc:Latn}[\\\\pL^]", "extended": false, "valid": false}
+{"pattern": "(?(a)[\\d😀]+(?<![[.a.]]{2,}(?(?C1)(?=a)${,3})\\g<-1>)", "extended": false, "valid": false}
+{"pattern": "[+?(*atomic:\\10[^]?)(\\k<a>|0{2,})(?C)[^a-\\d\\h]", "extended": false, "valid": false}
+{"pattern": "\\P{Xan}{ 2 , 3 }(?P<a>(?<b>[\\d\\cAa\\]]*+\\g<a>)(?(R)_|{{,2}{3,2}||(*nlb:\\pb)(?<!\\o{101}{ 2 , 3 }(*ACCEPT)|[\\w😀]))|\\g{-1}*?|[]*)", "extended": false, "valid": false}
+{"pattern": "\\81++😀\\cA[\\p{L}]|\\k'b'", "extended": false, "valid": false}
+{"pattern": "(?(-1)(?<!(?(1)\\d|\\K?^)\\U)|-[\\cAz-a\\p{L}]){2,}", "extended": false, "valid": false}
+{"pattern": "(?<=(?|(?C256)\\g{+1}\\d|[\\b[.a.]\\g]\\x41)+?(?J)[^[:bogus:]])", "extended": false, "valid": false}
+{"pattern": "(?(?=a)(?!(?(a){ 2 }\\g<-1>)[^]+|(?#c))(?<=(*BOGUS)[^[:alpha:]z-a[\\C])(?>\\U){65536})[]", "extended": false, "valid": false}
+{"pattern": "(?C){2,3}", "extended": false, "valid": false}
+{"pattern": "(?!(?&a))\\p{Bogus}(?<!0[[\\R\\\\b]|(?<!\\b+)|b(?u))(*pla:[[=a=]]*?(?J:(*ACCEPT){2,3}[^\\h^]))|", "extended": false, "valid": false}
+{"pattern": "(?>(*sr:(?<!}+?)(*pla:|[^\\8a]{,3}[\\g[=a=]])|(?-1)|[][][.a.]]+?|.(?(<a>)(?(?C1)(?=a)&\\cA)))*+[a-z]", "extended": false, "valid": false}
+{"pattern": "\\g<-1>*|(?+1)(?Cx)*\\8([](*sr:(?C256)|(?|&(?C256))++)*(?:(?=++|(?&a){(?Cx))[\\pL\\C\\g]\\Qa)\\E)|(?(DEFINE)\\x41?\\K){[]{)", "extended": false, "valid": false}
+{"pattern": "\\cé[^a\\p{L}]", "extended": false, "valid": false}
+{"pattern": "(?J:(?>[\\w😀-😂\\E](?R)))(?(R1)\\p{ L }{2,3}(*BOGUS)(?R){3,2}|(?(<a>)(*nlb:?\\g<a>)*|(*atomic:)(?(DEFINE)\\Qa)\\E++[^])[\\x{41}\\E\\N])[^\\d-a\\p{L}\\C])\\x{ 41 }?\\cA{2,3}", "extended": false, "valid": false}
+{"pattern": "\\g1|[[:bogus:][\\pL]](?&a)(?(R1)[[=a=]\\g[:^alpha:]\\8]|^(?(?=a)[]{)(?J:(?(-1))(?&a)\\k'b'{65536}|\\Qa)\\E*?[^z-a](?i))+?)", "extended": false, "valid": false}
+{"pattern": "(?(1)\\K\\1)\\g{+1}(?(DEFINE)\\B*?[a[:alpha:]z[:^alpha:]])", "extended": false, "valid": false}
+{"pattern": "(*plb:\\p{L&}*(?(R1)[]\\C]z-a]\\B|)++", "extended": true, "valid": false}
+{"pattern": "[[\\E\\](?=(?#c)+|(?<a>(*atomic:(?C\"x\")*+\\012{2,3}^|(?(DEFINE){2,1}+|\\81{3,2}|)(?![[:word:]\\\\cA]\\p{L}&?)(?&a)){,3}(?<=\\G)).((?^))", "extended": true, "valid": false}
+{"pattern": "(?<b>(?![]{3,2}\\o{101}){65536}| []{2})\\g-1(*MARK:m)\\8", "extended": true, "valid": false}
+{"pattern": "[[:alpha:]\\x{41}a", "extended": true, "valid": false}
+{"pattern": "(?>\\p{^Lu}+(?P<a>(?(R1)(?#c)\\_]*?)(?(1)[😀-😂\\][=a=]\\b])||(*atomic:(?i)(*MARK){ 2 }++)\\x{110000}(?P>a))(?(VERSION>=10.4){,2}[]\\h\\g])[\\N[:word:]😀-😂[=a=]][]", "extended": false, "valid": false}
+{"pattern": "(?'a'\\cA[z\\-][z-a])", "extended": false, "valid": false}
+{"pattern": "[a-\\d][]\\E\\E(?<![\\]\\b\\b](?(<a>)\\k'b'&|(*atomic:\\d)[]*+|\\012(?=(?P<a>)|(*ACCEPT)*?(?(?=a)a\\c|[\\cA])[z-a]+)[a-z[=a=]]]?)", "extended": false, "valid": false}
+{"pattern": "[\\]\\bz-a[=a=]]\\U", "extended": false, "valid": false}
+{"pattern": "[^](?P>a)(?(R)\\g<-1>(?<=[\\h[=a=][:bogus:]\\d]\\é|(*BOGUS)(?|\\p{L&}|)(?P<a>\\x{110000})){|(?(?C1)(?=a)[]|\\h|a{,3}(?J:0){2,})){2}", "extended": false, "valid": false}
+{"pattern": "([[.a.]]\\A|\\z)*+(?i:(*pla:[]*+|[]\\_|(*UTF)[^\\[:^alpha:]]))[]*", "extended": false, "valid": false}
+{"pattern": "\\g1(?(<a>)(?i)\\x41(?(<a>)(*UTF){ 2 , 3 }(*atomic:[[=a=][:alpha:]))|(?i:(?<b>\\_\\1|\\g-1\\p{L}|)\\p{ L }(?P<a>[]*(?^)(?J)*){2,}))", "extended": false, "valid": false}
+{"pattern": "(?aD)\\g<a>\\w{65536}(*pla:(?(a)(?(R1))(?(?C1)(?=a)[\\]\\p{L}]\\k){2,3})++)[[=a=]😀]*?", "extended": false, "valid": false}
+{"pattern": "(?C256)*+(?(<a>)(?<=(?(-1)|[a](*FAIL)){,3}(?R)}|(?i:(*sr:\\pb?[\\da-\\dz-a]|\\k{a})(?P=a)|-|\\N{U+41}(?>b||\\C**)(*sr:(?Cx)(?+1)|a(?#c))|){2,})", "extended": false, "valid": false}
+{"pattern": "\\N++\\p{L}", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=\\g{-1})(?u)\\h{", "extended": false, "valid": false}
+{"pattern": "[a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=-)[](?^)", "extended": false, "valid": false}
+{"pattern": "[z\\R]?(?(a)(?:[😀-😂\\Q-]\\E\\d])|(?aD))(?|(?i:\\é*?a++\\A|[😀\\]\\C]{2}b)\\x41*)", "extended": false, "valid": false}
+{"pattern": "[\\d\\x{41}](?P>a)\\G[[:word:]^](?i: +\\g<1>{2})", "extended": false, "valid": false}
+{"pattern": "(?(1)\\p{^Lu}{2,}|\\d\\_\\R)\\G(*pla:(?=[z-a\\p{L}z](?|)|(?i:**#\\w)(?<a>(*ACCEPT)|[^](?i)))(?i:(*atomic:[z-a\\cA\\p{L}😀-😂][-[:^alpha:]\\E][\\p{L}]{)(?i:\\d)\\x{41}+?|{,2}b\\g{+1}|\\z(?<=(?(?C1)(?=a)[(?#c))))", "extended": false, "valid": false}
+{"pattern": "\\k<a>{2}[^]", "extended": false, "valid": false}
+{"pattern": "(*plb:é(*atomic:(?&a)\\A))(?(-1)(?(?=a)[\\N\\N]|(?<!)\\k{a})|\\g{+1}[a-\\d]])(?<a>(?<a>(?(VERSION>=10.4)(*BOGUS)\\k++)\\2(?(1)\\p{L}[]|[\\E[:^alpha:]\\R\\p{L}]|\\p{^Lu}(?(VERSION>=10.4)[^][:alpha:]\\8\\d-a]{3,2}||{2,})*?(*plb:(?R)))(?=(?(DEFINE){2,1}{ 2 , 3 }(?x)|\\U**|(?C1))|(*MARK){2,3}(?R)\\g1)\\Q\\E{65536}", "extended": false, "valid": false}
+{"pattern": "[\\b[:alpha:]a-z\\b]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:(?(R)(?C\"x\")(?i:[]?{,2}|\\x{41})){,3}\\cé+(*FAIL)|(?:(?=\\Q\\E|[[:alpha:]\\pL]](?1)){2,3}\\x{41}?)(?aD))(?^)]", "extended": false, "valid": false}
+{"pattern": "\\c\\g1", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\x{41}\\8](?<a>[^\\8\\g])", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(*nlb:{[z-\\h\\d-a])", "extended": true, "valid": false}
+{"pattern": "[\\p{L}\\][=a=]😀]{,2}", "extended": false, "valid": false}
+{"pattern": "(*nlb:\\Qa)\\E(*sr:(?<b>[😀\\da-\\d]+?++|(*pla:[\\Q-]\\E]|)[\\d-a])?)", "extended": false, "valid": false}
+{"pattern": "[\\E[:word:]\\Q-]\\E][\\Ra]?é\\K", "extended": true, "valid": false}
+{"pattern": "\\cA{3,2}\\G(?<a>(?(-1)(?(R1)\\x{ 41 })[[.a.]\\8\\Q-]\\E]|(?#c))(?Cx){3,2}{2,1}**|[\\E\\Q-]\\E]\\g{+1}{2,}\\c{2})++\\K[]+", "extended": false, "valid": false}
+{"pattern": "(?C256)(?P=a)(?(R)(?(?=a)[😀-😂\\ga]{,3}|(?J:\\N{3,2}|[\\cAa-\\d][\\d\\d]|\\E)(?!(*SKIP)\\h+?\\G{){2,3}\\z{ 2 , 3 }){ 2 , 3 }(?#c)\\pL)*+[\\g\\cA\\ga-\\d]", "extended": true, "valid": false}
+{"pattern": "(*SKIP)(?<=[](?|(?R){65536}[\\E😀-😂]{ 2 , 3 }|(?(R)\\k'b'\\A|[\\d]|))[\\x{41}\\8]|[]){2}\\pL(*BOGUS)(?(DEFINE)(?C)(?(?=a)(?'a'[]**|[\\8\\h\\p{L}])\\h)", "extended": true, "valid": false}
+{"pattern": "\\g{a}(?<![[:word:]]||\\o{101}{2,3}(*pla:\\g<1>{)", "extended": false, "valid": false}
+{"pattern": "[\\-^[=a=]😀-😂]\\g-1[^\\Q-]\\E\\C😀-😂\\8]", "extended": false, "valid": false}
+{"pattern": "[[=a=]\\d-a(?P<a>\\U*?)", "extended": true, "valid": false}
+{"pattern": "[\\b\\C]_\\012", "extended": true, "valid": false}
+{"pattern": "(*atomic:[z])\\p{L}{2,}[]z😀]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\g1{,3}[\\b\\8\\cA\\b](\\g<-1>)++", "extended": true, "valid": true, "captures": 1, "names": []}
+{"pattern": "\\k'b'**\\g<a>&+?(*atomic:\\cé[\\-\\cA\\h[]\\pb*+)\\o{101}{2,3}", "extended": false, "valid": false}
+{"pattern": "\\p{ L }(?i:(*BOGUS))\\k<a>{,3}(?u)", "extended": true, "valid": false}
+{"pattern": "(?(?C1)(?=a)(?1){ 2 , 3 }|\\pL(*atomic:(?<b>[^a-\\d[:alpha:]])[a-z](?(<a>)\\b\\é))\\X)", "extended": false, "valid": false}
+{"pattern": "(?<=(?Cx){2,})(?(-1)(?>[]{65536}(*atomic:\\x{41}**(*ACCEPT){65536}|\\x{110000}++|*+)|[](*atomic:😀|[^😀\\b]|[[.a.]])(?!(?i:(?u)*?|)|-\\p{^Lu}|))**a&|", "extended": true, "valid": false}
+{"pattern": "(?<!\\012|\\g<1>(?(VERSION>=10.4)(?:\\R*?){2,}(*nlb:(*BOGUS)|(*BOGUS)[][[:^alpha:]😀😀-😂])|(?={2})|\\012{)*+|)", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)(?P<a>[[:^alpha:]]||(?(?C1)(?=a)[]{,3}[^\\\\C]|^*+\\2[^^[:bogus:]a-\\d\\C]+?))\\é|(*plb:(?(VERSION>=10.4)\\g-1|(?n)\\A(?x))))\\k", "extended": false, "valid": false}
+{"pattern": "[😀-😂z]|(*MARK:m)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*atomic:(?(a)(?P=a)|[[\\cA\\d-a]|\\g<-1>)[\\d]|(?-1)(?<!\\pb++)(?<!(?(1)(*BOGUS)|\\g{-1})é(?(R)[a-\\d\\pL]*+\\A++){2,3}))(?=\\p{^Lu}[a-\\d]|[\\[:alpha:][:^alpha:]]\\p{L})\\G\\p{Greek}", "extended": true, "valid": false}
+{"pattern": "_#(?|\\g<a>(*nlb:(*nlb:\\p{L}{)\\g{+1}*?)", "extended": false, "valid": false}
+{"pattern": "(?^) [^zz\\\\N]{\\A\\é", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|(?(R1)\\x{ 41 }(?+1)){(?<a>[a-z]|(?:|)(?J)))(?i:(*FAIL)[^[.a.]\\cAz-a\\C](?![\\E](?(R1)(*BOGUS){ 2 , 3 }){[[=a=]\\Rz-a])++**|(?aD)(?<a>[^\\p{L}][^\\C]{,3})+", "extended": false, "valid": false}
+{"pattern": "(?(R)(?<=${65536}(?J:{ 2 , 3 }#\\A*?)(?(DEFINE)\\g{a})+?)(?P<a>(?(1)\\N|)*+\\81)+?|(?(DEFINE)(?|\\p{L}*?\\o{101}))[\\x{41}\\x{41}^[=a=]])", "extended": true, "valid": false}
+{"pattern": "[\\b]\\h", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?=(?(<a>)(?^)(?<!{,2}){2}\\g1+?){ 2 , 3 }(*pla:(?(1)0**|\\g-1||){2,3}|^)(?P<a>[\\C]{,2}|\\012){2,}|)(?i:[\\dz-a😀\\-]-){3,2}(?(?=a)(?(?C1)(?=a)(*atomic:\\g{-1})(*atomic:\\u0041\\G)(*nlb:^{2,}|)))(*sr:(?(R1)(*pla:é)[^[:^alpha:][:^alpha:]]\\]](*sr:\\u0041||[]|))#*?|)*\\b", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)(?n)(?<=(?>**\\x{110000}|[^\\d[:bogus:]\\C]**){[]))[]**\\G{2,3}\\012{2}([a-\\d\\p{L}z-a](?(R1){ 2 })\\x41)|", "extended": false, "valid": false}
+{"pattern": "(?(<a>)(?>[\\8\\C]**|(*plb:.\\81||[\\d-a\\pL\\E])*+(?P<a>{2,1}|))(?<a>\\g{a}[z-a\\b]{3,2}(?:\\N{U+41}|\\N{2,3}++|]))|\\R{[^aa\\-]+[a-z])\\g-1{3,2}\\k'b'|", "extended": false, "valid": false}
+{"pattern": "^[\\C\\R[\\d-a]\\p{Bogus}", "extended": false, "valid": false}
+{"pattern": "((?C256)(?(<a>)\\x{110000}(\\pL[a-z\\8[:^alpha:]\\R]|)(?|{2,1}))|(?(R)(?(?C1)(?=a){ 2 })😀 )*+(?1)){65536}[a\\b\\cA]", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]\\]|", "extended": false, "valid": false}
+{"pattern": "\\k'b'*?(?-1)\\R(*pla:\\p{L}){3,2}[\\b]", "extended": false, "valid": false}
+{"pattern": "[\\cA\\d\\N]]{2,3}[[:bogus:]a-z😀-😂]", "extended": false, "valid": false}
+{"pattern": "_|\\k[😀\\d-a\\cA[:^alpha:]][\\Q-]\\E\\h\\pL]", "extended": false, "valid": false}
+{"pattern": "\\pL+\\g1", "extended": false, "valid": false}
+{"pattern": "(?(R1)[[a-\\d]**(*nlb:\\p{Bogus}\\u0041|(*plb:(?C256)\\w{2,3}|\\p{ L }))|(?<a>(?&a)|[^^\\R]\\-]{3,2}(?P>a)|(?(DEFINE)){,3}\\2++)){2,3}|😀{2,1}+?", "extended": false, "valid": false}
+{"pattern": "[😀-😂\\a\\h\\x{ 41 }\\k{a}\\1{(?<!.\\N{U+41}{\\d+)", "extended": true, "valid": false}
+{"pattern": "\\pL+?\\w", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?|\\B(?J:(*FAIL))|(*plb:\\E(?(a)\\U)||[]*+)){3,2}[[:^alpha:]]\\k'b'", "extended": false, "valid": false}
+{"pattern": "$(?(R1)(?+1)(?n){ 2 , 3 }\\g<1>+?)(?(-1)[^]]){", "extended": false, "valid": false}
+{"pattern": ".\\x{ 41 }", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(DEFINE)(?J:(?(a)\\p{ L }[z-a[=a=][.a.]\\h]{,3}){2,3}\\g<a>\\A{)[](?|$\\g{-1}(*sr:))|)(?J)(*MARK){2}(?=(?>[]\\X||{2,1}\\012(*pla:{+?|)\\10|\\g<a>|[](?(-1)[))", "extended": false, "valid": false}
+{"pattern": "[\\8\\p{L}\\C][]", "extended": false, "valid": false}
+{"pattern": "(?!(?'a'(?(DEFINE)[\\ha-\\d]{ 2 , 3 }.|(?:\\8|[\\\\d-a])(?(R)(?'a')(?>[a-\\d]){ 2 , 3 })(*UTF))", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)[z\\h\\C]|\\Q\\E(*UTF))(?R)(*SKIP){,3}", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)\\Qa)\\E||[^\\w\\N\\]*[]", "extended": false, "valid": false}
+{"pattern": "(?'a'(?(DEFINE)(?i:\\N(?i)|+){ 2 , 3 })(*UTF))[-\\N\\x{41}]*+\\2|[-\\cAa-z]\\k'b'", "extended": true, "valid": false}
+{"pattern": "[\\p{L}\\R*+\\x{41}(*sr:\\g-1+|}\\10(?(a)(*sr:\\g<a>\\N\\1){2}(?x)(?<b>\\h(?x){2,}|\\R{(?i){2,}))){(?=(?+1)(?![^](*plb:\\k'b'**)(?:|b\\k{a}){2}|)\\c(?C256)", "extended": false, "valid": false}
+{"pattern": "[\\x{41}]\\Nz-a]|(?'a'\\x{ 41 }(*SKIP)*+)^(?(?C1)(?=a)[\\][.a.]\\R]\\Q\\E(?:(?i){2,}\\U**(?P<a>é*| {2,3}|\\012{2,3})|))|", "extended": false, "valid": false}
+{"pattern": "[[=a=][:^alpha:]]{ 2 , 3 }\\p{^Lu}+?(*FAIL)(?'a'(?aD)+?(?i:\\g-1|(?(R)\\é{3,2})++|\\p{^Lu}(?:){3,2})[z-a[:word:]]|[\\x{41}a-z](?<!(?(<a>)\\012|\\X[😀[=a=]\\cA]|)|[a-\\d\\Q-]\\E\\w\\pL](?:\\10[[:alpha:]]|)\\Qa)\\E){2,}){\\cA", "extended": false, "valid": false}
+{"pattern": "[\\R[:bogus:]\\g][[.a.]\\-😀-😂\\E](\\U|(?J:(*sr:[]\\x{41}{3,2})|\\k'b'(*sr:-{||(?J)|\\g<1>+?))\\x41)", "extended": true, "valid": false}
+{"pattern": "[^\\pL(*nlb:(?(DEFINE)(?<=)){,3})|[^]*+(?(-1)[\\E[\\b](?C1){65536}\\b)(?>(?-1){2,}", "extended": true, "valid": false}
+{"pattern": "[]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA|(?-1)[]](?(<a>)(?u)(?(R1)[\\Q-]\\E\\w]|\\x{41})[^\\x{41}[]+)", "extended": true, "valid": false}
+{"pattern": "(*atomic:(?aD){2,}(?(a)(*MARK:m)|(?+1){)(?(1)(?!(?Cx)**)(*atomic:)*))", "extended": false, "valid": false}
+{"pattern": "\\cA\\012\\8*", "extended": false, "valid": false}
+{"pattern": "(?|(?(<a>)(?(-1)*?))|(?(-1)[^\\C\\d^[=a=]]+?)(?:(?<!)(*pla:*+\\81|(?J)*?){3,2}|[]a[.a.]]))[\\x{41}\\E[:word:]\\8]", "extended": false, "valid": false}
+{"pattern": "(?(<a>)[^\\C\\Q-]\\E\\da](?J:\\G|(?(R)[(?x)\\U)(*MARK)**|(*ACCEPT))|(?(DEFINE)(?(<a>)(*MARK))\\c&{2}|[^😀😀a-\\d]{2,3}|(*pla:\\k'b'[\\ga]++)|)[\\x{41}\\C]++)+?\\g<a>", "extended": true, "valid": false}
+{"pattern": "(*UTF)(*pla:\\8**(?(<a>)\\pL*(?<b>(?&a)|\\G)(?&a){3,2}){2}(?>(?(1)\\p{L&}|{ 2 , 3 }[\\C\\R\\pL][]**)😀{\\Qa)\\E|(?P>a)(?<a>{2,3}(?C\"x\")){|\\P{Xan}?)){,3}(?(1)[a-\\d](?(R)(?+1)(?(<a>)\\8?)|))*+(?'a'(?i:(?(1)\\g-1++){ 2 , 3 }{,2}{|(?J:|\\81)(?C)\\d*+)[\\h*+(?(1)(?+1)(?(-1)b\\g<1>)(?(a)[[.a.]\\N\\g]|){2,})", "extended": false, "valid": false}
+{"pattern": "(?i:(?(R1)(?C\"x\")[]])(*nlb:[\\d[=a=]\\da]{2,3}[-\\-]{2}0)\\u0041)[^\\h\\Q-]\\E](?(<a>)[^\\8😀-😂]|[(*nlb:a\\K(?>[][:^alpha:]\\C\\pL](*FAIL)))[\\\\x{41}a\\N])(?(?C1)(?=a)[[.a.]\\h](?C1)(?C)|(?<a>a)*+)", "extended": false, "valid": false}
+{"pattern": "(?<a>[^\\pL-[:bogus:]a-\\d]*+(?i:[\\pL-]\\h|{,2}++\\x{ 41 }((?+1)[^a\\E\\cA\\cA]{2}|{65536})|\\x{41}*\\g<1>{2,3})\\G(*SKIP)", "extended": false, "valid": false}
+{"pattern": "\\Q\\E*+ (?aD)(*FAIL){2}", "extended": false, "valid": false}
+{"pattern": "](?n)\\c", "extended": false, "valid": false}
+{"pattern": "(?(a)[[:bogus:]\\C[=a=]]|[\\]+?)(?(-1)[\\R\\R][[:word:][\\]\\x{41}]{2,}||\\cA*|)", "extended": false, "valid": false}
+{"pattern": "(?<!\\k+?\\p{L&}\\X{3,2})[^\\[=a=][:bogus:][:^alpha:]]\\p{L&}b|\\K", "extended": false, "valid": false}
+{"pattern": "\\x41(*ACCEPT)|\\Qa)\\E{2,1}\\k{a}", "extended": false, "valid": false}
+{"pattern": "(?<!(?'a'(?(R1)(?J){,3}#|[\\R\\b[=a=]\\x{41}]){2,3}(?J:{65536}[[:bogus:]]|(?i)))\\o{101}{ 2 })", "extended": false, "valid": false}
+{"pattern": "(?|\\d(*UTF))(?'a'(?i:(?C1)[^]^]^)|[a-\\d]{3,2})(?i).", "extended": true, "valid": false}
+{"pattern": "[]]\\h", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?P<a>[\\\\-[:alpha:]-]\\N{U+41}|){3,2}\\g<-1>|[]++(\\Q\\E{3,2}[a-\\d\\h\\]\\Q-]\\E]{ 2 , 3 }|(?i:(*nlb:(?-1))]\\z*+|)_{)(?<=(?^)(?(1)(?'a'^|[]z\\x{41}[:alpha:]]{3,2}?[\\bz])(*nlb:\\p{ L }*?{3,2}^))(?<a>(?(R1)*?|[\\w^\\C]|[😀-😂\\b\\8-]\\2)(?J:)|(*nlb:))|){,3}", "extended": true, "valid": false}
+{"pattern": "(?C1)++\\k{a}[\\b]$", "extended": false, "valid": false}
+{"pattern": "\\o{101}|(?|[^]\\x41[[:word:]\\N\\C\\d-a]**)é\\p{sc:Latn}", "extended": false, "valid": false}
+{"pattern": "\\C(?(1)[^a-z])(?(VERSION>=10.4)(?(R1)(?<b>[[=a=]-[{2}\\81😀)\\pb|[\\w\\R]\\Q\\E\\p{L&})?|(?=(?P<a>\\Q\\E[^a-\\d\\d\\p{L}\\-]\\A))|", "extended": false, "valid": false}
+{"pattern": "\\p{sc:Latn}(?=(?(R)(?:){2,3}(|(?P=a)))(?:(?(R1)(?x)+[\\R^\\E]|[]\\N{U+41}é))|(?(R1)\\p{sc:Latn}?\\pb{3,2}|(?!(?+1){2,}|[a-\\d)))\\b(?=(?<b>[?(*pla:|\\x{41}\\pb++)[\\😀\\p{L}😀]|(*pla:.)(?(R1)[\\x{41}a-zz\\R]|*[^[\\b\\R]){2,3}[])(\\p{sc:Latn}\\x{ 41 })(?1))", "extended": false, "valid": false}
+{"pattern": "(*nlb:[\\cAa-\\d\\C]*?)**", "extended": false, "valid": false}
+{"pattern": "[😀a-\\d\\d-a]|", "extended": true, "valid": false}
+{"pattern": "(?<b>(?'a'(?(?C1)(?=a)\\G\\X\\h\\g{a}){2,1}\\B+?)\\pb", "extended": false, "valid": false}
+{"pattern": "(*BOGUS)(?<!(?<a>[]|{1}|)){ 2 , 3 }0(*plb:\\é", "extended": false, "valid": false}
+{"pattern": "é\\é{ 2 , 3 }{1}(?(a)])\\k'b'+?", "extended": true, "valid": false}
+{"pattern": "\\g{-1}{|(?+1){ 2 , 3 }\\p{L}(?<=[\\dz-a\\][:word:]])|", "extended": true, "valid": false}
+{"pattern": "(*sr:[\\{3,2}\\A)(?(?=a)(?x)\\Qa)\\E|(?'a'\\p{Bogus}{2,3})){ 2 , 3 }(?&a)(?(-1)[^\\8])", "extended": false, "valid": false}
+{"pattern": "(?i:[\\d-a[:bogus:]]+(?:_(?<!\\g{-1}||{3,2})|(?x){ 2 , 3 }[]{2,3}\\A)[\\h]|\\A\\u0041{,3}\\P{Xan}|)\\g<a>", "extended": false, "valid": false}
+{"pattern": "(?|(?(a)[^\\p{L}|(?:(?-1)\\R)?[\\d\\Q-]\\E\\g\\]])(?'a'(?(?C1)(?=a)\\é\\g<1>{2,})[\\x{41}]*+[\\g]|\\o{101}+?(?-1)))", "extended": false, "valid": false}
+{"pattern": "b[\\w[:alpha:]\\h][[:word:]a-\\d\\C]", "extended": false, "valid": false}
+{"pattern": "\\g-1{,3}\\u0041\\cA{2}(?(R)(?+1){2}\\pL", "extended": false, "valid": false}
+{"pattern": "(?(<a>)\\E?){,3}(*nlb:(*atomic:#[\\d](?aD)|[\\-z\\cA]{ 2 , 3 }[[[:^alpha:]]\\k<a>\\N)(?|.{{65536}\\g{-1}{2,3}) *+", "extended": false, "valid": false}
+{"pattern": "{,2}}(?C1)+_(?<=[[\\p{L}\\-(?i:\\c|(?Cx)+?😀[a-z]]){2,}(*sr:(?(R1)&\\10||+?(*BOGUS))[\\w\\8]*+[])){65536}", "extended": false, "valid": false}
+{"pattern": "(?1)(?&a)++[-]*+(?'a'[^a-z][^-])(?J:[^\\\\R(?(R1)\\012)){2,3}", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)\\2)*?", "extended": true, "valid": false}
+{"pattern": "(?<=[^a-z\\C[.a.]\\8](?(<a>)(?&a)(?u){2,3}|[\\C]**|(*sr:*?|[\\d-a\\ba-z][])\\B)(?i:[a\\ha-z]{2})|\\b{2,})(?(1)(?:\\k{a}+?[^\\d]))", "extended": false, "valid": false}
+{"pattern": "\\b(*sr:\\x41(*sr:[\\d😀])(*sr:(?R)))|[-\\8]**", "extended": false, "valid": false}
+{"pattern": "\\2(?(1)\\1\\U)", "extended": false, "valid": false}
+{"pattern": "[]*(?x)", "extended": true, "valid": false}
+{"pattern": "(?i:\\c)\\81++(*nlb:\\u0041)", "extended": false, "valid": false}
+{"pattern": "(?|(*UTF)(?+1))(?'a'(*MARK)){2}(?<=\\b(?Cx)|(?i:\\z{,3}\\N\\81+?)++(*sr:(*atomic:|\\k'b'*|{2})|${,3})(?(a)\\A))+(?n)\\x41{2,}", "extended": true, "valid": false}
+{"pattern": "\\X[[.a.]]*?(?(R)[\\Q-]\\E\\wa-z\\p{L}](*nlb:(*pla:\\p{sc:Latn}\\C**)[a-\\da-z\\\\d])|\\k{a})(?'a'0|\\A)(?C1)", "extended": false, "valid": false}
+{"pattern": "(?(<a>)[\\ba-\\d\\d-a]](?=(?|\\o{101}\\pL|\\g-1)[][a-z-\\E]|(*nlb:[[.a.]\\[:^alpha:]]](?C256){2,3}|))(?(VERSION>=10.4)(?<!\\c[]{2,})(?(R)[\\pL]{2,})|(?J))*?|(*pla:(?>}*})#?(?>a[[:^alpha:]]))*(?>(*UTF)){)\\d", "extended": false, "valid": false}
+{"pattern": "[\\g][=a=]]*+[\\-\\pL](*plb:(?(VERSION>=10.4)}\\N[^\\w]**|){2,3}[[z[:bogus:]\\x{41}])|[\\w][\\d-a\\C😀]", "extended": true, "valid": false}
+{"pattern": "\\012+?(?(?=a)\\p{sc:Latn}(?^)\\P{Xan})(?J:\\C)(?(a)\\p{L}(?|(?<b>a\\p{^Lu})(?i:\\p{^Lu}[a-z[.a.]]){3,2})|(?'a'(?:\\é)(?(R)[a-z\\b]|(?(DEFINE)(?C)|[\\]a])\\2(?(R)(?!\\p{sc:Latn}\\10?){2,1}(*pla:{ 2 }#{3,2}|(*FAIL)(?C1))|(?'a'[\\C[=a=]]))*?)", "extended": false, "valid": false}
+{"pattern": "(?i){2}[\\cA\\p{L}(?(<a>)é|^(?<b>(?<!|(?1))(?=){,3}(?(<a>)(?-1)(?C\"x\"){2}|(?x){)))", "extended": false, "valid": false}
+{"pattern": "[\\w-]]{2}(?'a'\\x{41}**|[]\\8\\b]|(?!{1}{2,1}))", "extended": false, "valid": false}
+{"pattern": "(?(DEFINE)(*atomic:(*sr:\\x41))(?#c)[\\d-a](?<=b(?R)\\x{110000}++)|(?(?C1)(?=a)\\g<1>){2,3}", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)\\k'b'([^]\\N][]*?)?)(?'a']**(?(R)[^\\h](?(?C1)(?=a){,2}(?C\"x\")\\G|&)|(?<b>(?C){ 2 , 3 })[\\p{L}\\x{41}\\E]++)[\\C]|\\b(*pla:(?(1)\\B|)\\pb?||_){_)(?(<a>){,2}*\\k{a}(*MARK:m)){2,1}", "extended": false, "valid": false}
+{"pattern": "(*sr:(?Cx)+\\8{2,3}\\2)(?#c)\\Q\\E(?<!(?<!(*pla:[^z-a-\\8\\d]|)|[^[\\d-a\\w](|\\10\\p{Bogus}|)(?={ 2 , 3 }))[\\R\\]{,3}[^-][:^alpha:]z-a]{2,}|(?J:\\X(?i)))(?:[\\E]{3,2}(*nlb:{ 2 }[a-z]|(?J:\\X{2,3}){[\\8])\\G)", "extended": true, "valid": false}
+{"pattern": "[]#", "extended": false, "valid": false}
+{"pattern": "\\Qa)\\E[](?C)[-[:bogus:]]\\p{L&}{2,}", "extended": false, "valid": false}
+{"pattern": "(?x){ 2 }(?(1)(*sr:\\U\\p{Bogus}\\p{Bogus})|😀{3,2}\\012)(?P<a>(*nlb:\\N)\\p{sc:Latn}|\\cé\\d++[^\\d-a😀-😂\\g\\b])[[.a.]\\g]", "extended": false, "valid": false}
+{"pattern": "(*UTF){(?(R)(?(a)\\K)(?(?C1)(?=a)\\g{+1}**)(?+1){2,})|[\\N\\Rza](?(R)\\012(*nlb:\\g<1>[\\d-a[:^alpha:]]|😀*?|\\p{^Lu}\\X(?^)))(*ACCEPT)", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]\\8\\d-a]", "extended": false, "valid": false}
+{"pattern": "[z\\pL|(?<=(?(?C1)(?=a)\\z(?(?C1)(?=a)\\b|\\o{101}+?)|){2,}|[^\\C]{2,}(?(?C1)(?=a)(*plb:\\b|\\b)(*atomic:[\\da[:bogus:]]|\\k{a})+| ?(?=[\\Nz-a\\p{L}\\w😀)?\\10))(?(DEFINE)\\o{101}[\\w]^)\\g1*?|(*atomic:[\\R^\\N\\N[^\\R\\E\\Ea]**|(?i:(?(DEFINE)(?P=a)?|(*MARK)|*+\\p{sc:Latn}?.)(*pla:\\g-1)(?<!\\p{L&}*|[]{ 2 , 3 }))\\pb(?^))", "extended": true, "valid": false}
+{"pattern": " [^[:word:]\\E[:alpha:]][^]", "extended": false, "valid": false}
+{"pattern": "(?<!(*nlb:(?'a'(?P=a)|\\g1*?\\x{ 41 })+?[^\\x{41}\\R\\C+?|[\\Na]|\\p{L&})(?!(*nlb:(*plb:a)(?![\\d-a\\Q-]\\E]é|(*ACCEPT))|\\cé(?=\\cé\\10é?))(?C1)|(*sr:$😀\\z)\\z+?)?\\8", "extended": false, "valid": false}
+{"pattern": "(?<!\\x{41}{ 2 , 3 }(?=[\\d[:alpha:]a]\\_))", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?i){2,3}|", "extended": false, "valid": false}
+{"pattern": "#(?(a)(?(a)[](?<=(?C256)|{[^a-z\\x{41}]))|\\Qa)\\E|(?u)|(?(R)}(*ACCEPT)|[]|))", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?C1)(?=a)(?J:[^]{|\\Qa)\\E+?[^\\b\\R[]))(?Cx){1}", "extended": false, "valid": false}
+{"pattern": "\\81(?P=a){,3}[\\hza-\\d]}", "extended": false, "valid": false}
+{"pattern": "\\g<a>|(?aD)", "extended": true, "valid": false}
+{"pattern": "[^]{ 2 , 3 }(?(DEFINE)(?i:\\k)|(?x))[]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:(?'a'$([-z]{2,3}|-|\\u0041|)|(?(1)\\p{Bogus}\\Q\\E*?{ 2 , 3 }){,3}\\p{ L }+?|)|[\\][:bogus:]\\p{L}\\C]++", "extended": false, "valid": false}
+{"pattern": "(*atomic:(*sr:(?C){ 2 , 3 }|(?(?=a){2,3}(?P>a))(?<=(?#c)\\k{a}[\\N]|\\w[^\\]]*?)))+?\\E?#", "extended": false, "valid": false}
+{"pattern": "a\\R(?=(?=\\E{(?<=[-]))(*sr:\\d)(*pla:(?|[\\N😀])|)*b", "extended": false, "valid": false}
+{"pattern": "\\B(?(-1)(?(?C1)(?=a)\\N{U+41}\\u0041(?(DEFINE)(?&a))||[^]))(?|(?'a'(*sr:{ 2 }[]{65536}|){2}\\g<-1>)**)", "extended": false, "valid": false}
+{"pattern": "\\k{a}\\b(*SKIP)(?(R)\\p{Bogus}(?i:\\g{+1}(?=(*ACCEPT)#*+))**\\X)\\012", "extended": false, "valid": false}
+{"pattern": "[]{ 2 , 3 }|", "extended": false, "valid": false}
+{"pattern": "{2,1}", "extended": false, "valid": false}
+{"pattern": "(*ACCEPT)(?<!(?'a'[\\d\\b\\pL\\8)?)(?i:(*plb:\\R)|)[\\p{L}\\][a]+?", "extended": false, "valid": false}
+{"pattern": "(?<a>(?C1)\\G\\8)-(?C1)(?(R)[^][^\\h\\w\\Q-]\\E](?<!(?J:)||(*pla:\\N|[^]?\\Qa)\\E)*?|(?J:\\p{Greek}\\N{U+41}(?n)|\\k'b')))*+(?!😀(?<a>\\g<a>{2}\\81(?(1)[^😀-😂[:^alpha:][:word:]]|{ 2 , 3 })|)(?(<a>)(?(DEFINE)[^-\\d-a\\R]||[^[.a.]])|\\U){2,3}|[a-z[.a.][:alpha:]])+?", "extended": false, "valid": false}
+{"pattern": "\\k'b'+(?i:(?>\\k++(*pla:[\\h-[:bogus:]][^z-a]||${ 2 , 3 }\\x{110000})}|\\z(?i:[\\\\g](?>\\cé)))", "extended": true, "valid": false}
+{"pattern": "[](?<!(?J:(?<=\\81|(?u)**[^[:alpha:]z-a]|)+]))?", "extended": false, "valid": false}
+{"pattern": "(?>[[:word:]\\cAa-z]|[-]](?(1){{,3}[^]|[\\p{L}\\-][a\\g😀-😂])[^]|)(?>[^](?J)((?>[\\-[=a=]\\]]{65536}))|[]{2,}|[\\-\\p{L}\\Q-]\\E]\\g1)\\p{sc:Latn}\\o{101}*?(*plb:(*atomic:\\w[\\]](*ACCEPT)|])\\N{U+41}[]|[^\\cA😀\\cA]])", "extended": true, "valid": false}
+{"pattern": "\\_|\\u0041|", "extended": false, "valid": false}
+{"pattern": "[\\d-a[=a=][.a.]]|", "extended": false, "valid": false}
+{"pattern": "\\p{^Lu}|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(*pla:}{65536}\\U(?(R1)\\p{^Lu}\\g<-1>)|[\\g\\cA[:bogus:]\\N]?|[]|)[][\\E\\g]", "extended": true, "valid": false}
+{"pattern": "\\p{Greek}(?:(?(?=a)\\g{-1}\\pL(?C1))[\\ha]|(?&a){3,2})(?!(?(a)(?n)**|(?(R1){3,2}|[^\\pL\\p{L}]{2,})?[\\]]{ 2 , 3 })(?(R)[^][^\\pL\\Q-]\\E\\-][\\h]++)|(?(DEFINE)(?P<a>{|[^a\\8]{65536})|))[\\]\\]\\Q-]\\E😀-😂\\N{U+41}?", "extended": false, "valid": false}
+{"pattern": "(*ACCEPT)\\c\\10{ 2 , 3 }[^]", "extended": false, "valid": false}
+{"pattern": "\\p{L}|-**|", "extended": false, "valid": false}
+{"pattern": "(?R)\\8", "extended": false, "valid": false}
+{"pattern": "\\B\\pL\\P{Xan}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\u0041{1}[\\R\\8\\pL\\8]\\é{2,}|(?(1)\\p{sc:Latn}{2}|[[=a=]](?(a)(?<a>\\pL[\\cA]{,3}){2})*", "extended": true, "valid": false}
+{"pattern": "(?(1)[😀\\p{L}|\\k<a>)+?(?<b>(?+1)(?>(?P=a)(?(?=a)|\\g{+1}{){2,})(*ACCEPT)){ 2 , 3 }(?<=(*pla:[^a-z]\\p{L}[:word:]]|0)\\cA", "extended": false, "valid": false}
+{"pattern": "[^\\cA\\h]\\E[]a-\\d[:bogus:]]{65536}(?(?C1)(?=a)b*|(?<a>(?(1)\\p{Greek}|)++\\k|)(?<=(?C256)))", "extended": false, "valid": false}
+{"pattern": "[\\-\\C[=a=]]", "extended": true, "valid": false}
+{"pattern": "_{,3}[[=a=]\\d-a\\z]**[\\\\]]+?", "extended": true, "valid": false}
+{"pattern": "(?Cx){2,}b(?=b++)(*nlb:(?i:{ 2 }?\\é))(?Cx){2,3}", "extended": false, "valid": false}
+{"pattern": "\\g{a}*?[\\]\\dz-a]{\\N", "extended": false, "valid": false}
+{"pattern": "(?'a'\\A)(?P>a){ 2 }", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(?=a)(?(R1)(?C1)|[^\\b^\\]\\b]))+?(?'a'(*MARK:m))", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?:(?(VERSION>=10.4)(*atomic:_(?R))))", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\Qa)\\E{2}a\\R", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=(?(<a>)[\\E😀\\-]{2,3})){,3}(?!(?:(?(a)*)[[=a=]]\\C|[a](?:é|\\8{65536})(?C256)){3,2}(*sr:\\o{101}(*sr:(?R)**|[^[\\\\][=a=]](?&a)){2,}[\\b[:alpha:]])|(?<b>[\\-\\b\\G)\\Qa)\\E|)(?<!\\N(?<b>[]\\d\\B)^)(?=a{2,}(?:(*BOGUS)|[\\C😀\\p{L}])*)\\81", "extended": false, "valid": false}
+{"pattern": "\\81\\R[\\b\\C😀][]", "extended": false, "valid": false}
+{"pattern": "[\\cA]\\p{Greek}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?1)|", "extended": true, "valid": false}
+{"pattern": "(*SKIP)[]\\81{2}", "extended": false, "valid": false}
+{"pattern": "(?<a>(?(R1)\\X(?C256)){,3}(?i)|(?C))|[\\Q-]\\E]😀a-z]|", "extended": false, "valid": false}
+{"pattern": "(?(VERSION>=10.4)\\g{a}|[^\\E😀\\Ra]\\8(?(R1)(?'a'\\w||\\g1[[:bogus:]]**)**|)\\k'b'[\\N\\x{41}\\pLz]*(?(R1)(?|(?<a>|)(*nlb:|\\P{Xan}[])|[\\\\N\\x{41}][^][\\b[:^alpha:]\\-a]*){2}(?(<a>)(?<a>|(?n)|\\u0041?\\k\\K)+(?<!\\c*+(?u){2,})|(?(a)[\\w[=a=]\\d]|(?(<a>)\\g<-1>|\\x41{2}|[^[:^alpha:]\\d\\g]{ 2 , 3 }\\p{sc:Latn})[]|\\p{L&}0", "extended": false, "valid": false}
+{"pattern": "[a-z[:^alpha:]\\b\\Q-]\\E[]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^\\1{ 2 , 3 }\\cé[^]|", "extended": true, "valid": false}
+{"pattern": "[[:word:]\\pL\\cA]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "b{2}|\\k<a>|\\E(?C1)?((?'a'(?P=a){)*){", "extended": false, "valid": false}
+{"pattern": "[^\\d]\\N{ 2 , 3 }({2,1}{|\\x{41}[\\cA[:word:]\\N]*?|)++", "extended": false, "valid": false}
+{"pattern": "(?(?C1)(?=a)(?(VERSION>=10.4)\\cé)|(?'a'\\p{Greek}?(?:\\hb)|(*pla:){2}|[^😀]\\cA][^]{65536})**[\\Q-]\\E\\]\\h\\Q-]\\E]{2,3}|\\g-1[^😀\\C😀-😂[:word:]](?&a))(?i:\\Q\\E\\u0041){2}(?i)", "extended": false, "valid": false}
+{"pattern": "(?i:(?(1)[]))(*pla:(*SKIP)[^\\8[:alpha:]\\]| (*atomic:\\p{^Lu}(*MARK)**)?)$\\x41|[\\d-a\\d-a]", "extended": false, "valid": false}
+{"pattern": "\\012", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?aD){65536}[\\Q-]\\E]", "extended": false, "valid": false}
+{"pattern": "\\X\\U*", "extended": true, "valid": false}
+{"pattern": "\\g<-1>(?|\\p{^Lu}+?|(?^)*?[a^a-z\\b])(*ACCEPT)\\P{Xan}**", "extended": false, "valid": false}
+{"pattern": "(?<b>.)[[:alpha:]-](?aD)(?i:(?:(?aD)[]|\\cA{2,}\\E$)*+[[:alpha:]\\z[.a.]](*FAIL))", "extended": false, "valid": false}
+{"pattern": "[😀-😂\\b]\\x{110000}(?|{\\g1+?| |)(?(DEFINE)\\é\\p{Bogus}||(?(R)(?<b>\\_|){2,3}[\\d\\d]*+(?=\\x41?++))[])", "extended": false, "valid": false}
+{"pattern": "(*sr:(?i:\\P{Xan}[-z-aa](?(1))|[]**(?<![[:word:]a😀\\]\\1|\\2_\\é){65536}|)|(*sr:[\\-[.a.]])|[\\-]*?(?C1)+?)+?(?(DEFINE)[[.a.]z]{2,}(?:(?(DEFINE)^\\012|\\o{101}|\\G)**(?P<a>[a\\pL]))[\\x{41}\\C\\h😀-😂]|[[.a.]\\N^]*(?(DEFINE){1}|(?i)\\p{^Lu})+?)+(?(<a>)(\\2){ 2 , 3 }(?:(?R))+)\\g1(?i:(?<=(?(VERSION>=10.4)\\k{a}|}(?C\"x\"))[\\]\\Q-]\\Ea-\\d]|[[:alpha:]]]{2,}|[])|[[:alpha:]\\R\\cA]{(?i)(?<a>(?(1)_|[\\w\\C[.a.]\\p{L}]{3,2})\\U{3,2}[\\b]|)|)", "extended": false, "valid": false}
+{"pattern": "[[=a=]\\d-a[=a=]](*MARK:m)**(?(R)(*ACCEPT){2,3}|[^[:alpha:]][\\d]++|(?(VERSION>=10.4)[\\Q-]\\E](?-1)*?(?<a>|\\p{Greek}|)))|(?J)|(?(R)\\10*?)", "extended": false, "valid": false}
+{"pattern": "(?P<a>(*plb:-|(?(R))é)\\P{Xan}?(*pla:\\K\\g<1>[\\h[[=a=]]*+)|\\x{110000}){,3}[]\\x41", "extended": true, "valid": false}
+{"pattern": "(?#c)\\X[\\Q-]\\E]$", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?^)+?", "extended": false, "valid": false}
+{"pattern": "\\g{a}", "extended": false, "valid": false}
+{"pattern": "(*nlb:[^\\b](*MARK:m)|)**😀{ 2 , 3 }|", "extended": false, "valid": false}
+{"pattern": "(?Cx){3,2}(?(1)${3,2}\\G|\\p{^Lu})[]](?(-1)[[:alpha:]])\\p{Greek}", "extended": false, "valid": false}
+{"pattern": "(?<b>((?(R1)\\x{41})(?(a)&**)|))(?>{,2}[^\\-\\b\\C](?i:[^a\\8]))", "extended": true, "valid": false}
+{"pattern": "&*+.[\\cA\\cA]*|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(a)[\\[.a.][:alpha:]]\\g{-1})", "extended": false, "valid": false}
+{"pattern": "(*sr:\\k(?J)[^]**|[^](?P<a>\\1*+|(?(?C1)(?=a)\\Qa)\\E{2,1}+|*+\\C)||(?(R1)(?n)+?)|[^\\C\\b\\b]{2}(?(?C1)(?=a)(*UTF)))|)[a-z\\]](?!\\A{3,2}\\g<1>[]**|[z-a\\]**0){(?(R)\\pL{2,}(?(-1)[]z]){65536})|(?(<a>)b{ 2 , 3 })+", "extended": true, "valid": false}
+{"pattern": "\\c(*plb:[😀-😂\\Q-]\\E]\\z(?(a)(?aD))|", "extended": true, "valid": false}
+{"pattern": "[^[\\8]}\\k{a}{2,}\\p{^Lu}", "extended": false, "valid": false}
+{"pattern": "[^\\-[.a.][.a.]][^[:bogus:]](?:(?C256)(?(a){2,1})*+\\é|(?C\"x\"){(?(R)[\\C\\x{41}z-a\\]{2}){65536}", "extended": true, "valid": false}
+{"pattern": "(?<=^|(?<a>(*atomic:^[\\h\\w\\d\\]]))|[\\b])\\p{ L }(?(<a>)$)|\\N+?(?'a'(?:\\c)|\\pL*?)", "extended": false, "valid": false}
+{"pattern": "((?<a>0{2,3})|(?!\\8){(*nlb:[\\p{L}[:bogus:]😀-😂](?C)(?(<a>)\\g<-1>+?)|[^\\d](?(1)\\p{L})))|(?R){2,}[a\\d[]", "extended": true, "valid": false}
+{"pattern": "[\\wa-z\\z-a][]++", "extended": true, "valid": false}
+{"pattern": "(?|\\g<a>||[\\E\\bz]){,3}(*MARK){2}[]", "extended": true, "valid": false}
+{"pattern": "[](?<a>(?(?=a)[z-a\\N][]{ 2 , 3 }\\012)(?(<a>)(*plb:(?C\"x\")(?P=a))|(?<=)\\K\\B))", "extended": false, "valid": false}
+{"pattern": "(?(R)((*plb:){ 2 , 3 })\\pL|[\\-\\w]|(*pla:\\x{ 41 }(*atomic:[[=a=]$)+?[[:word:]]|(?(R))*+|)^)?[[:alpha:]]]*?", "extended": false, "valid": false}
+{"pattern": "[\\8](*sr:\\k'b'{a(?(1)(?<=)**(*BOGUS)^))\\x41[^\\]\\]😀-😂\\d]{2,}", "extended": false, "valid": false}
+{"pattern": "(?(1)[\\x{41}😀z]+(?(?=a)_(?|[\\E\\8-]{65536}|\\p{ L }|\\pb)\\x41{65536})(?|(?i)(*UTF)\\x{41}))[\\C]", "extended": false, "valid": false}
+{"pattern": "\\N$[\\pLa-\\d\\cAa-\\d]", "extended": false, "valid": false}
+{"pattern": "[a-z[.a.]a\\C]{2,3}\\p{ L }\\C(?>\\cé)(?-1){65536}", "extended": true, "valid": false}
+{"pattern": "\\x{110000}(?(R)\\h)(?&a)\\N{U+41}", "extended": true, "valid": false}
+{"pattern": "(?<a>\\cA[^a-z\\x{41}[:^alpha:]]+?){2}[-]{ 2 , 3 }", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?(?=a)\\10(?(R1)(?(<a>)|[[:^alpha:]\\E[:^alpha:]]{1})**(?i:[\\x{41}\\8\\R\\R])(?=[^]\\A|(?J)+?)|\\U(?<=\\Q\\E\\p{L&}|{)[\\x{41}z])|(?<a>\\K\\d(?(a)\\z)?)*+)|[az-a^]][[:bogus:]\\pL[:^alpha:]\\d-a]", "extended": false, "valid": false}
+{"pattern": "(?C)[][[=a=][:^alpha:]](?<!(?(VERSION>=10.4)(?|\\k{a}\\10a*){\\g<-1>[^\\8]\\Q-]\\E])(?(DEFINE)(?J)+?(\\cA||{,2}{65536})[\\[[:word:]\\8]){65536}{2,}(?'a'(?u)|(?>[][[-\\cA\\x{41}]*+|(?:\\p{Greek}(?-1)[]|{3,2})[])\\u0041\\k{a})*?", "extended": false, "valid": false}
+{"pattern": "]{2,3}(?(-1)\\g<1>{2})+?", "extended": false, "valid": false}
+{"pattern": "(?>\\g1{65536}[\\\\w\\-](?(DEFINE)\\k{a}(?(-1)(?1)[^\\g\\8a-\\d]|[]{65536}_*?)))(?<!(?(DEFINE)[^\\C\\N]\\X){,3})", "extended": false, "valid": false}
+{"pattern": "[z\\8]**[\\-^[=a=]]**", "extended": false, "valid": false}
+{"pattern": "(?J)(?aD)(?J)(?(R1){2,1}\\p{L&}(?C1){2,})(*SKIP)|", "extended": true, "valid": false}
+{"pattern": "(?|(?C256))**", "extended": false, "valid": false}
+{"pattern": "[[[=a=]]*_**", "extended": false, "valid": false}
+{"pattern": "[^](?(a)\\cA{65536}|0(?'a'\\8|.(?C)*?(?(R)+?||[]*+^|))+?*", "extended": false, "valid": false}
+{"pattern": "\\C(\\p{Bogus}(?(a)[-\\\\h])(*atomic:\\E|(*sr:(?^)(*FAIL)\\N++|\\Qa)\\E**{{ 2 })|)|(?(DEFINE)(*plb:(?P>a))b(?<b>[^\\w]{2}){2})(?(a)\\z)[\\[=a=]\\g\\R])[\\Ra-za\\p{L}]{3,2}|(\\x{41}|\\g<1>++|a)(?Cx)|", "extended": false, "valid": false}
+{"pattern": "(*plb:\\x{41}|\\x{41})\\x41\\c", "extended": true, "valid": false}
+{"pattern": "\\Qa)\\E(?(R)(?R))\\N{U+41}\\x41", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k{a}?\\p{L}{,3}[^]**", "extended": true, "valid": false}
+{"pattern": "[]\\g<a>\\10[[\\Q-]\\Ez-a]*?", "extended": false, "valid": false}
+{"pattern": "b\\c\\g<-1>{2,}\\g1", "extended": false, "valid": false}
+{"pattern": "(*atomic: )\\g<-1>(?<a>[](?(-1)\\1(?<![^\\R\\x{41}[:word:]a-z**)(*atomic:{ 2 }){,3}))", "extended": false, "valid": false}
+{"pattern": "(?<a>(?(1)\\w|[][.a.]])(?P<a>\\N{2,3}))[\\](?R)(?(-1)\\b\\P{Xan}[\\N\\d]?)", "extended": false, "valid": false}
+{"pattern": "\\d+[\\C\\x{41}\\Q-]\\E😀]b(*MARK)", "extended": false, "valid": false}
+{"pattern": "[\\]\\g<-1>[z-a\\p{L}]*+(*UTF)", "extended": false, "valid": false}
+{"pattern": "(*UTF)[]++|", "extended": true, "valid": false}
+{"pattern": "\\k(*SKIP)\\P{Xan}((?Cx)\\x{41}|\\pL\\X*+^{2,}[^]++", "extended": false, "valid": false}
+{"pattern": "a(?(1)\\B\\g<a>)|(*sr:(*plb:\\N{U+41}{))", "extended": true, "valid": false}
+{"pattern": "[a-z\\x{41}-]](*atomic:\\1(?(R)[^\\h](?C1)(?(R1)(?aD){2,}{2,1}*?||)|){2,})[]", "extended": false, "valid": false}
+{"pattern": "(?:[z-a\\R](?|([^a\\8][^^\\d-a]|[-\\Q-]\\E])[][[.a.][:alpha:]\\cA]{)|\\R)|[^z-a[=a=]][]", "extended": false, "valid": false}
+{"pattern": "(?:[\\R\\R][^😀-😂\\Q-]\\E\\]\\-](?P=a))", "extended": false, "valid": false}
+{"pattern": "(?<=(?aD)|\\x{110000}(?(-1)(?(R)\\d|[^\\R])😀\\pb|(?(DEFINE)(?i)*?|{2}[^\\]\\pL^\\])[\\d]|(?![]\\8\\]^]\\2++[😀-😂]){ 2 , 3 }|)){3,2}", "extended": true, "valid": false}
+{"pattern": "[[:^alpha:]\\h-\\Qa)\\E](?C)", "extended": false, "valid": false}
+{"pattern": "[\\E\\C]+?", "extended": true, "valid": false}
+{"pattern": "\\cé?\\x{110000}(*FAIL)", "extended": false, "valid": false}
+{"pattern": "&[\\p{L}]|\\8", "extended": false, "valid": false}
+{"pattern": "\\pb(?(R)(?-1)\\X(?-1))*+", "extended": false, "valid": false}
+{"pattern": "(?<b>(?(1)\\P{Xan}++|(?i:)(?u))||[\\w\\cA\\b*+(*MARK)++(?![a-za-\\d]++[😀\\E\\d-a\\cA]\\x{ 41 }|(?C){\\R{3,2}))\\K|(?!(?(?C1)(?=a)\\8{))", "extended": false, "valid": false}
+{"pattern": "(*SKIP)\\d", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\Q-]\\E]|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\X++\\pb[^\\b\\C[=a=]]{2,}[\\p{L}\\]\\g[:word:]]", "extended": false, "valid": false}
+{"pattern": "\\_(?(-1)[[:alpha:]\\w😀])|", "extended": false, "valid": false}
+{"pattern": "[\\-z]$(?<b>\\Q\\E(?(R)(?-1))\\10{)|", "extended": false, "valid": true, "captures": 1, "names": [["b", 1]]}
+{"pattern": "(?n){", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(?=a)\\C(?J:\\G(?J)\\1)|)[^][]\\10", "extended": true, "valid": false}
+{"pattern": "(?(R1)(?<b>\\P{Xan}(?^)|\\x{41})*?(?P<a>(?(?C1)(?=a)(?P=a)|)*+(*nlb:\\w|[\\cAa-\\d])(?(1)\\k'b'+?)|#)|\\z)\\N{U+41}{2,}(?(?=a)[\\])[^\\8[:word:]]", "extended": false, "valid": false}
+{"pattern": "(?>\\p{L&}(?(1)\\_|)\\h)(?:(?!(?J)[\\E\\]a-\\d])*+[\\p{L}](*nlb:(*atomic:\\E{3,2}(*ACCEPT))|(?<b>[^\\N\\g]{)))(?J)\\u0041", "extended": true, "valid": false}
+{"pattern": "(?(DEFINE)(?<!\\E(?<b>\\p{ L })(*nlb:_{,3}|_))|(?>(?!|.){(?aD))\\k<a>{2,3}\\k<a>)(*nlb:[😀-😂[:^alpha:]\\C]*+\\p{^Lu}|[^[:bogus:]z\\pL]([])*+)(?(R)\\N{3,2}\\10{ 2 , 3 })", "extended": true, "valid": false}
+{"pattern": "é", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:(?<a>(?(?=a)[\\cA\\C])a|\\2(?C256))[^z-a😀-😂z\\b][a-z[\\\\h]*+|[^\\p{L}a-\\d\\g][])?(?>(*atomic:(?C1)\\N|))\\p{ L }", "extended": false, "valid": false}
+{"pattern": "-}\\cA\\g-1{2}|", "extended": false, "valid": false}
+{"pattern": "\\k{a}(?|\\x{41}&{3,2}|", "extended": false, "valid": false}
+{"pattern": "(*sr:\\g{+1}||[z-a^\\x{41}]{2,1}[]){3,2}(?'a'(?i:(*SKIP){2,3})\\_(*SKIP)*|\\p{L}{(?<!\\c(?<b>)++)\\G{2,}){ 2 , 3 }(?C1){3,2}", "extended": false, "valid": false}
+{"pattern": "(?aD){ 2 , 3 }[]++", "extended": false, "valid": false}
+{"pattern": "(?(a)(?P<a>(?(1))|[[=a=]\\8a-z[:word:]](?(?C1)(?=a)\\k?)*|[\\C[.a.]]+?[]){2}.(?R)++|(*ACCEPT)*(?(a)\\U*+|(?'a'(?R)\\k<a>|(?(a)\\pL+)(?'a'\\pL|{2,3})(?(VERSION>=10.4)[\\N\\d-a](?i)))**(*SKIP)) ", "extended": true, "valid": false}
+{"pattern": "(?R)\\x{110000}b", "extended": true, "valid": false}
+{"pattern": "\\p{Script=Greek}{1,2}+\\b{3,2}", "extended": false, "valid": false}
+{"pattern": "\"[^^\\8!!\\q{ab}]\\.*?[\\-\\!!\\8]<", "extended": false, "valid": false}
+{"pattern": "[&=&a-zA]{2,}[)\\p{L}]\\c1**", "extended": true, "valid": false}
+{"pattern": "\\k<a>[][\\c1]{2,}[^\\p{L}--[:alpha:]]*?", "extended": false, "valid": false}
+{"pattern": "\\0\\f+{\\10", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "#[]{2}\\k\\v[^a-z[\\s]??", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{,2}(?'a'\\2\\k<b>[a-\\d\\x41\\]A]**|(?(a)\\k<a>\\k<a>|[\\\\}])|)(?<a>\\A\\p{Script=Greek}|/{)\\k<a>+? ", "extended": false, "valid": false}
+{"pattern": "[..z)\\-]+?[]", "extended": false, "valid": false}
+{"pattern": "[.A😀*+(?<=\\z(?|\\x41|[\\s\\cA*?\\v++\\A)|)(?i)[^.]]*?\\3??|(?(?=a){1,2}[^[\\c1]|)\\B*?\\3\\t", "extended": false, "valid": false}
+{"pattern": "\\x4[\\p{L}]*", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?#[^])", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=:\\1|)\\0\\d{\\k{2,1}\\x4??|", "extended": true, "valid": false}
+{"pattern": "\\w*&+\\x411}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(a)é{3,2})[]((<a>),{2,3}?)*", "extended": false, "valid": false}
+{"pattern": "(?P<a>{1}*=\\s{)(?<a-b>[](?<a-b>\\a{2}#(?'a'[{{\\d]\\e{{|\\s?))(?<b>\\v\\v))\\w\\8?", "extended": false, "valid": false}
+{"pattern": "\\.\\2", "extended": true, "valid": false}
+{"pattern": "^{[)\\D??&\\w", "extended": false, "valid": false}
+{"pattern": "(-|[\\d\\]{2}a{2,})(?<b>[^Az|a-z][]|(?-i:a(?P<a>\\w|\\8**)<):)'\\cA{\\P{Lu}", "extended": false, "valid": false}
+{"pattern": "\\10{3,2}", "extended": false, "valid": false}
+{"pattern": "\\[A\\q{ab}-]\\D\\c1", "extended": false, "valid": false}
+{"pattern": "(?(?=a)(?i:\\G))\\v\\G(?i)\\k<b>|+?A", "extended": true, "valid": false}
+{"pattern": "_?'**^(?<b>(?<a-b>\\10[.}]|\\10))]", "extended": false, "valid": false}
+{"pattern": "[&&\\cA--](?(1):{2})a\\8}|", "extended": false, "valid": false}
+{"pattern": "(\\k<b>)\\k[a]*?é(?i)<[$!!", "extended": false, "valid": false}
+{"pattern": "[^\\-.a-z](?(a)[({[]*?-{2}(?>[😀\\cA\\p{L}*\\t.)**)++[\\\\\\q{ab}]9??é|", "extended": false, "valid": false}
+{"pattern": "[]{1,2}\\pL*+-?(?(<a>)#*+\\c1\\1|)[^\\p{L}z|]**", "extended": false, "valid": false}
+{"pattern": "(?=(?<!\\w+\\v??[\\p{L}??!)\\p{Script=Greek}", "extended": true, "valid": false}
+{"pattern": "\\s{,2}\\^n-😀[z-a\\b{)]{2,3}", "extended": false, "valid": false}
+{"pattern": "[!!][\\cA\\](?<!(?(a)\\/(?<!b[^]*+[]**))\")=\\k<b>\\x41", "extended": false, "valid": false}
+{"pattern": "(?<=(?|{2,1}(?(a)\\n{,3}\\\\))\\]k{2,}|_b=)++\\Z\\-&\\x41*+", "extended": false, "valid": false}
+{"pattern": "[\\s-\\\\]", "extended": false, "valid": false}
+{"pattern": "(?#\\c1){\\k<a>(?!\\x41?(?:(?i)[^a-z\\a]<\\P{Lu}\\G))", "extended": false, "valid": false}
+{"pattern": "[😀z-a]*+\\8[^😀\\sA\\q", "extended": false, "valid": false}
+{"pattern": "0*\\v\\10", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\d|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\tb-++\\p{L}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\n[a-\\d][)]", "extended": false, "valid": false}
+{"pattern": "\\t{2,}.{2,}0", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{1}{2,3}?\\/??\\d}$?", "extended": true, "valid": false}
+{"pattern": "\\f{3,2}\\a{2,}\\k{2,3}?", "extended": true, "valid": false}
+{"pattern": "\\k<b>(?i:<*?\\f{1,2}++|\\x4*|)\\q(?!$*?[^.\\c1\\d\\d]|[\\bz--]:\\t)\\u{41}", "extended": false, "valid": false}
+{"pattern": "\\k<b>{3,2}(\\d{3,2}0{3,2}(?:\\3)*?]++\\12{2,3}?", "extended": true, "valid": false}
+{"pattern": "\\b*><", "extended": true, "valid": false}
+{"pattern": "[|", "extended": false, "valid": false}
+{"pattern": "\\e+? *?[^\\s|\\c1$]\\k<b>{,3}[--z-aa/](?|\\n{2,3}\\0\\\\|[a-z\\0a-z[^--{[:alpha:]]|){3,2}", "extended": false, "valid": false}
+{"pattern": "😀\\v(?x)(?=\\k)(?P<a>[\\p{L}.\\\\.]*?,||(#\\^w{2})*+\"*?=**)||\\t\\3>{,3}[]+$", "extended": false, "valid": false}
+{"pattern": ">{,+3}(?x)\\-{2,3}?a\\k{,3}", "extended": false, "valid": false}
+{"pattern": "\\D\\A*😀+?\\3(?#[\\b][\\\\a-z}.])", "extended": false, "valid": false}
+{"pattern": "[\\w][--z]&(?<b> {2,3}?(?'a'\\x4{2,}))", "extended": false, "valid": true, "captures": 2, "names": [["a", 2], ["b", 1]]}
+{"pattern": "#*|?\\B,\\x41+", "extended": false, "valid": false}
+{"pattern": "\\q\\s{2,}\\v+\\x41{2,}'{[\\p{L}\\b]", "extended": true, "valid": false}
+{"pattern": "(?x)\\v[z-aa[:alpha:][]|9{,3}??\\x4\\d\\n[^\\cAA]\\-", "extended": false, "valid": false}
+{"pattern": "(?'a'[^]{,3},[^&&])[^a-\\d])??a[\\8\\]]", "extended": true, "valid": false}
+{"pattern": "\\-[][&&}\\w]\\D{(?<=[!!|&&😀]++\\w\\1){'", "extended": false, "valid": false}
+{"pattern": "[][^\\8&]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?!{1}|\\k<b>(?!\\0*+|0\\2{2,}\\P{Lu})(?>\\c1[^--]]))|", "extended": false, "valid": false}
+{"pattern": "\\k<b>\\a\\G[\\s]", "extended": true, "valid": false}
+{"pattern": "[-]*+(?(<a>)[\\p{>L}A\\c1[[:alpha:]])[A]{\\p{Script=Greek}^", "extended": false, "valid": false}
+{"pattern": "\\c1*+[][]/z-a]*(?(<a>)0{,3}\\12|/\\c1\\3)\\u{41}\\v", "extended": false, "valid": false}
+{"pattern": ",{23}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "9[^|]😀?\\k", "extended": true, "valid": false}
+{"pattern": "\\cA{2}(?(a)(?'a'(?(1)]\\1*+*\\k++{,2}[\\cA]??))\\k<a>\\b |", "extended": true, "valid": false}
+{"pattern": "\\P{Lu}}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{1}[]=??\\3+:", "extended": false, "valid": false}
+{"pattern": ",", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\3\\.\\pL(?(<a>){)*+(?=({?:(?i:[z-a{\\8a]{,2}\\P{Lu}|)(?=\\B\\2[😀!!]{2,3}?)??),\\\\+?)[)[]", "extended": false, "valid": false}
+{"pattern": "[][-)]\\A(?-i:/)(?i:\\Z)\\q", "extended": true, "valid": false}
+{"pattern": "(?x):{2}[][|^a-za-z][^\\]\\w][!!\\s&&](?(?=a)(\\u{41}++(?'a'\\G|\\A)(?(a)^)??)*?|\\1)", "extended": true, "valid": false}
+{"pattern": "(?'a'A)\\n|", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "{,2}😀\\-{2,3}?\\s{1}**\\f", "extended": false, "valid": false}
+{"pattern": ",2}\\e++[-!!", "extended": false, "valid": false}
+{"pattern": "!\\0'>", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^](?|(?=(?+<!&\\a|\\f*?)\\1)++(?##+[^\\\\\\x41[\\b]{,3}[]*+)\\0{2,3}|(?<!\\qA)??\\k<a>\\B)**{1}>+", "extended": false, "valid": false}
+{"pattern": "\\f(?<=(?'a'(?(?=a)\\pL}*?\\1|[/\\p{Script=Greek}\\c1))([]\\x41|\\q&)|(?:(?<!😀\\p{Script=Greek}).|){2})(?P<a>\\1\\cA\\k\\f(\")", "extended": false, "valid": false}
+{"pattern": "[]+$[A\\p{L}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": ">[\\c1$\\\\\\x41]!(?=(?i:_)|)\\c1", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>(?x)(?<b>{{2,3}?|)}<**[{{\\]]|0\\w\\8)(?=b[\\cA\\1[:alpha:]\\bb])\\G😀\\v", "extended": false, "valid": false}
+{"pattern": "(?P<a>\\pL{2}(?<a>](?i)\\A*?[])(?<a>\\k<b>){)(?x)(?(a)\\t)**[]\\B|\\w|++", "extended": true, "valid": false}
+{"pattern": "[\\cA-\\s](?!{1}{2,3})9(?P<a>[\\0]^\\0][^z]\\s)(?=#{2}\\8{2,3}('|[\\8\\\\[]_){2,})", "extended": false, "valid": false}
+{"pattern": "", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{1,2}++[a-\\da]", "extended": true, "valid": false}
+{"pattern": ".+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\12\\\\1\\s[\\s]$]]?[]**[\\c1)\\-\\]", "extended": false, "valid": false}
+{"pattern": "\\s++\\s(?>\\D?\\x4é||(?x)>{2}/{,2}[]{,3})\\pL", "extended": true, "valid": false}
+{"pattern": "\\P{Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]*?[\\x41]{2}\\e{,3}[]{,3}", "extended": false, "valid": false}
+{"pattern": "A?[{\\w]]{2}(?-i:\\e|([][\\s--\\p{L})(?(1)\\12|\\w^**\\a)\\b**\\u{41}??0", "extended": false, "valid": false}
+{"pattern": "\\t\\.+?_<{3,2}", "extended": false, "valid": false}
+{"pattern": "(?>(?<=\\/{3,2} =??)(?(<a>)[](?-i:\\D[^\\8--]++{1}?|[a)][{]{3,2}\\s)\\k'+?)[\\8\\0]\\a(?<!\\8[!!]|[-\\]a$]?)++|", "extended": true, "valid": false}
+{"pattern": "\\t*?&\\cA{2,3}?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA?\\2+(?>(?i:[\\](?|0?#+?)|[\\wa\\]][.(]++(?<b>\\G\\s\\2+))):", "extended": true, "valid": false}
+{"pattern": "\\q{2,3}{\\e(?!\\pL}{2,3}\\.)[]/+", "extended": false, "valid": false}
+{"pattern": "(?|\\p{Script=Greek}(?:_)\\t{3,2})[]\\e??[{\\q{ab}]*+\\v{2,3}([z-a](?(?=a)a[]+))", "extended": false, "valid": false}
+{"pattern": "\\/(?x)(?(<a)^|\\A{,2}(?:$_))", "extended": true, "valid": false}
+{"pattern": "9|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\A?\\w", "extended": false, "valid": false}
+{"pattern": "[a\\s$--]{2,1}", "extended": false, "valid": false}
+{"pattern": "{\\s", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>(?|a>[^\\sz-a{]{3,2}\\A|A{2,})\\v]+?[]]*?", "extended": false, "valid": false}
+{"pattern": "(?i){2,1}**\\-[\\1]+?[a-\\d](?'a'9)|", "extended": true, "valid": false}
+{"pattern": "[\\da-\\d\\cA]\\p{L}{1,2}{2,3}", "extended": false, "valid": false}
+{"pattern": "=+(?<=\\B{2})+?[]\\f&(?<!\\x41+-??.*+", "extended": true, "valid": false}
+{"pattern": "\\Z*$+?(?(<a>)(?(1)[]\\z[\\q{ab}.]|(?<![.a&&|]\\cA.|a))**!(?:!)|)*?[)\\cA[]**", "extended": false, "valid": false}
+{"pattern": "(?>}\\]\\)", "extended": false, "valid": false}
+{"pattern": "(?<<={,2}\\k<b>\\0+|-**)??", "extended": false, "valid": false}
+{"pattern": ".\\B+\\x4", "extended": false, "valid": false}
+{"pattern": "A(?<b>[\\]\\cA\\b😀]_[^\\8&&])_\\cA", "extended": false, "valid": true, "captures": 1, "names": [["b", 1]]}
+{"pattern": "(?(a)$[\\p{LA]=*?|(?!(?(?=a)\\\\{2}))*+)*+\\3(?i:\\-\\\\{2}[&&zz|_\\1😀*?)[{\\0a]*\\k<b>?(?x)\\e:?", "extended": false, "valid": false}
+{"pattern": "\\x4{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": " ^[^]*+", "extended": true, "valid": false}
+{"pattern": "z]|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B(?-i:(?-i:(?>\\z+?|)\\2)+|A+(?#{1,2}*+[\\w&&][\\w.z|]{2,}))[\\0\\p{L}\\p{L}]", "extended": false, "valid": false}
+{"pattern": "\\k{2,3}?(?<a>\\A)+\\/{2,}](?<b> (?<!\\w**/)){2}\\0:", "extended": false, "valid": false}
+{"pattern": "\\p{Script=Greek}0b", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a-b>0[^\\p{L}]\\e)[[.{\\d]", "extended": false, "valid": false}
+{"pattern": "\\-{32}\\t|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]?{2,1}[--]", "extended": false, "valid": false}
+{"pattern": "}{2,}\\B{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?x)(?>\\pL|😀\\t*-){\\P{Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\B", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]{2}[[\\😀/]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\/[$A({]{2,1}", "extended": true, "valid": false}
+{"pattern": "'$", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": " {3,2}|", "extended": true, "valid": false}
+{"pattern": "\\\\{2,}\\-é(?#!?(?<!3[a-z$])*+)++", "extended": false, "valid": false}
+{"pattern": "b\\q{,3}(?!\\)t*?){", "extended": true, "valid": false}
+{"pattern": "(?x)[^/\\1\\s\\q{ab}]{,3}|(?(?=a)\\A(?x){\\cA{2}\\A$)+?\\cA{2,3}\\Z||", "extended": true, "valid": false}
+{"pattern": "[]|", "extended": false, "valid": false}
+{"pattern": "(?x)\\x44<\\cA|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:[z-aa--\\cA| )**\\x41{3,2}(?>\\e\\q:)[]", "extended": false, "valid": false}
+{"pattern": "[-\\p{L}a\\s]++^\\P{Lu}(?P<a>(?<a-b>#{,3}😀\\12||\"*{2,1}){,3}*\\x41\")😀a{2}|", "extended": false, "valid": false}
+{"pattern": "Aé", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\w]*(?!(\\12(?#&|a{,3}|)){2,3})[^\\w--]*?", "extended": false, "valid": false}
+{"pattern": "\\a[]\\1", "extended": false, "valid": false}
+{"pattern": "(?<!a\\c1!){(?'a'[\\w\\-\\cA.]{1,2}\\b|)(?=[a-z])>\\Z\\k<a>", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "(?<=(?i)\\x41(?#[]|\\p{L}\\B{2,3}?[^\\8[:alpha:]--])[/\\\\]a_)**[a-z]*+[|]", "extended": false, "valid": false}
+{"pattern": "(?|[\\p{L}\\1a-\\d\\cA*+|\\x4{2}\\k{2,3}?)\\Z]", "extended": false, "valid": false}
+{"pattern": "(?#[\\wA]++|[\\0]<++\\e{2,3}|)+?[\\]\\cA\\c1\\k<a>**", "extended": false, "valid": false}
+{"pattern": "[(],", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\$.?\\a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\1]\\s\"\"(?(<a>),(?P<a>[](?x)\\\\||\\p{Script=Greek}{2}&'b+|(?:\\t)\\d){<\\zb", "extended": false, "valid": false}
+{"pattern": "^\\b\\x4[\\s&&^]{2,3}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(=?<=\\G[\\-){2} [$A]", "extended": false, "valid": false}
+{"pattern": "(?x)\\2|**\\c1(?'a'\"(?#(?<a>[\\p{L}-\\c1]\\P{Lu}\\A)[\\-\\8]++))A<\\8", "extended": false, "valid": false}
+{"pattern": "=!(?|{1}??)", "extended": true, "valid": false}
+{"pattern": "ab(?<=[\\b][\\c1a\\x41])(?(1)[a-\\da/\\1])[]{,3}\\2", "extended": false, "valid": false}
+{"pattern": "(?#[$\\0[:alpha:]/(?\\k<a>[A]{2}|\\pL^){)\\v\\p{L}'[--$", "extended": false, "valid": false}
+{"pattern": "{1,2}{2,3}?|", "extended": false, "valid": false}
+{"pattern": "\\1(?-i:\\8{2,3}?<{|)é(?(1)(?<![a-\\d](?|[[][)]\\D?)[a]| =)*?A){,3}(?<!# ++(?-i:\\/)).", "extended": true, "valid": false}
+{"pattern": "(?i)\\A(?<=\\cA{2}|[a\\q{ab}]]+?\\k<a>)[\\]a| {,3}\\.0+\\q{1,2}\\k<a>?a\\a", "extended": false, "valid": false}
+{"pattern": "{1,2}[<\\q{ab}]](?x){1}b++\\u{41}", "extended": false, "valid": false}
+{"pattern": "(?i:\\Z\\x4{2,3})|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[^[-][\\8][{\\-", "extended": true, "valid": false}
+{"pattern": "[!!!!\\1&&](?=/|\\P{Lu}[^Az-a]{)++|", "extended": true, "valid": false}
+{"pattern": "\\a{a[$]*\\x41*?\\k<a>{,3}", "extended": true, "valid": false}
+{"pattern": "[\\xx41\\cA--]\\10+?[/]+?\\e", "extended": false, "valid": false}
+{"pattern": "[zz\\\\8]{2,3}?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p-{L}\\\\.[]{,3}\\n", "extended": false, "valid": false}
+{"pattern": "(?'a'(?>(?(a)\\Z[\\b\\0a-z]?!?\\k<a>)[]\\/|\\p{L}{2,3}[]|[\\8]a-z&&])\\v**(?#\\e|)(?!\\B)**", "extended": false, "valid": false}
+{"pattern": "\\3\\2", "extended": false, "valid": false}
+{"pattern": " [][.!!{\\w][\\p{L}^{,3}😀*?", "extended": false, "valid": false}
+{"pattern": "\\Z{2,3}[--\\-\\--\\s**|", "extended": true, "valid": false}
+{"pattern": " +=", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]\\f[]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\cA{2,}\\p{L}?[zza-za-\\d]{,3}&", "extended": false, "valid": false}
+{"pattern": "0[^\\]", "extended": false, "valid": false}
+{"pattern": "[]?[\\]][(?<!(\\z)\\q\\b|[/[](?<=[a-z\\x41](?<b>\\a){2,}|\\u{41}{3,2})\\e{2,})", "extended": false, "valid": false}
+{"pattern": "[\\c1/(\\0]?(?#[\\x41^|#{{(?-i::[]]{3,2}))[]/]\\]]", "extended": false, "valid": false}
+{"pattern": "{2,1}{2}[]]}+?(?-i:(?:(?-i:\\x41)[\\p{L}\\x41])+?)\\n", "extended": false, "valid": false}
+{"pattern": "(?x)={,2}|[]}/++\\G(\\p{L})", "extended": false, "valid": false}
+{"pattern": "\\10[^\\8\\c1]\\u{41}+?", "extended": false, "valid": false}
+{"pattern": ".[z\\b\\x41](?P<a>\\v|\"\\q{)(?x)[](?<a-b><)(?(<a>)[-][^[]{2,3}?(?(?=a)({{3,2}[\\-\\d)]#)\\q))", "extended": false, "valid": false}
+{"pattern": "\\a[a\\\\[:alpha:]]>{2,3}?&|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\x4{[\\d\\d😀a]\\d[^|]\\.{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{1}{,3}=(?<!(?<!\\k)+\\2*?){(?(a)(?<!\\t[\\\\]*)\\12[\\q{ab}++)[](?=\\2\\qa)", "extended": false, "valid": false}
+{"pattern": "[z-a]!", "extended": false, "valid": false}
+{"pattern": "\\z\\t|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[.$\\c", "extended": false, "valid": false}
+{"pattern": "{\\12(?-i:(?!\\p{Script=Greek}\\z{2})++\\k{2,3}\\x41|[\\8\\s\\d]*?)[Aa-z\\d]{2,3}?,é", "extended": false, "valid": false}
+{"pattern": "[--][]\\f[\\c1\\\\]+?", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:\\G[]{2,3}|[-z]\\8)é[[:alpha:]&&{][^\\-&&]\\e", "extended": false, "valid": false}
+{"pattern": "\\10*+(?'a\\-*[^]).++{2,1}$?>+?|", "extended": false, "valid": false}
+{"pattern": "(?!-|(?(?=a),)[\\w|😀{]**\\cA|)\\G+?\\b", "extended": true, "valid": false}
+{"pattern": "\\=f'??", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<=[\\w\\][\\cA])&+A\\.==", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s\\.{2,3}<?\\da+/", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "['*+&", "extended": false, "valid": false}
+{"pattern": "[z\\q${ab}\\dA]", "extended": true, "valid": false}
+{"pattern": "[]\\-[\\q{ab}a]++\\D\"?|", "extended": false, "valid": false}
+{"pattern": ">9{2,3}?<=]\\d\\z", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1\\n", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[b", "extended": true, "valid": false}
+{"pattern": "(?-i:[-(\\]\\c1\\{2}(?i:[^zA]\\0|)++/+?|)", "extended": false, "valid": false}
+{"pattern": "[😀\\]😀^]\\v??<", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[[:alpha:]\\](?:(?P<a><!\\e*?|[(\\cA)(]{,3}\\b??)\\u{41}(?<=\\A(?(?=a)]+&0*|{1}))){3,2}\"\\p{Script=Greek}++(?:[-a-\\d\\8$](\\a(?'a'\\e++[|]|[z-az]]){2,3})|)", "extended": false, "valid": false}
+{"pattern": "[\\d\\x41]\\p{Script=Greek}\\8+.\\B[!!😀]*?", "extended": false, "valid": false}
+{"pattern": "\\k(?(?=a)/|^+(?=[^]\\8\\8", "extended": false, "valid": false}
+{"pattern": "\\e*?\\\\(?-i:(?<=[\\-aa-\\d]+\\8{2,3}?(\\c1\\a\\\\)) ){2,}>(?<a>(?:\"+?(?<a>[&&/{(]$+\\u{41}))*[--]|\\c1*+(?:})){(?(?=a)\\k<b>|\\2{,3}", "extended": true, "valid": false}
+{"pattern": "[|\\1(a]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]](?<=(?'a'-)[]|\\f)😀\\/", "extended": false, "valid": false}
+{"pattern": "[..](?'a'[[:alpha:][:alpha:]a-\\d(]*+[^\\p{L}]**|(?<b>\\x41\\10|[^[\\q{ab}😀][^])$^{2,3}?{2,1}|)\\G\\u{41}?[][z\\x41\\])]*?", "extended": false, "valid": false}
+{"pattern": "\\P{Lu}*$\\c1|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\v\\1{2+}_\\s", "extended": false, "valid": false}
+{"pattern": "é\\3[]]\\w]", "extended": true, "valid": false}
+{"pattern": "[]{,3}(?<a>\\x4)(?|\\\\){2,}(?(<a>)(?<=\\10*?&\\10)\\a\\w|\\\\{2,3}?)", "extended": false, "valid": false}
+{"pattern": "[[\\8-\\d][^](?'a'(?#(?=/\\G[\\a-\\d-\\\\]*+)\\a)\\}a(?'a'[]A{2})(?x)[\\w\\q{ab}^]??", "extended": false, "valid": false}
+{"pattern": "(?>9|\\\\).0\\3", "extended": false, "valid": false}
+{"pattern": "\\p{L}{2,3}[\\w\\-\\\\]b**{,2}\\e.", "extended": true, "valid": false}
+{"pattern": "\\-v(?x)\\v|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\-#&\\x41?\\B\\b|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\1d{2,3}?\\t", "extended": false, "valid": false}
+{"pattern": ":{,3}[[]\\n*+", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<a>\\t\\]c1", "extended": false, "valid": false}
+{"pattern": "(?(a)\\\\f{2}[}(|]{[z\\x41z]{,3}[^^-\\s]{,3}(?'a'!{3,2}\\B*)?[^\\0[:alpha:]]\\3{2,3}?\\12", "extended": false, "valid": false}
+{"pattern": "(?!\\u{41}{2,3}?)\\z", "extended": true, "valid": false}
+{"pattern": "$k\\P{Lu}[\\x41]+\\n{", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a-b>[z[$\\q{ab}]**[\\p{L}z\\])(?'a'\\A{2,}(|?|9\\e|\\q[^\\[\\0][]{,3})[(a-\\d\\sz]||-\\d[\\])", "extended": false, "valid": false}
+{"pattern": "\\>z{>+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\pL(?P<a><){2,3}?\\P{Lu}{2,}\\A", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "\\12*+\\.\\10\\0", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "9[😀A\\cA\\0](?i:\\q|😀\\z", "extended": false, "valid": false}
+{"pattern": "[\\w[:alpha:]]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "_\\x4*[\\\\\\|\\cA]**", "extended": true, "valid": false}
+{"pattern": "[\\[)]++[][:alpha:]!!|", "extended": false, "valid": false}
+{"pattern": "\\-\\p{L}(?<a-b>\\d\\e\\e{{,2}?\\B\\D", "extended": true, "valid": false}
+{"pattern": "(?!\\3[\\8]\\\\)*?,{2,}>\\f", "extended": false, "valid": false}
+{"pattern": "[^.$[:alpha:]\\]{2,}{,2}[]*\\x4{2,1}", "extended": false, "valid": false}
+{"pattern": "(?<a-b>{[\\p{L}z](?|\\1))", "extended": false, "valid": false}
+{"pattern": "(?<b>\\8{3,2}$\\a|)(?:-)+(?x)(?(1)/(?<a-b>\\cA{3,2}\\-{2}|{1,2}|)[^]|{1,2}(?:\\.|\\{x41+?\"*?)\\k<a>)[.(\\d\\c1]|(?=[.z-a]){2,3}?\\x4++??(?<a>[]|{,2})|", "extended": false, "valid": false}
+{"pattern": "(?<b>\\Z)(?i:\\A{2,3}?\\d|[😀{)]{2,}(?P<a>{1}))+\\cA:", "extended": false, "valid": false}
+{"pattern": "(?(?=a)[\\w][\\\\\\d]|(?<a>[|]\\s?? |\\-\\c1)**}**)", "extended": false, "valid": false}
+{"pattern": "{1}[}|\\\\[\\q{ab}{]\\10b{2,}", "extended": false, "valid": false}
+{"pattern": "(?![^a-z^.][^\\x41\\w\\d--]\\k<a>*+|[\\b😀)a-\\d]é<)é**=", "extended": true, "valid": false}
+{"pattern": "\\8\\Z(\\p{L},(?'a'\\0{2,}|}\\\\*))", "extended": false, "valid": false}
+{"pattern": "\\G}{3,2}</!", "extended": false, "valid": false}
+{"pattern": "&|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\s(?<a-b>^{2,3}(?x)(?<!,?#??|\\10\\P{Lu}{,3}[\\x41\\c1\\b])++\\c1+?9{2,3}[\\x41]++|\\1(?<b>[}\\-+|[\\-a&&&&]???)\\v_{[]\\p{L}", "extended": false, "valid": false}
+{"pattern": "\\.\\B++(?(?=a)(?>😀))\\q\\k<b>a", "extended": false, "valid": false}
+{"pattern": "(?(1)[\\[:alpha:]])(?i:\\Z)\\*+", "extended": false, "valid": false}
+{"pattern": "\\w\\Z*?\\D", "extended": false, "valid": false}
+{"pattern": "\\.{\\B(?>\\B(?x)[*+(?(1)\\12){,3}(?<=\\u{41}{2,1})|(?<!\\w\\c1{2})\\cA(?<b>[]a\\.++)|[\\0]?,){2,3}9\\A*?", "extended": false, "valid": false}
+{"pattern": "a{,3}(?!(?!(?=\\12[^\\bz-aA$]\\A)*>*+(?(a)[^]^])|-{2,3}\\v[])|(?>}(?<a-b>[^\\x41.[:alpha:]{]*?\\p{Script=Greek}\\G)){3,2}[^(\\]a-z}{2,3}?)??((?<b>\\cA[^)]{2}\\1|[^a-\\d\\\\]??|)*+(?>\\1{2}|\\-)9){^", "extended": true, "valid": false}
+{"pattern": "&\\A[\\w\\8]-\\u{41}\\A*+", "extended": false, "valid": false}
+{"pattern": "\\.(?:\"**(?(1)\\a<\\cA{)??){2,3}(?-i:=é+|(?#{,2}{2,3}(?i){1}|\\0*+\\d[A]{3,2}|**)?)?{2,}", "extended": false, "valid": false}
+{"pattern": "\\u{41}\\d*+\\pL??}(?(?=a)[)z-a]8*+\\1)++|", "extended": true, "valid": false}
+{"pattern": "\\10 (?>\\P{Lu}[)\\c1[:alpha:]]*😀", "extended": true, "valid": false}
+{"pattern": "(-[\\c1]", "extended": false, "valid": false}
+{"pattern": "\"\\x4{2,}(?<!(?-i:(?=>\\Z[^&&\\ba-\\d\\p{L}])|(?={2,1}\\w?é||[^.\\sa-\\d]a?[\\b]))|\\k<a>\\w*+b|)??\\e\\cA+?[^]{2,3}?", "extended": false, "valid": false}
+{"pattern": "[][A&&!!/]\\v{2,}\\p(L[z]*?/", "extended": false, "valid": false}
+{"pattern": "[^z-az-a-]\\cA*+A{2,3}", "extended": true, "valid": false}
+{"pattern": "\\G{2,3}(?'a'[z-a\\p{L}-])\\d(?i:(?|(?=[^{2}})\\P{Lu}')[-😀]{2,3}?[]^😀)]{2,3}?)", "extended": false, "valid": false}
+{"pattern": "\\k<b>\\s\\A[\\p{L}\\1]]\\B", "extended": false, "valid": false}
+{"pattern": "[\\\\1]\\cA{22,3}?", "extended": false, "valid": false}
+{"pattern": "'", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?(1)(?(?=a)9\\a[[\\x41(z]))", "extended": false, "valid": false}
+{"pattern": "\\x41]|", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "([😀]-][|\\w\\c1}][a\\\\\\]|)*+", "extended": false, "valid": false}
+{"pattern": "\\1\\v{1,2}{{2,}|", "extended": false, "valid": false}
+{"pattern": "[]😀|]\\pL:\\P{Lu}*+", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\<\\", "extended": true, "valid": false}
+{"pattern": ":{2,3}$+?\\D-\\3{2}", "extended": false, "valid": false}
+{"pattern": "[\\]**.", "extended": false, "valid": false}
+{"pattern": "{1,2}(?<b>\\3\\-|[\\-\\d](?!#\\k<b>😀){2,3})(?<\\u{41}|\\p{Script=Greek}\\e**", "extended": false, "valid": false}
+{"pattern": "[][\\d--\\1]\\3|", "extended": false, "valid": false}
+{"pattern": "\\b\\c1??[z-a}[:alpha:](][^{1,2}{2}[\\q{ab}]|", "extended": false, "valid": false}
+{"pattern": "\\10\\x4{\"(?(<a>)(?-i:(?x)[\\\\}]\\]{2}{2,1}*?||&^**#[😀z-a\\1]*?)[^\\b\\p{L}]+|:?(?![]|)\\D*?|)|", "extended": false, "valid": false}
+{"pattern": "0[]-{,2}", "extended": false, "valid": false}
+{"pattern": "\\w*+[\\b\\-a-z[\\0\\],", "extended": true, "valid": false}
+{"pattern": "/++\\Z[^\\]a-z]][]+", "extended": false, "valid": false}
+{"pattern": "[\\x41.(\\d]\\v(?<=\\D)[\\b$a-\\d--]\\1*[\\]\\q{ab}z\\cA]", "extended": false, "valid": false}
+{"pattern": "(?i)[^\\s]+?|(?<a-b>\\.*)(\\u{441}|\\D|){,3}*+!", "extended": true, "valid": false}
+{"pattern": "(?#_)[a\\x41\\cA}](?(<a>)<)^", "extended": false, "valid": false}
+{"pattern": "[}\\-a-z]'|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?-i:\\a)(?P<a>[^}][z-a[:alpha:]😀[]++\\D){2,3}[\\c1--a-z]\\u}{41}[z-az-aa\\]{2,}", "extended": false, "valid": false}
+{"pattern": "A[z-a\\\\[:alpha:]**\\a|", "extended": true, "valid": false}
+{"pattern": "\\3{3,2}\\pL", "extended": true, "valid": false}
+{"pattern": "\\1[--!!(]\\k", "extended": false, "valid": false}
+{"pattern": "{,{2,3}\\A++|", "extended": false, "valid": false}
+{"pattern": ">{\\8*+(?'a'(?(<a>)(?|\\p{Script=Greek})|(?:\\f|\\p{Script=Greek}\\-)+|){2,3}?|[\\1$^]\\1?)", "extended": false, "valid": false}
+{"pattern": "\\t{2,}{,2}\\1+\\2\\\\.(?i:\\x41*|\\/{2,3}?|)", "extended": true, "valid": false}
+{"pattern": "\\x4[^^\\\\.a-z", "extended": false, "valid": false}
+{"pattern": "'(?>-)\\D++", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": ":\\q{,3}]\\pL|", "extended": false, "valid": false}
+{"pattern": "\\B(?<!(?<={,3}[](?'a'[^\\]a.\\d]++)|)){(?<=[\\d\\\\\\d\\-])", "extended": true, "valid": false}
+{"pattern": "_(?={1,2}\\n{,3}", "extended": true, "valid": false}
+{"pattern": "{1,2}", "extended": false, "valid": false}
+{"pattern": "[|]\\\\**}\\k<a>{2}\"+[$\\d\\]\\q{ab}", "extended": false, "valid": false}
+{"pattern": "\\.>{2,3}?[\\cAa-z\\d](?-i:\\10)[^]*", "extended": false, "valid": false}
+{"pattern": "\\n(?(a)(?(1)(?'a'\\12>!)|\\-\\3<)**\\d)(?i:]\\x41[\\cA]|).{2,}\\0{3,2}", "extended": true, "valid": false}
+{"pattern": "\\B{2,}\\D{2,3}\\e++(?:\\10||{,2}[\\ba](?i)-\\2*+\\.|)!_", "extended": false, "valid": false}
+{"pattern": "&!{.+?\\n", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "'{2,3[/^[\\t", "extended": false, "valid": false}
+{"pattern": "\\\\\\d", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\"\\Z_{[\\c1\\0", "extended": false, "valid": false}
+{"pattern": "\\t\\v{2}[]\\w", "extended": false, "valid": false}
+{"pattern": "\\1?(?(a)\\w(?i)0{2}\\u{41}+|\\k<a>**[&&z-a][/😀](?<a>[|a-za/{|\\k<a>{2,}(?<b>\\c1\\x4^)?){3,2}{,2}", "extended": false, "valid": false}
+{"pattern": "[]-\\k", "extended": true, "valid": false}
+{"pattern": "9{3,2}\\.\\f(?=(?:\\12{2,3}}*?\\p{L}|){2}'\\p{Script=Greek}){2,3}?", "extended": false, "valid": false}
+{"pattern": "\\c1?)?", "extended": false, "valid": false}
+{"pattern": "\"-(?#[}/a-z]{2}\\8|}{1,2}$)(?(?=a)[^]++(?<!{,2}\\cA|{,2}[\\q{ab}\\1[:alpha:]\\q{ab}]+|).", "extended": true, "valid": false}
+{"pattern": "(?i)(?#(?<b>\\c1)*+){2,3}?\\n*[\\\\]", "extended": true, "valid": false}
+{"pattern": "{(?'a'\\q{2,}[\\]]\\z+?)(?:(?<a-b><\\pL|){2,}\\pL+?)a*?\\pL{2,}", "extended": false, "valid": false}
+{"pattern": "\\pL[]{2,3}{\\2[\\s\\s\\bA]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\q++", "extended": false, "valid": false}
+{"pattern": "[&&]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "9[\\\\a-\\d|$]\\x4", "extended": true, "valid": false}
+{"pattern": "\\**:\\u{41}+\\x4(?<b>[z-a\\\\]{){", "extended": true, "valid": false}
+{"pattern": "][(a-z\\cA\\]][](?<=\\G+?[a-\\dz\\p{L}&&]{2,3}?|\\s|)\\/", "extended": false, "valid": false}
+{"pattern": "\\pL\\3[|z-a\\]z-a]+?[A\\\\]\\w[]&&{]**", "extended": false, "valid": false}
+{"pattern": "[\\8]{2,}(?<a>(?-i:(?(a)A+?\\k<b>'|\\cA\\p{Script=Greek}){,2}\\b*|\\p{L})(?(?=a)>{3,2}=)|(\\109\\B)++)+?[\\]]", "extended": false, "valid": false}
+{"pattern": "(?{i:[(\\x41\\s]\\x4*+\\.{2,3}?|\\cA+)\\d++<#(?<a-b>\\c1[.]\\n)??\\f+?", "extended": false, "valid": false}
+{"pattern": ":(?i)[!!\\8][^a-z😀]|\\d[|a-\\d😀]**\\0\\10\\2{", "extended": false, "valid": false}
+{"pattern": "0[][!!]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": " ?\\k<b>{,3}", "extended": true, "valid": false}
+{"pattern": "(?<![[:alpha:]){\\cA[[|", "extended": true, "valid": false}
+{"pattern": "\\cA(?-i:\\1&{2,1})(?|(?:\\12)é)(\\cA(?<!(?(a)\\/\\k{2,3}[\\8])[a-\\d.](?x)A>[\\8]))*\\10*?", "extended": false, "valid": false}
+{"pattern": "\\k<a>(?(1)[]??|(?-i:[[:alpha:]&&])\\b)", "extended": true, "valid": false}
+{"pattern": "(?<=$)\\p{Script=Greek}(?|\\n{\\b[a--\\c1\\\\]{2,}|0*+(?P<a>\\z&{2,3}?|)\\k)[|\\q{ab}](?##*-{3,2}\\B{2,3}?)!(?i)(?<a>\\10[()]>|)[[/]", "extended": false, "valid": false}
+{"pattern": "-{", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\c1<\\c1??(?(1)[]{2,3,}|{1})\\z\\x4", "extended": false, "valid": false}
+{"pattern": "(?!(?|\\.+?)++\\G)[az]\\k[\\-]*", "extended": false, "valid": false}
+{"pattern": "(?(?=a)\\x41|,){2,}\\k<b>[\\0\\8\\0]{1,2}{\\d+_|", "extended": false, "valid": false}
+{"pattern": "[\\x41$)][|-\\wa-z](?(1)(?x)(?'a'[[:alpha:]\\c1(]{,2})):", "extended": false, "valid": false}
+{"pattern": "\\wé[^:]{,3}|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?:b)(?<=\\A\\2{3,2}\\e),**[\\q{ab}\\cA!!\\|1]", "extended": false, "valid": false}
+{"pattern": "[]\\Z+?(?=(?<!(?x).|\\d)(?>(?<b>\\1{2,3}?)){\\d){,3}", "extended": false, "valid": false}
+{"pattern": "\\k(?<>\\c1)\\3\\d\\P{Lu}", "extended": false, "valid": false}
+{"pattern": "[!!!😀\\\\][]\\z*", "extended": false, "valid": false}
+{"pattern": "[.[]?\\c1{2,1}", "extended": false, "valid": false}
+{"pattern": "\\/cA\\1,", "extended": true, "valid": false}
+{"pattern": "\\t{2,3}\\.", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": ">>", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\P{Lu}[(}|][^\\b!!\\]]??[a-z/z-a]", "extended": false, "valid": false}
+{"pattern": "\\t\\8[}]\\10", "extended": true, "valid": false}
+{"pattern": "[\\\\😀-](?=\\-(?-i:(?<![\\p{L}$-])\\b{3,2}\\n|\")(?i:-{2,3}?\\k<a>{3,2}[]*?(?=:*+[^\\d[:alpha:]]??)\\pL++\\.+(?=\"+?[\\s|\\x41](\\w\\b(?#b|\\A)))", "extended": false, "valid": false}
+{"pattern": "[a]{2,3}\\3{2,3}?\\a", "extended": false, "valid": false}
+{"pattern": "=[\\--/]^+?\\/\\v**", "extended": false, "valid": false}
+{"pattern": "A(?(1)[\\8\\p{L}]{[\\p{L}](?i:\\Z\\x4-1)[[]|", "extended": false, "valid": false}
+{"pattern": "$[z$a-z\\\\][\\(?'a'\\b*|:\\x41", "extended": true, "valid": false}
+{"pattern": "(?'a'é**|\\3\\a|)\\B**", "extended": false, "valid": false}
+{"pattern": "\\G[^\\8z\\&&{", "extended": false, "valid": false}
+{"pattern": "[\\x41|]\\pL_\\2\\k<b*>\\pL", "extended": false, "valid": false}
+{"pattern": "(?=(?|(?x)A+?[^\\]😀z-a\\-]||(?#\\p{Script=Greek}\\2\\k<b>{3,2}))*+(?(?=a)\"|{1,2}\\pL|)😀[^]", "extended": false, "valid": false}
+{"pattern": "\\2\\w?\\8}{[^--\\x41&&\\](?i){1,2}\\x4{2,}", "extended": false, "valid": false}
+{"pattern": "[[\\8\\b]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": ".{2,3}?(?i)\\f\\a\\b{2,3}?\\b", "extended": false, "valid": false}
+{"pattern": "\\k<b>]{\\B{2,}[]\\cA[\\\\A]", "extended": false, "valid": false}
+{"pattern": "(?>(?=}(?x)<|[z-aa-\\d\\]{2-,3}?[^A^](?|[^\\b][\\w]\\c1){,3})*)[^&&\\b]+?\"{,2}\\-+", "extended": false, "valid": false}
+{"pattern": "\\D??", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "<\\d{,2},{2,3}^?\\8??", "extended": true, "valid": false}
+{"pattern": "[^][/\\1--|??(?>[[--\\x41\\x41]^{2}(?(1)a)|\\.)b", "extended": false, "valid": false}
+{"pattern": "(?i)[]\\G|\\s\\v{2,}:<??\\b", "extended": true, "valid": false}
+{"pattern": "\\P{Lu}/++d&++>[&&\\-z-a--]++", "extended": false, "valid": false}
+{"pattern": "\\cA\\k<b>{_[\\c1(?<a>(?<a>\\p{Script=Greek}!\\/))", "extended": false, "valid": false}
+{"pattern": "$0[(\\\\-]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "$\\q++={3,2}\\0{3,2}", "extended": false, "valid": false}
+{"pattern": "{2,1}(?(?=a)\\p{L}[\\z(]|A\\k<b>*+ {2,3}?|)(?'a' (?<b>(?<! |{1}**'.|))\\d**){2,}\\1", "extended": false, "valid": false}
+{"pattern": "[^\\q{ab})&&^]?:\\2+\\w?", "extended": false, "valid": false}
+{"pattern": "\\3{2}[^\\q{ab}\\cA]\\a(?(1)(?'a'\\cA'){2,3})+\\D*+\\P{Lu}+?|", "extended": false, "valid": false}
+{"pattern": "[\\b]\\k<a>+", "extended": false, "valid": false}
+{"pattern": "](\\w\\v=??{2,}(?=(?'a'[)\\q{ab}],|)\\k\\k+?|[--[\\8])(?(<a>)[\\w]+(?:[]{\\.[-A])\\t)[😀[\\cA\\]]*+", "extended": false, "valid": false}
+{"pattern": "\\-**\\z'(?!(?>[\\s]\\b))😀++", "extended": false, "valid": false}
+{"pattern": "((?i:\\.*+{1,2}|\\k<a>??\"{(?>:\\x41\\x41)\\cA\\k", "extended": false, "valid": false}
+{"pattern": "[\\A]>\\G++", "extended": false, "valid": false}
+{"pattern": "\\\\{2,}(?<![^}&&|]++[)][}a-.][|{1}[^{a|])<+?{1}", "extended": false, "valid": false}
+{"pattern": "(?(<a>)\\u{41}'(?![\\q{ab}\\b]|))*+(?:\"**|[])++", "extended": true, "valid": false}
+{"pattern": "[^\\--😀\\s](?|é[a-\\da])(?i)(?x)[a-z\\]]{,3}[\\s.\\w**\\s|{1,2}\\v{,3}\\\\\\k<b>|", "extended": false, "valid": false}
+{"pattern": "\\Z(?(?=a)(?<a>(?<!\\\\**\\k\\s)||[^\\1--.\\d]*?(?i)\\z\\x4\\u{441}{2}|é)|)[^\\1A]<**", "extended": false, "valid": false}
+{"pattern": "#[^}a-\\d\\d\\s][😀]{2,3}+?\\x4{2}(?:a)", "extended": false, "valid": false}
+{"pattern": "(?<!\"|[&&&&w\\cA]{,2}{2,})", "extended": false, "valid": false}
+{"pattern": "[]{2,3}\\0\\3\\\\", "extended": false, "valid": false}
+{"pattern": "\\3,(?<a-b>\\x4\\p{Script=Greek}|[^]++\\e)[}\\\\-]:", "extended": false, "valid": false}
+{"pattern": "[]?*+\\v[\\])]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "_=(?(1)^\\/|(?!😀)((\\12b\\k|[.a\\cAz-a]{2,1})|\\/{3,2}\\\\{2,}[\\sA]))", "extended": false, "valid": false}
+{"pattern": "\\p{L}*?[|]\\a[\\q{ab}|]\\8", "extended": false, "valid": false}
+{"pattern": "\\-{,3}(?'a'!{2,3}?-{2,})[a-z]{:,3}", "extended": true, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "\"{\\8_{,3}(?i:\\e*+)", "extended": false, "valid": false}
+{"pattern": ":(?'a'\\s||(?<a>\\pL)||)\\a+", "extended": true, "valid": false}
+{"pattern": " {2,}}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "(?<a>\\P{Lu})\\3{,3}\\v[A\\q{ab}\\p{L}][^)]", "extended": true, "valid": false}
+{"pattern": "[a-z\\p{L}0]{3,2}\\c1{2,3}(?:\\0(?-i:[^\\wa-\\d\\cA\\1]))", "extended": true, "valid": false}
+{"pattern": "][^z\\1^]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\d[[:alpha:]\\]]/>*?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\k<aa>??", "extended": false, "valid": false}
+{"pattern": "\\z{2,3}?[\\w-{](?(1)(?-i:=)+\\0b)|", "extended": false, "valid": false}
+{"pattern": "(?=: [])'{[^\\d\\-)A]\\c1+", "extended": false, "valid": false}
+{"pattern": "[--(?(1)[^\\c1\\0a]\\D{2,3})<+?(?(<>)\\k<a>(?<![^][\\-/]{2,})|[]+|)\\1\\\\", "extended": false, "valid": false}
+{"pattern": "!](?<=\\f[^}.]**)[))\\p{L}\\x41](?<a>\\/**#*+0||\\cA\\k<a>)\\n{2}", "extended": false, "valid": false}
+{"pattern": "\\cA![A\\x4", "extended": true, "valid": false}
+{"pattern": "{1,2}{2,}[]-\\c1+?\\a", "extended": false, "valid": false}
+{"pattern": "\\P{Lu}/[](?#(?i\\s>\\t){\\s)", "extended": false, "valid": false}
+{"pattern": "[{]{2,3}.\\k<^a>:{", "extended": false, "valid": false}
+{"pattern": "(?!'-|[--]{2,3}$)", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[][\\]\\q{ab}-]^a|", "extended": false, "valid": false}
+{"pattern": "P{Lu}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\p{Script=Greek}*?(?(<a>)0{[[:alpha:]]\\x4|[\\w][:alpha:]]?(?P<a>\\p{Script=Greek}\\0\\B|$){\\10,", "extended": true, "valid": false}
+{"pattern": "\\.**(?(a){2,1}(?x)[]\\2(?#\\.\"|&A{2,1}|)(?-i:\\s[a-z\\dz-a](?'a'^[&&\\-\\1z]|é)*?){,3}\\2{2,}A", "extended": false, "valid": false}
+{"pattern": "<", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "😀(?x)[😀a-\\d]{2}|#+?[\\cA[alpha:]\\q{ab}]'$", "extended": false, "valid": false}
+{"pattern": "[😀z-a]", "extended": true, "valid": false}
+{"pattern": "[^\\x41-\\-][/]{2,}[\\x41\\p{L}]{2}\\u{41}\\z**", "extended": false, "valid": false}
+{"pattern": "(?(?=a)(?<b>{2,1}\\v(\\10{3,2}|[^]{[&&\\p{L}(\\d]{,2}))'\\a*|[\\--[:alpha:]])??\\.\\pL+9??\\t[\\x41\\8!!z]", "extended": false, "valid": false}
+{"pattern": "{,2}][\\b\\8a--\\d\\d]*\\u{41}++", "extended": false, "valid": false}
+{"pattern": "[\\0](?!:*?[-\\u{41}**[^a-z(?!(?i)(?(a)]\\z|^#)?[]*?|\\-{|)(?!A){.{,3}", "extended": false, "valid": false}
+{"pattern": "(?(a):?|[-]*+)\\p{L}\\t(\\x41++{2,1}|\\A😀??\\A", "extended": true, "valid": false}
+{"pattern": "[^]\\d{2}\\f*?(?x)[$|\\0]\\/|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[]**9\\x41{,3}\\p{L}", "extended": false, "valid": false}
+{"pattern": "\\f{2,3}?[\\w(}]\"[]\\a(?'a'(?(1)(?-i:\\G)-{2,3}?')*\\cA\\B)", "extended": true, "valid": false}
+{"pattern": "(?i)(?<b>[^|)\\b]{2,3}[\\1\\cA])++\\q", "extended": false, "valid": false}
+{"pattern": "(?<a-b>\\3)(?=$(?(?=a)\\x41**\\q*+\\p{Script=Greek}){||\\b[\\1]|){?[}]*?[[\\8z-az]/{2}", "extended": false, "valid": false}
+{"pattern": "(?<=\\A*+)\\:b{2,1}'+", "extended": false, "valid": false}
+{"pattern": "\\8(?P<a>[^z]){,2}<{[^[:alpha:]\\8-}](?(a)[}])*?|", "extended": false, "valid": false}
+{"pattern": ":[^\\s]{2,}{1,2}\\x41😀\\D", "extended": false, "valid": false}
+{"pattern": "(?<=[^]**.)\\1(?=[.]**(?<=\\P{Lu}\\s😀)?[^$\\]])(?-i:[\\b]++){\\Z[\\\\\\p{L}\\c1}]", "extended": false, "valid": false}
+{"pattern": "\\A\\qq\\v", "extended": false, "valid": false}
+{"pattern": "_(?(1)#(?'a'(?<b>!\\8?-*||[^][]+[])\\Z+))(?(a)>[\\w\\p{L}\\0[])*?", "extended": false, "valid": false}
+{"pattern": "(?(a)\\d0)+?*\\eb", "extended": false, "valid": false}
+{"pattern": "-[\\d\\p{L}]", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "{\"\\pL\\p{L}\\q ", "extended": false, "valid": false}
+{"pattern": "\\.++", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "😀\\x41\\{41}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "é{3,2}#**\\d{3,2}(?a'\\1(?i:(?<!$\\12[\\z.])(?(a)\\.{,3}a\\A|){[--z-a[\\\\]+?|\\u{41}(?i:}{2,3}?)\\x4|)A?-++", "extended": true, "valid": false}
+{"pattern": "[^]*[$$a]\\k<b>??[!!!!^]{2,3}?", "extended": false, "valid": false}
+{"pattern": "(?(<a>)[](?:(?-i:<+|\\10\\Z?😀)[]))[\\\\!!][][^", "extended": true, "valid": false}
+{"pattern": "(?'a'<{,3}(?<b>{1}|[]?)[\\0]){2}('?x)(?#.{2}\\P{Lu}😀*?|\\2++é^)[\\]\\p{L}]++|\\p{L}*\\n[]", "extended": false, "valid": false}
+{"pattern": "0\\/\\A&[z\\0]\\a", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[\\cA\\-]{$2}", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\f\\x41*?=(?:\\B(?'a'(?<=\\1||=\")){,3}[[:alpha:]\\w]{1}*", "extended": false, "valid": false}
+{"pattern": "\\k<a>**?", "extended": false, "valid": false}
+{"pattern": "-=?\\s+?\\A\\z*?[^!!$\\x41]]{2,3}(?(a)[\\8A]++[\\w^])", "extended": false, "valid": false}
+{"pattern": "((?'a'[]\\Z|[^.+[]??)", "extended": false, "valid": false}
+{"pattern": "\\w*?(?-i:\\D&?([}A]|[(?(?=a)\\k<a>?|)[])#?>{2,}0|", "extended": false, "valid": false}
+{"pattern": "[^?\\0\\s]", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "\\ww[]+", "extended": false, "valid": false}
+{"pattern": "[\\c1-\\\\]", "extended": true, "valid": false}
+{"pattern": "\\.*+|", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[---]\\A*[]", "extended": false, "valid": false}
+{"pattern": "[^\\w]{2,3}\\z*", "extended": false, "valid": false}
+{"pattern": "é[].\\B\\D", "extended": false, "valid": false}
+{"pattern": "\\u{41}\\12#[^(^^!!][(A]*+0", "extended": false, "valid": false}
+{"pattern": "(?x)(?P<a>[]??\\dd\\A{2,3}\\w[$]]", "extended": false, "valid": false}
+{"pattern": "(?<b>^0||[{\\8\\w$[)]<{3,2}=)", "extended": true, "valid": false}
+{"pattern": "{,2}_+(?(a)(\\z|[\\]\\-\\b])\\Z?\\e", "extended": false, "valid": false}
+{"pattern": "(?:\\u{41}*?}**){3,2}[\\b][^\\c1]\\12\"", "extended": true, "valid": false}
+{"pattern": ",[Aa-z\\x41--]{2,3}\\k<b>/\\b\\.", "extended": false, "valid": false}
+{"pattern": "[^\\]a-z]\\c1][^😀}\\8]a?!(?<a>\\/)", "extended": false, "valid": true, "captures": 1, "names": [["a", 1]]}
+{"pattern": "\\c1](?![{-]\\k<b>)\\1\\A+\\k<b>", "extended": false, "valid": false}
+{"pattern": "(?!\\A9)+?[^[^\\]]=", "extended": true, "valid": true, "captures": 0, "names": []}
+{"pattern": "[a-z/](?<a-b>[\\b)\\0][^]--}])", "extended": false, "valid": false}
+{"pattern": "\\e{\\0}[]", "extended": false, "valid": false}
+{"pattern": "(?i)\\B||\\x41+?", "extended": false, "valid": true, "captures": 0, "names": []}
+{"pattern": "[|\\](?i:[A](?<=\\12a+\\D+?)]{2,3}\\Z{2}é", "extended": false, "valid": false}
+{"pattern": "\\a**\\p{Script=Greek}(?(a)[(\\\\]\\1]|}){2,3}", "extended": false, "valid": false}
+{"pattern": "[]$*\\12**", "extended": false, "valid": false}

--- a/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/PosixConformance.jsonl
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/PosixConformance.jsonl
@@ -1,0 +1,3012 @@
+{"pattern": "a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(a)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a", "dialect": "ere", "valid": false}
+{"pattern": "a)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "()", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(?:)", "dialect": "ere", "valid": false}
+{"pattern": "(?", "dialect": "ere", "valid": false}
+{"pattern": "(?)", "dialect": "ere", "valid": false}
+{"pattern": "[", "dialect": "ere", "valid": false}
+{"pattern": "]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]", "dialect": "ere", "valid": false}
+{"pattern": "[^]", "dialect": "ere", "valid": false}
+{"pattern": "[]a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^]a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a-]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[-a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a-z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[z-a]", "dialect": "ere", "valid": false}
+{"pattern": "[a-a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\d-z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[z-\\d]", "dialect": "ere", "valid": false}
+{"pattern": "[\\w-\\d]", "dialect": "ere", "valid": false}
+{"pattern": "[a-\\w]", "dialect": "ere", "valid": false}
+{"pattern": "[\\b]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\B]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[.]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{", "dialect": "ere", "valid": false}
+{"pattern": "}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{}", "dialect": "ere", "valid": false}
+{"pattern": "{1}", "dialect": "ere", "valid": false}
+{"pattern": "a{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{,1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{1,}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{1,2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{2,1}", "dialect": "ere", "valid": false}
+{"pattern": "a{ 1}", "dialect": "ere", "valid": false}
+{"pattern": "a{1 }", "dialect": "ere", "valid": false}
+{"pattern": "a{1, 2}", "dialect": "ere", "valid": false}
+{"pattern": "a{1,2", "dialect": "ere", "valid": false}
+{"pattern": "a{65535}", "dialect": "ere", "valid": false}
+{"pattern": "a{65536}", "dialect": "ere", "valid": false}
+{"pattern": "a{2147483647}", "dialect": "ere", "valid": false}
+{"pattern": "a{2147483648}", "dialect": "ere", "valid": false}
+{"pattern": "a{99999999999}", "dialect": "ere", "valid": false}
+{"pattern": "a{1}{2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{1}?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{1}+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a**", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a*?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a*+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a+?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a++", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a?+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a???", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "*", "dialect": "ere", "valid": false}
+{"pattern": "+", "dialect": "ere", "valid": false}
+{"pattern": "?", "dialect": "ere", "valid": false}
+{"pattern": "a|*", "dialect": "ere", "valid": false}
+{"pattern": "(*)", "dialect": "ere", "valid": false}
+{"pattern": "(+)", "dialect": "ere", "valid": false}
+{"pattern": "(|*)", "dialect": "ere", "valid": false}
+{"pattern": "^*", "dialect": "ere", "valid": false}
+{"pattern": "$*", "dialect": "ere", "valid": false}
+{"pattern": "\\b*", "dialect": "ere", "valid": false}
+{"pattern": "\\B+", "dialect": "ere", "valid": false}
+{"pattern": "a|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "|a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "||", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(|)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\", "dialect": "ere", "valid": false}
+{"pattern": "a\\", "dialect": "ere", "valid": false}
+{"pattern": "[\\", "dialect": "ere", "valid": false}
+{"pattern": "[a\\", "dialect": "ere", "valid": false}
+{"pattern": "\\0", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\00", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\000", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\01", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\07", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\08", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\1", "dialect": "ere", "valid": false}
+{"pattern": "\\2", "dialect": "ere", "valid": false}
+{"pattern": "\\8", "dialect": "ere", "valid": false}
+{"pattern": "\\9", "dialect": "ere", "valid": false}
+{"pattern": "\\10", "dialect": "ere", "valid": false}
+{"pattern": "\\11", "dialect": "ere", "valid": false}
+{"pattern": "\\12", "dialect": "ere", "valid": false}
+{"pattern": "\\18", "dialect": "ere", "valid": false}
+{"pattern": "\\19", "dialect": "ere", "valid": false}
+{"pattern": "\\99", "dialect": "ere", "valid": false}
+{"pattern": "\\377", "dialect": "ere", "valid": false}
+{"pattern": "\\400", "dialect": "ere", "valid": false}
+{"pattern": "\\777", "dialect": "ere", "valid": false}
+{"pattern": "(a)\\1", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a)\\2", "dialect": "ere", "valid": false}
+{"pattern": "(a)\\10", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "dialect": "ere", "valid": true, "captures": 10}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "dialect": "ere", "valid": true, "captures": 9}
+{"pattern": "\\1(a)", "dialect": "ere", "valid": false}
+{"pattern": "\\2(a)(b)", "dialect": "ere", "valid": false}
+{"pattern": "(a\\1)", "dialect": "ere", "valid": false}
+{"pattern": "[\\1]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\0]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\8]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\x", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\x4", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\x41", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\x4g", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\xg", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\x{41}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\x{}", "dialect": "ere", "valid": false}
+{"pattern": "\\x{110000}", "dialect": "ere", "valid": false}
+{"pattern": "\\x{D800}", "dialect": "ere", "valid": false}
+{"pattern": "\\u", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\u4", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\u004", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "A", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\u{41}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\u{}", "dialect": "ere", "valid": false}
+{"pattern": "\\u{110000}", "dialect": "ere", "valid": false}
+{"pattern": "\\u{10FFFF}", "dialect": "ere", "valid": false}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "dialect": "ere", "valid": false}
+{"pattern": "\\c", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\cA", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\ca", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\cz", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\c1", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\c_", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\c@", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\c[", "dialect": "ere", "valid": false}
+{"pattern": "\\c?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\c]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\cA]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\c1]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\c_]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\c@]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\e", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\f", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\n", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\r", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\t", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\v", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\A", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\Z", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\z", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\G", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\K", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\Q", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\E", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\Qa\\E", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\Qab", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\Q\\E", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\Q]\\E]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\Qa-z\\E]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\h", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\H", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\R", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\X", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\N", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\C", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\g", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\g1", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\g{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\g-1", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(a)\\g-1", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a)\\g{-1}", "dialect": "ere", "valid": false}
+{"pattern": "(a)\\g{+1}", "dialect": "ere", "valid": false}
+{"pattern": "\\g<1>", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\L", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\l", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\U", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\i", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\I", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\j", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\m", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\o", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\o{101}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\o{}", "dialect": "ere", "valid": false}
+{"pattern": "\\o{8}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\N{U+41}", "dialect": "ere", "valid": false}
+{"pattern": "\\N{U+}", "dialect": "ere", "valid": false}
+{"pattern": "\\N{LATIN}", "dialect": "ere", "valid": false}
+{"pattern": "\\y", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\-", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\/", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\:", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\,", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\=", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\!", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\<", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\>", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\@", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\#", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\%", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\&", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\~", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\`", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\\"", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\'", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\_", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\$", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\^", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\.", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\[", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\\\", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\p", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\pL", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\pLu", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\p{L}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Lu}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{L", "dialect": "ere", "valid": false}
+{"pattern": "\\p{}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{^L}", "dialect": "ere", "valid": false}
+{"pattern": "\\P{^L}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Letter}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Uppercase_Letter}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{gc=L}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{General_Category=Letter}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{sc=Greek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Script=Greek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{scx=Grek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Script_Extensions=Greek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Greek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{IsGreek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{InGreek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Bogus}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Any}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{ASCII}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Assigned}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Alphabetic}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Alpha}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{L&}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Xan}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Xwd}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Emoji}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{RGI_Emoji}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Basic_Emoji}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{lu}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{ L}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{L }", "dialect": "ere", "valid": false}
+{"pattern": "\\p{Script=}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{=Greek}", "dialect": "ere", "valid": false}
+{"pattern": "\\p{sc=Bogus}", "dialect": "ere", "valid": false}
+{"pattern": "\\P{RGI_Emoji}", "dialect": "ere", "valid": false}
+{"pattern": "[\\p{RGI_Emoji}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^\\p{RGI_Emoji}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k<", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k<a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k<a>", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k<1>", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k'a'", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\k{a}", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)\\k<a>", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)\\k<b>", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)\\k", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)\\k<a", "dialect": "ere", "valid": false}
+{"pattern": "\\k<a>(?<a>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)(?<a>y)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)", "dialect": "ere", "valid": false}
+{"pattern": "((?<a>x)|(?<a>y))", "dialect": "ere", "valid": false}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)((?<a>y)|z)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>", "dialect": "ere", "valid": false}
+{"pattern": "(?<a", "dialect": "ere", "valid": false}
+{"pattern": "(?<>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<1a>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a1>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<_>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<$>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a$>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a-b>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a b>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?<\\u{61}>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?'a'x)", "dialect": "ere", "valid": false}
+{"pattern": "(?P<a>x)", "dialect": "ere", "valid": false}
+{"pattern": "(?P<a>x)(?P=a)", "dialect": "ere", "valid": false}
+{"pattern": "(?P>a)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)(?P>a)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)(?&a)", "dialect": "ere", "valid": false}
+{"pattern": "(?&a)", "dialect": "ere", "valid": false}
+{"pattern": "(?R)", "dialect": "ere", "valid": false}
+{"pattern": "(?0)", "dialect": "ere", "valid": false}
+{"pattern": "(?1)", "dialect": "ere", "valid": false}
+{"pattern": "(a)(?1)", "dialect": "ere", "valid": false}
+{"pattern": "(a)(?-1)", "dialect": "ere", "valid": false}
+{"pattern": "(a)(?+1)", "dialect": "ere", "valid": false}
+{"pattern": "(?+1)(a)", "dialect": "ere", "valid": false}
+{"pattern": "(?-1)", "dialect": "ere", "valid": false}
+{"pattern": "(a)(?-2)", "dialect": "ere", "valid": false}
+{"pattern": "(?C)", "dialect": "ere", "valid": false}
+{"pattern": "(?C1)", "dialect": "ere", "valid": false}
+{"pattern": "(?C255)", "dialect": "ere", "valid": false}
+{"pattern": "(?C256)", "dialect": "ere", "valid": false}
+{"pattern": "(?C\"a\")", "dialect": "ere", "valid": false}
+{"pattern": "(?C{a})", "dialect": "ere", "valid": false}
+{"pattern": "(?Ca)", "dialect": "ere", "valid": false}
+{"pattern": "(*FAIL)", "dialect": "ere", "valid": false}
+{"pattern": "(*F)", "dialect": "ere", "valid": false}
+{"pattern": "(*ACCEPT)", "dialect": "ere", "valid": false}
+{"pattern": "(*COMMIT)", "dialect": "ere", "valid": false}
+{"pattern": "(*PRUNE)", "dialect": "ere", "valid": false}
+{"pattern": "(*SKIP)", "dialect": "ere", "valid": false}
+{"pattern": "(*THEN)", "dialect": "ere", "valid": false}
+{"pattern": "(*MARK:a)", "dialect": "ere", "valid": false}
+{"pattern": "(*:a)", "dialect": "ere", "valid": false}
+{"pattern": "(*MARK)", "dialect": "ere", "valid": false}
+{"pattern": "(*BOGUS)", "dialect": "ere", "valid": false}
+{"pattern": "(*UTF)", "dialect": "ere", "valid": false}
+{"pattern": "(*UCP)", "dialect": "ere", "valid": false}
+{"pattern": "(*CR)", "dialect": "ere", "valid": false}
+{"pattern": "a(*UTF)", "dialect": "ere", "valid": false}
+{"pattern": "(*", "dialect": "ere", "valid": false}
+{"pattern": "(*a", "dialect": "ere", "valid": false}
+{"pattern": "(?=a)", "dialect": "ere", "valid": false}
+{"pattern": "(?!a)", "dialect": "ere", "valid": false}
+{"pattern": "(?<=a)", "dialect": "ere", "valid": false}
+{"pattern": "(?<!a)", "dialect": "ere", "valid": false}
+{"pattern": "(?=a)*", "dialect": "ere", "valid": false}
+{"pattern": "(?!a)+", "dialect": "ere", "valid": false}
+{"pattern": "(?<=a)?", "dialect": "ere", "valid": false}
+{"pattern": "(?<!a){2}", "dialect": "ere", "valid": false}
+{"pattern": "(?<=a+)", "dialect": "ere", "valid": false}
+{"pattern": "(?<=a*)", "dialect": "ere", "valid": false}
+{"pattern": "(?<=a|bc)", "dialect": "ere", "valid": false}
+{"pattern": "(?<=(a)\\1)", "dialect": "ere", "valid": false}
+{"pattern": "(?>a)", "dialect": "ere", "valid": false}
+{"pattern": "(?>a)*", "dialect": "ere", "valid": false}
+{"pattern": "(?|(a)|(b))", "dialect": "ere", "valid": false}
+{"pattern": "(?|(a)|(b)(c))\\3", "dialect": "ere", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "dialect": "ere", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "dialect": "ere", "valid": false}
+{"pattern": "(?i)", "dialect": "ere", "valid": false}
+{"pattern": "(?i)a", "dialect": "ere", "valid": false}
+{"pattern": "(?i:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?-i)", "dialect": "ere", "valid": false}
+{"pattern": "(?-i:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?i-m:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?im-s:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?-)", "dialect": "ere", "valid": false}
+{"pattern": "(?-:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?i-:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?ii:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?i-i:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?x)", "dialect": "ere", "valid": false}
+{"pattern": "(?s:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?m:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?n:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?n)(a)", "dialect": "ere", "valid": false}
+{"pattern": "(?q)", "dialect": "ere", "valid": false}
+{"pattern": "(?^)", "dialect": "ere", "valid": false}
+{"pattern": "(?^i)", "dialect": "ere", "valid": false}
+{"pattern": "(?^i:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?xx)", "dialect": "ere", "valid": false}
+{"pattern": "(?J)", "dialect": "ere", "valid": false}
+{"pattern": "(?U)", "dialect": "ere", "valid": false}
+{"pattern": "(?a)", "dialect": "ere", "valid": false}
+{"pattern": "(?u)", "dialect": "ere", "valid": false}
+{"pattern": "(?aD)", "dialect": "ere", "valid": false}
+{"pattern": "(?r)", "dialect": "ere", "valid": false}
+{"pattern": "(?i", "dialect": "ere", "valid": false}
+{"pattern": "(?i:a", "dialect": "ere", "valid": false}
+{"pattern": "a(?i)*", "dialect": "ere", "valid": false}
+{"pattern": "(?i)*", "dialect": "ere", "valid": false}
+{"pattern": "(?#comment)", "dialect": "ere", "valid": false}
+{"pattern": "(?#comment", "dialect": "ere", "valid": false}
+{"pattern": "(?#)a", "dialect": "ere", "valid": false}
+{"pattern": "a(?#x)*", "dialect": "ere", "valid": false}
+{"pattern": "a(?#x){2}", "dialect": "ere", "valid": false}
+{"pattern": "(?(1)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(1)a|b)(x)", "dialect": "ere", "valid": false}
+{"pattern": "(?(1)a|b|c)(x)", "dialect": "ere", "valid": false}
+{"pattern": "(?(a)x|y)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)(?(a)x|y)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "dialect": "ere", "valid": false}
+{"pattern": "(?<a>x)(?('a')x|y)", "dialect": "ere", "valid": false}
+{"pattern": "(?(<a>)x|y)", "dialect": "ere", "valid": false}
+{"pattern": "(?(R)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(R1)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(R&a)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(DEFINE)(?<a>x))", "dialect": "ere", "valid": false}
+{"pattern": "(?(DEFINE)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(+1)a|b)(x)", "dialect": "ere", "valid": false}
+{"pattern": "(?(-1)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(x)(?(-1)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(VERSION>=10.0)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?=a)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?!a)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?<=a)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?:a)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(a)", "dialect": "ere", "valid": false}
+{"pattern": "(?(", "dialect": "ere", "valid": false}
+{"pattern": "(?()a)", "dialect": "ere", "valid": false}
+{"pattern": "(?(1a)x)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?#c)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?<n>x)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "(?(?'n'x)a|b)", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:bogus:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:]", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha]]", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[.hyphen.]]", "dialect": "ere", "valid": false}
+{"pattern": "[[.-.]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[=a=]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[=ab=]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:]-z]", "dialect": "ere", "valid": false}
+{"pattern": "[a-[:alpha:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]-z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:ALPHA:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:^alpha:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:word:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:blank:]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[:alpha:]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a[]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a[b]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a-z-[aeiou]]", "dialect": "ere", "valid": false}
+{"pattern": "[a-z-[b]c]", "dialect": "ere", "valid": false}
+{"pattern": "[a-[b]]", "dialect": "ere", "valid": false}
+{"pattern": "[[a]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[a]b]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a&&b]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a--b]", "dialect": "ere", "valid": false}
+{"pattern": "[a--]", "dialect": "ere", "valid": false}
+{"pattern": "[--a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a&&]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[&&a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[a]&&[b]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[a]--[b]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\w&&\\d]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\w--\\d]", "dialect": "ere", "valid": false}
+{"pattern": "[a&&b&&c]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a--b--c]", "dialect": "ere", "valid": false}
+{"pattern": "[a&&b--c]", "dialect": "ere", "valid": false}
+{"pattern": "[ab&&c]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a-z&&[aeiou]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[a-z]&&[aeiou]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\q{abc}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\q{abc|d}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^\\q{abc}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^\\q{a}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\q{}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\q{a}", "dialect": "ere", "valid": false}
+{"pattern": "[|]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[(]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[)]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[{]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[}]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[/]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[-]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\&]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\!]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\#]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\%]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\,]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\:]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\;]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\<]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\=]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\>]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\@]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\`]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\~]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\$]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\^]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[!!]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[##]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[$$]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[%%]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[**]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[++]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[,,]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[..]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[::]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[;;]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[<<]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[==]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[>>]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[??]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[@@]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^^]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^^^]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[``]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[~~]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a^^]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[&]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[&&&]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\d-]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[-\\d]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a-\\d]", "dialect": "ere", "valid": false}
+{"pattern": "[\\s-\\S]", "dialect": "ere", "valid": false}
+{"pattern": "[\\p{L}-z]", "dialect": "ere", "valid": false}
+{"pattern": "[a-\\p{L}]", "dialect": "ere", "valid": false}
+{"pattern": "[\\x41-\\x5A]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\x5A-\\x41]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[A-Z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\cA-\\cZ]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\0-\\x20]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\b-\\n]", "dialect": "ere", "valid": false}
+{"pattern": "[\\n-\\b]", "dialect": "ere", "valid": false}
+{"pattern": "[\\--a]", "dialect": "ere", "valid": false}
+{"pattern": "[a-\\-]", "dialect": "ere", "valid": false}
+{"pattern": "[%--]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[+--]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a^]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[$]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\]a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\\\]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\\\]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a\\]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a\\]b]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[#]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[ ]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{1", "dialect": "ere", "valid": false}
+{"pattern": "x{a}", "dialect": "ere", "valid": false}
+{"pattern": "x{1,a}", "dialect": "ere", "valid": false}
+{"pattern": "x{,}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{,5}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{ ,5}", "dialect": "ere", "valid": false}
+{"pattern": "x{5, }", "dialect": "ere", "valid": false}
+{"pattern": "x{1,2}{3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{1}*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{0}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{0,0}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{00001}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{1}{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(?:a){1}{2}", "dialect": "ere", "valid": false}
+{"pattern": "^", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "$", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^^", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "$$", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a^", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "$a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a^b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a$b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(^a)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a$)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "a|^b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a$|b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^*a", "dialect": "ere", "valid": false}
+{"pattern": "\\(a\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1,\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1,2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{,2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{2,1\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\|b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "*a", "dialect": "ere", "valid": false}
+{"pattern": "**", "dialect": "ere", "valid": false}
+{"pattern": "\\(*a\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(^a\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\|*b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1\\}\\{2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a*\\{2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)\\1", "dialect": "ere", "valid": false}
+{"pattern": "\\1\\(a\\)", "dialect": "ere", "valid": false}
+{"pattern": "\\(a\\)\\2", "dialect": "ere", "valid": false}
+{"pattern": "\\w", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\W", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\s", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\S", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1\\}*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(a)*", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a)+?", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a){2}{3}", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "a+*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a?*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a*{2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{2}*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{2}+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(?:", "dialect": "ere", "valid": false}
+{"pattern": "(?=", "dialect": "ere", "valid": false}
+{"pattern": "(?<", "dialect": "ere", "valid": false}
+{"pattern": "(?<=", "dialect": "ere", "valid": false}
+{"pattern": "(?'", "dialect": "ere", "valid": false}
+{"pattern": "(?P", "dialect": "ere", "valid": false}
+{"pattern": "(?P=", "dialect": "ere", "valid": false}
+{"pattern": "(?P>", "dialect": "ere", "valid": false}
+{"pattern": "(?P<", "dialect": "ere", "valid": false}
+{"pattern": "(?&", "dialect": "ere", "valid": false}
+{"pattern": "(?R", "dialect": "ere", "valid": false}
+{"pattern": "(?1", "dialect": "ere", "valid": false}
+{"pattern": "(?C", "dialect": "ere", "valid": false}
+{"pattern": "(?(1)", "dialect": "ere", "valid": false}
+{"pattern": "(?#", "dialect": "ere", "valid": false}
+{"pattern": "\\Q(\\E", "dialect": "ere", "valid": false}
+{"pattern": "\\Q[\\E", "dialect": "ere", "valid": false}
+{"pattern": "(\\Qa)\\E)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "[\\Qa\\E]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\Q\\E]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\E]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a\\Q]\\E]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\E\\E", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(?x)a b", "dialect": "ere", "valid": false}
+{"pattern": "(?x)a#b", "dialect": "ere", "valid": false}
+{"pattern": "c", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(?x)[a b]", "dialect": "ere", "valid": false}
+{"pattern": "(?x)[ ]", "dialect": "ere", "valid": false}
+{"pattern": "(?x)a {2}", "dialect": "ere", "valid": false}
+{"pattern": "(?x)a{2} ?", "dialect": "ere", "valid": false}
+{"pattern": "(?x)a\\ b", "dialect": "ere", "valid": false}
+{"pattern": "(?x)\\", "dialect": "ere", "valid": false}
+{"pattern": "(?x)(? :a)", "dialect": "ere", "valid": false}
+{"pattern": "(?x)( ?:a)", "dialect": "ere", "valid": false}
+{"pattern": "(?x)(?#)", "dialect": "ere", "valid": false}
+{"pattern": "(?x)a#(", "dialect": "ere", "valid": false}
+{"pattern": "(?x)\\p{ L}", "dialect": "ere", "valid": false}
+{"pattern": "(?x)\\k< a>", "dialect": "ere", "valid": false}
+{"pattern": "(?x)a+ +", "dialect": "ere", "valid": false}
+{"pattern": "(?xx)[a b]", "dialect": "ere", "valid": false}
+{"pattern": "[[=a=]-z]", "dialect": "ere", "valid": false}
+{"pattern": "[a-[=z=]]", "dialect": "ere", "valid": false}
+{"pattern": "[a-[.z.]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[z-[.a.]]", "dialect": "ere", "valid": false}
+{"pattern": "[a-z-9]", "dialect": "ere", "valid": false}
+{"pattern": "[--0]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[a-z-]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]-]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[-[:alpha:]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:a]b:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:]]", "dialect": "ere", "valid": false}
+{"pattern": "[[::]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:][:digit:]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[.]", "dialect": "ere", "valid": false}
+{"pattern": "[[.].]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[=]=]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[.space.]]", "dialect": "ere", "valid": false}
+{"pattern": "[[.-.]-z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[\\w]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]-a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^]-a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]-]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[b-a]", "dialect": "ere", "valid": false}
+{"pattern": "a{2}{3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(a)**", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "a$*", "dialect": "ere", "valid": false}
+{"pattern": "\\<*", "dialect": "ere", "valid": false}
+{"pattern": "\\>*", "dialect": "ere", "valid": false}
+{"pattern": "\\`*", "dialect": "ere", "valid": false}
+{"pattern": "\\'*", "dialect": "ere", "valid": false}
+{"pattern": "\\B*", "dialect": "ere", "valid": false}
+{"pattern": "\\w*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(^)*", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(*a)", "dialect": "ere", "valid": false}
+{"pattern": "(+a)", "dialect": "ere", "valid": false}
+{"pattern": "(|a)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(a|*b)", "dialect": "ere", "valid": false}
+{"pattern": "a|*b", "dialect": "ere", "valid": false}
+{"pattern": "a|+b", "dialect": "ere", "valid": false}
+{"pattern": "a|?b", "dialect": "ere", "valid": false}
+{"pattern": "a|{1}b", "dialect": "ere", "valid": false}
+{"pattern": "({1}a)", "dialect": "ere", "valid": false}
+{"pattern": "x{,2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{1,}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{}", "dialect": "ere", "valid": false}
+{"pattern": "x{ }", "dialect": "ere", "valid": false}
+{"pattern": "x{1a}", "dialect": "ere", "valid": false}
+{"pattern": "x}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{32767}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{32768}", "dialect": "ere", "valid": false}
+{"pattern": "a{255}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a{256}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{00}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{01}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a||b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(a|)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "a))", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "())", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "(()", "dialect": "ere", "valid": false}
+{"pattern": "a{", "dialect": "ere", "valid": false}
+{"pattern": "a{1", "dialect": "ere", "valid": false}
+{"pattern": "a{1,", "dialect": "ere", "valid": false}
+{"pattern": "(a)(b)\\2", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "(a)\\0", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "^a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a??", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x{1}?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a^*", "dialect": "ere", "valid": false}
+{"pattern": "(a)|\\1", "dialect": "ere", "valid": false}
+{"pattern": "(a|)b", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "[a", "dialect": "ere", "valid": false}
+{"pattern": "[^", "dialect": "ere", "valid": false}
+{"pattern": "a[]b]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\d", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(\\{1\\}\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\|\\{1\\}b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{2\\}*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)\\{2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a\\1\\)", "dialect": "ere", "valid": false}
+{"pattern": "a\\+\\?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a|b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\|a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(\\|a\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x\\{,2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x\\{1", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x\\{a\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x\\{\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{32768\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a$", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a$\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a$\\|b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\|^b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x\\{1\\}\\?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)\\|\\1", "dialect": "ere", "valid": false}
+{"pattern": "a\\|^*b", "dialect": "ere", "valid": false}
+{"pattern": "\\(^*a\\)", "dialect": "ere", "valid": false}
+{"pattern": "x*\\+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "x\\+*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(\\+a\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\|\\+b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\+a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\?a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^\\+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^\\{1\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\{1,2", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)\\{1\\}*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^\\{2,3\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\>\\{2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\b\\{2,3\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\b**", "dialect": "ere", "valid": false}
+{"pattern": "\\b\\?*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\<.\\<**", "dialect": "ere", "valid": false}
+{"pattern": "{**", "dialect": "ere", "valid": false}
+{"pattern": "?(<[][]*)((b\\)({,2}?{$))[[]\\|{2,})\\n\\(+*", "dialect": "ere", "valid": false}
+{"pattern": "[^--[.[.-.]][z[.]{2,}", "dialect": "ere", "valid": false}
+{"pattern": "[[[:bogus:]$$]*?(()[z*](\\(b*?[])||\\>([[.-.]-az](,*))+*)+", "dialect": "ere", "valid": false}
+{"pattern": ",3,2}\\w[a.],|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "([^\\]**[[.-.][.-.]][[:]{2,3}){{", "dialect": "ere", "valid": false}
+{"pattern": "[[*]*[z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": ".\\*\\?{2,?[][\\z]*?", "dialect": "ere", "valid": false}
+{"pattern": "[]{,}", "dialect": "ere", "valid": false}
+{"pattern": "\\.+|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "|[\\z-aa-z[:bogus:]]{1,2}(\\>)[a[.a.]]", "dialect": "ere", "valid": false}
+{"pattern": "\\a\\((\\{)\\{1\\}{2,}-\\a{3<,2}", "dialect": "ere", "valid": false}
+{"pattern": "+*([][:alpha:]]{3,2}[|({||[[.-.][:alpha:][.a.]]]{3,2}\\x41)),)", "dialect": "ere", "valid": false}
+{"pattern": "\\1[^.]\\{1,2\\}{2}[[.a.][.a-z](\\2||\\<?\\\\[[[[:bogus:]]?)**", "dialect": "ere", "valid": false}
+{"pattern": "?\\a?.{2,3}(+)", "dialect": "ere", "valid": false}
+{"pattern": "\\!(+", "dialect": "ere", "valid": false}
+{"pattern": "{|[]\\?", "dialect": "ere", "valid": false}
+{"pattern": ")?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "b([[]**", "dialect": "ere", "valid": false}
+{"pattern": "([[.-.]\\W|)?\\(\\|{,3}[][[:[.*]", "dialect": "ere", "valid": false}
+{"pattern": "(\\+[$$\\]{3,2}\\(*b[]", "dialect": "ere", "valid": false}
+{"pattern": "\\b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(^)){2}", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": ".((|[][:a-z]){2,}0){(\\2{\\?(a?|(\\{1,2\\}+{2,}\\s{,3}))|\\\\\\+([^z-a]?(\\(*+*)\\.*)).+\\n", "dialect": "ere", "valid": false}
+{"pattern": "{1}*(([]|)(\\b[[=a=]z$*]{(\\.+|)|{,2}*?(||[*[^z-a][:bogus:]-])(\\2*?|))+|)(\\)\\W[$[:bogus:][:bogus:][.a.]]", "dialect": "ere", "valid": false}
+{"pattern": "(({2,'3}{,2}\\x41)[\\*]", "dialect": "ere", "valid": false}
+{"pattern": "(\\\\)({,2}\\*)[-]**\\([^.[.-.].]|", "dialect": "ere", "valid": false}
+{"pattern": "((\\>*?(0[[:[.a.]a]0||)(()+|$(0\\*){(\\n){,3}){3,2})[[:]\\n[]*[z[=a=]]{3,2}\\<{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "+\\w((\\|\\a{2,})|)+*[a-z]{1}{,3}", "dialect": "ere", "valid": false}
+{"pattern": "[[[.a.][:alha:]]*?", "dialect": "ere", "valid": false}
+{"pattern": "?(((a{1}\\b|))(a||\\\\*[^]]{2}^){{2}", "dialect": "ere", "valid": false}
+{"pattern": "{}\\?{,3}\\w", "dialect": "ere", "valid": false}
+{"pattern": "-[[.[.-.][=a=]-", "dialect": "ere", "valid": false}
+{"pattern": "\\\\={2,3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[](?a{2,})", "dialect": "ere", "valid": false}
+{"pattern": "(,|\\x41\\>{2,}|)*", "dialect": "ere", "valid": false}
+{"pattern": "\\b\\)2}.{1}\\)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1\\}((\\|)?\\\\+){,3}|", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "\\?(*^(\\W\\**)|(($0*?{||)[^*[:bogus:]]{[])-)\\}**", "dialect": "ere", "valid": false}
+{"pattern": "\\+\\>((\\n+\\{1,2\\}(\\>a{|)|\\a**\\{1,2\\}(\\|\\)\\|)){,3}\\>)*?\\>.", "dialect": "ere", "valid": false}
+{"pattern": "(0\\b**)[]a[=a=]]*([]|\\2?)|", "dialect": "ere", "valid": false}
+{"pattern": "b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[=a=]]{2,3}{\\*}{((^[]^]{2}[]{2,3}|(*\\bb)(\\w{3,2}\\*)[]{2,3}*)\\>", "dialect": "ere", "valid": false}
+{"pattern": "(", "dialect": "ere", "valid": false}
+{"pattern": "[[:-z]{2,3}({1,2}\\{|)\\.{2,}){2}?***+", "dialect": "ere", "valid": false}
+{"pattern": "[][z-a[.a.]]+^(?{\\a)[-", "dialect": "ere", "valid": false}
+{"pattern": "(\\<*){,3}(,(.){2,}0((\\1{3,2}){1,2}+*)+*", "dialect": "ere", "valid": false}
+{"pattern": "(0\\+|+++(()\\>)($\\n|{[^z]{2,3}\\\\{){))|", "dialect": "ere", "valid": false}
+{"pattern": "\\*{2,3}[$[:alpha:][.][a]*(\\{1\\}\\<*?)[z]", "dialect": "ere", "valid": false}
+{"pattern": "((\\<\\|))*\\W,\\s1", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "(+*++){,3}(\\1[a-z]z]\\*)\\.", "dialect": "ere", "valid": false}
+{"pattern": "\\<\\x41{3,2}?[]", "dialect": "ere", "valid": false}
+{"pattern": "{[\\]\\1({,2})|({{2,3}[^]**\\)){", "dialect": "ere", "valid": false}
+{"pattern": "{1,2}^{,3}(\\2{2,}|).(a\\\\|\\}+0[^-[:alpha:]\\])", "dialect": "ere", "valid": false}
+{"pattern": "(\\\\)*((({3,2}\\.\\>{3,2}|)\\W(\\*\\\\)){2,3}([[]?++\\{)*\\{**)*?[[]", "dialect": "ere", "valid": false}
+{"pattern": "(.&\\.|\\>b()\\s\\<{,3})*?)(\\.|[.]*?\\}\\\\{3,2}){0(", "dialect": "ere", "valid": false}
+{"pattern": "((^|.?[[:[=a=][])[](\\w*|}(?+\\w\\x41|\\{1\\}\\|)\\?))\\W\\{{*{,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\{1\\}?(\\}{,2}),*?", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "[^]zz-a][^]|", "dialect": "ere", "valid": false}
+{"pattern": "\\b(\\{1,2\\}*{,2}[^[:])?+a\\{", "dialect": "ere", "valid": false}
+{"pattern": "[$*^\\{2,}", "dialect": "ere", "valid": false}
+{"pattern": "[[<.-.]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\(\\{1,2\\}\\?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\a+{[a-za-z[:\\", "dialect": "ere", "valid": false}
+{"pattern": "-+\\w(((0-^||[[.[.-.]]+\\+))((+{2}\\)|\\+\\|)\\()\\{{)[[]((\\|\\>{))+*", "dialect": "ere", "valid": false}
+{"pattern": "^([[:bogus:]z.]{2}{,3}{1,2}([])|", "dialect": "ere", "valid": false}
+{"pattern": "\\{+\\\\\\.+*([^^$[:alpha:][{2,}|{,2}*\\|)|", "dialect": "ere", "valid": false}
+{"pattern": "\\2b(\\\\\\{[]|\\?\\|{)\\w(\\b(\\.{1,2\\}){2,3})((-){2,3}|(\\b\\<**(a[^a-z[.-.]]|{1,2}+)|[^]])[\\[$])", "dialect": "ere", "valid": false}
+{"pattern": "[z-a[.][]\\n|", "dialect": "ere", "valid": false}
+{"pattern": "$+*((++(\\|a)*?|(a**[a[[:alpha:]]]\\<)+[^.]\\}),(\\.?)|((\\?{[a-z[.-.]-[.a.]]\\b+|)[^[:bogus:]z-a*]{2,3}(\\>{2}|\\2[^]\\]{|))[[.a.]a]{,2})[z-a]*.\\x41", "dialect": "ere", "valid": false}
+{"pattern": "()?[]{2,})*\\2{,3}()[^^]\\<|(${^[\\\\[:]){2,}[^*\\a-z{2}([[.-.]*$.]**\\2{2,3}|{2,3}|\\?\\2\\w", "dialect": "ere", "valid": false}
+{"pattern": "\\+{1}\\a[[alpha:]\\[]^|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[][:]]?", "dialect": "ere", "valid": false}
+{"pattern": "[]{2}\\)", "dialect": "ere", "valid": false}
+{"pattern": "\\s\\s\\n{3,2}()\\a+\\|)\\>|", "dialect": "ere", "valid": false}
+{"pattern": "{{2,}([[=a=][:bogus:]z]*?)(", "dialect": "ere", "valid": false}
+{"pattern": "[*]\\W){+*+", "dialect": "ere", "valid": false}
+{"pattern": "\\([^\\[.],[[:bogus:][:[:^]^|{2,}b|", "dialect": "ere", "valid": false}
+{"pattern": "(+),{2}\\W?(\\(a[-*]](\\}?\\2|^{)))", "dialect": "ere", "valid": false}
+{"pattern": "\\{1\\}?{1}+*$?\\{1\\}", "dialect": "ere", "valid": false}
+{"pattern": "[^[[:]*?(-.|){,2}{3,2}\\.{,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\<([]|[^]+*$)a0[^]\\\\", "dialect": "ere", "valid": false}
+{"pattern": "()|[[=a=]--^][-[:]))[][.]", "dialect": "ere", "valid": false}
+{"pattern": "([^z-a[:-){,3}[]\\n*?)^[^[=a=][$]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "((\\n{1})[[:[.-.]]*\\){,2}(*\\1|)", "dialect": "ere", "valid": false}
+{"pattern": "\\+{2,3}?\\2\\a0-", "dialect": "ere", "valid": false}
+{"pattern": "{,2}}{,3}[]*\\2", "dialect": "ere", "valid": false}
+{"pattern": "-", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^a[:bogus:]\\\\]", "dialect": "ere", "valid": false}
+{"pattern": "-(\\.{)\\.*[[.-.][.-.]]**(", "dialect": "ere", "valid": false}
+{"pattern": "\\++(({,2}**(\\a\\}?{,3})\\{1\\}||\\2*()\\x41{,2,})?)-*)|", "dialect": "ere", "valid": false}
+{"pattern": "\\}(\\?{,3}^\\b*?)", "dialect": "ere", "valid": false}
+{"pattern": "((|(\\([z-a[:bogus:]]{2,3}\\{1,2\\}{3,2})|a(-||+*)(){3,2}a{{2,3}\\+{[*\\]", "dialect": "ere", "valid": false}
+{"pattern": "))[]**", "dialect": "ere", "valid": false}
+{"pattern": "\\<\\+\\\\[]|", "dialect": "ere", "valid": false}
+{"pattern": "(a,**)[*\\1\\>${\\{1,2\\}*?", "dialect": "ere", "valid": false}
+{"pattern": "b{2}[[.a-z[:](\\>{,3}\\{\\a?)\\.{", "dialect": "ere", "valid": false}
+{"pattern": "){,3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\{{|\\W[]+)", "dialect": "ere", "valid": false}
+{"pattern": ")", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "({1}|(([]0\\.){{,3}|{,2})[[:alpha:]z[:alpha:][:bogus:]])[][^.[.-.]\\-]{({1,2}{3,2}a||[][:alpha::][:*][]\\w)\\{1\\}\\W", "dialect": "ere", "valid": false}
+{"pattern": "\\w[\\[a[[:alpha:]]\\>{2,3}\\{1\\}+", "dialect": "ere", "valid": false}
+{"pattern": "\\w?^", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(?\\+\\2|((\\b|)[^[:alpa:]z]z-a]\\1|+\\*)+[$z^[.a.]\\w)[z]{1,2}[^a[:]*[]", "dialect": "ere", "valid": false}
+{"pattern": "([^a]\\}*?((()**){2})+[*a-z--]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\)({,2}[[[[]*|\\{**\\{+)([--a-zz])*+", "dialect": "ere", "valid": false}
+{"pattern": "\\\\((-)[][.-.][]\\?**)\\w?", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "([[.[:[:bogus:][]?{,2}{3,2})[-][.-]\\({,2}?|", "dialect": "ere", "valid": false}
+{"pattern": "(b{1}([z-aaa-z^]+*\\n)((\\n?))", "dialect": "ere", "valid": false}
+{"pattern": ")(,{,3})[[:]+*\\b{2,3}b[a-z]", "dialect": "ere", "valid": false}
+{"pattern": "[^]*\\1", "dialect": "ere", "valid": false}
+{"pattern": "))", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1\\}[^[:bogus:]z-aa-z][$[.-.][=a=]]?(b({1}+*|)(\\n[*])+*){1,2}((\\({2,3}(^+{,3})**|\\?)", "dialect": "ere", "valid": false}
+{"pattern": "{,2}(([]*\\W$+*|\\{1,2\\}**\\|?)", "dialect": "ere", "valid": false}
+{"pattern": "[}\\w?|", "dialect": "ere", "valid": false}
+{"pattern": "{1}},[][:alpha:][][[:bogus:][[.-.][]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "[[.a]\\.]\\b+\\b", "dialect": "ere", "valid": false}
+{"pattern": "[][^-*^[.[[=a=]]+\\?", "dialect": "ere", "valid": false}
+{"pattern": "[^.[.]]{,?3}", "dialect": "ere", "valid": false}
+{"pattern": "{,2}", "dialect": "ere", "valid": false}
+{"pattern": "([](\\b{2})({1})|{^,{2,3})|[^\\a-z]a", "dialect": "ere", "valid": false}
+{"pattern": "(\\{1\\}+*((\\|)\\w)|[\\z-a^])+*\\+)**[$[]]\\{\\>[]", "dialect": "ere", "valid": false}
+{"pattern": "\\w(\\.(\\b|([^[.[[:alpha:]]\\\\){2}(\\<{2}|\\s\\*+*)(.{2,}))}(\\|[a[=a=]]){3,2}[a][.[]\\b,", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:][.-.]$]**{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{[-z-a-^]", "dialect": "ere", "valid": false}
+{"pattern": "(a?|((-{,2}){3,2}){2,3}){3,2}", "dialect": "ere", "valid": false}
+{"pattern": ".*a[[-]{", "dialect": "ere", "valid": false}
+{"pattern": "[-]|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "|\\a[[.a.]--\\][[:][^]", "dialect": "ere", "valid": false}
+{"pattern": "\\*\\a{1}+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\+{2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\>*?\\2{2,3}0", "dialect": "ere", "valid": false}
+{"pattern": "([[:alpha:][:bogus:].a][z-a]*?)(\\x41\\}{2,})\\1", "dialect": "ere", "valid": false}
+{"pattern": "(\\.[^.*])),[z[:\\]*[a][[:bogus:][:alpha:]]", "dialect": "ere", "valid": false}
+{"pattern": "\\a*(\\{1,2\\}|\\x41+\\w*-){2,}((\\w$+))[]{,2}[]]{2,}", "dialect": "ere", "valid": false}
+{"pattern": "[a\\[.+-.]^]|", "dialect": "ere", "valid": false}
+{"pattern": "\\w([[^][*$.z-a]*?", "dialect": "ere", "valid": false}
+{"pattern": "\\>\\W\\n\\|?+*${", "dialect": "ere", "valid": false}
+{"pattern": "(\\b?*){2,3}", "dialect": "ere", "valid": false}
+{"pattern": "[^[.a.]\\z\\-a*]{2,3}(\\a(-\\({,3})(\\{1\\}[-a[:]\\<{3,2}))", "dialect": "ere", "valid": false}
+{"pattern": "?}\\>^^", "dialect": "ere", "valid": false}
+{"pattern": "[^$[:]][z-a\\]\\a{,2}**\\>", "dialect": "ere", "valid": false}
+{"pattern": "[*[.-.]]{,3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "$\\", "dialect": "ere", "valid": false}
+{"pattern": "([]^z-aa-z]{,3})", "dialect": "ere", "valid": false}
+{"pattern": "*(\\\\{|\\1{<2,}", "dialect": "ere", "valid": false}
+{"pattern": "\\\\)0*((+|)+\\<|\\\\+.)*?", "dialect": "ere", "valid": false}
+{"pattern": "[]\\1?\\)$", "dialect": "ere", "valid": false}
+{"pattern": "[a[:alpha:][:alpha:[.a.]]\\n{1}?(\\a)\\n\\{1\\}|", "dialect": "ere", "valid": false}
+{"pattern": "((|\\W){2,}\\..(\\1{2,3})", "dialect": "ere", "valid": false}
+{"pattern": "(||){3,2}(\\\\\\\\*?){3,2}((){1})+^)*\\n", "dialect": "ere", "valid": false}
+{"pattern": "[[*=a=][](\\w[]{2,3}})*?\\{1,2\\}^*?{1,2}*", "dialect": "ere", "valid": false}
+{"pattern": "[^.]*[[:a-z[:]}-[a-z[:[:alpha:]a]", "dialect": "ere", "valid": false}
+{"pattern": "\\+**{1,2}**\\2,{^{3,2}(({,3}((.?)?[*^.*]|\\w\\w)\\x41){,3}", "dialect": "ere", "valid": false}
+{"pattern": "[z[.a.]z-a]", "dialect": "ere", "valid": false}
+{"pattern": "\\w{2}[-[.-.]$^{1}(\\)\\\\\\{1\\}{2,3}|0([][*[=a=]-]{3,2})?[^]{2,})\\<{2}|", "dialect": "ere", "valid": false}
+{"pattern": "((\\x41[^[.[.-.].]{2,3})(\\w\\n\\.)*\\s{{,2}{2,}[]{,3}\\*{", "dialect": "ere", "valid": false}
+{"pattern": "(([z[.a.]])|((\\n[^]|\\b[.])[--]*?\\\\){,2}{,2})\\{1,2\\})*?((\\)\\*'){3,2}[])", "dialect": "ere", "valid": false}
+{"pattern": "(\\n\\+|\\>{2,}\\\\)[]*()}{3,2}\\2{,3>})", "dialect": "ere", "valid": false}
+{"pattern": "[-a-za]?b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{1}\\|(([]|)\\+[$-^[:alpha:]=){", "dialect": "ere", "valid": false}
+{"pattern": "\\|\\W+((\\<[\\[..]]|b[-a]**|{2,}|({(|*?[\\[:z-a]**|[].))", "dialect": "ere", "valid": false}
+{"pattern": "[[:[.-.]]", "dialect": "ere", "valid": false}
+{"pattern": "\\2\\\\[\\[.a.][=a=]{2,3}", "dialect": "ere", "valid": false}
+{"pattern": "{,2}{2,}[$](**+{", "dialect": "ere", "valid": false}
+{"pattern": "\\>^{2,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\*{2,}{,2}{2}\\{1,2\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "+\\w-([^*[alpha:]*^]|){,3}|){,3}\\w+\\b{", "dialect": "ere", "valid": false}
+{"pattern": "[z-a]]?,{2}((((\\[1)b[[:z]|\\*)\\2\\{1,2\\}+*)", "dialect": "ere", "valid": false}
+{"pattern": "\\WW", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\?((\\}[[.a.][=a=]$z]\\2|b})[^{2,}\\w){3,2}|", "dialect": "ere", "valid": false}
+{"pattern": "{(,{3,2}{\\{|\\{[[:z-a[.-.]]**}{2,}(()?|\\w\\\\+({,2}{2,}.)\\{1\\})\\x41+[^[a-z]([\\\\a]|([]\\{1\\}\\<{3,2}(0|\\*\\s)|)", "dialect": "ere", "valid": false}
+{"pattern": "()+)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\{1\\}*?b[$*[.-.][.a.]]*?(b(\\s{2})\\{1\\}+*|)^()+*(\\\\\\\\))", "dialect": "ere", "valid": true, "captures": 4}
+{"pattern": "[^-][[.-.]a.](", "dialect": "ere", "valid": false}
+{"pattern": "(\\a{2,}())a{[.a.][.-.][:bogus:]]{", "dialect": "ere", "valid": false}
+{"pattern": "[\\n{2}\\<\\s", "dialect": "ere", "valid": false}
+{"pattern": "\\{1,2\\}(a{\\(+*|\\1?|)){1,2}[^]", "dialect": "ere", "valid": false}
+{"pattern": "[.$](\\),\\x41)[^[=a=][=a=]]^", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "({2,3}(?\\|*?)+[.[::]((+^**||\\2){a)+*", "dialect": "ere", "valid": false}
+{"pattern": "[^a]]\\.b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\){3,2}[a[:bogus:]]\\W", "dialect": "ere", "valid": false}
+{"pattern": "([[a-z[=a=][][[[:alpha:]]{2,})b", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "]\\>", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\n){2}a", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "0", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a\\)b?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[.[.]{,2}[^-[.*[:alpha:]]", "dialect": "ere", "valid": false}
+{"pattern": "(?[-.$$]{2,})\\}{3,2}\\<((\\.\\..){2,}\\n)\\2{,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\<*\\<(\\*b)\\{1\\}", "dialect": "ere", "valid": false}
+{"pattern": "[[.--.]]", "dialect": "ere", "valid": false}
+{"pattern": "\\x41\\)(}", "dialect": "ere", "valid": false}
+{"pattern": "\\}{2,}[[:alpha:][:[.a.][:]\\1{3,2}(([^])*)", "dialect": "ere", "valid": false}
+{"pattern": "(a:{1}|?)|", "dialect": "ere", "valid": false}
+{"pattern": "([[:alpha:][:alpha:]]]\\.a*?)?-{2}|**\\W", "dialect": "ere", "valid": false}
+{"pattern": "\\<({1,2})**", "dialect": "ere", "valid": false}
+{"pattern": "{+*(+*|", "dialect": "ere", "valid": false}
+{"pattern": "-|[]", "dialect": "ere", "valid": false}
+{"pattern": "\\b\\{\\{1,2\\}\\\\{\\|", "dialect": "ere", "valid": false}
+{"pattern": "([z-az]{|([[:]\\?\\w)[^)(\\w{,\\\\|[a]$^]|\\<)^[^^[.-.]]\\<", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]]b+*b{3,2}|", "dialect": "ere", "valid": false}
+{"pattern": "[[.?([^](0{2}|\\{(\\|+*|^*)(\\{1\\}?)))", "dialect": "ere", "valid": false}
+{"pattern": "\\{**[\\]\\*{1,2\\}\\(\\w+*|", "dialect": "ere", "valid": false}
+{"pattern": "[[.\\](\\a.)(\\{1,2\\}(\\>|(\\{|{,2})\\a+\\*){2,3\\})(\\*\\<?|*|)\\x41", "dialect": "ere", "valid": false}
+{"pattern": "\\n,+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\)[]\\|", "dialect": "ere", "valid": false}
+{"pattern": "([]*[|(^([.]*\\1)[[:alpha:]][:z))*(([[:bogus:]]](\\)a{2,}))[]+)", "dialect": "ere", "valid": false}
+{"pattern": "b?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1,2[\\}", "dialect": "ere", "valid": false}
+{"pattern": "\\|*)((\\s\\<+*^", "dialect": "ere", "valid": false}
+{"pattern": "[[*=a=][.-.]z]{2}[[:alpha:]]{,3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": ".a-zaa]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\?{1,2}(\\n[[?\\(|\\+[a-z[=a=]z-a[.]*?[$a])^[a]", "dialect": "ere", "valid": false}
+{"pattern": "({[$[:alpha:]$[:bogus:]]-|?((b*,|\\2++.)[[:]*\\W)\\x41)\\x41", "dialect": "ere", "valid": false}
+{"pattern": "[]*", "dialect": "ere", "valid": false}
+{"pattern": "[]\\]*(\\>{,3}[^*[:bogus:]]", "dialect": "ere", "valid": false}
+{"pattern": "((", "dialect": "ere", "valid": false}
+{"pattern": "+$", "dialect": "ere", "valid": false}
+{"pattern": "+\\\\}(((^|\\w)(\\n\\(\\w?)){2,}[])", "dialect": "ere", "valid": false}
+{"pattern": "\\\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[](\\s{,2}+*|{1}*\\+)[]{,3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]{1}\\)|", "dialect": "ere", "valid": false}
+{"pattern": "[]a-zz-a]+\\)**(^+\\<{,3}([^[.-.][.-^^))\\W", "dialect": "ere", "valid": false}
+{"pattern": "\\>(0[])\\?-+,", "dialect": "ere", "valid": false}
+{"pattern": "},{2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\w($**[z]{1,2}**)b", "dialect": "ere", "valid": false}
+{"pattern": ".}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "([[=a=]a-z*][^\\[:bogus:]a-z^])", "dialect": "ere", "valid": false}
+{"pattern": "", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\b),().{2,3})(\\>(((a{3,2}\\x41)\\{[[:a-z]{2})|a{2,3}\\{1,2\\}**)\\b", "dialect": "ere", "valid": false}
+{"pattern": "-,{{1,2}(\\W\\))\\W", "dialect": "ere", "valid": false}
+{"pattern": "b{,2}\\2[].]", "dialect": "ere", "valid": false}
+{"pattern": "([^[.^z]\\**|)*\\s{2}(\\(-{32}){2,}^{2,3}\\a**\\2*?|", "dialect": "ere", "valid": false}
+{"pattern": "((({1}\\2){(\\)**[^z-a[:bogus:]])|)*?\\>)\\a+{,2}{,3}[[=a=]][]", "dialect": "ere", "valid": false}
+{"pattern": "**\\1-*?-**|", "dialect": "ere", "valid": false}
+{"pattern": "\\[\\z-a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]}[^[:aa-z]\\2", "dialect": "ere", "valid": false}
+{"pattern": "{,2}{,3}[[.a.]*.]", "dialect": "ere", "valid": false}
+{"pattern": "[$z-a[]$", "dialect": "ere", "valid": false}
+{"pattern": "(((*)){,3}){2}", "dialect": "ere", "valid": false}
+{"pattern": "[z-a][^[=a=]\\[:]((.\\*{)){3,2}[^$$z[][[:alpha:]a-za-z](\\a{\\<{1}", "dialect": "ere", "valid": false}
+{"pattern": "([[:bogus:][:alpha:]^]**((\\\\**\\*|))**|\\+\\{1,2\\}{2,3}){2,}", "dialect": "ere", "valid": false}
+{"pattern": "[z-a]$\\|-((([[]{2,}\\<|\\{1\\})+(\\),**))|\\(){1,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\(\\1{{2}^", "dialect": "ere", "valid": false}
+{"pattern": "\\<{{,2|", "dialect": "ere", "valid": false}
+{"pattern": "($?\\>\\1+)*?{,2}{,3}\\x41", "dialect": "ere", "valid": false}
+{"pattern": "[][=a=]\\]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(([[:alpha:]][=a=][=a=]]+\\s:[[:alpha:])[-]){1}{3,2}a)+\\{*", "dialect": "ere", "valid": false}
+{"pattern": "\\}{2,}[^.]*[[$a-z]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]^[:[]a\\>*[$]]", "dialect": "ere", "valid": false}
+{"pattern": "(\\\\*(([]\\{|\\x41{1,2}?\\n)^{3,2}){,3}\\.)[^]z-aa$]?", "dialect": "ere", "valid": false}
+{"pattern": ".[$[.-.]]{2,}\\a(}[[[.a.]]\\>\\(|{*)(([]|,(\\)**)}+)", "dialect": "ere", "valid": false}
+{"pattern": "(.{3,2}?)^{2,3}\\w(\\2|){,3}(\\2b$|\\x41+*[]\\s){,3}(([-^z]\\{1\\}\\W)+*\\))*?", "dialect": "ere", "valid": false}
+{"pattern": ",[^[.]", "dialect": "ere", "valid": false}
+{"pattern": "{,{2}**[^[:[=a=]\\z]+(\\}\\{1,2\\}{2}\\n{)[[\\][:bogus:]]\\*[^a]", "dialect": "ere", "valid": false}
+{"pattern": "[^]{2}b*", "dialect": "ere", "valid": false}
+{"pattern": "([z]+*[]){3,2}((\\?[[:alpha:][.-.]]z][^]{2,3}|(?{2}\\b\\+){2,3}[[:])**(({,2}{,3}|(\\>*?[]+*[]{2})\\2[^]\\[:.])){*", "dialect": "ere", "valid": false}
+{"pattern": "([].{2'}((^+\\\\.)+|", "dialect": "ere", "valid": false}
+{"pattern": "[[:bogus:]][.a.]]**{1}{2,3}[[.a.]*]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\b+", "dialect": "ere", "valid": false}
+{"pattern": "\\+\\{1,2\\}[a-z](*{2,}})", "dialect": "ere", "valid": false}
+{"pattern": "**+\\W+", "dialect": "ere", "valid": false}
+{"pattern": ".(\\}[z-a[.a.]]\\n){3,2}|", "dialect": "ere", "valid": false}
+{"pattern": "[[:bogus:][:bogus:]$[.]", "dialect": "ere", "valid": false}
+{"pattern": "\\{1,2\\}{2,}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(((\\?[[.-]\\s+*){1,2}+*{1}**){2,})\\b[]?([\\^[$]|[{2})*", "dialect": "ere", "valid": false}
+{"pattern": "\\1{3,2}[]{3,2}[^z]**", "dialect": "ere", "valid": false}
+{"pattern": "\\x41[^[.-.][:bogus:]a[:]\\1", "dialect": "ere", "valid": false}
+{"pattern": "(((0|[z[:bogus:][*]{3,2}\\){2,3})){{2,3}\\{([*[:alpha:]]\\a{2,}([[.a.].]*)+)[[:-]", "dialect": "ere", "valid": false}
+{"pattern": "\\}(){\\<){(\\{1\\}[]]|(\\)(\\{1\\}{2}||\\{1,2\\}{,2}**)|\\{1\\}\\|{).(\\|)){2,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\[|\\b**{1,2}{[^^]\\1-", "dialect": "ere", "valid": false}
+{"pattern": "$-{3,2}(^)(,}\\?)+[]*(\\{1\\}\\){2,3}(^([$z]{)+*))", "dialect": "ere", "valid": false}
+{"pattern": "{1,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\2\\)\\2\\bb)+", "dialect": "ere", "valid": false}
+{"pattern": "[^[[[.-.]](([[.-.][.-.]]{2,3}||(\\{1\\}[])\\.[\\][[:alpha:][:bogus:]a[:]){3,2}-\\W", "dialect": "ere", "valid": false}
+{"pattern": "+-{2}[a*z]|", "dialect": "ere", "valid": false}
+{"pattern": "\\(\\{12\\}?\\{1\\}[[:alpha:]\\z-a]", "dialect": "ere", "valid": false}
+{"pattern": "[^[.a.]]\\|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\}{1,2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{1}b\\>{,3}(}+)", "dialect": "ere", "valid": false}
+{"pattern": "[aa-zz[.a.]](${1}){3,2}", "dialect": "ere", "valid": false}
+{"pattern": "{,2}([[.[]\\**\\|)$", "dialect": "ere", "valid": false}
+{"pattern": "0?[]az\\[:alpha:]]$$", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\1[[^]{2}[[*[](([])([[=a=]](\\}\\||[]\\*\\>{2}|)[|\\+{\\1)|(,[[:bogus:]\\*]+|{", "dialect": "ere", "valid": false}
+{"pattern": "\\{1\\}\\>[*\\{1,2\\}[$*[.-.]*]}*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[*.]**((,*|\\w*)+)", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "\\?*((|(\\)b[]*){2,}[][:[.a.]])({1,2}?\\}", "dialect": "ere", "valid": false}
+{"pattern": "[^[.][[:alpha:]](\\.[^$]]{2,3}\\{,1\\})*|", "dialect": "ere", "valid": false}
+{"pattern": "(\\?|\\\\)\\+-*?\\w(\\1+*\\}|\\))[^a-za[.]", "dialect": "ere", "valid": false}
+{"pattern": "\\){", "dialect": "ere", "valid": false}
+{"pattern": "\\>{2}^**([^])\\a*?", "dialect": "ere", "valid": false}
+{"pattern": "[^z[.a.]*[.][[[.a.]$[.]**", "dialect": "ere", "valid": false}
+{"pattern": "(\\>\\{+\\**)(0+*|(({{3,2}\\})){3,2})\\<^(\\w|", "dialect": "ere", "valid": false}
+{"pattern": "\\2**\\s+*[[:]\\+*\\|\\\\", "dialect": "ere", "valid": false}
+{"pattern": "[a\\]{2,})", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "*\\2", "dialect": "ere", "valid": false}
+{"pattern": "[\\w[[.*z[.]", "dialect": "ere", "valid": false}
+{"pattern": "[^[.a-z[:alpha:]-]\\2{,2}+([]){){2,}${3,2}\\*{2,3}", "dialect": "ere", "valid": false}
+{"pattern": "[a-z]*?(\\\\{{3,2}((|*?\\()*|\\<?*?))*?\\b[[:$^]-{,3}\\1|", "dialect": "ere", "valid": false}
+{"pattern": "[^[:a[.-.](}\\+{2}(\\W+{3,2}))", "dialect": "ere", "valid": false}
+{"pattern": "{,2}\\*[[.-.]]?", "dialect": "ere", "valid": false}
+{"pattern": "^\\}a", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "}(}**[[:[.a.]\\]\\)|\\((\\{,2\\})){(\\1[^[=a=]a-z[]|)", "dialect": "ere", "valid": false}
+{"pattern": "(\\{1,2\\}0{3,2}a{2,3})([](\\{),)\\<*\\n\\(|", "dialect": "ere", "valid": false}
+{"pattern": "\\|[[.a.]]$[=a=]\\]{2}([\\]a-z)^\\)*?", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\w*?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]$]|{2,}(+([z])?)", "dialect": "ere", "valid": false}
+{"pattern": "{[\\]\\b[^z](\\+)\\?", "dialect": "ere", "valid": false}
+{"pattern": "[\\[=a=]]^[$z]{2,3}(-[[.-.]$])+[^a-z]{,3}{", "dialect": "ere", "valid": false}
+{"pattern": "+.\\n[[:alpha:]a-z[:\\]\\?", "dialect": "ere", "valid": false}
+{"pattern": "((\\w{2}(\\n|([$z[[.-.]]+\\+|{1}{,3})**)){3,2}([*^]*?\\2*\\||\\>(\\{1,2\\}?)({))[z.z][^[.-]{,3}({,2}[z-a^[:bogus:]z]|{2})", "dialect": "ere", "valid": false}
+{"pattern": "[-[.a.]?[.[.]+", "dialect": "ere", "valid": false}
+{"pattern": "\\*((?)}|([-][[.-.]](\\>b|){[-.^]{2,}){3,2}\\({2,}\\<({1,2}{3,2}\\|+||\\?)[z-az[.-.][:bogus:]", "dialect": "ere", "valid": false}
+{"pattern": "[:bogus:]**", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "+({2,})[[=a=]]{", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:]z[.]|", "dialect": "ere", "valid": false}
+{"pattern": "[$..]**", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\w{,3}\\41\\+\\n[[:bogus:]]\\){2}", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]]**", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(^*|)\\2{2,}\\.", "dialect": "ere", "valid": false}
+{"pattern": "$^", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "}{1,2}.*?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1}\\{\\\\[.]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[*]\\\\w[]", "dialect": "ere", "valid": false}
+{"pattern": "[[.\\][=a=][[.z-a[.a.]]-+", "dialect": "ere", "valid": false}
+{"pattern": "\\a((\\2({)|)|--*?(\\{1,2\\}(([[.z-a.z-a])){2}|)+)", "dialect": "ere", "valid": false}
+{"pattern": "[^[.[.](-{1}{3,2}\\{)({1}^*?(\\?\\{))[^-[=a=]](([[:*][])){,3}(", "dialect": "ere", "valid": false}
+{"pattern": "^{,3}{,2?}*(\\W\\|{2,})\\{1\\}", "dialect": "ere", "valid": false}
+{"pattern": "(\\W{2,3}((\\}([^a][]**|\\{1\\}+*\\>a)\\W|[[:alpha:]],{2}\\\\)[-]+*|\\?)[]?[^]{,3}{1,2}{,2}{,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\a)\\{0", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\2{,3}[a[:alpha:]]^(\\(\\w*?(({,3}{3,2})\\{", "dialect": "ere", "valid": false}
+{"pattern": "((|,|),+**)[]\\}?*{,2}0", "dialect": "ere", "valid": false}
+{"pattern": "0\\W}|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\<*?0[^$a[.+|", "dialect": "ere", "valid": false}
+{"pattern": "\\?[[.]*^\\*{2}[[.[.[.a.]$]{({1,2}{2,3}([[\\]+[]a-[.a.]])|\\b*?)", "dialect": "ere", "valid": false}
+{"pattern": "(\\(?((\\w{2}).{3,2}|(,|*)(*{,3}0\\>)(\\b+*)+){2,})\\{\\s[^.\\z-a]**\\1", "dialect": "ere", "valid": false}
+{"pattern": "\\({3,2}:[[]", "dialect": "ere", "valid": false}
+{"pattern": "\\{1\\}\\x1", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1,2\\}|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\+{2,,3}", "dialect": "ere", "valid": false}
+{"pattern": "b*?.**[[:bogus:][.-.]]", "dialect": "ere", "valid": false}
+{"pattern": "\\(\\2[^.:].+*\\2\\n", "dialect": "ere", "valid": false}
+{"pattern": "\\n\\|([]*)[\\[:alpha:]]+*", "dialect": "ere", "valid": false}
+{"pattern": "{}[^[.[]{3,2}\\\\", "dialect": "ere", "valid": false}
+{"pattern": ":{1}\\b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:][]+*({,2}*|[-]]\\}*){3,2}{{1}[^[.]{,3}", "dialect": "ere", "valid": false}
+{"pattern": "+{2}\\({,3}\\\\", "dialect": "ere", "valid": false}
+{"pattern": "[-.]\\n", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[z]{1,2}+*|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[.$]\\|(((\\*[[.a.]$]){|(\\>)({1}:\\W{,3}b)\\W{2,3})\\w[][:alpha:]^])\\|", "dialect": "ere", "valid": false}
+{"pattern": "(?{{2,3}\\x41{2,3}|)", "dialect": "ere", "valid": false}
+{"pattern": "\\*'\\|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\+[^*][][a[:alpha:][.a.]][^]{2,}\\<", "dialect": "ere", "valid": false}
+{"pattern": "a(\\s{3,2}-)(\\s+)\\{1,2\\}{\\||", "dialect": "ere", "valid": false}
+{"pattern": ")[][.a.]z-a.]\\.{2}([^.$*]{1,2}{2}){3,2}a", "dialect": "ere", "valid": false}
+{"pattern": "(a{2}(\\)(\\w*\\>\\.|\\***\\b)(\\\\|\\}\\([[.\\]))+*|\\a+)\\w([^[]0a)?", "dialect": "ere", "valid": false}
+{"pattern": "[^[=a=].[:z]\\)w\\*", "dialect": "ere", "valid": false}
+{"pattern": "{1,2}{2&,3}", "dialect": "ere", "valid": false}
+{"pattern": "(|{,3}(\\1([a[.-.]-a[][.a.]]|[]**$))){[^]", "dialect": "ere", "valid": false}
+{"pattern": "(([]\\\\+*[^^])[z][:alpha:]\\]+*-+|+[$[=a=]*-]),{3,2}[]]((\\>{2,}({a\\{)|((\\\\|(*?\\1{[][:alpha:][.a.]\\])?[[:^-]|\\s[^a-z])+*", "dialect": "ere", "valid": false}
+{"pattern": "(\\\\(\\+{,2}{2,3}(?,{1,2}))[[z])[]\\<?|", "dialect": "ere", "valid": false}
+{"pattern": "[^]\\W*[a[:alpha:]*]*\\.?{1}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(a{2,}([^]?b^|)\\)|[[:]+*-|", "dialect": "ere", "valid": false}
+{"pattern": "($)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "([]\\W*?[\\[=a=][=a=]$])-", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": ")\\W", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\()*?[[*]]{2}[z-a^\\]\\(a}", "dialect": "ere", "valid": false}
+{"pattern": "[^*^]*\\1", "dialect": "ere", "valid": false}
+{"pattern": "({1,2}^[z-a[:$[=a=]]+*)\\\\-", "dialect": "ere", "valid": false}
+{"pattern": "[z](\\*{2})*.[^]{2}", "dialect": "ere", "valid": false}
+{"pattern": "(\\*\\?{2,}\\2*\\+[](\\}{2}[\\[=a=']]|b{2,3}\\n+*)", "dialect": "ere", "valid": false}
+{"pattern": "{1,2}?\\{", "dialect": "ere", "valid": false}
+{"pattern": "\\s{3,2}({1}{3,2}\\{)([-[=a=]]{2}\\|", "dialect": "ere", "valid": false}
+{"pattern": "[^]|", "dialect": "ere", "valid": false}
+{"pattern": "\\wb[^]\\b{2,3}\\\\{2}|", "dialect": "ere", "valid": false}
+{"pattern": "\\{1<\\}[[.-.]-\\]\\b\\1[^]+*", "dialect": "ere", "valid": false}
+{"pattern": "\\))[[.aa.]*][].+*[\\.]", "dialect": "ere", "valid": false}
+{"pattern": ".|{,3}\\{1\\}[[.a.]\\]((\\|{2,3})||){2}((\\a))-", "dialect": "ere", "valid": false}
+{"pattern": "+\\s{2,", "dialect": "ere", "valid": false}
+{"pattern": "${2,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\{1,2\\}{", "dialect": "ere", "valid": false}
+{"pattern": "\\.((|*[z-az-a])(\\??){3,2}0(})?[a\\]z]*?|", "dialect": "ere", "valid": false}
+{"pattern": "b*{1,2}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": ")\\2\\n(\\s**|((a*?\\a[]*)))", "dialect": "ere", "valid": false}
+{"pattern": "(((+?\\.|0()|(\\\\))+*){}\\|\\{1\\}\\?{,3}.", "dialect": "ere", "valid": false}
+{"pattern": "[]\\\\\\{1,2\\}((\\na{3,2}[**)", "dialect": "ere", "valid": false}
+{"pattern": "+\\.(\\1**,\\<|)({,2}({2}\\s|(\\{1,2\\}\\x41+*(\\*\\s\\\\||[[:^]*?)|([)[[:alpha:]^*]){2}){\\w|)", "dialect": "ere", "valid": false}
+{"pattern": "\\)[]}{2,3}-{2,3}\\??|", "dialect": "ere", "valid": false}
+{"pattern": "[^[.-.]]\\){,2}{", "dialect": "ere", "valid": false}
+{"pattern": "!+(\\b*[]*?|){2}[]", "dialect": "ere", "valid": false}
+{"pattern": "{,2}]", "dialect": "ere", "valid": false}
+{"pattern": "(\\?[[.$.[.][^]|{({$*|[^]-[.a.]z-a]|)*\\x41a*{+", "dialect": "ere", "valid": false}
+{"pattern": "0{2,3}\\)+*({,2}}[])+.", "dialect": "ere", "valid": false}
+{"pattern": ")\\)[[:]{\\2", "dialect": "ere", "valid": false}
+{"pattern": "\\?}{2,3}\\2\\x41{", "dialect": "ere", "valid": false}
+{"pattern": ",", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\.{2,}{{2,3}[^]*", "dialect": "ere", "valid": false}
+{"pattern": "(}|)[?(\\s{2,}[[.[.a.][.-.]]*?){2})", "dialect": "ere", "valid": false}
+{"pattern": "\\?**{1}*[.*[.a.]]{2,}{\\?(({,2}*?){3,2}([*.-][]{2}b){2}|-?[\\$[.-.]])", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]]\\}\\>\\?\\>", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[$[:alpha:][.]\\{1,2\\}\\{1,2\\}a+*\\)", "dialect": "ere", "valid": false}
+{"pattern": "[z{,3}\\<\\|((\\s[]{2,}\\+)[$](([z$]+*\\<\\.+)(\\+*}{1,2}?|[^[:bogus:]])|\\W{,3}\\{.)?){2}", "dialect": "ere", "valid": false}
+{"pattern": "((()*|\\{1,2\\}\\((\\+\\<{))\\s{).{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "(\\x41{3,2}}{2}[^z-a[:]+*)(a{,3}||([]z.]\\{1\\}**\\2|\\|\\x41)){,3}){,3}[-a-]0{([][:alpha:][]*?(a{1,2}?)\\w){1,2}", "dialect": "ere", "valid": false}
+{"pattern": "(\\b[z-a^[.-.]]**)^?\\?[z-a]", "dialect": "ere", "valid": false}
+{"pattern": "[][\\[.a-]", "dialect": "ere", "valid": false}
+{"pattern": "\\2\\x41|{2,3}[[=a=][.][^]", "dialect": "ere", "valid": false}
+{"pattern": "(a{{+*\\.)+{3,2}{1,2}|", "dialect": "ere", "valid": false}
+{"pattern": "-++", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^\\", "dialect": "ere", "valid": false}
+{"pattern": "[a[.a\\x41\\<a+-[[.a.][:alpha:]z", "dialect": "ere", "valid": false}
+{"pattern": "***((\\s|[[]())[a-z[:bogus:]])**)+", "dialect": "ere", "valid": false}
+{"pattern": "[[=a=]*+\\W[]][:bogus:]](0{2}){,3}|", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "[[,.]{1}{|*", "dialect": "ere", "valid": false}
+{"pattern": "(|", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:]z-a\\\\]{[^*z-a[:alpha:]]{2,}*\\+{,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\<{,3}0}{2,}[]\\*", "dialect": "ere", "valid": false}
+{"pattern": "\\{({1}[[[.-.]z]+*b{2,}){2}", "dialect": "ere", "valid": false}
+{"pattern": "0[a-z]{2,}\\*+*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^[:bogus:]]{3,2}{,2}+{1,2}|", "dialect": "ere", "valid": false}
+{"pattern": "(|[]{3,2}|\\s\\1).+", "dialect": "ere", "valid": false}
+{"pattern": "\\{[^$]a-z][.*]{([^][:bogus:]]+*([]*?\\1({,2}\\w|\\|*[-[=a=]z-a]{2}|){\\b)(^[[=a=]][:a-z]\\W)\\>{,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\a[[.]]", "dialect": "ere", "valid": false}
+{"pattern": "\\}{2}[[:.z-a]\\n[[=a=][.[=a=]]{,3}[[:bogus:][:alpha:]a-z]*?[]{", "dialect": "ere", "valid": false}
+{"pattern": "\\({{1}+*", "dialect": "ere", "valid": false}
+{"pattern": "^{+}{,3}[\\\\[[:]", "dialect": "ere", "valid": false}
+{"pattern": "((\\{a|((\\.\\s|\\\\))\\|*?((+*|*{2,3}.)(\\\\[][:alpha:]]])[]+*(\\{1,2\\}\\*{2,}[[]])", "dialect": "ere", "valid": false}
+{"pattern": "\\2([[.-.]$[=a=]]]\\}(\\*{2})\\2**", "dialect": "ere", "valid": false}
+{"pattern": ".}{3,2}(0\\x41\\<{3,2}|\\>{2})\\?+*0", "dialect": "ere", "valid": false}
+{"pattern": "\\bb", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(0{{3,2}),\\1{,3}{,2:}{2,3}0*\\)", "dialect": "ere", "valid": false}
+{"pattern": "(+[]|[]^\\>+|)+\\x41{,2}", "dialect": "ere", "valid": false}
+{"pattern": "[^\\](\\s)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\{1,2\\}+\\a+*\\?\\n(\\([^$[.-.][]\\a{[]{b)*(\\{*?|-+)", "dialect": "ere", "valid": false}
+{"pattern": "[[]\\?(((\\W-))\\|*?$|\\+){2,}\\w+[\\z\\]*?a|", "dialect": "ere", "valid": true, "captures": 3}
+{"pattern": "\\{\\}*?[^-[:]\\n\\{(-", "dialect": "ere", "valid": false}
+{"pattern": "(((\\+**([][^z-a])+)\\x41|\\2{\\{){2,3}(([]({,2}\\<{2,3}))|\\<){\\<?", "dialect": "ere", "valid": false}
+{"pattern": "{,}", "dialect": "ere", "valid": false}
+{"pattern": "[^-a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\*(\\\\{|\\\\\\.\\))\\2{2}\\*+*\\>", "dialect": "ere", "valid": false}
+{"pattern": "([[\\z-a]\\*(\\|)(\\?{2,3}}}|0*)|*\\\\([z-a]*,))||{3,2})(\\>\\1{3,2}|{2,3}){1}(*{", "dialect": "ere", "valid": false}
+{"pattern": "(.(()||([^])[]**[]){,3}", "dialect": "ere", "valid": false}
+{"pattern": "(\\.(\\.\\2[]|({1}{){2}?)?[[:\\[.a.]\\]{2}", "dialect": "ere", "valid": false}
+{"pattern": "(|{3,2}(**?)){2,}(+\\>{3,2}\\){2,3})(a[^[=a=]-.]*)**$,", "dialect": "ere", "valid": false}
+{"pattern": "(((\\*[za])([*]{3,2}\\>*?\\1**)|+[[.-.]a]*?))\\W", "dialect": "ere", "valid": false}
+{"pattern": "[\\]:*[]+*[z-a[:bogus:]za]\\a?{1,2}([[a-za-z-]\\){,3}){2,3}", "dialect": "ere", "valid": false}
+{"pattern": "}+(\\a)([[[:$\\]}+", "dialect": "ere", "valid": false}
+{"pattern": ",|{(\\<{2,3}(([a-z]{1}{,3})+){2,}\\w\\W+*\\}", "dialect": "ere", "valid": false}
+{"pattern": "[]*a-z.]\\<\\2", "dialect": "ere", "valid": false}
+{"pattern": "\\1\\W--[[aa*]+*|", "dialect": "ere", "valid": false}
+{"pattern": "\\2{,3}\\n+", "dialect": "ere", "valid": false}
+{"pattern": "[]*?[[.[.-.][:alpha:]a]^{\\)**[z-a]]-", "dialect": "ere", "valid": false}
+{"pattern": ")\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{?\\<\\b[a]]", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:][:bogus:]]+\\??\\n([^].[])[a]?", "dialect": "ere", "valid": false}
+{"pattern": "[^[:bogus:]]\\+{", "dialect": "ere", "valid": false}
+{"pattern": "\\{1\\})({1}([^]\\{1\\}+*[[.]|\\)\\{(}\\*{2}[[:alpha:][.a.]]){,3}?)\\{(\\n\\<**){", "dialect": "ere", "valid": false}
+{"pattern": "[][=a=]][[.a.]\\][[a-z.]]{3,2}[^]$(\\.||\\s[[.]){2}|", "dialect": "ere", "valid": false}
+{"pattern": "\\x41?{{{{,,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\2[[.-.]a[.-.][:alpha:]]({2,}|", "dialect": "ere", "valid": false}
+{"pattern": "[[.[:^a-z]-", "dialect": "ere", "valid": false}
+{"pattern": ")?\\}\\>}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\*[[:[[:-a-zz]**^\\1|", "dialect": "ere", "valid": false}
+{"pattern": "(\\|((.[\\a){2,3})|^\\)+-\\1{2,3}){2}\\W?", "dialect": "ere", "valid": false}
+{"pattern": "\\bb{", "dialect": "ere", "valid": false}
+{"pattern": "\\+\\>a{2,}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "b[a][]\\s([[.a.][:[:alpha:]]\\w+*[^[=a=][=a=]]]|$)+", "dialect": "ere", "valid": false}
+{"pattern": "((\\2|{2,3\\?)(^|0){2,3}\\s.\\{1,2\\}", "dialect": "ere", "valid": false}
+{"pattern": "[^.[]0?[a-zaa-z[:]\\1(({1,2}*[^.*[:]?\\\\|[[:alpha:]]{{{2,3}\\b\\1+*){,2}", "dialect": "ere", "valid": false}
+{"pattern": "(\\{1=\\}\\1(\\(|)**)\\n{,2}\\*[[.][][=a=]]*", "dialect": "ere", "valid": false}
+{"pattern": "\\|((\\n{2}[a-za-zz]|\\\\+*(\\n)?)\\b+*){,3}(([[.]\\2+\\{1\\}*)+*[[$]{2,3}{)", "dialect": "ere", "valid": false}
+{"pattern": "\\b{\\as[[.a.][:[]**", "dialect": "ere", "valid": false}
+{"pattern": "[][[[|", "dialect": "ere", "valid": false}
+{"pattern": "(,(\\b[^]*|(\\+\\(**[]|\\n\\b{1}|)^{2,3}|))?", "dialect": "ere", "valid": false}
+{"pattern": "((a{2}*|,|){,3}\\x410|)\\b(\\n[]--]*?||([[.-.]z-a]{3,2}|[a[.-.]*]{2,3}\\{1,2\\}[])\\|)", "dialect": "ere", "valid": false}
+{"pattern": "[^.](\\{1,2\\}{,3})**", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\)*?a|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\)[a-z[.a.]](\\x41+\\|.|[](\\)\\?+*\\>||\\a{2,}[^])\\x41)|){1}-\\W", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "[\\a]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\s[az-a])|", "dialect": "ere", "valid": false}
+{"pattern": ".|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\>*\\b+)[]{3,2}[aa*][]+,*?", "dialect": "ere", "valid": false}
+{"pattern": "(^(|**([^.]\\{1,2\\}|.*[]))\\.{)*\\{{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\|(*[[.-.]\\-a]\\({,3})", "dialect": "ere", "valid": false}
+{"pattern": "0\\{11,2\\}{,3}(a\\?*?|-)(\\W)+", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "\\}{3,2}\\>,\\*(:[[.a.]$]{1}+*)**\\2{,3}", "dialect": "ere", "valid": false}
+{"pattern": "[$*]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1,2\\}.|(\\a([][.a.]\\]|)?[[.-.]\\.])\\*", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": ")(?\\x41{32}", "dialect": "ere", "valid": false}
+{"pattern": "{1,2}((\\x41{2,3}\\??\\x41)[^\\*]*.)", "dialect": "ere", "valid": false}
+{"pattern": "+[[.a.]\\[:bogus:].]{2,3}[-[]\\|", "dialect": "ere", "valid": false}
+{"pattern": "\\1}{2}(\\<+*{,2}({1,2}[[z\\]*?)){,2}?", "dialect": "ere", "valid": false}
+{"pattern": "(([]{).*({-|\\()\\1", "dialect": "ere", "valid": false}
+{"pattern": "?+[^[=a]a]b", "dialect": "ere", "valid": false}
+{"pattern": "([\\[.][]\\)[.*]+*)[^[:alpha:]^]*", "dialect": "ere", "valid": false}
+{"pattern": "0{{{,3}", "dialect": "ere", "valid": false}
+{"pattern": "bb*(**{,2}", "dialect": "ere", "valid": false}
+{"pattern": "((\\{1,2\\}?|.|)\\\\)", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "\\]*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\*\\\\+\\b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1\\}\\(?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\b([)\\)|", "dialect": "ere", "valid": false}
+{"pattern": "[^$[.]\\W)(\\\\|)*?\\n{[a-z**", "dialect": "ere", "valid": false}
+{"pattern": "^[.[:[.-.][=a=]]", "dialect": "ere", "valid": false}
+{"pattern": "\\b{^\\){3,2}\\{(\\W\\\\**([^^[.a.]])**)\\>+*", "dialect": "ere", "valid": false}
+{"pattern": "[[.a]a-z]\\|{}*?[****(+", "dialect": "ere", "valid": false}
+{"pattern": "\\w+|{{3}", "dialect": "ere", "valid": false}
+{"pattern": "{1}a", "dialect": "ere", "valid": false}
+{"pattern": "((\\{{)\\s*?){([za-zz-a]\\*([*[.z**)*?|(\\{|(\\{1,2\\}?**+|\\.\\x41{2}{,2})))", "dialect": "ere", "valid": false}
+{"pattern": ")*?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[[.{]](\\w\\n", "dialect": "ere", "valid": false}
+{"pattern": "\\a\\2", "dialect": "ere", "valid": false}
+{"pattern": "{1}}[[.a-z[:bogus:]$]", "dialect": "ere", "valid": false}
+{"pattern": ")\\\\*?[z*]^$**\\n", "dialect": "ere", "valid": false}
+{"pattern": "[](\\+{3,2}|a+*[][a]]{)(([[:]{\\a(-{,3})+|([-]\\{\\}|[]]){3,2})\\W", "dialect": "ere", "valid": false}
+{"pattern": "+[[.-.]]{2,3}[^[]", "dialect": "ere", "valid": false}
+{"pattern": "?(|[^^][a-z$^]{,3})([:[.a-za-zz]((*+)){2}\\+)", "dialect": "ere", "valid": false}
+{"pattern": "ba{2}}+b[]{", "dialect": "ere", "valid": false}
+{"pattern": "($*?[[=a=]*[=a=][.a.]][[z-a,])\\.\\|-", "dialect": "ere", "valid": false}
+{"pattern": "\\{&|(-{3,2})\\|)0.|{", "dialect": "ere", "valid": false}
+{"pattern": "a\\)*?{1}\\?{23}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\2[^[.a.]][:alpha:]](\\>*?[])[[.z-a^$]{", "dialect": "ere", "valid": false}
+{"pattern": "\\x41((\\){1}?[^a])})|+*[a-z[:alpha:]][:]+|)\\)+-|", "dialect": "ere", "valid": false}
+{"pattern": "-}.([^-z-a][a[=:]+*|([[.]{[^[.-.]])((\\s\\{1\\})*\\+{2,3}[a[:alpha:]]){3,2}{,2}{2,3})", "dialect": "ere", "valid": false}
+{"pattern": "0{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\x41{2,}$", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\){\\$>()|", "dialect": "ere", "valid": false}
+{"pattern": "[[[=a=]]{,3}\\W*}[*[.[:]]*?", "dialect": "ere", "valid": false}
+{"pattern": "+^\\*\\<,", "dialect": "ere", "valid": false}
+{"pattern": "\\+{,2}\\([[.-.]]z[=a=]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "((){,2})+*(\\.0\\a){3,2}$)", "dialect": "ere", "valid": false}
+{"pattern": "+**-|", "dialect": "ere", "valid": false}
+{"pattern": "\\\\{([z]\\{{2,3}\\|){", "dialect": "ere", "valid": false}
+{"pattern": "(a(0){2})[\\[.-.][<:bogus:][]\\+[z]*\\(", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "[]{[[.a.]\\z[.-.]]{2}a[]", "dialect": "ere", "valid": false}
+{"pattern": "}\\W", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:a]\\({3,2}.?,(\\})(([]\\w**))?", "dialect": "ere", "valid": false}
+{"pattern": "(((\\>)+[[...]{3,2}\\{1,2\\}||[[.-.]]\\w\\a{2})+[\\[.a.][.]){2}[[$:alpha:]]{{2,}", "dialect": "ere", "valid": false}
+{"pattern": "(\\+[-]{,3}([^z]))*?|\\\\|", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "^{2,3}\\*", "dialect": "ere", "valid": false}
+{"pattern": "[^[:bogus:]a[:[=a=]", "dialect": "ere", "valid": false}
+{"pattern": "[za[:]", "dialect": "ere", "valid": false}
+{"pattern": "+(\\{1,2\\}.?[][.]+*)[[.a.]]{2,3}\\1\\{1\\}{,3}([z-a$.a-z{2,3}{1,2}|)", "dialect": "ere", "valid": false}
+{"pattern": "([])[a-z[[:(*\\<", "dialect": "ere", "valid": false}
+{"pattern": "(\\1{,2}{3,2}|\\{1\\}\\W([^[:alpha:=]z]))+*\\>{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\(({([]-+*)){2,}\\((\\.+[[.-.]a[:bogus:]]|0\\a?)+)\\s[[.a.]]", "dialect": "ere", "valid": false}
+{"pattern": "[]^.[.](\\.^)?(0-|\\W{2,}\\.{2})((\\x41\\{1,2\\})|)}", "dialect": "ere", "valid": false}
+{"pattern": "(((((|))*[^$[:alpha:]]\\<\\W**[a-z^[.-.][:alpha:]](a\\<+*|b}({+*({1}[^]\\n+)?,{3,2}|)+)", "dialect": "ere", "valid": false}
+{"pattern": "\\^\\s+*\\s?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a(\\<\\w|***)?\\}*?", "dialect": "ere", "valid": false}
+{"pattern": "\\2a({1}{2}{,2}{1})[z\\.]{2,3}|", "dialect": "ere", "valid": false}
+{"pattern": "\\+(([\\-[.z-a]\\2)[[:bogus:][=a=]^[=a=]]|[[:bogus:]]+*){2,}[^]", "dialect": "ere", "valid": false}
+{"pattern": "\\>{2,3}|", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]]([a-z\\z-a][]*)\\{1,2\\}{,3}\\n", "dialect": "ere", "valid": false}
+{"pattern": "[a-z][.a.]][^\\\\]{1,2}[^\\\\z-a](?{2,3}\\<[^^])", "dialect": "ere", "valid": false}
+{"pattern": "[]^)([[.-.]a]]0|^\\)\\.){", "dialect": "ere", "valid": false}
+{"pattern": "(a)((\\))(\\<{,3})|(\\n|\\.\\\\)))+*\\x41\\|\\\\", "dialect": "ere", "valid": false}
+{"pattern": "${\\{1,2\\}{,3}{1}(\\W|(\\a{|0)([]]))", "dialect": "ere", "valid": false}
+{"pattern": "[..z-a[.-.]]([]+*|(b?.[.a-z[.-.]]**|[[:alpha:][:]\\}[[.a.]]|)+*{)*?{1}\\{1,2\\}{{,2}[[:bogus:]]", "dialect": "ere", "valid": false}
+{"pattern": "\\a\\?{2}[^[.a.][:](b[^a-z![]{){,2}{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\a+*\\{\\w\\2(^(+(a\\{1,2\\}[[=a=]a-z])\\\\{2}|+{1}{2,}b))[^[.a*]", "dialect": "ere", "valid": false}
+{"pattern": ")\\b+*\\{1,2+\\}{2,3}[^\\a-z]", "dialect": "ere", "valid": false}
+{"pattern": "\\n[\\]\\n*-\\({,3}\\{", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{,3}|", "dialect": "ere", "valid": false}
+{"pattern": "$)***", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "|{3,2}|", "dialect": "ere", "valid": false}
+{"pattern": "\\b*+", "dialect": "ere", "valid": false}
+{"pattern": "\\.[^z-a]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\<{,}{1}", "dialect": "ere", "valid": false}
+{"pattern": "(\\s?a$|b([.]|{,2}|[.^[=a=]]\\b*?)+*\\W{2,})", "dialect": "ere", "valid": false}
+{"pattern": "\\+${2,3}\\s\\?{2}", "dialect": "ere", "valid": false}
+{"pattern": "(\\{{3,2}[])\\}", "dialect": "ere", "valid": false}
+{"pattern": "(({,2}[^[.-.]\\]?|)[^[=a=]$])\\{1,2\\}(({,2}\\}", "dialect": "ere", "valid": false}
+{"pattern": "((a\\b(.\\?\\.))\\\\)*{1,2}\\*\\\\", "dialect": "ere", "valid": true, "captures": 3}
+{"pattern": "[[]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{1}(*)**\\2(\\w(\\x41[[.z[.a.]]0+*))?\\?[z[\\]+*", "dialect": "ere", "valid": false}
+{"pattern": "\\s-**?+*[a-z]+*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\\\b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "*\\s\\???*[^[[=a=]][]**", "dialect": "ere", "valid": false}
+{"pattern": "()\\{1\\}|[^aa[.]\\})", "dialect": "ere", "valid": false}
+{"pattern": "\\n(\\<?\\|{{2,3}|[[:bogus:][.a.][.]|{2,})", "dialect": "ere", "valid": false}
+{"pattern": "(\\)){,3}{,2}\\W\\+\\b{2,3}\\s", "dialect": "ere", "valid": false}
+{"pattern": "[)a-z][:alpha:]z]\\s", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{1,2}\\x41", "dialect": "ere", "valid": false}
+{"pattern": "[-[:bogus:]]\\(\\{\\(([a-z[=a=]*\\]{3,2}{)|[^.]\\x41", "dialect": "ere", "valid": false}
+{"pattern": "\\}\\([]", "dialect": "ere", "valid": false}
+{"pattern": "(\\{1\\}+*)[^a$]?\\)(\\{1\\}[[:bogus::]\\b?", "dialect": "ere", "valid": false}
+{"pattern": "!\\b|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "?\\n(.)*", "dialect": "ere", "valid": false}
+{"pattern": "[-a[=a=][.a.]](\\w+*[[.][:]{,3}|[z-a[.z[]|)b", "dialect": "ere", "valid": false}
+{"pattern": "*{{((,{([^]*?{2,}|\\*))([^a-za-z[.]?\\W)?([\\-)){", "dialect": "ere", "valid": false}
+{"pattern": "[[:[:bogus:]][[=a=]]{(b{2}\\1", "dialect": "ere", "valid": false}
+{"pattern": "\\{1\\}\\+\\>{", "dialect": "ere", "valid": false}
+{"pattern": "|\\{1\\}\\\\\\1([a][:bogus:]$[^[.-.][.a.]*]{,2})+*", "dialect": "ere", "valid": false}
+{"pattern": "\\)}\\<|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "??", "dialect": "ere", "valid": false}
+{"pattern": "[za-za-z]\\\\[*z[.-.]]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1\\}\\<\\?}*}+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\>*?$)[$[:[]", "dialect": "ere", "valid": false}
+{"pattern": "(,)(\\,([z]{2}\\{1\\}|{1}{2,}(\\>+*\\w|\\}{2,3}[^$[:bogus:][:]{{2}))||[z-a[[:alpha:]]](({1,2}|\\*{2,})*?)0?))", "dialect": "ere", "valid": false}
+{"pattern": "[^$[:alpha:]z]?[-[=a=]]>((\\b(\\?)[^[=a=]]])||({1}0(\\.)){2,3}){2,3}", "dialect": "ere", "valid": false}
+{"pattern": "|{2}\\(**0*", "dialect": "ere", "valid": false}
+{"pattern": "\\x41[z],{2,}|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "}((\\W|(,*?\\{1\\}*?\\\\{3,2})[[.]]+*){([^.[]\\x41)){,2}?\\b($a\\<?|\\?((\\x41\\}\\b){2,}|))", "dialect": "ere", "valid": false}
+{"pattern": "\\|{3,2}\\+{,2}[^[.-.]a[*]", "dialect": "ere", "valid": false}
+{"pattern": "((}+(\\w||(\\s{3,2})?,[z[.a.][:[.]){2,3}0+|){*?((([^[.[:-]\\(**|\\|*},)|\\n?.))*a{[a$]", "dialect": "ere", "valid": false}
+{"pattern": "([[=a=]*[=a=]])(\\a[]|([{2,3}|\\{1\\}{,3})){,3}^(b*?){,3}|", "dialect": "ere", "valid": false}
+{"pattern": "(([--z]{2,}({1})|([[.-.][[]\\w|^\\2)+)))[^$.$]{1}\\s-?((\\>\\{1\\}\\x41*?|,", "dialect": "ere", "valid": false}
+{"pattern": "[^a-zz-a**]((\\{\\>{2,}||?\\|\\\\)),\\w^**\\s|", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:][:]+", "dialect": "ere", "valid": false}
+{"pattern": "){1}*?({3,2}", "dialect": "ere", "valid": false}
+{"pattern": "\\x41[*a[.$]{2}\\}+", "dialect": "ere", "valid": false}
+{"pattern": "a\\w", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\]w\\{1\\}|{({1,2})", "dialect": "ere", "valid": false}
+{"pattern": "\\1|a{2,}b{\\n", "dialect": "ere", "valid": false}
+{"pattern": "\\a*?\\<\\{[a\\[.[.a.]]{2}\\>(((\\.)\\((\\w\\?|^\\a{2,3})|)\\()", "dialect": "ere", "valid": false}
+{"pattern": "{+*?", "dialect": "ere", "valid": false}
+{"pattern": "*()a[z*[.-.][.-.]]){2}(\\\\s{2}|)(\\1{(\\2){2,}|***", "dialect": "ere", "valid": false}
+{"pattern": "\\{1,2\\}?\\bb*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[z-a.[[.-.]z]0){3,2}^?([^[.a.]z]*?-*|)(", "dialect": "ere", "valid": false}
+{"pattern": "[[.z-a]?", "dialect": "ere", "valid": false}
+{"pattern": "(?|[^\\[:alpha:][:bogus:]]\\}{3,2}[^[.-.][:alpha-:]]?)[a-z]*?}", "dialect": "ere", "valid": false}
+{"pattern": "(,[[=a=]]}(a+|)(\\W++*|)", "dialect": "ere", "valid": false}
+{"pattern": "[z[=a==]\\]+*.+{1,2}\\+\\x41", "dialect": "ere", "valid": false}
+{"pattern": "[^[.](+?){3,2}|((-{3,2}\\{1\\}{,3}\\2)[^][]\\s\\n){,3}\\+", "dialect": "ere", "valid": false}
+{"pattern": "\\x41[][:](\\{1\\}+*)\\>", "dialect": "ere", "valid": false}
+{"pattern": ".", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "((\\.)\\?{2}\\}|.\\+*?{,2})((\\W{3,2}\\n[$*.z-a]{3,2}|({\\?|\\2\\\\{|)[zz-a]({3,2})\\b)\\W", "dialect": "ere", "valid": false}
+{"pattern": "(([z-a[.-.]][])\\*?)+*\\{1\\}**", "dialect": "ere", "valid": false}
+{"pattern": "\\?\\|){2,3}\\.,\\*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[][\\]+^*?}*?", "dialect": "ere", "valid": false}
+{"pattern": "(}[]*)**[-[.]\\{", "dialect": "ere", "valid": false}
+{"pattern": "|*[^]+[z-az-a$][[=a=][.a.]]\\a|", "dialect": "ere", "valid": false}
+{"pattern": "[]\\|{\\>\\\\*?(\\x41((\\\\)){2,3})\\s)", "dialect": "ere", "valid": false}
+{"pattern": "\\*+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{1,2}^-?\\x41+*", "dialect": "ere", "valid": false}
+{"pattern": "[]\\x41(\\2([a-z$a]]+*?\\}*){1}*?|\\{1\\}){", "dialect": "ere", "valid": false}
+{"pattern": "\\>((\\b*?(\\W$)){,,3}|\\*){2,3}[^[.a.].[:]", "dialect": "ere", "valid": false}
+{"pattern": "\\}+)", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(([z-a]|\\a{2}\\|+*)\\(){2}", "dialect": "ere", "valid": false}
+{"pattern": "(\\x41{2,}|\\)\\W^", "dialect": "ere", "valid": false}
+{"pattern": "(\\\\){,2}{2,}-\\1", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\x41\\{1,2\\}\\20", "dialect": "ere", "valid": false}
+{"pattern": "b*((\\2)*.[^-[.a.]^$]\\2{2,}", "dialect": "ere", "valid": false}
+{"pattern": "\\..[]z-a]|", "dialect": "ere", "valid": false}
+{"pattern": "\\xx41*?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\n({,2}[z[.-.]][[.-.][\\[.]**)[[:alpha:][:bogus:]]{3,2}\\}\\n|", "dialect": "ere", "valid": false}
+{"pattern": "([[.-.][[.]+((a0{,2}))\\W+*\\|{2}$\\?", "dialect": "ere", "valid": false}
+{"pattern": "[a.[[[:]{3,2}-0", "dialect": "ere", "valid": false}
+{"pattern": "(([[:bogus:]z-][[.a.]^[$]*?([[.-.]$[.-.]]+[[:bogus:]\\z-a]\\{?|\\*\\.)^a({2}[]\\}[^]", "dialect": "ere", "valid": false}
+{"pattern": "{^*?\\.?0[a$[.a.]]*", "dialect": "ere", "valid": false}
+{"pattern": "\\b[}]\\x41(\\b+\\<|b{3,2}([[:bogus:][:alpha:][:alpha:]^]((*|\\a)|)(\\??.(||)))+*\\*(0[]*?)", "dialect": "ere", "valid": false}
+{"pattern": "?*?|", "dialect": "ere", "valid": false}
+{"pattern": "?(\\{1\\}+{,2}||{,3}|)[$[..^+]\\{1\\}\\n", "dialect": "ere", "valid": false}
+{"pattern": "[$--]}=*?", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^{2,}[^a]?[[.a-z[.a.]][]{\\x41{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "^{2,}\\s", "dialect": "ere", "valid": false}
+{"pattern": "\\+{", "dialect": "ere", "valid": false}
+{"pattern": "(\\<\\w|(\\x41{,3}[[.[=a=][:alpha:]^]{2,3}a**|([^])\\1\\s)*?\\a([^]|)\\w[]\\>", "dialect": "ere", "valid": false}
+{"pattern": "?)\\.{3,2}[\\[.-.][.[+*\\|[*a-z]\\|", "dialect": "ere", "valid": false}
+{"pattern": "\\x41**[[.-.].z-a$](-|[^]?)\\({,3}.{{2,}(\\a{+^||(\\b**)[$[.-.]^$])", "dialect": "ere", "valid": false}
+{"pattern": "(.[^a-z*[.{2}\\|{,3}){2,3}?[\\[:.[=a=]]+*", "dialect": "ere", "valid": false}
+{"pattern": "\\(}\\(", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(\\>||[aa-${){2}(\\(\\w\\}", "dialect": "ere", "valid": false}
+{"pattern": "(\\.\\?*(($\\{1,2\\}|\\>()[[:allpha:][=a=]]+(-?\\{1\\}))||[[:alpha:]]+)[]]*", "dialect": "ere", "valid": false}
+{"pattern": ".b\\}\\{1,2\\}+", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": ",[$[:]", "dialect": "ere", "valid": false}
+{"pattern": "b\\?.{2,}((\\W))", "dialect": "ere", "valid": true, "captures": 2}
+{"pattern": "(.\\n*?[*])\\|{2,3}", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "[[=a=]]a[=a=]]([[:alpha:]]*?(\\){3,2})[.\\]|+(\\1.^))((\\b(.){\\n+[*^^<]*|(\\n?)\\*{[-[:z-a[.a.]]{2,3})(\\n\\a|[\\[.-.]](\\{1\\}[*[:bogus:]{3,2})\\.{2})\\a", "dialect": "ere", "valid": false}
+{"pattern": "(((0**)+){2}(.{2}[a-zz-az-a][\\[:]||((\\W)*(*)[^[.a.][.-.]z-a^])\\s)", "dialect": "ere", "valid": false}
+{"pattern": "[[:a-z.[]", "dialect": "ere", "valid": false}
+{"pattern": "(([^]\\W*?(}*?||(b){3,2}|\\x41{1})(\\|^{)||[[:bogus:][=a=]{[^z-a[.a.][.-.]]*?)\\}", "dialect": "ere", "valid": false}
+{"pattern": "\\\\{,3}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "{,2}\\|a***", "dialect": "ere", "valid": false}
+{"pattern": "W)(\\2{,3})", "dialect": "ere", "valid": false}
+{"pattern": "0{2}((-{{2}((+0{1})(\\)[a*]))[[z])\\*{2,3}\\<([]\\?{2})){[z-a-[.]", "dialect": "ere", "valid": false}
+{"pattern": "({1,2}-){3,2}\\2\\.{2,3}(({[1}[[=a=][:alpha:]-\\1+|^{,3})((\\(?\\x41|){3,2}|[z-a][]]){2,3}[[*[.^])", "dialect": "ere", "valid": false}
+{"pattern": "\\x}41[]\\w[a][:\\]{{", "dialect": "ere", "valid": false}
+{"pattern": "(*?-[*]", "dialect": "ere", "valid": false}
+{"pattern": "{1,2}{2,3},,|", "dialect": "ere", "valid": false}
+{"pattern": "[[.[=a=]a$]}(+*[[..]", "dialect": "ere", "valid": false}
+{"pattern": "\\\\<", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\}\\*", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[[:bogus:][-]\\x41{2,3}\\<{2}\\{1,2\\}", "dialect": "ere", "valid": false}
+{"pattern": "[[.^](\\w[]{2}\\\\)*?\\a\\<{\\*|", "dialect": "ere", "valid": false}
+{"pattern": "[](aa|)[$[.a.]]\\}|", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[]+(\\.+\\a*?\\<||{1,2})\\s{2}[[.-.]za][^^[]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(((**(\\*x41\\()**|)([-*[=a=]]{[$[.])+*)-)|", "dialect": "ere", "valid": false}
+{"pattern": "|[a-z]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(*([\\a-z$]?)([^z^\\]][z[.^[.-.](-)+[-]+))+*)b**(\\)){&,3}(\\(\\a\\.){", "dialect": "ere", "valid": false}
+{"pattern": "((\\)|[[.-.]a*])[.[:bogus:]]a]\\.?|\\<{})b}{2,3}^**([\\[.-.]z-a*(\\s)){2,}($+*\\2(\\b\\s{?|[][$])|,.){2,}", "dialect": "ere", "valid": false}
+{"pattern": "\\\\(\\w(${2,3}[^[.a]\\*||\\b**[[:alpha:]]*)){3,2}", "dialect": "ere", "valid": false}
+{"pattern": "{*\\w{,3}(\\|)([$[.-.]a-z\\]\\\\\\1|\\+)(\\+\\b{3,2}|{{,2}{3,2}))", "dialect": "ere", "valid": false}
+{"pattern": "[[[:a.]$(+)+*[^*[=a=]*]{|", "dialect": "ere", "valid": false}
+{"pattern": "[.[$]\\\\", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\{1,2\\}\\\\|^?", "dialect": "ere", "valid": false}
+{"pattern": "[[=a=][.^]\\(a\\>**", "dialect": "ere", "valid": false}
+{"pattern": "}[^[.[:bogus:]]{2,}a[^\\-^]?,{3,2}|", "dialect": "ere", "valid": false}
+{"pattern": "[]([$z-a[:]((\\n|[[.]{\\{)\\W\\>)\\2\\s(\\x41\\*)", "dialect": "ere", "valid": false}
+{"pattern": "\\<{2}\\***{\\w", "dialect": "ere", "valid": false}
+{"pattern": "\\n|{3,2}\\>[[:bogus|:]^[:alpha:]a-z*", "dialect": "ere", "valid": false}
+{"pattern": "(\\<)*??[[.|", "dialect": "ere", "valid": false}
+{"pattern": "*\\}(b{2,3})", "dialect": "ere", "valid": false}
+{"pattern": "\\'?", "dialect": "ere", "valid": false}
+{"pattern": "\\>+{1,2}{2,3}[[=a=][]**", "dialect": "ere", "valid": false}
+{"pattern": "\\b\\\\*?\\<", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\W*[^^[.a.]a[=a=]z]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "(([^$[:bogus:]]({1,2}{3,2})+*))?\\s\\b|)[^a\\\\1^[^[.-.]\\]{3,2}", "dialect": "ere", "valid": false}
+{"pattern": "$\\([[.a.]$[]*\\s**", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\W\\b", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "(([[.-.]]+*(.{3,2}[]**({1}**){2,}){,3}|){1,2}*", "dialect": "ere", "valid": false}
+{"pattern": "\\a[]\\1", "dialect": "ere", "valid": false}
+{"pattern": "[[.a.]$][*\\[.[:]\\x41{2,3}", "dialect": "ere", "valid": false}
+{"pattern": "\\s++", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\)\\1", "dialect": "ere", "valid": false}
+{"pattern": "\\x41[a-z[.-.]]]][[.[:bogus:]][z\\*]", "dialect": "ere", "valid": false}
+{"pattern": "(\\1[a-z[.a.]]^])\\x41{,3}[[.-.]z[.-.]]][zz]", "dialect": "ere", "valid": false}
+{"pattern": "\\1{[]{*?", "dialect": "ere", "valid": false}
+{"pattern": "(\\2", "dialect": "ere", "valid": false}
+{"pattern": "[]\\w\\1{2,3},$", "dialect": "ere", "valid": false}
+{"pattern": "($,{){2,3}[\\*^]++*", "dialect": "ere", "valid": false}
+{"pattern": "[[=a=](]][[.\\z]([z-a]", "dialect": "ere", "valid": false}
+{"pattern": "[$*]{3,2}|", "dialect": "ere", "valid": false}
+{"pattern": "(^\\x41)\\2", "dialect": "ere", "valid": false}
+{"pattern": "[*]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^{2,}\\*(+*", "dialect": "ere", "valid": false}
+{"pattern": "({,2[^]+|\\)", "dialect": "ere", "valid": false}
+{"pattern": "\\)[([^])[^[*]**", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "([z-a]{3,2}[^z[.-.][.]\\+)\\([^]\\z-a[.][a\\*\\]", "dialect": "ere", "valid": false}
+{"pattern": "-?+{,3}(-{,2}{2,3}[])+*[^a]{2}[[.a.-a-z]]", "dialect": "ere", "valid": false}
+{"pattern": "([*z-a^a-z][$[=a=][.\\-.][=a=]]{2,3}++)*\\W{2,}", "dialect": "ere", "valid": false}
+{"pattern": "\\Wn)(b)", "dialect": "ere", "valid": true, "captures": 1}
+{"pattern": "\\?+|*\\)", "dialect": "ere", "valid": false}
+{"pattern": "\\>([[.-.][::bogus:]z[]{2,}", "dialect": "ere", "valid": false}
+{"pattern": "}\\)\\b{1,2\\}+*,", "dialect": "ere", "valid": false}
+{"pattern": "+\\2{", "dialect": "ere", "valid": false}
+{"pattern": "\\\\{\\<[$][[.a.][.-.]]", "dialect": "ere", "valid": false}
+{"pattern": ".{2}\\}", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "^+*[z]((*\\>+)b)\\(", "dialect": "ere", "valid": false}
+{"pattern": ")?\\<b{,3}\\.", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "\\+[](((\\W\\x41)|[--][[=a=]]{,2})+*\\n+|\\w?|)[-]", "dialect": "ere", "valid": false}
+{"pattern": "-\\?**[]", "dialect": "ere", "valid": false}
+{"pattern": "{,2}{,3}([]\\<\\})\\{1\\}(|-|[[<:alpha:]^]{,3}[.[:alpha:]-[.a.]]*?)\\b{2,3}", "dialect": "ere", "valid": false}
+{"pattern": "([]\\.\\a{,3}){2,}b?\\.", "dialect": "ere", "valid": false}
+{"pattern": "{1}[]{3,2}\\*{2,3", "dialect": "ere", "valid": false}
+{"pattern": "((a\\\\\\n)(b{3,2}){2,3^}(\\w|)*b{2,}", "dialect": "ere", "valid": false}
+{"pattern": "(((\\2)|{,2}([^]{2,3}\\<[^]))[^]\\s{1}{3,2}*\\w", "dialect": "ere", "valid": false}
+{"pattern": "[[:alpha:]]\\{1,2\\}\\}\\n?{", "dialect": "ere", "valid": false}
+{"pattern": "{\\>\\**", "dialect": "ere", "valid": false}
+{"pattern": "\\x41+\\W", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "[^\\*]", "dialect": "ere", "valid": true, "captures": 0}
+{"pattern": "a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "()", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?:)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[", "dialect": "bre", "valid": false}
+{"pattern": "]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]", "dialect": "bre", "valid": false}
+{"pattern": "[^]", "dialect": "bre", "valid": false}
+{"pattern": "[]a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^]a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[-a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-z]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[z-a]", "dialect": "bre", "valid": false}
+{"pattern": "[a-a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\d-z]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[z-\\d]", "dialect": "bre", "valid": false}
+{"pattern": "[\\w-\\d]", "dialect": "bre", "valid": false}
+{"pattern": "[a-\\w]", "dialect": "bre", "valid": false}
+{"pattern": "[\\b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\B]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[.]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{,1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1,}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{2,1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{ 1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1 }", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1, 2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1,2", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{65535}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{65536}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{2147483647}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{2147483648}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{99999999999}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1}{2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1}?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1}+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a**", "dialect": "bre", "valid": false}
+{"pattern": "a*?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a*+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a+?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a++", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a?+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a???", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(+)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(|*)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "$*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\b*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\B+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "|a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "||", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(|)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\", "dialect": "bre", "valid": false}
+{"pattern": "a\\", "dialect": "bre", "valid": false}
+{"pattern": "[\\", "dialect": "bre", "valid": false}
+{"pattern": "[a\\", "dialect": "bre", "valid": false}
+{"pattern": "\\0", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\00", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\000", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\01", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\07", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\08", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\1", "dialect": "bre", "valid": false}
+{"pattern": "\\2", "dialect": "bre", "valid": false}
+{"pattern": "\\8", "dialect": "bre", "valid": false}
+{"pattern": "\\9", "dialect": "bre", "valid": false}
+{"pattern": "\\10", "dialect": "bre", "valid": false}
+{"pattern": "\\11", "dialect": "bre", "valid": false}
+{"pattern": "\\12", "dialect": "bre", "valid": false}
+{"pattern": "\\18", "dialect": "bre", "valid": false}
+{"pattern": "\\19", "dialect": "bre", "valid": false}
+{"pattern": "\\99", "dialect": "bre", "valid": false}
+{"pattern": "\\377", "dialect": "bre", "valid": false}
+{"pattern": "\\400", "dialect": "bre", "valid": false}
+{"pattern": "\\777", "dialect": "bre", "valid": false}
+{"pattern": "(a)\\1", "dialect": "bre", "valid": false}
+{"pattern": "(a)\\2", "dialect": "bre", "valid": false}
+{"pattern": "(a)\\10", "dialect": "bre", "valid": false}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\10", "dialect": "bre", "valid": false}
+{"pattern": "(a)(b)(c)(d)(e)(f)(g)(h)(i)\\10", "dialect": "bre", "valid": false}
+{"pattern": "\\1(a)", "dialect": "bre", "valid": false}
+{"pattern": "\\2(a)(b)", "dialect": "bre", "valid": false}
+{"pattern": "(a\\1)", "dialect": "bre", "valid": false}
+{"pattern": "[\\1]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\0]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\8]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x4", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x41", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x4g", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\xg", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x{41}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x{}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x{110000}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x{D800}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u4", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u004", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "A", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u{41}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u{}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u{110000}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\u{10FFFF}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\u{1F600}-\\u{1F602}]", "dialect": "bre", "valid": false}
+{"pattern": "\\c", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\cA", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\ca", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\cz", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\c1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\c_", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\c@", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\c[", "dialect": "bre", "valid": false}
+{"pattern": "\\c?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\c]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\cA]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\c1]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\c_]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\c@]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\e", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\f", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\n", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\r", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\t", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\v", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\A", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Z", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\z", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\G", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\K", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Q", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\E", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Qa\\E", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Qab", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Q\\E", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\Q]\\E]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\Qa-z\\E]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\h", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\H", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\R", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\X", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\N", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\C", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\g", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\g1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\g{1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\g-1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)\\g-1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)\\g{-1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)\\g{+1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\g<1>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\L", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\l", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\U", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\i", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\I", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\j", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\m", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\o", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\o{101}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\o{}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\o{8}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\N{U+41}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\N{U+}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\N{LATIN}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\y", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\-", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\/", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\:", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\,", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\=", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\!", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\@", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\#", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\%", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\&", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\~", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\`", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\"", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\'", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\_", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\$", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\^", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\.", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(", "dialect": "bre", "valid": false}
+{"pattern": "\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\[", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\\", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\pL", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\pLu", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{L}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Lu}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{L", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{^L}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\P{^L}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Letter}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Uppercase_Letter}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{gc=L}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{General_Category=Letter}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{sc=Greek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Script=Greek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{scx=Grek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Script_Extensions=Greek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Greek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{IsGreek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{InGreek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Bogus}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Any}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{ASCII}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Assigned}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Alphabetic}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Alpha}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{L&}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Xan}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Xwd}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Emoji}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{RGI_Emoji}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Basic_Emoji}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{lu}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{ L}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{L }", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{Script=}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{=Greek}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\p{sc=Bogus}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\P{RGI_Emoji}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\p{RGI_Emoji}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^\\p{RGI_Emoji}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k<a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k<a>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k<1>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k'a'", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k{a}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)\\k<a>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)\\k<b>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)\\k", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)\\k<a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\k<a>(?<a>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)(?<a>y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)|(?<a>y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "((?<a>x)|(?<a>y))", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?:(?<a>x)|(?<a>y))\\k<a>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)|(?<a>y)|(?<a>z)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)((?<a>y)|z)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<1a>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a1>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<_>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<$>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a$>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a-b>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a b>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<\\u{61}>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?'a'x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P<a>x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P<a>x)(?P=a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P>a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)(?P>a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)(?&a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?&a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?R)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?0)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)(?1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)(?-1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)(?+1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?+1)(a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?-1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)(?-2)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C255)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C256)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C\"a\")", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C{a})", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?Ca)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*FAIL)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*F)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*ACCEPT)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*COMMIT)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*PRUNE)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*SKIP)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*THEN)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*MARK:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*MARK)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*BOGUS)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*UTF)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*UCP)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*CR)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a(*UTF)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?=a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?!a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<!a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?=a)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?!a)+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=a)?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<!a){2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=a+)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=a*)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=a|bc)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=(a)\\1)", "dialect": "bre", "valid": false}
+{"pattern": "(?>a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?>a)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?|(a)|(b))", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?|(a)|(b)(c))\\3", "dialect": "bre", "valid": false}
+{"pattern": "(?|(?<a>x)|(?<a>y))", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?|(?<a>x)|(?<b>y))", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i)a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?-i)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?-i:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i-m:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?im-s:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?-)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?-:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i-:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?ii:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i-i:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?s:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?m:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?n:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?n)(a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?q)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?^)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?^i)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?^i:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?xx)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?J)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?U)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?u)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?aD)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?r)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i:a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a(?i)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?i)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?#comment)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?#comment", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?#)a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a(?#x)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a(?#x){2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(1)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(1)a|b)(x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(1)a|b|c)(x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(a)x|y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)(?(a)x|y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)(?(<a>)x|y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<a>x)(?('a')x|y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(<a>)x|y)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(R)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(R1)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(R&a)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(DEFINE)(?<a>x))", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(DEFINE)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(+1)a|b)(x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(-1)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(x)(?(-1)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(VERSION>=10.0)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?=a)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?!a)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?<=a)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?:a)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?()a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(1a)x)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?#c)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?<n>x)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(?'n'x)a|b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:bogus:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha:]", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha]]", "dialect": "bre", "valid": false}
+{"pattern": "[[.a.]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[.hyphen.]]", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[=a=]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[=ab=]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha:]-z]", "dialect": "bre", "valid": false}
+{"pattern": "[a-[:alpha:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[.a.]-z]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:ALPHA:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:^alpha:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:word:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:blank:]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[:alpha:]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a[]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a[b]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-z-[aeiou]]", "dialect": "bre", "valid": false}
+{"pattern": "[a-z-[b]c]", "dialect": "bre", "valid": false}
+{"pattern": "[a-[b]]", "dialect": "bre", "valid": false}
+{"pattern": "[[a]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[a]b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a&&b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a--b]", "dialect": "bre", "valid": false}
+{"pattern": "[a--]", "dialect": "bre", "valid": false}
+{"pattern": "[--a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a&&]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[&&a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[a]&&[b]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[a]--[b]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\w&&\\d]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\w--\\d]", "dialect": "bre", "valid": false}
+{"pattern": "[a&&b&&c]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a--b--c]", "dialect": "bre", "valid": false}
+{"pattern": "[a&&b--c]", "dialect": "bre", "valid": false}
+{"pattern": "[ab&&c]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-z&&[aeiou]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[a-z]&&[aeiou]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\q{abc}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\q{abc|d}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^\\q{abc}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^\\q{a}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\q{}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\q{a}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[|]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[(]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[)]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[{]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[}]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[/]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[-]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\&]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\!]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\#]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\%]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\,]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\:]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\;]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\<]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\=]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\>]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\@]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\`]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\~]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\$]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\^]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[!!]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[##]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[$$]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[%%]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[**]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[++]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[,,]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[..]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[::]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[;;]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[<<]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[==]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[>>]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[??]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[@@]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^^]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^^^]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[``]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[~~]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a^^]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[&]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[&&&]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\d-]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[-\\d]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-\\d]", "dialect": "bre", "valid": false}
+{"pattern": "[\\s-\\S]", "dialect": "bre", "valid": false}
+{"pattern": "[\\p{L}-z]", "dialect": "bre", "valid": false}
+{"pattern": "[a-\\p{L}]", "dialect": "bre", "valid": false}
+{"pattern": "[\\x41-\\x5A]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\x5A-\\x41]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[A-Z]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\cA-\\cZ]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\0-\\x20]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\b-\\n]", "dialect": "bre", "valid": false}
+{"pattern": "[\\n-\\b]", "dialect": "bre", "valid": false}
+{"pattern": "[\\--a]", "dialect": "bre", "valid": false}
+{"pattern": "[a-\\-]", "dialect": "bre", "valid": false}
+{"pattern": "[%--]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[+--]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a^]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[$]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\]a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\\\]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\\\]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a\\]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a\\]b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[#]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[ ]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{a}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1,a}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{,}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{,5}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{ ,5}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{5, }", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1,2}{3}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1}*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{0}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{0,0}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{00001}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1}{1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?:a){1}{2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "$", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^^", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "$$", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a^", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "$a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a^b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a$b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(^a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a$)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|^b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a$|b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^*a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(a", "dialect": "bre", "valid": false}
+{"pattern": "a\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\{1\\}", "dialect": "bre", "valid": false}
+{"pattern": "a\\{1\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\{1,\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\{1,2\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\{,2\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\{2,1\\}", "dialect": "bre", "valid": false}
+{"pattern": "a\\{1", "dialect": "bre", "valid": false}
+{"pattern": "a\\{", "dialect": "bre", "valid": false}
+{"pattern": "a\\|b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "*a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "**", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(*a\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(^a\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "a\\|*b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\{1\\}\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "a*\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(a\\)\\1", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\1\\(a\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(a\\)\\2", "dialect": "bre", "valid": false}
+{"pattern": "\\w", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\W", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\s", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\S", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\{1\\}*", "dialect": "bre", "valid": false}
+{"pattern": "(a)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)+?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a){2}{3}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a+*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a?*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a*{2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{2}*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{2}+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?:", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?=", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?<=", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?'", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P=", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?P<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?&", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?R", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?C", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?(1)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?#", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Q(\\E", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\Q[\\E", "dialect": "bre", "valid": false}
+{"pattern": "(\\Qa)\\E)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\Qa\\E]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\Q\\E]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\E]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a\\Q]\\E]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\E\\E", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a#b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "c", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)[a b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)[ ]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a {2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a{2} ?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a\\ b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)\\", "dialect": "bre", "valid": false}
+{"pattern": "(?x)(? :a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)( ?:a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)(?#)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a#(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)\\p{ L}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)\\k< a>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?x)a+ +", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(?xx)[a b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[=a=]-z]", "dialect": "bre", "valid": false}
+{"pattern": "[a-[=z=]]", "dialect": "bre", "valid": false}
+{"pattern": "[a-[.z.]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[z-[.a.]]", "dialect": "bre", "valid": false}
+{"pattern": "[a-z-9]", "dialect": "bre", "valid": false}
+{"pattern": "[--0]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-z-]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]-]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[-[:alpha:]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:a]b:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:]]", "dialect": "bre", "valid": false}
+{"pattern": "[[::]]", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha:][:digit:]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[.]", "dialect": "bre", "valid": false}
+{"pattern": "[[.].]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[=]=]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[.space.]]", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.]-z]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[\\w]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]-a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^]-a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]-]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[b-a]", "dialect": "bre", "valid": false}
+{"pattern": "a{2}{3}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)**", "dialect": "bre", "valid": false}
+{"pattern": "a$*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\<*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\>*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\`*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\'*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\B*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\w*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(^)*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(+a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(|a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a|*b)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|*b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|+b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|?b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|{1}b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "({1}a)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1,}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{ }", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1a}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{32767}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{32768}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{255}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{256}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{00}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{01}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a||b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a|)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a))", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "())", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(()", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a{1,", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)(b)\\2", "dialect": "bre", "valid": false}
+{"pattern": "(a)\\0", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a??", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x{1}?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a^*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(a)|\\1", "dialect": "bre", "valid": false}
+{"pattern": "(a|)b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a", "dialect": "bre", "valid": false}
+{"pattern": "[^", "dialect": "bre", "valid": false}
+{"pattern": "a[]b]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{1}", "dialect": "bre", "valid": false}
+{"pattern": "a\\{1}", "dialect": "bre", "valid": false}
+{"pattern": "\\d", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\{1\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "a\\|\\{1\\}b", "dialect": "bre", "valid": false}
+{"pattern": "a\\{2\\}*", "dialect": "bre", "valid": false}
+{"pattern": "\\(a\\)*", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(a\\)\\{2\\}", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(a\\1\\)", "dialect": "bre", "valid": false}
+{"pattern": "a\\+\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a|b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\|a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\|a\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "x\\{,2\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x\\{1", "dialect": "bre", "valid": false}
+{"pattern": "x\\{a\\}", "dialect": "bre", "valid": false}
+{"pattern": "x\\{\\}", "dialect": "bre", "valid": false}
+{"pattern": "a\\{32768\\}", "dialect": "bre", "valid": false}
+{"pattern": "a\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a$", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(a$\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "a$\\|b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "a\\|^b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x\\{1\\}\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(a\\)\\|\\1", "dialect": "bre", "valid": false}
+{"pattern": "a\\|^*b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(^*a\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "x*\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "x\\+*", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\+a\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "a\\|\\+b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\+a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\?a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "^\\{1\\}", "dialect": "bre", "valid": false}
+{"pattern": "a\\{1,2", "dialect": "bre", "valid": false}
+{"pattern": "\\(a\\)\\{1\\}*", "dialect": "bre", "valid": false}
+{"pattern": "^\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\>\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\b**", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\b\\?*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\<.\\<**", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\*[[:alpha:]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ".\\?\\2\\{\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\|\\({1}\\(?\\2\\+\\{\\)\\?", "dialect": "bre", "valid": false}
+{"pattern": "[^]b", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha]$[z]\\{1\\}**\\(\\{1,2\\}\\{2,\\}|\\)\\){1,2}", "dialect": "bre", "valid": false}
+{"pattern": "[^.[=a=]z-a]\\+[[.a.]$[:]", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\({1,2}**[a-zz[.-.][.-.]]||[]\\>\\{2\\}+\\)\\)[[.-.][:a-z]\\(,\\)|[^]]\\+\\?[]\\)\\{2,\\},[[:bogus:][]**+\\({[\\2\\{2,\\}\\)$", "dialect": "bre", "valid": false}
+{"pattern": "\\([^[.]\\{2,3\\}\\)\\+|[^[:alpha:]]", "dialect": "bre", "valid": false}
+{"pattern": "[^-]a-z]]}\\-***0", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\b[--]|\\1\\)^\\\\b", "dialect": "bre", "valid": false}
+{"pattern": "[a]z.]\\(\\a\\)**\\.\\.\\([-az]**{1},2}\\(\\<.\\{2,\\}\\)\\{2,\\}\\)\\(", "dialect": "bre", "valid": false}
+{"pattern": "\\(++\\{\\)", "dialect": "bre", "valid": false}
+{"pattern": "^\\{\\?", "dialect": "bre", "valid": false}
+{"pattern": ".\\+\\(\\([]|*\\(\\+|\\.\\)\\{2,3\\}\\)\\(\\|\\(+)\\{2,\\}|\\)||\\(}\\{,3\\}\\b\\(\\+\\{2,3\\}\\)\\{3,2\\}*\\2\\w\\+\\1\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\s*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([z]\\sb\\W\\?[{.]\\}b\\?", "dialect": "bre", "valid": false}
+{"pattern": "|\\?[$[=a=]*[=a=]]\\{2,\\}[^[:a-z[:]\\\\\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[^a^[:bogus:]]\\?**", "dialect": "bre", "valid": false}
+{"pattern": "\\$$", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(-\\{,3\\}[]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\\\\\(\\$?[z]]\\(\\?0{1,2}|\\)\\{3,2\\}\\{,3\\})*\\([]\\{3,2\\}[$a-z[=a=]],", "dialect": "bre", "valid": false}
+{"pattern": ",\\{a[]^]}**\\.\\(\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(b\\)\\{2,\\}\\(\\<\\([^]\\?\\)|\\)[[:bogus:]-][[=a=]][]\\W\\{,3\\}{1,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\1{,2}\\(\\*\\{,3\\}\\+*\\){,2}{\\(\\w^*^]", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\{2,3\\}{1,2}\\+[[=a=][:alpha:]z]\\{2,\\}\\a", "dialect": "bre", "valid": false}
+{"pattern": "[az-az][][.-*]\\?\\(\\([]\\x41*||\\{\\)\\{2,\\}\\)[^\\$]", "dialect": "bre", "valid": false}
+{"pattern": "0\\{3,2\\},[[:]\\(.\\(\\W\\)\\W\\{3,2\\}\\)\\{1,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\{2,^\\}\\2\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "{,2}\\{2,3\\}{\\<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{1}\\s", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ",\\?\\W[*[:bog>us:]]]\\1|", "dialect": "bre", "valid": false}
+{"pattern": "{\\{,3\\}\\)\\([[:-][]|\\\\\\)\\b\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\x41*\\)\\|\\{", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\b\\}\\{2,3\\}[]\\{3,2\\}\\1\\{2\\}\\(\\(0\\\\\\{2,3\\}[[=a=][.$]\\)", "dialect": "bre", "valid": false}
+{"pattern": "(++\\{2\\}[[:]\\([^[.-.][:]\\)\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\1\\{|\\2\\(\\([*^]\\?\\)b|\\w\\{2,\\}\\([*]$\\)[\\[]\\)\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\)\\>\\,.{,2}\\{{1,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\()\\b**\\{2,\\}\\)\\{2,3\\}\\w", "dialect": "bre", "valid": false}
+{"pattern": "[^[.a.]]]\\{(|\\a|", "dialect": "bre", "valid": false}
+{"pattern": "[([-*[:bogus:]]*b}\\{2,\\}[]a\\w", "dialect": "bre", "valid": false}
+{"pattern": "[z]\\)\\?[[:-$[:bogus:][^[:*a-z]", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.]-[.-.]]\\1\\(\\n[\\.^-[:]|\\x41\\*,\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\{1,2\\}(\\{,3\\}|\\([^-*]\\a\\)[z\\]\\<\\)\\)-b\\{\\*\\}\\(\\b\\(\\([[.-.][=a=][[]\\{2,3\\}\\s|\\w\\)?\\{3,2\\}|\\*\\\\\\([z[=a=][:alpha:][.a.]]*|\\a\\{?*?\\)\\)\\+[^]|[][=a=]]\\(\\1[aa-z[.-.]]|\\([^][a-]|\\a^\\)\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\({,2})|[^]\\{3,2\\}[]$^]\\(^\\(0\\{1\\}|[*]?}\\)\\{1,2\\}\\)\\?\\\\)\\({1}{1,2}\\{[[.a.]a]\\{2,3\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\({**\\)\\+\\{\\?+\\{2,\\}\\(\\<|^\\)", "dialect": "bre", "valid": false}
+{"pattern": "^\\({,2}|[*]\\([a.]\\{1\\}+\\)\\)\\{1,2\\}\\?[[]\\[.a.]]", "dialect": "bre", "valid": true, "captures": 2}
+{"pattern": "\\.^\\{,3\\}\\({\\{3,2\\}|\\{3,2\\}\\)\\1\\+b[^$[:alpha:]-a]", "dialect": "bre", "valid": false}
+{"pattern": "[][=a=]]\\{2,3\\})*[^[:bogus:]^\\-\\s\\{[a]\\+-", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\(\\({1}\\?\\(\\{,3\\}\\)\\+\\(b[[.a.]]{1,2}\\)^**\\)\\([[.[$z-a]$\\{2\\}[\\[^[.-.]]\\)\\(b\\a\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\($[[=a=]])\\)[^.]*\\}\\)[.z[.a.]]\\([^[:bogus:]]zz-a]{1,2}\\)\\(b\\)\\(\\(\\(\\}|\\)[[|\\(([[:bogus:]aa-z]*&{\\{\\)[^[.-.]]\\{2\\}\\W\\?\\)\\(\\(({1}\\{3,2\\}\\)[\\z-a]\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "b\\{2,3\\}\\\\\\2\\{2}", "dialect": "bre", "valid": false}
+{"pattern": "b\\({1}|(\\|\\)+\\(\\>\\{2,\\}|0\\{\\)\\(\\(\\(,|\\W\\a\\{2,3\\}[-$[:[:bogus:]]\\+\\)[]\\{2\\}|\\}\\)^|\\|\\)\\<|", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\([[:*-a]\\w\\||^b\\{2,\\}\\<\\)**[-[[:][[.-.]z-az]]", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.]a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ",^\\(\\)\\)\\1,\\{2,3\\}\\(.\\?\\?\\)\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\'?\\{1,2\\}$", "dialect": "bre", "valid": false}
+{"pattern": "\\(.*\\)\\{3,2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}{1,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[*^[][$]\\{,3\\})\\*.", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^[a[:*\\a", "dialect": "bre", "valid": false}
+{"pattern": "\\((\\{2,3\\}\\}?\\)\\+\\(\\b\\x41\\)", "dialect": "bre", "valid": true, "captures": 2}
+{"pattern": "[^]\\w*\\{2,\\}\\(\\(\\{1,2\\}|\\a|\\)**\\*[][=a=]a-z.]\\?||[[-[=a=][.-.]\\)", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha:][.-.]a]]\\+)", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\*\\){2,3\\}{\\{2,3\\}", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(\\*^[$z-a[:bogus:].]**\\)\\{($[]", "dialect": "bre", "valid": false}
+{"pattern": "\\)\\{={+\\(^\\(,\\)\\{3,2\\}\\1\\n\\?|", "dialect": "bre", "valid": false}
+{"pattern": "[az-[]\\?[\\]\\{2,3\\}[[z-a^z-a[]\\{3,2\\}[^z-a.]", "dialect": "bre", "valid": false}
+{"pattern": "\\([^]\\]\\?\\)\\{,3\\}\\n[]\\(\\\\|+\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\|[[.^a[:]\\{2,3\\}\\([^a-a-z[:]\\{2\\}\\)[a-z]\\?\\(\\(\\{1\\}b\\(\\{1\\}\\x41**\\)\\)\\.||\\()\\{2,3\\}\\1\\)\\{", "dialect": "bre", "valid": false}
+{"pattern": "a[z[.-.]a-z][-[=a=]]\\(\\b\\(\\(\\s\\>[^^]\\)|.\\)[\\z-a]\\)\\{1\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\.\\),\\{2,3\\}\\(\\(\\(\\b|\\)\\)\\?\\({,2}\\W+*|[^]\\1\\)\\{1\\}\\),", "dialect": "bre", "valid": false}
+{"pattern": "^\\2)", "dialect": "bre", "valid": false}
+{"pattern": "*'\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^[:alpha:][]\\{", "dialect": "bre", "valid": false}
+{"pattern": ",\\", "dialect": "bre", "valid": false}
+{"pattern": "[[a.]][:]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\\\\{1,2\\}\\(.\\)\\{2,\\}[[:[.-.]z-a]", "dialect": "bre", "valid": false}
+{"pattern": "|\\{3,2\\}0|", "dialect": "bre", "valid": false}
+{"pattern": "\\((\\a[[:\\[:z]\\)\\2?", "dialect": "bre", "valid": false}
+{"pattern": "\\([]<\\?{1}\\{,3\\}\\x41\\w\\{", "dialect": "bre", "valid": false}
+{"pattern": "[a^aa:]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([$\\?^\\)\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "[[:*z-a[.a.]]\\(\\(*|\\($\\?[[=a=]a-z*[=a=]][*\\)$\\)([[.\\]\\){*[[:alpha:]]\\a\\{,3\\}+*", "dialect": "bre", "valid": false}
+{"pattern": "[]\\+*^\\b", "dialect": "bre", "valid": false}
+{"pattern": "|\\.**+[[:alpha:][.a.]]\\(\\(\\2,\\()\\b|[[:alpha:]]\\n\\1\\)*\\)\\{3,2\\}\\))\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[]\\{2\\}b^\\+[*z-a[.-.]]\\w,\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\ss(\\+*", "dialect": "bre", "valid": false}
+{"pattern": "a\\}[[.[:alpha:]]]{\\}+\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\W\\(}*\\)\\{\\(|\\(\\{1,2\\}(\\)\\(\\+||\\(\\*0|[*]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\n**\\n{,2}\\{2\\}\\{1\\}\\{3,2\\}\\)**", "dialect": "bre", "valid": false}
+{"pattern": "\\\\[*[:bogus:]]\\+|", "dialect": "bre", "valid": false}
+{"pattern": ":0", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a]\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\($\\s\\{2,3\\}|", "dialect": "bre", "valid": false}
+{"pattern": "|**\\)", "dialect": "bre", "valid": false}
+{"pattern": ".-{1,2}[^a]$$]b[[[.]", "dialect": "bre", "valid": false}
+{"pattern": "\\w.\\{2,\\}\\*\\{,3\\}[z[:bogus:]]", "dialect": "bre", "valid": false}
+{"pattern": "+\\(\\(|\\|[]$[.-.][.-.]]|\\)$|", "dialect": "bre", "valid": false}
+{"pattern": "\\>**\\1", "dialect": "bre", "valid": false}
+{"pattern": "\\2?\\?b", "dialect": "bre", "valid": false}
+{"pattern": "^\\b*[[z-a$]\\w\\}*", "dialect": "bre", "valid": false}
+{"pattern": "*|\\{2,\\}\\(\\([\\]\\+\\((\\{\\)\\a||\\(\\)\\?\\s\\>\\{2,\\}\\)\\{2,\\}[a$[\\]\\)\\)\\([^-*[:^][]\\)+[^[:alpha:]z-aa]", "dialect": "bre", "valid": false}
+{"pattern": "+\\{,3\\}{1,2}\\b\\{3,2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "[][[:aalpha:][:bogus:]z-a$]", "dialect": "bre", "valid": false}
+{"pattern": "[\\[:alpha]z$].", "dialect": "bre", "valid": false}
+{"pattern": "\\.\\<$\\([.^[.a.]a][a[=a=]]\\?\\)\\([=a=][.][.a.]]\\<\\{2\\}|\\)\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\({\\(\\}\\x41\\1||[*]\\(\\b*\\{1}\\+||[[.-.]][\\[[:z-a]\\{2,\\}[^[:[:alpha:]z-a$]\\)\\)\\?\\)\\+{1,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\+\\{2,\\}{1}\\<\\n{1}|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\>\\{,3\\}\\(\\W\\{2,\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\*b[[=a=]z-a[:alpha:][.]\\(*\\{,3\\}\\{1,2\\}**|*[[:\\x41\\)", "dialect": "bre", "valid": false}
+{"pattern": ",\\{\\x4?1*{1,2}\\s", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\*\\{2\\}\\(\\(\\(\\*\\{2\\})[]]\\)\\<\\)$\\{,3\\}|\\(\\{[$$[]\\?.\\)*\\)\\(\\(.\\{2,\\}|\\x41\\{,3\\}\\?\\([a]\\x41\\{2\\}\\)}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(+\\b|\\(\\?\\{2,3\\}\\(\\1{1,2}\\+\\)\\(\\n\\{2,\\}|\\2.\\{2\\}[]\\)\\{2,\\}\\))\\)**\\([[.-.]]\\?|\\)\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\<|\\|?*\\)|\\{(\\{2,\\}|", "dialect": "bre", "valid": false}
+{"pattern": "$*\\x41b0\\{2,\\}1", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "}\\>\\?|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\*\\n\\1", "dialect": "bre", "valid": false}
+{"pattern": "b[][[:a-z[.[.-.]])\\{3,2\\}[.][.a.{]]", "dialect": "bre", "valid": false}
+{"pattern": "\\(^$\\)\\{3,2\\}\\.b", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}\\x41\\{2\\}\\(\\(\\(\\+|[^[=a=]],\\?\\)\\{2\\}\\(\\>[a[:alpha:]],\\?\\)\\(.{1}[^[.-.]a-z\\[.a.]]**\\)\\)\\+a**$", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\2)\\+\\)|\\(\\([][:alpha:]]\\)\\{2,\\}\\?\\b**\\(\\n\\<", "dialect": "bre", "valid": false}
+{"pattern": "\\(}", "dialect": "bre", "valid": false}
+{"pattern": "|[^](\\>(+\\)", "dialect": "bre", "valid": false}
+{"pattern": "[-]+a\\{1\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\b**\\(\\([]\\)\\)\\+|\\{\\{\\{,3\\}\\)[[:alpha:]$a-z-]\\?**\\(\\>|\\([[.a.]\\][]\\)\\)a", "dialect": "bre", "valid": false}
+{"pattern": "(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[*]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "-[[]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\{1\\}\\)\\{2,\\}\\{\\}\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\}\\(\\w\\+\\\\{,3\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\<\\({,2}*\\(\\([\\[:bogus:][^]|\\)[]\\{2,3\\}\\{1\\}\\)\\{2\\}\\((\\(\\{1,2\\}a\\{3,2\\}[aa-z[]\\)\\{2,\\}\\)\\+\\)\\(\\{(\\{1,2\\}*}\\)\\)\\{3,2\\}^\\({1})\\{1,2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\?\\()**|", "dialect": "bre", "valid": false}
+{"pattern": "(\\{,3\\}[]\\(\\([^[:[.a.]-]\\)(|", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\}\\{,3\\}\\(\\+b),)", "dialect": "bre", "valid": false}
+{"pattern": "w", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\\\(\\)\\{,3\\}\\+^**\\)|\\(,\\($**\\)\\?\\)\\(\\{1\\}\\)b\\)\\?\\([[:alpha:]a]**|\\)\\{2\\}\\b{,2}|", "dialect": "bre", "valid": false}
+{"pattern": "\\<[z-az-a[zz]\\(\\>|}|\\w\\)", "dialect": "bre", "valid": false}
+{"pattern": "^+\\{2,3\\}|\\(*\\?\\([[$[=a=][:*]\\)\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\n\\(\\?|\\{\\(\\)\\)[^]\\?\\([]\\?\\w\\(\\\\*\\)\\)\\w[^a-z^][[.]", "dialect": "bre", "valid": false}
+{"pattern": "-\\)\\{2,\\}[[.-.]a^\\]\\W", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\(\\.\\)|\\(\\>[[.a.]zz-a]*\\)|\\)*\\{1\\}\\{\\)\\{3,2\\}[[.-.]^[:]\\{,3\\}{,2}\\(.\\1||[[:bogus:][:bogus:]]\\(\\$(\\}\\)**|.\\{3,2\\}}[[:bogus:][:[.-.]]\\)|\\)\\b", "dialect": "bre", "valid": false}
+{"pattern": ",\\{[[[.a.][]\\>\\+\\n\\{2,3\\}\\|[-a-z]]", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(}\\{|[[:alpha:][:alpha:]a-z]\\+|\\).**\\(\\([[:alpha:]z[=a=]]**\\)\\{2\\}\\(\\.\\\\|[-.*z][]\\+\\)\\(-\\)[.[=a=]]b", "dialect": "bre", "valid": false}
+{"pattern": "){2\\}|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\*\\{2,3\\}\\2$[z[:bogus:]\\[.-.]]\\(\\([]\\()\\{2,3\\|\\+\\{,3\\}[^[.[.a.]^]\\+)\\{2\\}\\)[^^[:alpha:]]\\{\\)|[.]\\)\\()", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\{1\\})\\)[[.z-a]]**\\)\\W", "dialect": "bre", "valid": false}
+{"pattern": ")[][a]]\\(\\a*\\\\{,2}\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\!<\\W\\)\\(?|\\.{,2}\\([[.a-zz-a]\\{2,3\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "[$z]**", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\{,3\\}\\{1,2\\}**{,2}?{,3\\}[aa-z]\\+", "dialect": "bre", "valid": false}
+{"pattern": "{,2}[$[.-.]^]\\W}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\a\\{\\(\\)[[:bogus:]]^\\(.[[.-.]]\\{2,3\\}\\)\\", "dialect": "bre", "valid": false}
+{"pattern": "\\([]\\)\\+\\}\\{|\\(a\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\{1,2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(b|}\\?\\)\\(\\([^a-\\\\)\\+{1}*\\)[]?-\\{\\2", "dialect": "bre", "valid": false}
+{"pattern": "[[:]\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\()\\(+.\\+*\\)*\\{1\\}\\?|\\(?\\{1,2\\}\\)\\x41**\\)\\?\\(.+\\)|(\\([[:]\\+\\\\\\>\\)\\{1,2\\}\\)a\\>\\{3,2\\}.*\\2\\\\**", "dialect": "bre", "valid": false}
+{"pattern": "}[]\\+\\()\\x41|\\(|\\s\\{2,\\}^\\)\\)\\(\\b\\{,3\\}[[=a=]]\\(\\|\\)|$\\)(", "dialect": "bre", "valid": false}
+{"pattern": "[^[.^]\\{,3\\}(", "dialect": "bre", "valid": false}
+{"pattern": "$\\)**\\(\\([a[.a.][=a=]z]\\)\\{2\\'}\\)\\{,3\\}b", "dialect": "bre", "valid": false}
+{"pattern": "\\\\a\\(\\<]*\\(}\\(\\<\\)\\<\\{2,3\\})\\)", "dialect": "bre", "valid": false}
+{"pattern": "}\\([$[.^][[.a.]]\\(\\w\\n\\{3,2\\}\\)\\)\\{", "dialect": "bre", "valid": false}
+{"pattern": "}\\{2\\}\\([^[.a.][=a=]][z-a\\]\\}|\\+\\W\\{2,3\\}\\([-a[]|[-$a-z]\\{,3\\}\\({1}\\)a\\{3,2\\}\\)\\)+\\+", "dialect": "bre", "valid": false}
+{"pattern": "+$[^]?\\(\\(\\s|[^\\a-za\\\\{1,2\\}\\?\\|\\)*|?\\?\\)\\{2,\\}?", "dialect": "bre", "valid": false}
+{"pattern": "\\.\\{2,\\}\\}\\(\\{1\\}\\{,3\\}\\)\\{2\\}^\\)\\)[.]", "dialect": "bre", "valid": false}
+{"pattern": ",\\{1,2\\}\\{1,2\\}[^[.-.][:bogus:][:lpha:][.-.]]", "dialect": "bre", "valid": false}
+{"pattern": "[^].\\{,3\\}\\(\\n\\{,3\\}{1}}\\)\\(\\+\\{2\\}\\),", "dialect": "bre", "valid": false}
+{"pattern": ",,,", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\\[a-z[.]*\\(\\(\\}\\(((\\)\\{2,3\\}\\)[^a-z\\]]\\)[[:-[.[.](\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\{,3\\}\\(\\{*[]**\\)\\.\\|**[.\\]\\?.", "dialect": "bre", "valid": false}
+{"pattern": "([.-a-z[:alpha:]]**?", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(?\\(\\?*0\\{2,3\\}\\{1\\}\\{2,3\\}\\)\\)\\n\\)\\1\\{3,2\\}\\*\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "[a-z[:bogus:]][]0\\(\\(\\s\\{3,2\\}\\([^]|0\\)|,\\)\\(0\\(\\(|\\{\\)\\?\\({1,2}\\+\\{2\\}\\(\\)\\)\\{}|\\|\\)[]\\{\\{2,3\\}[^[=a=]z-a\\]\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\?\\(,[]\\{,3\\}*\\{3,2\\}\\b\\)[\\^]\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[^][.]\\\\\\+\\n", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\", "dialect": "bre", "valid": false}
+{"pattern": "\\([.]z-a]^**\\n\\)*[.[=a=][.a.][:alpha:]]\\{\\n\\W\\(\\s\\(}|[^[=a=].]\\)\\)|", "dialect": "bre", "valid": false}
+{"pattern": ",?\\{,3\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\b{1}\\?\\|*\\(|\\{3,2\\}\\+**\\)", "dialect": "bre", "valid": false}
+{"pattern": "}\\{2\\}[z-a[.-.][.-.]]\\(\\a\\{3,2\\}\\w[[:alpha:]*&^[:]\\)\\2**", "dialect": "bre", "valid": false}
+{"pattern": "[[]$[z[:][.^])\\{3,2\\}\\([*a-z*]\\)\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\:<-.|\\(b[^[.[.a.][.]|\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "*\\{\\?)\\{+", "dialect": "bre", "valid": false}
+{"pattern": ",\\<\\([[=a=][.a.]z]a\\(}0|[[.-.].]\\{,\\}[.z-a[:$]**[-[.[.]\\)\\)\\{3,2\\}.\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\([.[:[.a.][.-.]]\\(\\){,2}\\+[*\\]-]|\\n\\|\\{,3\\}\\)\\b**\\)\\{,3\\}{1,2}\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\}\\{2,\\}[^z-a]z-a]-", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\(^[][z-a]\\)*[[:[:alpha:]a\\)|\\(\\.a[[:bogus:][:bogus:]z]\\)\\{,3\\}{1,2}\\)\\+*\\)\\)\\x41\\W\\|{,2}", "dialect": "bre", "valid": false}
+{"pattern": "^\\W", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "?\\w*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ">\\b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(0\\)[^z-az-[]\\(\\\\\\((\\s\\([.a[:bogus:]](|0\\<\\{,3\\}^\\)\\)|\\(\\(\\}([[..]*\\)|{1}\\w[^-[*]|\\)b**\\)\\{2,\\}\\{1,2\\}\\+^[[:bogus:]-[.]", "dialect": "bre", "valid": false}
+{"pattern": "0\\{,3\\}[^.-.]a-z\\s", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{1,2\\}\\}*\\{2,3\\}[*]\\?\\|", "dialect": "bre", "valid": false}
+{"pattern": "{1}\\(\\\\)[]\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "[a-z]{1}\\([a]][[=a=]a-z]\\{2,3\\}[a-]\\+\\)\\+\\|\\{1\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\+**\\(\\\\|\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\>[]\\(\\*\\)\\)\\({1}|\\)*\\(\\b-|\\(\\)\\{,3\\}[z]", "dialect": "bre", "valid": false}
+{"pattern": "\\s0\\1[[:bogus:]*[]\\()\\)", "dialect": "bre", "valid": false}
+{"pattern": "}\\+,\\{2,3\\}[[.a.]]\\|\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\|\\?[[*]\\(}\\{2,3\\}*[[:alpha:]]|\\)\\(^\\{2,3\\}\\(\\?b\\?|\\)|-\\w\\)\\(,[]]\\{2\\}\\)\\)[^[[.[:a>lpha:]-]*[]\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\[^-\\\\[.]\\+-\\)[^[:bogus:]a-z]", "dialect": "bre", "valid": false}
+{"pattern": "\\s^|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ",", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\)\\?", "dialect": "bre", "valid": false}
+{"pattern": "{?\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\([^][:alpha:][.[]**$|\\(-\\)\\?(\\s\\{,3\\}[[.a.][:alpha:][:bogus:]]\\?b", "dialect": "bre", "valid": false}
+{"pattern": ")()\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{,[2}[[*", "dialect": "bre", "valid": false}
+{"pattern": "[^a]^$\\{1\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([*$[.[:bogus:]]\\{\\*[^a-z]|))[.[aa]\\?\\)", "dialect": "bre", "valid": false}
+{"pattern": "^)\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\({1,2}\\{3,2\\}\\a*\\{2,3\\}\\)\\s?", "dialect": "bre", "valid": false}
+{"pattern": "\\+**\\([.[.a.]\\]\\{,3\\}\\1\\b\\)\\}\\?\\{1,2\\}[^z-a[\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\W\\s\\{2,\\}\\|(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ",,\\{2,\\}\\<\\{3,2\\}[a-z].", "dialect": "bre", "valid": false}
+{"pattern": "\\>\\{3,2\\}?\\{3,2\\}\\n*\\{,2\\}\\.\\{1,2\\}\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": ",\\(|?\\(\\(\\.?\\{?\\)[]|+\\{1\\}|\\)\\{2,3\\}\\)\\({\\{\\){1,2}", "dialect": "bre", "valid": false}
+{"pattern": "[[a]**$\\(\\b*|\\1{1}*\\(|\\)\\([z-a.a[:]\\)\\?\\)\\1*", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\{1\\}|\\({\\)\\{2,\\}[]\\{\\{3,2\\}\\)[-a\\{2,\\}\\([a]\\.\\)*\\W\\>\\{1\\}\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[]\\{2,\\}(\\(\\w+\\+\\)\\+", "dialect": "bre", "valid": false}
+{"pattern": "$\\)[\\]", "dialect": "bre", "valid": false}
+{"pattern": "\\b[]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{1}[]\\}*", "dialect": "bre", "valid": false}
+{"pattern": "\\(}\\n*[z-a]\\{2,\\}|\\)b\\(\\(\\+\\{2,3\\}b\\)**\\(^|\\)\\{2,\\}\\)}\\}\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}(**\\\\W\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\.\\a\\}\\{1,2\\}\\({,2}\\*|\\2\\)\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\})\\(\\)\\(\\(||\\n}|\\)\\{2\\}|\\w\\|\\||\\)\\\\|[]][z-a*$.]*\\)\\{2,\\}\\n+", "dialect": "bre", "valid": false}
+{"pattern": "\\+\\?[z-a]", "dialect": "bre", "valid": false}
+{"pattern": "a[[=a=]*^]\\+[]\\+,**[^z$-a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-z]*\\(\\(,\\n\\a\\)\\{b\\{,3\\}\\\\|\\n\\)0", "dialect": "bre", "valid": false}
+{"pattern": "\\.\\([a]\\{2\\}[.zz$]\\*|\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[-z-a]\\(\\|,\\(\\}\\{3,2\\}\\(\\+|\\.\\++\\\\**[z-a\\)\\1", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\(0?a\\{2\\}\\)\\{\\(\\}\\([[.a.]a-z^$[z-aa-z[:bogus:]]]\\+\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\s[^^^]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]}|.", "dialect": "bre", "valid": false}
+{"pattern": "[[:bogus:]z]**\\s[]\\{2,\\}\\(\\([a-z[:z-a$]\\))\\)\\{3,2\\}\\+\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\{1\\}|\\(.\\(\\W\\)\\>**|\\<|\\b\\)\\+{1}\\{2,3\\}\\)\\{\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\|[^]\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\(?\\>|\\(\\(\\.\\{2,3\\}{1}\\)*\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\*\\n\\)\\{1,2\\}\\{\\<\\<\\2", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha:]-[=a=]]*\\(\\(\\(\\2*a\\{2,\\}\\a\\)\\(\\x41\\{3,2\\}|*\\(\\{1\\}\\{2,\\}[^[=a=]$]|+|\\)\\)\\{3,2\\}\\(\\}\\.**|\\(-[[.a-z.[.-.]]\\{3,2\\}\\)\\{2,3\\}\\<[^[.-.]-]\\)\\{3,2\\}\\)\\{3,2\\}^\\(\\>\\{3,2\\}[^^][:]{\\)\\{,3\\}[]{", "dialect": "bre", "valid": false}
+{"pattern": "\\}-[^aza.]([$.*]\\{,3\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[.-.]\\^[][^*]\\([^z]\\{,3\\}\\)a\\.**\\s|", "dialect": "bre", "valid": false}
+{"pattern": "\\|\\{2\\}\\(-{1,2}[[.a-z]a]-\\x41(\\a\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\){1}[^z-a][]", "dialect": "bre", "valid": false}
+{"pattern": "\\?))\\.", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{,2}\\1&?{1}\\2a", "dialect": "bre", "valid": false}
+{"pattern": "\\2?.|", "dialect": "bre", "valid": false}
+{"pattern": "bb|\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "?\\(-*\\{|\\)", "dialect": "bre", "valid": false}
+{"pattern": "$\\{2\\}0\\{2,3\\}[\\]\\*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\+|[-]z-a]**[z-a](\\{\\)\\([$]\\W\\{,3\\}[z-a[=a=]]\\?|\\(\\()(\\?*\\)\\+\\([[:bogus:]a-z$]+\\?||a*-)\\{2\\}\\)|\\)\\(\\(\\(.\\+|[[:alpha:][:alpha:]]\\)\\{2\\}\\(\\({|.?\\{\\){1}\\|\\)|[^]\\{,3\\}\\?[^[.a.]]\\)0\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\|\\x41\\2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "[[=a==]-.[:]\\*\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\?&|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]\\{2\\}\\<*\\w**", "dialect": "bre", "valid": false}
+{"pattern": "[^[:bogus:][.*[:]", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\}\\{2,\\}|\\)\\{{1}\\{2\\}\\(\\(\\)\\+\\}|[[:bogus:]z]\\)\\{2\\}\\1?\\)$[$[.a.]]", "dialect": "bre", "valid": false}
+{"pattern": "[^]\\{2,\\}\\(0\\{\\)\\(\\(\\(\\a\\{3,2\\}||[[:alpha:]^$[][a*[.a.][.]\\w+|[\\]\\)\\{2,\\}\\)[^[:bogus:]a]", "dialect": "bre", "valid": false}
+{"pattern": "[:alpha:]]*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]{[a\\?+[z-a^[.]", "dialect": "bre", "valid": false}
+{"pattern": "*\\{2,3\\}[z-a[.a.]<z[=a=]]", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\([[]\\(b\\{3,2\\}\\)\\)\\?\\()\\([]\\)a\\{2,3\\}\\)\\{2,3\\}\\)[[.-.]z-az-][[=a=]][[.-.]][a-z]\\({,2}|\\)**", "dialect": "bre", "valid": false}
+{"pattern": "\\n{\\{2,3\\}[\\[.[.]\\W\\($[^za\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\(\\{1,2\\}\\)\\(\\W-\\)\\)\\|\\{2,3\\}\\(\\>\\)\\)\\(\\([[:alpha:]$[:$]\\({1}||[^[=a=]]\\)|\\({,2}\\)\\)\\+\\)\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\}\\{3,2\\}\\(\\([^]\\1\\{2,\\}\\(\\+**\\x41\\)\\)\\{2,3\\}\\<\\\\\\)\\(,.\\a|\\(\\{1\\}*\\)\\?\\)0\\)\\([.]0\\{2,3\\}\\)\\+*\\*", "dialect": "bre", "valid": false}
+{"pattern": ")", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([z[.a.]a]\\)\\([-[.a.][.a.]]**)|\\>\\{2,3\\}\\(\\+\\)\\)\\w\\x41", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\{2\\}[^[.a.]][^][]**[.*<*b", "dialect": "bre", "valid": false}
+{"pattern": "0\\{2,\\}}\\(\\(}\\)*\\)[$-]\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(+\\)\\<\\2\\{2,3\\}|\\?\\($\\{,3\\}\\W[]\\{2,3\\}\\)\\)$\\(\\([^.[:bogus:][.-.]]\\(\\s||\\+\\)?\\{,3\\}\\(|\\{1,2\\}\\)\\{2\\}\\{1\\}\\(\\(\\(\\)**\\<**\\w\\?|\\s[]\\+\\)\\(\\}\\s\\)|\\)\\x41\\+|\\([^[:a]$\\+||[]\\{\\)?\\)[^]", "dialect": "bre", "valid": false}
+{"pattern": "-\\(\\(\\(.|-\\?\\)\\{2,\\}\\)\\<\\(\\*\\1\\)\\){1}\\{2\\}\\b\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\)\\{2\\}\\|[[.za-z]\\++\\^", "dialect": "bre", "valid": false}
+{"pattern": "|{\\{2\\}.\\2\\(*", "dialect": "bre", "valid": false}
+{"pattern": "a\\{,3\\}\\([^[[=a=]^]0\\{,3\\}\\x41\\{32\\}\\)\\}", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "{1}\\.\\({[[.-.][.[]\\)\\(\\W\\)\\+\\(\\{1,2\\}\\W\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\{\\(\\(\\(,**[[:alpha:]]]\\{|[]\\{3,2\\}^[^[.-.]z[.a.]]\\<\\).**[\\.]\\([[.]\\))[[=a=]a-]\\?|", "dialect": "bre", "valid": false}
+{"pattern": "[[.-..][.]]\\w\\{,3\\}[-a*[.][]]", "dialect": "bre", "valid": false}
+{"pattern": "[a^*]\\+[^[:[=a=][:[:alpha:]]\\([^*-|^\\)\\{,[3\\}\\)[^]\\{3,2\\}\\2\\+)**", "dialect": "bre", "valid": false}
+{"pattern": "$\\([z[=a=]]\\b\\{\\(\\n\\+\\)\\)\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\(}\\{2,3\\}\\(\\?.|\\)\\\\\\)[[:alpha:][.-.][.]\\{,3\\}\\2\\|*\\?\\{3,2\\}[\\]", "dialect": "bre", "valid": false}
+{"pattern": "+$\\{2,3\\}\\(\\($\\)\\)", "dialect": "bre", "valid": true, "captures": 2}
+{"pattern": ")\\{{,2}[[=a=]]{1,2}\\(\\n\\{2,3\\}|\\)**+\\(\\<([[:alpha:][.a.]a[.a.]]\\)\\)\\{3,2\\}\\x41\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "^\\{2,3\\}\\a\\{{2\\}\\([^]\\{[[:bogus:]-]\\s\\)[^[.z$]]\\(,\\{2,\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(.\\{2,\\}\\>\\)\\{2\\}\\\\\\{2\\}\\{1,2\\}\\(\\<\\)\\w\\{2,\\}(", "dialect": "bre", "valid": false}
+{"pattern": "\\n[*.]\\(\\(b||a*\\)|\\?[[:bogus:][.a.]^]\\?\\)\\{,3\\}*\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\a\\)^\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\({,2}\\)\\(^^\\?|[[:alpha:].z]\\(\\1(|0[[z-aaz]\\{2,3\\}\\)|\\)\\{,3\\}|\\W|\\)\\{2,3\\}\\(\\x41\\x41(|\\?\\w+\\)**\\(\\(,|[]\\{2\\}{1}[]\\)[]*[.a.][.-.]]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\({1}[za-z$[:bogus:]]\\)\\([[:z$**\\}\\{2,3\\}[^[.]\\))", "dialect": "bre", "valid": false}
+{"pattern": "\\)\\+\\1\\+{,2}.[[:bogus:]\\\\][[.-<.][:bogus:]a.]", "dialect": "bre", "valid": false}
+{"pattern": "\\w\\{\\?\\(^\\{3,[2\\}}\\.\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\+\\}\\{2\\}\\(\\((.\\)\\w\\(\\)\\{,3\\}\\n\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\}[[=a=]-][-^]\\(b\\)\\+\\}", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(\\}b**\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\.[[:bogus:]z[:bogus:]a-z]*[]z-a]]\\{1\\}\\>\\{3,2\\}.", "dialect": "bre", "valid": false}
+{"pattern": "\\?[z-azz-a.-]$*", "dialect": "bre", "valid": false}
+{"pattern": "\\x41*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "}\\(", "dialect": "bre", "valid": false}
+{"pattern": "[^\\]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:[.a.][=a=]][-^^-]\\?", "dialect": "bre", "valid": false}
+{"pattern": "(\\{2,\\}a", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^[.a.]a-z[=a=]]{\\{2\\}\\*\\{,3\\}[a-z[a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{1,2\\}[[.]|[[.$[:alpha:]a]\\sa", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}\\{2,\\}{\\*[].[.-.]]]\\{", "dialect": "bre", "valid": false}
+{"pattern": "[a-z[:alpha:]\\]\\{,3\\}\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "b\\{1,2\\}\\{2,\\}\\(.[.[:]\\(\\([[:bogus:].]\\2|\\>\\{2\\}\\)[^^]|\\+\\)\\+\\)\\,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\s\\{2\\\\}\\([^$[]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\W\\2\\{2,\\}\\(\\{1\\}\\(\\<\\W\\){|\\(\\(\\1)\\?\\)\\([a[.[.a.]]]\\{|\\)\\)\\)\\){1}[[:alpha:]]]\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "[[.]?|", "dialect": "bre", "valid": false}
+{"pattern": "+^[$z-a]\\<\\?^", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\\\}{\\>\\{3,2\\}\\.\\(}\\{,3\\}{\\)\\?+", "dialect": "bre", "valid": false}
+{"pattern": "{1}\\\\+\\([]\\{3,2\\}\\a\\1|\\(\\(\\+[[:alpha:][*]\\{,3\\}\\)\\{**|\\)\\{2,3\\}\\)\\{2,\\}+{", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\{,3\\}\\([z-a*[.a.][.-.]]|**|\\?*\\(\\{1\\}**\\.\\)|\\{\\){1}\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "*\\|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\\[^-[.-.]$]\\{1,2\\}\\(\\([[.a.]z-a*]\\)[[:alpha:][[:alpha:]]}\\)\\?\\<\\(n\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "[\\]\\{2,\\}(+|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^a-z\\[.a.]][-.[:alpha:]]\\{3,2\\}\\?[[:bogus:]]\\{2\\}?\\{2,3\\}\\(\\n\\{2\\}[aa*a-z]\\{2,3\\}|.\\{2,3\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "0(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\w[[=a=]a]$]\\{2,\\}\\{1\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\(^\\{\\({\\?|\\(+a*|$*,\\)\\{,3\\}.\\{b\\)\\?\\1", "dialect": "bre", "valid": false}
+{"pattern": "\\(?\\)\\{2,?\\}[z-a]\\{2,3\\}{1,2}\\?\\([]\\{|\\({,2}\\{2\\}\\([a-z[=a=]]\\)|[[.]\\{\\)\\>**\\(\\W**\\)\\{\\))$", "dialect": "bre", "valid": false}
+{"pattern": "[][[=a=]\\[.-.][=a=]]\\{1\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{\\{1,2\\}\\(0*[[.[:alpha:]z](\\)\\{3\\}\\(\\b\\(\\b\\?\\>\\)\\){,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\(0\\{{1,2?*\\)\\n\\{\\.", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\w\\{,3\\}\\)\\{2,3\\}+\\+\\)*\\.\\+\\.\\s.\\{3,2\\}\\(\\.\\)\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\s\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\*\\{{,3\\}([]\\?", "dialect": "bre", "valid": false}
+{"pattern": "[[[a.].]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\\a\\?|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\w[**\\(\\(^[^]]{1}\\+\\)\\)\\{2,\\}\\)\\?\\w\\([^]\\)\\({\\)|", "dialect": "bre", "valid": false}
+{"pattern": "[a]\\(\\(\\b|\\)\\?|\\2\\{,3\\}\\)\\(\\*\\{2,\\}[^-^[.a.]]|\\n\\)\\(\\s\\+\\(\\*[^]\\{2\\}.\\)\\)\\?)\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\W*[]\\{1,2\\}}a", "dialect": "bre", "valid": false}
+{"pattern": "(\\*[[:alpha:][:[.a.]]\\{3,2\\}\\|{[$z]", "dialect": "bre", "valid": false}
+{"pattern": "\\W[][:alpha:][:alpha:[.a.]]**b\\b**|", "dialect": "bre", "valid": false}
+{"pattern": "[**]{\\a\\W\\*[[:", "dialect": "bre", "valid": false}
+{"pattern": "\\(+\\+\\([]\\)[.$a.]\\{2\\}\\(\\>\\w\\{3,2\\}\\){,2}\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\+[]**a\\(\\($\\(+\\x410\\)\\{\\)\\{3,2\\}\\({+\\+[\\[:]|\\{2,\\},\\?|(\\)-", "dialect": "bre", "valid": false}
+{"pattern": "[[.a.]\\[.]\\?[^]\\+\\{2,\\}[]][^\\]\\a", "dialect": "bre", "valid": false}
+{"pattern": "{,2}\\{[1\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\($\\)-\\+{1,2}\\{,3\\}", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[]\\2\\s[-{^]0", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[.[=a=].]\\{3,2\\}\\**b\\|", "dialect": "bre", "valid": false}
+{"pattern": "[[.*z-a]\\(\\(\\(?\\|\\?\\))\\b\\{2\\}\\{1,2\\}|\\).{,2}**", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\2\\}*\\{2,3\\}\\)\\?{1,2}\\(\\(\\{2\\}}\\)", "dialect": "bre", "valid": false}
+{"pattern": "$\\(\\(\\1\\{2,3\\}\\(*[z[.a-z]]\\{1\\}\\{,3\\}|\\|?\\{3,2\\}\\)|{,2}\\{2,\\}\\}\\)***\\+\\)\\(a\\+(\\?|\\(\\(\\W**{1}\\{,3\\}|\\)[[:z$]]\\{2,\\}\\.|[a-z[:bogus:]a]\\)\\{2,\\}\\?\\+|\\))", "dialect": "bre", "valid": false}
+{"pattern": "[[.a.]a]].\\{2,\\}0\\\\\\2[*$]", "dialect": "bre", "valid": false}
+{"pattern": "\\2*+*\\+b\\+}", "dialect": "bre", "valid": false}
+{"pattern": "\\({,2}\\)*\\(\\{1,2\\}a|\\(\\.\\)\\+\\*\\)|", "dialect": "bre", "valid": false}
+{"pattern": "\\b*\\\\\\?\\(\\{1,2\\}[\\\\(\\(^\\x41|\\2[^z[.-.a-za-z]\\2\\({1,2}}|\\)\\)\\)\\{", "dialect": "bre", "valid": false}
+{"pattern": "[*[=a=][.]\\{?", "dialect": "bre", "valid": false}
+{"pattern": "[[:bbogus:]]b", "dialect": "bre", "valid": false}
+{"pattern": "[z[:a)lpha:]]\\{|", "dialect": "bre", "valid": false}
+{"pattern": "\\.\\(([*]\\+$|[\\[.a]}\\{[^^]\\{3,2\\}\\)\\s[]\\)|", "dialect": "bre", "valid": false}
+{"pattern": "[]\\(\\2a\\{,3\\}\\)a\\{2,3\\}0[[:z-az-a]", "dialect": "bre", "valid": false}
+{"pattern": "\\({\\a\\{2,3\\}\\)\\{\\a\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\*{\\(\\b\\{3,2\\}\\1\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(,\\(0\\?\\)*\\w\\?[^z]b[z-a[.$]*\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\s^|\\{2,\\}|{\\)**,\\([]\\<\\(\\|\\?|*\\{2,3\\}.\\{2,\\}\\s\\)\\?\\)[$[=a=]$[:bogus:]]\\($\\)**", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\([][^[]\\(\\(**-\\1\\{2,\\}|)\\+\\2\\)*\\)+|\\(\\1\\{2,\\}\\{,3\\}\\)\\(\\{2,3\\}0\\),", "dialect": "bre", "valid": false}
+{"pattern": "[a].]\\(}\\\\\\)\\({\\<\\+\\)\\{2\\}\\([[:bogus:]..][^[.-.]z]**\\2\\)\\(!(\\1\\{3,2\\}^\\)", "dialect": "bre", "valid": false}
+{"pattern": "[-[:alpha:]^\\]\\([[:bogus:]]|[[.a.][]\\w\\)$", "dialect": "bre", "valid": false}
+{"pattern": "\\*0^{1,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\*$*\\>|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\([]\\)[[^-]", "dialect": "bre", "valid": false}
+{"pattern": "^\\*\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\{12\\}{**", "dialect": "bre", "valid": false}
+{"pattern": "\\((\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "{1\\}\\{2\\}\\1\\}*[^[:alpha:]]\\({1,2}\\{3,2\\}|\\{2,3\\}\\)\\{,3\\}0", "dialect": "bre", "valid": false}
+{"pattern": "\\***.[]\\?\\w\\{))\\{|", "dialect": "bre", "valid": false}
+{"pattern": "\\(}\\(+{,2}\\?[$-[^]\\),+\\{2,\\}\\(\\(\\b\\{2,\\}\\(\\.\\{2,\\})|\\{1\\}**\\)\\{3,2\\}[[.-.]z-a]|\\)\\{,3\\}|)\\)\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\)\\{2,\\}[]a-z.a-z][[=a=]]{,2}\\?,", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\(\\|\\{1\\}[z[:bogus:][.[.]|{1,2}\\)\\{2,3\\}-\\)\\{2\\}\\)\\(}\\)\\{3,2\\}+[[:bogus:]z-a]", "dialect": "bre", "valid": false}
+{"pattern": "\\b[a-za\\{3,2\\}\\\\\\?-\\x41**\\{1,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[--]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "=}-\\2*", "dialect": "bre", "valid": false}
+{"pattern": "+|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([^.$[:]\\{2,\\}\\)|\\n[]\\?[^]", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\*\\([^a-z[.a.][.-.][:alpha:]]\\([^z]||\\{\\.\\)\\{,3\\}[$[.-.][=a=]a-z]*|\\)[]\\)\\<\\(*\\)\\{2\\}?\\?\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\+\\+\\.+*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([.]\\|\\\\\\)\\1\\{3,2\\}b", "dialect": "bre", "valid": false}
+{"pattern": "$\\n\\x41[[=a=]^a-z]\\([[]\\{2,3\\}[]\\a\\{|\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\n\\([z^^^]{1}\\b|\\{\\)\\{\\)\\+\\)\\?\\(^|-\\?\\([z-a-][z]\\)|\\|\\{3,2\\}[].\\)\\(\\+[]*|\\\\)\\)\\w\\?{,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\(-||\\}\\b\\)+\\(\\.[[[:alpha:]$]**\\([[:bogus:]\\[]0\\)|", "dialect": "bre", "valid": false}
+{"pattern": "\\[(\\*||\\*\\)|", "dialect": "bre", "valid": false}
+{"pattern": "\\<|\\{2,\\}\\(\\s|\\(\\n\\(^+\\+\\)\\>\\?\\)\\)+|**", "dialect": "bre", "valid": false}
+{"pattern": "b[a[.-.]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^[.]\\(,\\(\\n-|\\)\\)\\)(\\?{1,2}\\{1,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(.\\|-\\+\\)[^[=a=][.(", "dialect": "bre", "valid": false}
+{"pattern": "[*]\\{3,2\\}[[:[.a.]^\\][a^[:alpha:][:bogus:]][[=a=]]\\(-\\+}^|\\{1\\}{\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(,\\+\\)\\(\\(\\)\\)\\+|[a-z-]\\{\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\n\\{,3\\}\\}|[[:[]\\)\\?|\\)\\{1,2\\}\\{1,2\\}-{\\+|", "dialect": "bre", "valid": false}
+{"pattern": "[z-a.]\\?\\s", "dialect": "bre", "valid": false}
+{"pattern": "[*[.a.]]-\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(\\+\\(\\}\\\\\\1\\(\\(\\(|[^[:*.]?\\+$\\)[^[:bogus:]$]\\)\\{\\)\\b$\\(\\(\\1\\{,3\\}{1,2}\\s\\)\\?\\)\\s", "dialect": "bre", "valid": false}
+{"pattern": "\\([^[.-.]z-a.]\\{\\(\\w.\\)\\([^*[.-.]]\\{3,2\\}\\)\\{2,\\}|\\+{,2}\\{,3\\}\\>\\)", "dialect": "bre", "valid": false}
+{"pattern": "[}^\\>", "dialect": "bre", "valid": false}
+{"pattern": "{1}\\{2,3\\}\\(a\\)\\n\\{2,\\}*", "dialect": "bre", "valid": false}
+{"pattern": "\\(}|\\(b\\?\\)\\{2\\}[^.[=a=]$$]-\\)\\{2,3\\}", "dialect": "bre", "valid": true, "captures": 2}
+{"pattern": "\\((\\+\\}\\)\\?*\\(\\*\\{2,3\\}[]-[:alpha:]]\\)**\\1,[a[=a=]]", "dialect": "bre", "valid": false}
+{"pattern": "?[]\\([^\\*\\($|\\(\\\\\\)\\?[^*-[:alpha:]]\\)\\?\\)\\{2,\\}\\{\\{2,3\\}a|", "dialect": "bre", "valid": false}
+{"pattern": "[=][:]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[]*", "dialect": "bre", "valid": false}
+{"pattern": "\\a,{1}{\\{[[.a.][.-.]]**^\\b", "dialect": "bre", "valid": false}
+{"pattern": "[z])|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{1,2\\}\\]{2,3\\}}**", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\|\\{2\\}\\\\\\{,3\\}\\($|\\s\\{,3\\}\\a\\{2,3\\}[[:]\\{|\\)\\{,3\\}|\\))", "dialect": "bre", "valid": false}
+{"pattern": "b[],\\{\\(\\(\\?\\{1\\}\\{3,2\\}|\\)", "dialect": "bre", "valid": false}
+{"pattern": "[^]*[z-a]\\+-\\+^", "dialect": "bre", "valid": false}
+{"pattern": "\\(,*\\(\\{1,2\\}\\{,3\\}\\)\\{,3\\}\\w\\)\\{2\\}{1,2}\\a\\{2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\b*\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\([[.a.]]*\\{|\\s\\+0\\{2,3\\}\\)0\\(\\n[^\\]\\{^**\\)[^][[.[=a=][.a.]]^", "dialect": "bre", "valid": false}
+{"pattern": "-\\{3,2\\}:b\\2[^*]|", "dialect": "bre", "valid": false}
+{"pattern": "[^]\\^$]\\{2,\\}\\([].***\\)\\([^.a[[:]\\{2,3\\}\\)[.[:-", "dialect": "bre", "valid": false}
+{"pattern": "\\\\\\?[[.-.][[=a=]z-a]?", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\{2,\\}\\}+[^[:alpha:]][:alph)a:]][-^[=a=]z-a]\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\x41\\}.[[:bogus:]*[[.][[$z-[=a=]]\\{,3\\}|", "dialect": "bre", "valid": false}
+{"pattern": "-**[[.a.]]?[a*^][^a-zz-a]", "dialect": "bre", "valid": false}
+{"pattern": "[[z]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(+\\{,3\\}\\a\\(\\(\\(?[^$-z]\\{1\\}\\)\\{$\\)*b\\{3,2\\}\\)*", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\(\\?|\\(\\(0\\{1\\}\\{[[.a.]]|[[.-.][:]\\)\\)\\{,3\\}\\)\\{,3\\}\\([*]\\)$\\{\\{2,3\\}\\b", "dialect": "bre", "valid": false}
+{"pattern": "0[[.[:^\\]\\*|", "dialect": "bre", "valid": false}
+{"pattern": "[][:b<ogus:]]\\{1\\}*", "dialect": "bre", "valid": false}
+{"pattern": "\\{1}\\(\\<\\(\\.\\()\\n\\{2,3\\}*\\)\\\\\\)\\}\\)[\\]*|", "dialect": "bre", "valid": false}
+{"pattern": "\\([[[.a.]^]\\n\\{2,\\}\\)+\\([]\\{2,}[^z[:alpha:]$]|\\n\\)\\(\\{1,2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\?[\\(\\{1,|2\\}\\(\\(\\1|\\)\\)b\\)b|", "dialect": "bre", "valid": false}
+{"pattern": "$\\(\\{1\\}**|\\([z\\^]\\w[^$[.$a]\\{3,2\\}\\)\\1\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\b", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\({1,2}\\)*\\", "dialect": "bre", "valid": false}
+{"pattern": "\\s\\{1,2\\}\\(\\}[]\\){1,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\W\\{{1,2}", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\s\\b\\(\\{\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\w\\{2,3\\\\.**\\W\\>\\w\\{\\(\\s\\{,3\\}|\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\b\\{3,2\\}\\)\\{2,3\\}[*]]\\?\\)b\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\}\\?[[[.-.]]*\\}\\{1,2\\}\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\{\\{,3\\}\\<\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(&0\\{2\\}\\([[:a-z$]\\{2,3\\}\\)\\)\\{2\\}[[.-.][.a.][.a.]a-z]|", "dialect": "bre", "valid": false}
+{"pattern": "\\x41[$[.a.][:[.a.]]\\+b\\{2\\}[^[:alpha:]]a", "dialect": "bre", "valid": false}
+{"pattern": "{,2}0\\x41\\{2\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "?\\{*|", "dialect": "bre", "valid": false}
+{"pattern": "\\()\\)\\{\\+a\\s\\(,\\{3,2\\}\\(\\*\\+a|*{,2}\\{3,2\\}\\{1,2\\}\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\({1,2}-\\*|[]{\\{?\\)\\(\\)\\{[z-a--]\\{|\\)\\{2,\\}|,\\)", "dialect": "bre", "valid": false}
+{"pattern": "[^[.-.][.a.][:alpha:]]0\\?^\\(\\b[]-\\)", "dialect": "bre", "valid": false}
+{"pattern": ".a}**", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\W*[z-a-]\\a|\\)\\+\\(\\x41**\\)\\{1\\}\\{2,\\}\\<*\\+\\{2,\\}[z-aa-z[.a.]]", "dialect": "bre", "valid": false}
+{"pattern": "b\\.\\s[[=a=][.a.]\\*]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[$[.a.]]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([]\\1**[.[=a=]][", "dialect": "bre", "valid": false}
+{"pattern": "\\({1}\\+[[.a.][:alpha:]][-]|\\)\\(a\\{2\\}\\)\\{2\\}\\||\\)\\W[]\\?[[[.-.][]\\([a-z]\\{\\+\\(\\2\\{3,2\\}\\)\\)\\s\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\'}*\\>\\+$\\w\\{*", "dialect": "bre", "valid": false}
+{"pattern": "\\{\\(\\}\\x41\\+\\)\\(\\b\\{2,3\\}|*\\)*|", "dialect": "bre", "valid": false}
+{"pattern": "$}-\\x41\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\\\(\\(\\)", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[]\\2\\{2\\}\\w", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\a\\)a\\+\\{3,2\\}\\(\\{1,2\\}\\)**", "dialect": "bre", "valid": false}
+{"pattern": "[]?\\(\\|\\)\\{,3\\}[$[[.]", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\(\\(.\\(\\{1\\}\\)\\x41[-]\\)[[:]\\{&a", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\?\\(\\($\\{,3\\})\\)\\)[z-aaz-a]\\(\\b\\{,3\\}\\}[[z*[:bogus:]]|\\)\\)\\){,2}\\(\\2\\+|\\)\\>", "dialect": "bre", "valid": false}
+{"pattern": ",\\.\\{2\\}*\\{1\\}*", "dialect": "bre", "valid": false}
+{"pattern": "\\s\\(\\(\\b\\{2,3\\}|\\([[:alpha:]]\\.[[:bogus:]\\)\\){1}\\{3,2\\}{,2}\\{|[.\\]\\)\\{1,2\\}\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\([]|[[:alpha:][.a.]$]\\)[$]b", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[^]\\(^\\{{2,\\}\\(\\+\\>-\\{,3\\}\\)\\{3,2\\}(\\{|\\(\\(*\\(b|\\\\\\W*\\)\\{1\\}\\)\\1[z-a]**\\)*\\($*\\)a{1,2}[]|", "dialect": "bre", "valid": false}
+{"pattern": "\\W^\\[a[=a=][]|\\)**\\*\\+", "dialect": "bre", "valid": false}
+{"pattern": "a,\\{3,2\\}\\()\\)\\{,3}\\.\\{1\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\x41\\<(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "*\\+?[[.-.][.a.][:alpha:]]\\{3,2\\}\\\\", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\*[z-a^<*]\\b\\)-\\{,3\\}\\(,\\{,3\\}\\b.\\)\\{2\\}\\s\\*\\?\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "}*\\(\\x41\\}-\\)*\\W$\\{3,2\\}\\(\\([$z-a[=a=]]\\)\\)|", "dialect": "bre", "valid": false}
+{"pattern": "[[:alpha:]]\\?\\{1,2\\}\\{2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\x41\\\\(\\a\\)[[.*][a-z[a-z]\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}\\([[.a.]]\\{\\(\\1\\{2,3\\}\\(\\*\\b\\?\\)*\\.\\?\\)\\<\\)", "dialect": "bre", "valid": false}
+{"pattern": "*\\{1,2\\}\\{2,3\\", "dialect": "bre", "valid": false}
+{"pattern": "\\)\\{2\\}a.z*]**\\()\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(b[*[[.a.]]|\\)\\1-^[[=a=][.[$>]", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\1b|[[:alpha:].[.]\\)[]\\(\\([]-]\\{{\\{3,2\\}|\\{1,2\\}b\\{2,\\}\\)[z-a^*$]**\\)\\n\\+\\.\\b", "dialect": "bre", "valid": false}
+{"pattern": "[^\\[.a.]z[.a.]]\\?\\+\\b|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": ".[^]*\\|\\{", "dialect": "bre", "valid": false}
+{"pattern": "(0\\*||?\\(\\.[^][:bogus:]][*$]\\)\\{2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "^[[=a=]\\a-zz]\\2\\(\\n\\{2\\}[a-z[.a.][=a=]]\\*\\)**", "dialect": "bre", "valid": false}
+{"pattern": "*{\\|\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "-[^a-z[a-z.]\\{2,\\}{", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(b|.*\\)\\(.\\{2\\}\\?|(\\(\\+{\\)\\)[^]a-z]\\<\\1", "dialect": "bre", "valid": true, "captures": 3}
+{"pattern": "\\>\\?\\<[^[.$]**{1,2}\\()\\{,3\\}[]\\)\\(,\\)**", "dialect": "bre", "valid": false}
+{"pattern": "0[^][^z-aa-z]a{1,2}\\{2,3\\}\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\..\\+{1,2}?[*[:bogus:]\\]*$", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\?\\)b\\?\\n[^[:bogus:]a-z'][z[.-.]$][\\..\\]", "dialect": "bre", "valid": false}
+{"pattern": "\\b[]|", "dialect": "bre", "valid": false}
+{"pattern": "\\W\\{3,2\\}\\?**\\<.\\b[[:bogus:]]\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "{1}\\($|[]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\\\a\\(\\}\\)\\>\\{2\\}\\<", "dialect": "bre", "valid": false}
+{"pattern": "{,2}-{{,2}\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\{1,2\\}}", "dialect": "bre", "valid": false}
+{"pattern": "?\\({12}\\b\\{|\\{1\\}\\{2\\}[.[]|\\)\\(\\?\\+\\*\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\}\\.\\([z-a[:bogus:][]\\.*|\\([]\\+|\\)\\?\\)\\<{(", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\{1,2\\}[[.a.][=a=][.z-a]\\b\\({,2}[^]\\{[^za[:]|\\}\\)|", "dialect": "bre", "valid": false}
+{"pattern": "{\\|)\\a\\{2\\}[^]+", "dialect": "bre", "valid": false}
+{"pattern": "x41", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^]\\(*\\1\\{\\){\\{", "dialect": "bre", "valid": false}
+{"pattern": "{1}[])**\\)", "dialect": "bre", "valid": false}
+{"pattern": "[\\[:bogus:]a]\\(", "dialect": "bre", "valid": false}
+{"pattern": "\\($0+\\)\\{2\\}([]\\a", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\?$-|\\)\\{2,3\\}\\W\\+", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\<,\\|\\n", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[*[]\\{{", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\(\\<\\{3,2\\}\\2\\{,3\\}\\{|[$-[:alpha:]]\\({[$]|{\\{,3\\}\\(\\)\\(\\{1\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\+{\\{,3\\}[.]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\w\\{3-,2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\\\(.", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\}[z[.-.][:bogus:]$]{1}\\{2\\}\\(\\n\\)+[z-az[.a]", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\{\\{(\\}", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\{|", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\2\\|\\<**,", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\(.\\{2\\}a\\)\\(0\\{1,2\\}\\)|b.\\)\\)+\\<*", "dialect": "bre", "valid": true, "captures": 4}
+{"pattern": "\\n\\{2\\}[[:alpha:][.<a.", "dialect": "bre", "valid": false}
+{"pattern": "\\([z[.a.]a-z[]|\\s\\{2,\\}\\)\\{2,3\\}\\{1\\}[[.-.][:^?", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.][.a.][a[.-.][.a.]]*\\<\\.\\(-\\(\\?\\(\\|[\\^][]\\{2,3\\}|[]0\\2\\)[]\\{2\\}\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": ".a\\x41\\s\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\+*\\{1\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\s[a-z][[:bogus:]^[:alpha:]]\\{\\)[\\^^]", "dialect": "bre", "valid": false}
+{"pattern": ",*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\b\\+|\\(\\(a\\{2,\\}|\\)[^]\\)\\)\\)\\({1,2}{1,2}[$]\\{2\\}\\)(*\\)\\{2,\\}[[:alpha:][.a.]]\\+\\2", "dialect": "bre", "valid": true, "captures": 3}
+{"pattern": "a?\\2\\2\\(\\}**[=[..*]|[^]\\)[[.a.][.a.]]]\\{|", "dialect": "bre", "valid": false}
+{"pattern": "\\1|", "dialect": "bre", "valid": false}
+{"pattern": "[zzz-a*]", "dialect": "bre", "valid": false}
+{"pattern": "*\\>\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\n[^].\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\(\\w\\{2,\\}{1,2}\\w\\{|\\n\\)\\+\\}\\{|\\({,2}{\\+\\>|\\>\\{\\s\\<\\)\\)\\(\\(+|,\\(\\{1,2\\}\\))\\?\\)\\({\\)\\+|[z-a-]\\2\\)\\{2,3\\}0\\)[^]$]\\{,3\\}\\\\\\+\\{1,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[[:bogus:]*a-z]", "dialect": "bre", "valid": false}
+{"pattern": "\\()\\a\\),\\{\\{1,2\\}\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\{3,2\\}[*]", "dialect": "bre", "valid": false}
+{"pattern": "[]\\{2,3\\}.\\?\\($^\\)\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "{1}\\|^\\+[^[:bogus:]]\\{2,\\}[]$*[:bogus:]]\\?", "dialect": "bre", "valid": false}
+{"pattern": "+\\n*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "}\\{\\{\\w[^a-z[.[.-.]z]\\b", "dialect": "bre", "valid": false}
+{"pattern": "[^[.-.]$z\\]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\([z-a[=a=]]]$\\([^a^$]\\{2,\\}\\{1,2\\}\\{\\)\\)*\\W\\)", "dialect": "bre", "valid": false}
+{"pattern": "[[:bogus:].]{1}^\\*\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "|\\]1b\\{\\1", "dialect": "bre", "valid": false}
+{"pattern": "-\\^(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\2\\)+\\)0", "dialect": "bre", "valid": false}
+{"pattern": "[?^-a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^[.*[]0\\{2\\}\\(\\(\\(\\<|\\a\\)\\)**[a-z]*|\\+\\(\\}[a-z[.$]\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}*\\)", "dialect": "bre", "valid": false}
+{"pattern": "{\\{2,3\\}\\(\\2\\)\\+\\n\\(\\1\\{2\\}\\)\\([[:alpha:]]\\||\\)", "dialect": "bre", "valid": false}
+{"pattern": "^$[[[=a=]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "0\\)\\{3,2\\}{1,2}{1}**|", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\w\\(\\+", "dialect": "bre", "valid": false}
+{"pattern": "{\\W", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\x41\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\+a{,2}(\\{2,3\\}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{\\*[^[=a=][:bogus:][.-.]]\\?\\(\\(b\\*\\)\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "*\\(*\\{3,2\\}\\>\\{3,2\\}[^*]]\\{2,\\}0\\{2,3\\}^\\{2,3\\}|", "dialect": "bre", "valid": false}
+{"pattern": "[z[:alpha:]*a]*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\(\\(-|}\\)\\{[[:[.a.]\\a]\\}\\?\\)++\\\\", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\.\\)\\<{", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\(\\(b|\\({1}\\{2,3\\}|\\\\([[:][:bogus:]]\\{,3\\}\\W\\)\\(^{,2}\\)\\)\\{2,3\\}\\(\\(\\x41\\)\\2|?\\2\\(\\n\\+\\)\\)\\1\\{3,2\\}\\)\\?\\2-\\{\\|(", "dialect": "bre", "valid": false}
+{"pattern": "[]\\{1,2\\}*\\(\\{2,\\}[\\{[]**", "dialect": "bre", "valid": false}
+{"pattern": ")\\{2,\\}\\(\\{1,2\\}[z]\\)", "dialect": "bre", "valid": false}
+{"pattern": "|\\([]|[[.a.][.-.][:alpha:][:]\\{2,\\}[[:alpha:]]\\<\\)\\{1,2\\}\\(\\1\\([$\\]\\)*)|?\\(\\({1,2}$|\\)||[**a-z][a*[=a=]-]\\{2,3\\}\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\n\\a\\{3,2\\{1,2}\\){1,2}\\{2\\}\\{1\\}\\b\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\|)\\1\\<\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\.***", "dialect": "bre", "valid": false}
+{"pattern": "[-[=a=][:bogus:]z]*[*]-$]\\{[a\\.[.-.]]\\{2,\\}[]\\+\\}", "dialect": "bre", "valid": false}
+{"pattern": "?\\\\\\([[.]\\{2,\\}[\\*]\\{2,\\}[^[.a.]a.[.]\\{2\\}", "dialect": "bre", "valid": false}
+{"pattern": "0\\{3,-2\\}\\b\\(\\(\\([^]|\\1\\){[^].]|\\}^\\?\\)|", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\*\\?\\+\\)\\(|\\{2,\\}-\\)[]", "dialect": "bre", "valid": false}
+{"pattern": "\\a[z.[:bogus:]]\\{2,\\\\}[\\]\\+|", "dialect": "bre", "valid": false}
+{"pattern": "{1}\\{33,2\\}\\*}*", "dialect": "bre", "valid": false}
+{"pattern": "\\({1,2}{,2}\\{1\\}[-[:>", "dialect": "bre", "valid": false}
+{"pattern": "\\1\\}{", "dialect": "bre", "valid": false}
+{"pattern": "2\\{,3\\}^\\{2,\\}{1}[]$]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]z[a][[:bogus:][:z-a]]\\.\\>\\{,3\\}\\w^", "dialect": "bre", "valid": false}
+{"pattern": "\\s\\?^{\\1\\{2,\\}a[]", "dialect": "bre", "valid": false}
+{"pattern": "\\1{1}\\({1,2},\\{\\(|\\(\\|***\\{2,3\\}*|[]\\)\\)|\\w\\\\\\)\\n", "dialect": "bre", "valid": false}
+{"pattern": "\\(|\\)[]", "dialect": "bre", "valid": false}
+{"pattern": "[^z[:alpha:]^a-z^\\}\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\\\(\\1", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\+\\(\\2\\{2,\\}\\)\\([[:alpha:]]\\)$\\{2,3\\}[a[:bog,us:]]", "dialect": "bre", "valid": false}
+{"pattern": "\\+\\{3,2\\}\\W[]\\{2,3\\}a\\{3,2\\}\\(}\\{3,2\\}\\.*\\)", "dialect": "bre", "valid": false}
+{"pattern": "[-][$[].-.]]]\\{3,2\\}\\(}\\{\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[^$[][.a.]a]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "([^\\[:][[:alpha:]a{1,2}\\<", "dialect": "bre", "valid": false}
+{"pattern": "\\s}\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[][[=a=]]\\{,3\\}}+**|", "dialect": "bre", "valid": false}
+{"pattern": "{,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*\\{1\\}**\\n", "dialect": "bre", "valid": false}
+{"pattern": "\\())\\*|", "dialect": "bre", "valid": false}
+{"pattern": "\\s\\s\\+\\(\\|,[a*]\\)\\{2,\\}[[.a.]a-z[=a=]]$\\{", "dialect": "bre", "valid": false}
+{"pattern": "+*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\)\\(\\<\\)\\n\\(\\(\\*\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\({1}\\{3,2\\}[-z]\\{\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\)*[]\\{2,3\\}\\(\\10**[:^z-a[.-.]]|[a][[:[:]|\\)\\{3,2\\}-\\(+\\{2\\}[][.][[\\*", "dialect": "bre", "valid": false}
+{"pattern": "[^$]\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[:alpha:]^[=a=-][.-.]]", "dialect": "bre", "valid": false}
+{"pattern": "^\\(^b\\)\\(\\<\\x41*\\1\\)\\{3,2\\}*[$[.*[.-.]]", "dialect": "bre", "valid": false}
+{"pattern": "[[=a=]\\za-z]\\{\\<\\b[[:bogus:][=a=]z?-a]\\([$]$]\\(\\{2,3\\}\\)\\?\\(\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\s\\{\\)\\(\\(\\{[$a-z]\\{3,2\\}\\((\\{2\\}^\\)|,\\)\\(b|\\{2\\}\\)\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(b\\+\\*\\1\\)\\(\\*\\(\\(^)|[[.a.]z[=a=][=a=]][^[.a.]]\\+a*\\[-]\\+b|\\s\\1\\)\\?|\\.\\{|\\)+\\+", "dialect": "bre", "valid": false}
+{"pattern": "\\\\{1}\\{2\\}[]\\{[[.-]za-z[.a.]]|", "dialect": "bre", "valid": false}
+{"pattern": "\\(0", "dialect": "bre", "valid": false}
+{"pattern": "b\\{,3\\}\\(\\(\\.\\<\\>\\{2,3\\}\\)\\{3,2\\}\\(*\\s\\{2,\\}\\([[.a.]]\\{[^[]]\\)|^\\|(|\\)\\)\\+.\\n?\\>", "dialect": "bre", "valid": false}
+{"pattern": "\\((\\a\\({,2}\\<\\W|\\)\\{,3\\}\\(\\*\\)\\{,3\\}|[]\\)\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\([]|\\\\\\(\\{1,2\\}.-|\\)*\\(\\()*[a]\\{\\)\\{,3\\}[.[:\\)\\.\\([]\\x41{,2}|\\w\\{2\\}\\|\\)|\\(\\{\\{1\\}\\\\{2,3\\}+\\{3,2\\}\\)\\\\", "dialect": "bre", "valid": false}
+{"pattern": "\\W*[z-[.]\\([^[:alpha:]]]\\(,)\\(\\\\\\b\\{1,2\\}**\\)\\)\\{\\)\\<\\++", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\n\\?\\{1,2\\}\\+\\)[a[:\\a-z\\)^\\}\\{3,2\\}\\>\\\\(\\\\\\{1,2\\}\\{3,2\\}^\\{3,2\\}\\)\\{2,3\\}\\|", "dialect": "bre", "valid": false}
+{"pattern": "}\\\\[]\\2", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\s\\)\\{1,2\\}\\{1,2\\}\\)\\{-*[*]\\([.]\\{2,3\\}|\\([-]\\{}\\x41\\{2,3\\}\\)\\{2\\}\\([[*z-a]|\\b\\)\\),\\?0\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "[-a-]\\{,", "dialect": "bre", "valid": false}
+{"pattern": "[a-z]\\+[^]\\([]{,2}**\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\\\\\>\\({,2}0\\)**[^-]\\{3,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(+{1,2}|[]\\)\\{2,\\}}\\(\\([[.[=a=]]\\+||\\{,3\\}[[.$[:z-a]\\)\\(\\(\\}\\{2,\\}\\{=1\\}\\)|[^]\\(\\{2,\\}\\)\\{{1,2}\\|\\?\\)\\(b*?|\\)*\\w\\)\\?|", "dialect": "bre", "valid": false}
+{"pattern": "\\?[](\\(0|\\(\\([]\\{^|\\?\\>\\{3,2\\}b\\)\\)\\n$*", "dialect": "bre", "valid": false}
+{"pattern": "*^\\{\\1\\{2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "?,$-|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\\\n\\{3,2\\}\\(\\(\\(\\s[$]|\\{1,2\\}.\\(**\\)\\)\\(\\||[a-z]\\{2,\\}\\(\\w^\\1\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "b\\b\\{", "dialect": "bre", "valid": false}
+{"pattern": "[-\\(.\\{2,\\}|[[.a.]-][^]]\\{1,2\\}\\)\\?)\\?\\1", "dialect": "bre", "valid": false}
+{"pattern": "[]}[[.-.]\\]*\\x41", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[=a=][]?**[[=a=]a-z^[:bogus:]]\\(\\(\\2|\\(\\x41\\}\\)[z-a]^[=a=]]\\(^\\{2\\}0\\2|0\\)\\)^-|[^]\\{{1}\\?\\(\\{1\\}*(\\)\\n\\?", "dialect": "bre", "valid": false}
+{"pattern": ",\\{3,2\\}\\n^\\{\\?\\{2,3!\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\([-[.-.]z-a]\\{2,3\\}|\\(\\({,2}\\W|{1,2}\\{,3\\}\\)|[[:bogus:][z-a]*[^$z-az-a]\\{2,3\\}\\)[a-za-zz-a[=a=]]\\)[^[:alpha:].]\\+\\|[-[:bogus:][:alpha:]]\\n\\(\\+\\{[2,\\}\\(\\(*,\\s\\){1}|\\)\\{3,2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\+{,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([-[.-.]]\\{2\\}|\\(\\(\\.\\)-|\\b\\(.*|\\)\\{2\\}\\<?|[*$[:a-z]\\.", "dialect": "bre", "valid": false}
+{"pattern": "[^[[:[:alpha:][[:alpha:][[.-]*", "dialect": "bre", "valid": false}
+{"pattern": "{\\?{1,2}\\W**{1,2}[^]\\?-\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\.|\\n\\)\\(*\\{2\\}\\\\-\\{2,\\}\\)\\{2,3\\}\\)**\\w\\)\\?\\<?", "dialect": "bre", "valid": false}
+{"pattern": "-?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\n1}{1,2}{,2}*[$]\\{2\\}|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[a-z]{1}*\\\\\\+", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\([[.[:bogus:]z[=a=]]\\1\\)[[:alpha:]$z[.|-.]]**\\+\\w\\($\\+\\{1\\}\\?|[^]\\W\\)|", "dialect": "bre", "valid": false}
+{"pattern": "[z-a[:]\\{,3\\}[-[=a=]*]", "dialect": "bre", "valid": false}
+{"pattern": "\\<\\(\\.\\+\\(\\.)\\(-[[.a.]]\\{2,3\\}\\{1,2\\}|\\)|[]*]\\x41|\\)\\{3,2\\}\\n\\)\\a[a-z[:[.-.]]]\\{\\([^-]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\\\\\{3,2\\}?|", "dialect": "bre", "valid": false}
+{"pattern": "\\([^[.-.]]\\)\\?", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\>\\|\\?", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "|(", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "$[aa$]\\(-+\\{2,3\\}\\+\\{2,\\}\\()b$\\?\\){,2}**", "dialect": "bre", "valid": false}
+{"pattern": "?*$\\{2,\\}+\\}\\+\\(", "dialect": "bre", "valid": false}
+{"pattern": "\\}[^])|", "dialect": "bre", "valid": false}
+{"pattern": "\\2\\{^", "dialect": "bre", "valid": false}
+{"pattern": "(\\W\\n\\s**[[.a.]^[.a.]]", "dialect": "bre", "valid": false}
+{"pattern": "|aa\\{0", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\.{,2}\\{,3\\}+|\\2\\{\\)\\)|", "dialect": "bre", "valid": false}
+{"pattern": "{,2}*[]\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\+\\{2,3\\}\\)\\<\\sa\\|[^*za]]", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[z-a[:bogus:]a[:alha:]].a\\{\\(\\.\\{2,\\}[[:bogus:]$[:alpha:][]0\\{2,\\}\\)**\\+\\{1,2\\}|", "dialect": "bre", "valid": false}
+{"pattern": "\\(*\\?[.]\\a\\)\\{2,\\}\\(\\x41\\{|\\)[[:alpha:][.-.]$*][]", "dialect": "bre", "valid": false}
+{"pattern": "\\?\\{2,3\\}(\\($\\?{,2}\\)[]\\+\\a[\\]", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[.a-z]\\{3,2\\}\\}||", "dialect": "bre", "valid": false}
+{"pattern": "[^[.]\\{2,3\\}[[*]\\W", "dialect": "bre", "valid": false}
+{"pattern": "|\\+\\([]\\{3,2\\}\\.^|-\\(\\s?[\\-[=a=]\\{2\\}\\)+\\)\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\}\\{2,\\}\\\\[[.-.]]{1}\\(\\([z^[:]\\(.\\{,3\\}0\\)*\\)\\Wb\\?|\\1\\(\\(\\|**|\\)|[$[:alpha:]]{\\(\\}|$\\{3,2\\}\\)\\{2,3\\}\\)\\{\\)\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "[$.[.-.]]\\{\\w,\\{2,3\\}[\\a-z[.a.]]\\{{\\([]\\+\\{\\{2,3\\}|[[.-.]a[=a=]]\\{2\\},\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(?\\(\\1\\)**0\\?|\\)\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\{\\([[]\\{3,2\\}\\1\\{\\:{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "[-[=a=]]\\{\\>", "dialect": "bre", "valid": false}
+{"pattern": "\\W|\\+\\*)\\{,3\\}{|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "?{,2}\\{[:alpha:]z-a$]]\\)[\\[.a.][:bogus:]]", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\}[[:alpha:].]z-a]", "dialect": "bre", "valid": false}
+{"pattern": "[$[-.][.]", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.]\\?\\(-\\(\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\}\\+\\(\\?\\2\\(\\?\\*\\b|[^]][=a=][=a=]]\\<)**\\)(\\([][az-a-]^|\\>\\(\\\\\\?}\\)\\{2,3\\}|\\(+\\(\\(\\w**+|[[.a.]]\\{\\.[]\\)**|\\|[[.]\\)\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\n\\(\\(\\)", "dialect": "bre", "valid": false}
+{"pattern": "[^[:]\\{2,\\}\\a[]'[^[.a.]][z-aa]", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}\\{2,3\\}\\(\\{\\)*\\{2,\\}{1,2}{1}\\{\\(\\\\)\\)\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\\\\\?,[^=[.a.][.a.]]$", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "{1}\\x41", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "0\\+\\\\{3,2\\}\\{1\\}\\+[]*", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\{\\<\\{2\\}{1}", "dialect": "bre", "valid": false}
+{"pattern": "}\\{", "dialect": "bre", "valid": false}
+{"pattern": "[*[.[:alpha:]]\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\(\\\\\\}\\)-\\))[]", "dialect": "bre", "valid": false}
+{"pattern": "\\+\\{\\(\\*\\{2,3\\}\\(*\\{2\\}\\)\\([[.[:alpha:]*]^\\)\\+\\)\\(\\1\\2\\([]\\{3,2\\}|\\n\\}\\)\\W\\(|.**|", "dialect": "bre", "valid": false}
+{"pattern": "\\>\\([z-a[:bogus:]]*[]\\{\\)(\\(\\({\\?\\|\\{3,2\\}\\)\\1|\\(\\(\\x41\\+\\)\\){,2}.\\)", "dialect": "bre", "valid": false}
+{"pattern": "[z-a\\z>]\\|", "dialect": "bre", "valid": false}
+{"pattern": ".\\{2\\}{,2}\\{", "dialect": "bre", "valid": false}
+{"pattern": ">\\*", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[^\\$.[:alpha:]]{1}]\\{2,3\\}[[=a=].[.a.]]a\\{,3\\}.|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\{\\*[[=a=][:bogus:]]\\(a*^0\\)*", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\({b\\{2\\}{,2}\\)\\{\\{1,2\\}?", "dialect": "bre", "valid": false}
+{"pattern": "\\b\\<\\b|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\|*\\()*}?**\\)[[=a=]]", "dialect": "bre", "valid": false}
+{"pattern": "|\\<", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "$\\(\\\\)\\{2,3\\}|\\){", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "\\([\\z[:alpha:]]\\?\\({1}\\{2,3\\}\\(\\w\\\\$**|\\)^\\}\\)\\{2\\}\\)-\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\([^[][:alpha:]]^\\\\\\)\\*\\(\\(*\\)\\2\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\>\\(\\w[^*\\]|\\(\\(,\\1?\\{2\\}\\)\\{2\\}0$\\{,3\\}\\)\\),\\([^.]\\(\\a\\)\\{\\2|\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\{1,2\\}{[]\\?\\(\\W[^^a[.a.][.a.]].\\)\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\.[]\\x41\\{2,\\}\\)\\(\\(\\(\\+\\{,3\\}\\s[[[.a.]]\\)||\\w{1,2}\\)?||\\{1\\}\\(a\\{\\s|0\\(\\1)\\)\\(0\\)\\+\\)\\(\\(^\\na\\)\\)\\)\\<[z]\\(\\s\\)\\{", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.]a-z][.-.)]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\a\\***\\(}", "dialect": "bre", "valid": false}
+{"pattern": "\\}[a-z]**[[:a-z]\\|\\{2\\}\\W", "dialect": "bre", "valid": false}
+{"pattern": "[^[.-.]]]", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\a\\{2\\}\\{1,2\\}>(", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\n||[^-]\\+\\(\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\b{2,3\\}\\?\\2^", "dialect": "bre", "valid": false}
+{"pattern": "\\([z-a[.-.][.a.][.][[]\\)[z][]]**\\(\\(\\<{1}\\+^\\{2\\}|\\)\\{,3\\}\\<[]\\{,3\\}\\)\\<*\\(\\(\\(\\+\\{2\\}\\?\\{2,3\\}\\)*[^z-a]]\\(\\\\|[[:alpha:]a-z-a]**\\)\\)|\\)\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\?[^z[.\\.\\{3,2\\}+*\\b\\{2,3\\}\\(\\>\\?\\(\\(\\nb[^[z-a[.]\\)**\\)|\\W\\{2\\}^\\s\\)||\\w\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\\\>\\?\\(-\\1\\(\\({{\\?\\2\\{,3\\}\\)\\?||*\\{2\\}[[:a][^z-a-^]\\)\\{2,3\\}|\\?\\+\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\(+[](\\)\\{3,2\\}[]]^", "dialect": "bre", "valid": false}
+{"pattern": "[][.a-[z^]\\|\\x41", "dialect": "bre", "valid": false}
+{"pattern": "b{1}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "[[.-.]*[.a.]\\?\\w\\{\\}\\).)", "dialect": "bre", "valid": false}
+{"pattern": "[a-z[:-z-a\\{-,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "[[.]**\\\\(\\1\\)\\\\", "dialect": "bre", "valid": false}
+{"pattern": "[\\[=a=]]\\+\\{3,2\\}\\?\\w\\n", "dialect": "bre", "valid": false}
+{"pattern": "+\\{3,2\\}\\.\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\nb&|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\a\\{[^[=a=]]\\{\\b\\{1\\[]|", "dialect": "bre", "valid": false}
+{"pattern": "\\?\\", "dialect": "bre", "valid": false}
+{"pattern": "\\?\\{2\\}\\.\\{2\\}[^*]\\([[:[=a=]\\$|,\\.\\x41\\)\\(\\)\\{3,2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\W\\{3,2\\}\\\\{\\)**\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\n[[:bogus:]", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\s\\({1}*|\\)\\)(\\(]\\{1,2\\}\\{2,\\}\\}\\{|\\)\\+$\\}\\?\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\({\\{,3\\}\\s{|\\*\\+[[:bogus:]]\\{2\\}\\)\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\>\\W\\x41\\{\\W", "dialect": "bre", "valid": false}
+{"pattern": "[a-z]\\(b(\\($\\{,3\\}\\(\\x41\\)\\([[:bogus:][.]+\\)**|\\w\\)\\)\\)\\2\\{,3\\}[^[.]$]\\+[[.\\z]", "dialect": "bre", "valid": false}
+{"pattern": "[[.-.][:alpha):]a]\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "{1,2}\\{2\\}\\1b{1[][[.-.]]", "dialect": "bre", "valid": false}
+{"pattern": "\\2|", "dialect": "bre", "valid": false}
+{"pattern": "}(\\b[^--^]\\>\\(.\\(\\\\}|\\)\\)\\+", "dialect": "bre", "valid": true, "captures": 2}
+{"pattern": "[[:bogus:]]a-z]\\(\\*+**", "dialect": "bre", "valid": false}
+{"pattern": "{\\}\\)[]^a-z]|", "dialect": "bre", "valid": false}
+{"pattern": "[^][*[=a=]]]\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "({\\+\\)\\<", "dialect": "bre", "valid": false}
+{"pattern": "\\1\\{2,3\\}|\\?[]\\?", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\([^a]\\)\\{3,2\\},*{12}", "dialect": "bre", "valid": false}
+{"pattern": "\\s*{,2}\\n\\{2,3\\}[]$\\}\\s", "dialect": "bre", "valid": false}
+{"pattern": "\\n[z\\[=a=]\\][a-z\\\\]$\\?\\{?", "dialect": "bre", "valid": false}
+{"pattern": "0{1,2}", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "0\\?-\\2,\\}a\\([[:bogus:]a][]|{,2}\\)a\\*", "dialect": "bre", "valid": false}
+{"pattern": "\\(\\\\\\){1,2}[^[:bogus:]\\[:[]\\(\\\\|-[^]*\\)\\{2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\())\\)\\>\\{2,3\\}\\(\\{2,3\\}\\(\\.\\{3,2\\}\\)", "dialect": "bre", "valid": false}
+{"pattern": "|(\\(\\?*\\(\\n\\))\\)\\+\\{,3\\}\\+\\1", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\(\\*\\{2,3\\}\\(\\b[[:[]^]\\n\\)\\?}\\(b\\)\\{,3\\}\\([[:alpha:]]\\?[]**\\)\\\\{2\\}\\\\", "dialect": "bre", "valid": false}
+{"pattern": "^*\\{1\\}\\}\\{2,3\\}a\\2", "dialect": "bre", "valid": false}
+{"pattern": "[a*]|", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "(*\\?[]\\{2,\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\([z-a[:bogus:][.-.]]\\)\\{3,2\\}\\W\\{[[.a.][a-za]\\(\\(\\()\\(\\{\\)\\x41\\{\\W\\))\\}\\)**\\a", "dialect": "bre", "valid": false}
+{"pattern": "\\a\\),\\a\\x41\\n[^]zz-a[]\\{3,2\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\{1\\}\\(\\>\\{2\\}|\\\\\\{2\\}b\\})[][^]|\\(\\n-\\?\\)\\{,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "\\*\\{2,3\\}\\{1\\}\\?\\(\\x41\\{3,2'\\}|\\)\\?\\<", "dialect": "bre", "valid": false}
+{"pattern": "{,2}\\*\\{2,3\\}{1}*[^]*\\a", "dialect": "bre", "valid": false}
+{"pattern": "\\x41\\(\\(\\W\\2\\)[[:bogus:][.-.][.]\\+\\([]\\{2,3\\}\\*|\\)\\{\\)\\([z-a]\\{2,\\}|\\s\\W*[[.-.]$*a]\\{2,\\}\\)*\\(\\x41\\b\\b\\{|\\(\\([[.-.]]|)\\)|^\\{2\\}(*|\\)\\{,3\\}\\w}\\(,\\x41\\?.[[.-.]]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\w[a-z[.", "dialect": "bre", "valid": false}
+{"pattern": "}\\{2,\\}\\(\\x41\\(\\n|\\(\\b\\{2,3\\}\\)\\)[]\\{3,2\\}\\)\\{2,3\\}", "dialect": "bre", "valid": false}
+{"pattern": "+\\(\\}*|[^]\\)", "dialect": "bre", "valid": false}
+{"pattern": "\\({1,2}},\\{2\\}\\)|", "dialect": "bre", "valid": true, "captures": 1}
+{"pattern": "[^[:bogus:]]*\\|{\\{", "dialect": "bre", "valid": false}
+{"pattern": "\\([[.a[.[:alpha:]\\([$[:alpha:]]\\)|\\)\\([[:bogus:]]\\($[\\^[.]\\))**\\).\\([]\\)\\([]\\s\\{3,2\\}[^*]-[:bogus:]]\\{\\)\\{2\\}$", "dialect": "bre", "valid": false}
+{"pattern": "\\{**\\([*[=a=]][]\\{3,2\\}|\\{1,2\\}\\|\\)", "dialect": "bre", "valid": false}
+{"pattern": ".\\na\\2\\+\\($\\)", "dialect": "bre", "valid": false}
+{"pattern": "*\\>", "dialect": "bre", "valid": true, "captures": 0}
+{"pattern": "\\($*\\x4(**", "dialect": "bre", "valid": false}
+{"pattern": "[[:[:alph]a:]$[.-.]]", "dialect": "bre", "valid": false}

--- a/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/conformance.md
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/Corpus/conformance.md
@@ -1,0 +1,30 @@
+# Conformance corpora
+
+`JavaScriptConformance.jsonl`, `PcreConformance.jsonl`, and `PosixConformance.jsonl` hold patterns together with the
+verdict the real engine gave for them. `RegexConformanceTests` replays every record through the parser.
+
+| File | Engine | How a pattern was compiled |
+| --- | --- | --- |
+| `JavaScriptConformance.jsonl` | V8 (Node.js 24, Unicode 17) | `new RegExp(pattern, flags)` with no flag, `u`, or `v`; the group count and names come from `new RegExp("(?:" + pattern + ")\|", flags).exec("")` |
+| `PcreConformance.jsonl` | PCRE2 10.47 | `pcre2_compile` with `PCRE2_UTF`, and `PCRE2_EXTENDED` when `extended` is true; `PCRE2_INFO_CAPTURECOUNT` and the name table |
+| `PosixConformance.jsonl` | glibc 2.36 (Debian 12) | `regcomp` with `REG_EXTENDED` for `ere` and without it for `bre`, under `C.UTF-8`; `re_nsub` |
+
+Each record has `pattern` and `valid`, and, when the engine accepted the pattern, `captures` (the highest group number
+for PCRE, the number of groups otherwise) and `names` where the dialect has named groups.
+
+The patterns are hand-written edge cases, one probe per escape letter inside and outside a class, and randomly
+generated patterns built from fragments of each dialect's grammar. POSIX records are ASCII only, because glibc's
+handling of non-ASCII bracket expressions depends on the locale rather than on the grammar.
+
+## Left out on purpose
+
+A handful of engine behaviours are not what the parser does, and the records that exercise them were dropped:
+
+- **V8 does not follow the specification's rule for duplicate group names.** It accepts `(?<a>x)(?:y|(?<a>z))` and
+  `(?<b>(?<b>a)|)`, where both groups can take part in the same match. The parser reports both, as ECMA-262 requires.
+- **V8 clamps quantifier bounds before comparing them**, so it accepts `a{99999999999,2147483648}`. The parser
+  compares the numbers as written and reports the range as reversed.
+- **PCRE2 ignores an empty `\Q\E` or a stray `\E` completely**, so a quantifier after one applies to what came before
+  (`[\w]\E+`), and a `^` after one at the start of a class still negates it. The parser keeps them as atoms of their
+  own, so the quantifier is reported as having nothing to repeat.
+- **glibc reads `\,` as a comma inside an interval**, so `a{2\,}` is `a{2,}` there. The parser does not.

--- a/tests/Meziantou.Framework.Language.Regex.Tests/Meziantou.Framework.Language.Regex.Tests.csproj
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/Meziantou.Framework.Language.Regex.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Corpus/*.txt" />
+    <EmbeddedResource Include="Corpus/*.jsonl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexClassSetTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexClassSetTests.cs
@@ -35,7 +35,7 @@ public sealed class RegexClassSetTests
     [InlineData(@"[\w--\d]", "--", 2)]
     [InlineData("[a--b]", "--", 2)]
     [InlineData("[a--b--c]", "--", 3)]
-    [InlineData(@"[\w--a-z]", "--", 2)]
+    [InlineData(@"[\w--[a-z]]", "--", 2)]
     [InlineData(@"[^\w--\d]", "--", 2)]
     public void AnOperationKeepsItsOperatorAndOperands(string pattern, string op, int operands)
     {
@@ -76,6 +76,11 @@ public sealed class RegexClassSetTests
     [InlineData("[a&&b--c]")]
     [InlineData("[[a][b]--[c]]")]
     [InlineData("[a&&]")]
+    [InlineData("[&&a]")]
+    [InlineData("[a&&&b]")]
+    [InlineData("[a&&bc]")]
+    [InlineData(@"[\w--a-z]")]
+    [InlineData("[a-z&&[aeiou]]")]
     public void AMalformedOperationIsReported(string pattern)
     {
         var tree = RegexSyntaxAssert.TextIsFaithful(pattern, SetMode);

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexConformanceTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexConformanceTests.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+
+namespace Meziantou.Framework.Language.Regex.Tests;
+
+/// <summary>
+/// Replays patterns whose verdict was recorded from the engines themselves: V8 for JavaScript, PCRE2 10.47 for PCRE,
+/// and glibc's <c>regcomp</c> for POSIX. Each record says whether the engine accepted the pattern and, when it did,
+/// how many groups it captures and what they are named.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the .NET differential test, these run on every target framework: the verdicts are frozen, so nothing here
+/// depends on what the machine running the tests has installed. <c>Corpus/conformance.md</c> says how the files were
+/// produced and which few engine behaviours were deliberately left out.
+/// </para>
+/// <para>
+/// A test gathers every disagreement before failing, because one parser change usually moves many records at once and
+/// the list is what shows the pattern behind them.
+/// </para>
+/// </remarks>
+public sealed class RegexConformanceTests
+{
+    [Fact]
+    public void JavaScript_AgreesWithV8()
+    {
+        var failures = new List<string>();
+        var count = 0;
+        foreach (var record in ReadRecords("JavaScriptConformance.jsonl"))
+        {
+            count++;
+            var pattern = record.GetProperty("pattern").GetString()!;
+            var flags = record.GetProperty("flags").GetString()!;
+            var options = new RegexParseOptions(RegexDialect.JavaScript)
+            {
+                PatternOptions = flags switch
+                {
+                    "i" => RegexPatternOptions.IgnoreCase,
+                    "u" => RegexPatternOptions.Unicode,
+                    "v" => RegexPatternOptions.Unicode | RegexPatternOptions.UnicodeSets,
+                    _ => RegexPatternOptions.None,
+                },
+            };
+
+            var tree = RegexSyntaxAssert.TextIsFaithful(pattern, options);
+            var label = $"/{pattern}/{flags}";
+            if (!CheckValidity(tree, record, label, failures))
+                continue;
+
+            var expectedNames = record.GetProperty("names").EnumerateArray().Select(name => name.GetString()!).ToArray();
+            var actualNames = tree.Captures.Select(capture => capture.Name).Where(name => !char.IsAsciiDigit(name[0])).Distinct(StringComparer.Ordinal).ToArray();
+            CheckCaptures(tree.Captures.Count, record, label, failures);
+            if (!expectedNames.SequenceEqual(actualNames, StringComparer.Ordinal))
+            {
+                failures.Add($"{label}: names [{string.Join(", ", actualNames)}], V8 has [{string.Join(", ", expectedNames)}]");
+            }
+        }
+
+        Assert.NotEqual(0, count);
+        Assert.Empty(failures, string.Join('\n', failures));
+    }
+
+    [Fact]
+    public void Pcre_AgreesWithPcre2()
+    {
+        var failures = new List<string>();
+        var count = 0;
+        foreach (var record in ReadRecords("PcreConformance.jsonl"))
+        {
+            count++;
+            var pattern = record.GetProperty("pattern").GetString()!;
+            var extended = record.GetProperty("extended").GetBoolean();
+            var options = new RegexParseOptions(RegexDialect.PcrePerl)
+            {
+                PatternOptions = extended ? RegexPatternOptions.IgnorePatternWhitespace : RegexPatternOptions.None,
+            };
+
+            var tree = RegexSyntaxAssert.TextIsFaithful(pattern, options);
+            var label = extended ? $"/{pattern}/x" : $"/{pattern}/";
+            if (!CheckValidity(tree, record, label, failures))
+                continue;
+
+            // PCRE reports the highest group number, which a branch reset group makes smaller than the group count.
+            CheckCaptures(tree.Captures.Count == 0 ? 0 : tree.Captures.Max(capture => capture.Number), record, label, failures);
+
+            // Every name with every number it is given, which duplicate names allowed by "(?J)" make more than one.
+            var expectedNames = record.GetProperty("names").EnumerateArray()
+                .Select(pair => FormattableString.Invariant($"{pair[0].GetString()}={pair[1].GetInt32()}"))
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            var actualNames = tree.Captures
+                .Where(capture => !char.IsAsciiDigit(capture.Name[0]))
+                .Select(capture => FormattableString.Invariant($"{capture.Name}={capture.Number}"))
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            if (!expectedNames.SequenceEqual(actualNames, StringComparer.Ordinal))
+            {
+                failures.Add($"{label}: names [{string.Join(", ", actualNames)}], PCRE2 has [{string.Join(", ", expectedNames)}]");
+            }
+        }
+
+        Assert.NotEqual(0, count);
+        Assert.Empty(failures, string.Join('\n', failures));
+    }
+
+    [Fact]
+    public void Posix_AgreesWithGlibc()
+    {
+        var failures = new List<string>();
+        var count = 0;
+        foreach (var record in ReadRecords("PosixConformance.jsonl"))
+        {
+            count++;
+            var pattern = record.GetProperty("pattern").GetString()!;
+            var dialect = record.GetProperty("dialect").GetString() == "ere" ? RegexDialect.PosixExtended : RegexDialect.PosixBasic;
+
+            var tree = RegexSyntaxAssert.TextIsFaithful(pattern, dialect);
+            var label = $"{dialect.Name} [{pattern}]";
+            if (CheckValidity(tree, record, label, failures))
+            {
+                CheckCaptures(tree.Captures.Count, record, label, failures);
+            }
+        }
+
+        Assert.NotEqual(0, count);
+        Assert.Empty(failures, string.Join('\n', failures));
+    }
+
+    /// <summary>Records a disagreement about validity, and returns whether the pattern is valid on both sides.</summary>
+    private static bool CheckValidity(RegexSyntaxTree tree, JsonElement record, string label, List<string> failures)
+    {
+        var expectedValid = record.GetProperty("valid").GetBoolean();
+        var diagnostics = tree.GetDiagnostics();
+        if (expectedValid && diagnostics.Count > 0)
+        {
+            failures.Add($"{label}: the engine accepts it, the parser reported {string.Join(", ", diagnostics.Select(diagnostic => $"{diagnostic.Id} {diagnostic.Message}"))}");
+        }
+        else if (!expectedValid && diagnostics.Count == 0)
+        {
+            failures.Add($"{label}: the engine rejects it, the parser reported nothing");
+        }
+
+        return expectedValid && diagnostics.Count == 0;
+    }
+
+    private static void CheckCaptures(int actual, JsonElement record, string label, List<string> failures)
+    {
+        var expected = record.GetProperty("captures").GetInt32();
+        if (actual != expected)
+        {
+            failures.Add(FormattableString.Invariant($"{label}: {actual} capture groups, the engine has {expected}"));
+        }
+    }
+
+    private static List<JsonElement> ReadRecords(string name)
+    {
+        using var stream = typeof(RegexConformanceTests).Assembly.GetManifestResourceStream($"Meziantou.Framework.Language.Regex.Tests.Corpus.{name}")
+            ?? throw new InvalidOperationException($"The corpus '{name}' is not embedded in the test assembly.");
+        using var reader = new StreamReader(stream);
+
+        var records = new List<JsonElement>();
+        while (reader.ReadLine() is { } line)
+        {
+            if (line.Length > 0)
+            {
+                using var document = JsonDocument.Parse(line);
+                records.Add(document.RootElement.Clone());
+            }
+        }
+
+        return records;
+    }
+}

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexDiagnosticTests.cs
@@ -41,6 +41,106 @@ public sealed class RegexDiagnosticTests
         Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
     }
 
+    /// <summary>The diagnostics only some dialects have, with the span each points at.</summary>
+    [Theory]
+    [InlineData("javascript", "(?<a>x)(?<a>y)", 0, "REGEX0035", 10)]
+    [InlineData("javascript", "[(]", 128, "REGEX0073", 1)]
+    [InlineData("javascript", @"[^\q{ab}]", 128, "REGEX0074", 0)]
+    [InlineData("javascript", "(?ii:a)", 0, "REGEX0075", 3)]
+    [InlineData("javascript", @"\p{Greek}", 64, "REGEX0034", 3)]
+    [InlineData("pcre", "a(*BOGUS)", 0, "REGEX0090", 1)]
+    [InlineData("pcre", "(?C256)", 0, "REGEX0091", 3)]
+    [InlineData("pcre", "x(?<=a+)", 0, "REGEX0092", 1)]
+    [InlineData("pcre", "(?(?:a)b)", 0, "REGEX0093", 2)]
+    [InlineData("pcre", "[[:nope:]]", 0, "REGEX0110", 3)]
+    [InlineData("ere", "ab{1", 0, "REGEX0111", 2)]
+    [InlineData("ere", "(a)|\\1", 0, "REGEX0030", 4)]
+    public void DialectPatternReportsTheExpectedDiagnostic(string dialectName, string pattern, int options, string id, int spanStart)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+        var patternOptions = (RegexPatternOptions)options;
+        if (patternOptions.HasFlag(RegexPatternOptions.UnicodeSets))
+        {
+            patternOptions |= RegexPatternOptions.Unicode;
+        }
+
+        var tree = RegexSyntaxAssert.TextIsFaithful(pattern, new RegexParseOptions(dialect) { PatternOptions = patternOptions });
+
+        var diagnostic = Assert.Single(tree.GetDiagnostics(), candidate => candidate.Id == id, $"[{pattern}] reported {string.Join(", ", tree.GetDiagnostics().Select(d => d.Id))}");
+        Assert.Equal(spanStart, diagnostic.Location.SourceSpan.Start);
+    }
+
+    /// <summary>
+    /// An error does not end the parse: what follows it is read the same way it would be without the error, so every
+    /// later construct is still in the tree and every later problem is still reported.
+    /// </summary>
+    [Theory]
+    [InlineData("net", @"a{5,2}(b)\q[c-a]d+", "REGEX0007,REGEX0015,REGEX0009")]
+    [InlineData("javascript", @"\a(b)[\d-z]d+", "REGEX0015,REGEX0016")]
+    [InlineData("pcre", @"(*BOGUS)(b)\p{Nope}d+", "REGEX0090,REGEX0034")]
+    [InlineData("ere", "{1(b)[[:nope:]]d+", "REGEX0005,REGEX0110")]
+    [InlineData("bre", @"\{1\(b\)[[:nope:]]d\+", "REGEX0005,REGEX0110")]
+    public void ParsingContinuesPastAnError(string dialectName, string pattern, string ids)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+        var options = new RegexParseOptions(dialect) { PatternOptions = dialect == RegexDialect.JavaScript ? RegexPatternOptions.Unicode : RegexPatternOptions.None };
+
+        var tree = RegexSyntaxAssert.TextIsFaithful(pattern, options);
+
+        Assert.Equal(ids, string.Join(",", tree.GetDiagnostics().Select(d => d.Id)));
+        var group = Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexCapturingGroupSyntax>());
+        Assert.Equal(1, Assert.Single(tree.Captures).Number);
+        Assert.True(group.ToString().Contains('b', StringComparison.Ordinal), $"The group is '{group}'.");
+        Assert.IsType<RegexQuantifiedSyntax>(tree.GetRoot().Alternation.Branches[^1].Terms[^1]);
+    }
+
+    [Fact]
+    public void AnUnterminatedGroupKeepsItsBranchesAndItsClass()
+    {
+        var tree = RegexSyntaxAssert.TextIsFaithful("(a|b[c", RegexDialect.Net);
+
+        Assert.Equal(["REGEX0003", "REGEX0002"], tree.GetDiagnostics().Select(d => d.Id));
+        var group = Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexCapturingGroupSyntax>());
+        Assert.True(group.CloseParenToken.IsMissing);
+        Assert.Equal(2, group.Alternation.Branches.Count);
+        Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexCharacterClassSyntax>());
+    }
+
+    [Theory]
+    [InlineData("net")]
+    [InlineData("javascript")]
+    [InlineData("pcre")]
+    public void AnUnmatchedCloseParenthesisDoesNotEndThePattern(string dialectName)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+
+        var tree = RegexSyntaxAssert.TextIsFaithful(@"a)b(c)\1", dialect);
+
+        Assert.Equal("REGEX0001", Assert.Single(tree.GetDiagnostics()).Id);
+        Assert.Equal(1, Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexBackreferenceSyntax>()).Number);
+    }
+
+    /// <summary>
+    /// The pattern is read twice, once to number its groups and once to build the tree. Only the second reading
+    /// reports, so a problem is never reported twice.
+    /// </summary>
+    [Theory]
+    [InlineData("net", @"(?<a>x)\k<b>[z-a](?<a>y)\p{Nope}(")]
+    [InlineData("javascript", @"(?<a>x)\k<b>[z-a](?<a>y)\p{Nope}(")]
+    [InlineData("pcre", @"(?<a>x)\k<b>[z-a](?<a>y)\p{Nope}(?<=a+)(")]
+    [InlineData("ere", @"[z-a](a\1)[[:nope:]]a{1(")]
+    public void EveryProblemIsReportedOnce(string dialectName, string pattern)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+        var options = new RegexParseOptions(dialect) { PatternOptions = dialect == RegexDialect.JavaScript ? RegexPatternOptions.Unicode : RegexPatternOptions.None };
+
+        var tree = RegexSyntaxAssert.TextIsFaithful(pattern, options);
+
+        var diagnostics = tree.GetDiagnostics();
+        Assert.True(diagnostics.Count >= 3, $"[{pattern}] reported {string.Join(", ", diagnostics.Select(d => d.Id))}");
+        Assert.HasCount(diagnostics.Count, diagnostics.Select(d => (d.Id, d.Location.SourceSpan)).Distinct().ToArray());
+    }
+
     [Fact]
     public void NestingBeyondTheConfiguredDepthIsReportedAndStillRoundTrips()
     {

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexOracleAuditTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexOracleAuditTests.cs
@@ -344,4 +344,494 @@ public sealed class RegexOracleAuditTests
             Assert.Empty(tree.GetRoot().DescendantNodes().OfType<RegexNamedBackreferenceSyntax>());
         }
     }
+
+    // ---- the second audit: every dialect replayed against its engine ----
+
+    private static void RejectsWith(string pattern, RegexParseOptions options, string id)
+    {
+        var tree = RegexSyntaxAssert.TextIsFaithful(pattern, options);
+
+        Assert.Contains(tree.GetDiagnostics(), d => d.Id == id, $"[{pattern}] reported {string.Join(",", tree.GetDiagnostics().Select(d => d.Id))}, expected {id}");
+    }
+
+    private static RegexParseOptions UnicodeMode => Options(RegexDialect.JavaScript, RegexPatternOptions.Unicode);
+
+    private static RegexParseOptions Pcre => Options(RegexDialect.PcrePerl);
+
+    private static RegexParseOptions Ere => Options(RegexDialect.PosixExtended);
+
+    private static RegexParseOptions Bre => Options(RegexDialect.PosixBasic);
+
+    /// <summary>
+    /// .NET numbers named groups after every unnamed one. JavaScript and PCRE number every group where it stands,
+    /// which decides what <c>\2</c> refers to.
+    /// </summary>
+    [Theory]
+    [InlineData("net", "1,2,3=x")]
+    [InlineData("javascript", "1,2=x,3")]
+    [InlineData("pcre", "1,2=x,3")]
+    public void NamedGroupsAreNumberedTheWayTheEngineNumbersThem(string dialectName, string expected)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+
+        var tree = Accepts("(a)(?<x>b)(c)", Options(dialect));
+
+        Assert.Equal(expected, string.Join(",", tree.Captures.Select(c => c.Name == c.Number.ToString(CultureInfo.InvariantCulture) ? c.Name : $"{c.Number}={c.Name}")));
+    }
+
+    [Fact]
+    public void JavaScriptAllowsADuplicateNameOnlyInAnotherAlternative()
+    {
+        var tree = Accepts("(?<a>x)|(?<a>y)", Options(RegexDialect.JavaScript));
+        Assert.Equal([1, 2], tree.Captures.Select(c => c.Number));
+        Assert.All(tree.Captures, c => Assert.Equal("a", c.Name));
+
+        Accepts(@"(?:(?<a>x)|(?<a>y))\k<a>", Options(RegexDialect.JavaScript));
+        RejectsWith("(?<a>x)(?<a>y)", Options(RegexDialect.JavaScript), "REGEX0035");
+        RejectsWith("((?<a>x)|(?<a>y))(?<a>z)", Options(RegexDialect.JavaScript), "REGEX0035");
+
+        // V8 accepts these two, but both groups can take part in one match, which the specification forbids.
+        RejectsWith("(?<a>x)(?:y|(?<a>z))", Options(RegexDialect.JavaScript), "REGEX0035");
+        RejectsWith("(?<b>(?<b>a)|)", Options(RegexDialect.JavaScript), "REGEX0035");
+    }
+
+    /// <summary>A decimal escape takes every digit, and names a group when the whole pattern has that many.</summary>
+    [Fact]
+    public void AJavaScriptDecimalEscapeCountsEveryGroupOfThePattern()
+    {
+        Assert.Single(Accepts(@"\1(a)", UnicodeMode).GetRoot().DescendantNodes().OfType<RegexBackreferenceSyntax>());
+        Assert.Equal(10, Assert.Single(Accepts(@"(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\10", UnicodeMode).GetRoot().DescendantNodes().OfType<RegexBackreferenceSyntax>()).Number);
+
+        // With a single group, "\10" is the legacy octal escape for a backspace, not a reference to group 1.
+        var escape = Assert.Single(Accepts(@"(a)\10", Options(RegexDialect.JavaScript)).GetRoot().DescendantNodes().OfType<RegexCharacterEscapeSyntax>());
+        Assert.Equal("\b", escape.Value);
+        RejectsWith(@"(a)\10", UnicodeMode, "REGEX0030");
+        RejectsWith(@"\2(a)", UnicodeMode, "REGEX0030");
+        RejectsWith(@"\08", UnicodeMode, "REGEX0015");
+    }
+
+    [Theory]
+    [InlineData(@"\a")]
+    [InlineData(@"\e")]
+    [InlineData(@"[\e]")]
+    public void JavaScriptHasNoBellOrEscapeCharacterEscape(string pattern)
+    {
+        RejectsWith(pattern, UnicodeMode, "REGEX0015");
+
+        // The web-compatibility grammar reads the letter itself.
+        var escape = Assert.Single(Accepts(pattern, Options(RegexDialect.JavaScript)).GetRoot().DescendantNodes().OfType<RegexCharacterEscapeSyntax>());
+        Assert.Equal(pattern[^1..] == "]" ? pattern[^2..^1] : pattern[^1..], escape.Value);
+    }
+
+    /// <summary>The <c>v</c> flag is the <c>u</c> flag with more, so it alone is enough for the strict grammar.</summary>
+    [Fact]
+    public void TheUnicodeSetsOptionAloneSelectsTheStrictGrammar() =>
+        RejectsWith(@"\q", Options(RegexDialect.JavaScript, RegexPatternOptions.UnicodeSets), "REGEX0015");
+
+    [Fact]
+    public void AModifiersGroupAppliesItsFlagsToItsBody()
+    {
+        var tree = Accepts("(?i-m:a)b", Options(RegexDialect.JavaScript, RegexPatternOptions.Multiline));
+        var group = Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexOptionsGroupSyntax>());
+        var literals = tree.GetRoot().DescendantNodes().OfType<RegexLiteralSyntax>().ToArray();
+
+        Assert.Equal("i-m", group.OptionsText);
+        Assert.Equal(RegexPatternOptions.IgnoreCase, literals[0].Options);
+        Assert.Equal(RegexPatternOptions.Multiline, literals[1].Options);
+    }
+
+    [Theory]
+    [InlineData("(?ii:a)", "REGEX0075")]
+    [InlineData("(?i-i:a)", "REGEX0075")]
+    [InlineData("(?-:a)", "REGEX0075")]
+    [InlineData("(?x:a)", "REGEX0075")]
+    [InlineData("(?i)a", "REGEX0010")]
+    public void AMalformedModifiersGroupIsReported(string pattern, string id) => RejectsWith(pattern, Options(RegexDialect.JavaScript), id);
+
+    [Theory]
+    [InlineData(@"(?<$>x)", "$")]
+    [InlineData(@"(?<\u0061>x)\k<a>", "a")]
+    [InlineData(@"(?<\u{61}b>x)", "ab")]
+    [InlineData("(?<\U0001D49C>x)", "\U0001D49C")]
+    [InlineData("(?<a\u00B7>x)", "a\u00B7")]
+    public void AJavaScriptGroupNameIsAnIdentifier(string pattern, string name)
+    {
+        var group = Assert.Single(Accepts(pattern, Options(RegexDialect.JavaScript)).GetRoot().DescendantNodes().OfType<RegexNamedGroupSyntax>());
+
+        Assert.Equal(name, group.Name);
+    }
+
+    [Theory]
+    [InlineData(@"\p{Lu}")]
+    [InlineData(@"\p{Uppercase_Letter}")]
+    [InlineData(@"\p{gc=Lu}")]
+    [InlineData(@"\p{Script_Extensions=Latn}")]
+    [InlineData(@"\P{ASCII_Hex_Digit}")]
+    public void AJavaScriptPropertyFromTheSpecificationIsAccepted(string pattern) => Accepts(pattern, UnicodeMode);
+
+    [Theory]
+    [InlineData(@"\p{lu}")]
+    [InlineData(@"\p{Greek}")]
+    [InlineData(@"\p{IsGreek}")]
+    [InlineData(@"\p{sc=Bogus}")]
+    [InlineData(@"\p{^L}")]
+    [InlineData(@"\p{Letter=L}")]
+    [InlineData(@"\p{RGI_Emoji}")]
+    public void AJavaScriptPropertyTheSpecificationLacksIsReported(string pattern) => RejectsWith(pattern, UnicodeMode, "REGEX0034");
+
+    [Theory]
+    [InlineData(@"[^\q{ab}]")]
+    [InlineData(@"[^\q{}]")]
+    [InlineData(@"[^[\q{ab}]]")]
+    [InlineData(@"[^\p{RGI_Emoji}]")]
+    [InlineData(@"[^\q{ab}--\q{ab}]")]
+    [InlineData(@"\P{RGI_Emoji}")]
+    public void ANegatedClassCannotContainStrings(string pattern) => RejectsWith(pattern, SetMode, "REGEX0074");
+
+    [Theory]
+    [InlineData(@"[^\q{a|b}]")]
+    [InlineData(@"[^\q{ab}&&a]")]
+    [InlineData(@"[^a--\p{RGI_Emoji}]")]
+    [InlineData(@"[\p{RGI_Emoji}]")]
+    public void AClassThatOnlyMatchesCharactersMayBeNegated(string pattern) => Accepts(pattern, SetMode);
+
+    [Theory]
+    [InlineData("[(]")]
+    [InlineData("[|]")]
+    [InlineData("[{]")]
+    [InlineData("[a-]")]
+    [InlineData("[-a]")]
+    public void TheSetGrammarWantsItsSyntaxCharactersEscaped(string pattern) => RejectsWith(pattern, SetMode, "REGEX0073");
+
+    [Theory]
+    [InlineData(@"[\&]")]
+    [InlineData(@"[\!]")]
+    [InlineData(@"[\~]")]
+    [InlineData(@"[\q{\u{1F600}}]")]
+    public void TheSetGrammarLetsItsReservedPunctuatorsBeEscaped(string pattern) => Accepts(pattern, SetMode);
+
+    /// <summary>In Unicode mode a range compares code points, so a surrogate pair is one endpoint rather than two.</summary>
+    [Theory]
+    [InlineData("[\U0001F600-\U0001F602]", "[\U0001F602-\U0001F600]")]
+    [InlineData(@"[\uD83D\uDE00-\uD83D\uDE02]", @"[\uD83D\uDE02-\uD83D\uDE00]")]
+    [InlineData(@"[\u{1F600}-\u{1F602}]", @"[\u{1F602}-\u{1F600}]")]
+    public void ARangeOfAstralCharactersComparesCodePoints(string pattern, string reversed)
+    {
+        var range = Assert.Single(Accepts(pattern, UnicodeMode).GetRoot().DescendantNodes().OfType<RegexCharacterRangeSyntax>());
+
+        Assert.NotNull(range.End);
+        RejectsWith(reversed, UnicodeMode, "REGEX0009");
+    }
+
+    [Fact]
+    public void AStrictShorthandClassCannotStartARange()
+    {
+        RejectsWith(@"[\d-z]", UnicodeMode, "REGEX0016");
+        Accepts(@"[\d-z]", Options(RegexDialect.JavaScript));
+        Accepts(@"[\d-]", UnicodeMode);
+    }
+
+    [Fact]
+    public void ABracedSurrogateEscapeIsParsedWithoutThrowing() => Accepts(@"\u{D83D}\u{DE00}[\u{D83D}]", UnicodeMode);
+
+    [Theory]
+    [InlineData(@"(?<a>x)\k<a", "REGEX0019")]
+    [InlineData(@"(?<a>x)\k", "REGEX0019")]
+    public void AMalformedNamedReferenceIsAnErrorOnceThePatternHasNames(string pattern, string id)
+    {
+        RejectsWith(pattern, Options(RegexDialect.JavaScript), id);
+        Accepts(pattern[7..], Options(RegexDialect.JavaScript));
+    }
+
+    // ---- PCRE ----
+
+    [Fact]
+    public void ABranchResetGroupNumbersEveryBranchFromTheSameStart()
+    {
+        var tree = Accepts(@"(?|(a)|(b)(c))(d)\3", Pcre);
+
+        Assert.Equal([1, 2, 3], tree.Captures.Select(c => c.Number));
+        Assert.Equal(3, Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexBackreferenceSyntax>()).Number);
+        Accepts("(?|(?<a>x)|(?<a>y))", Pcre);
+        RejectsWith("(?|(?<a>x)|(?<b>y))", Pcre, "REGEX0035");
+    }
+
+    [Fact]
+    public void PcreAllowsDuplicateNamesOnlyWhereTheJOptionIsInEffect()
+    {
+        RejectsWith("(?<a>x)(?<a>y)", Pcre, "REGEX0035");
+        RejectsWith("(?J:(?<a>x))(?<a>y)", Pcre, "REGEX0035");
+        RejectsWith("(?J)(?<a>x)(?-J)(?<a>y)", Pcre, "REGEX0035");
+
+        var tree = Accepts("(?J)(?<a>x)(?<a>y)", Pcre);
+        Assert.Equal(["a", "a"], tree.Captures.Select(c => c.Name));
+    }
+
+    /// <summary>A PCRE condition names a group without capturing anything, however it spells the name.</summary>
+    [Theory]
+    [InlineData("(?(<a>)x|y)(?<a>z)", "a")]
+    [InlineData("(?('a')x|y)(?<a>z)", "a")]
+    [InlineData("(?(a)x|y)(?<a>z)", "a")]
+    [InlineData("(?(R1)x|y)(z)", "R1")]
+    [InlineData("(?(R&a)x|y)(?<a>z)", "R&a")]
+    [InlineData("(?(-1)x|y)", "-1")]
+    [InlineData("(?(DEFINE)(?<a>z))", "DEFINE")]
+    [InlineData("(?(VERSION>=10.4)x|y)(z)", "VERSION>=10.4")]
+    public void APcreConditionIsAReference(string pattern, string name)
+    {
+        if (name == "-1")
+        {
+            pattern = "(z)" + pattern;
+        }
+
+        var tree = Accepts(pattern, Pcre);
+
+        Assert.Equal(name, Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexConditionalReferenceSyntax>()).Name);
+        Assert.Single(tree.Captures);
+    }
+
+    [Theory]
+    [InlineData("(?(a)x|y)", "REGEX0056")]
+    [InlineData("(?(0)x)", "REGEX0056")]
+    [InlineData("(?(-1)x|y)", "REGEX0030")]
+    [InlineData("(?(DEFINE)a|b)", "REGEX0051")]
+    [InlineData("(?(?:a)b)", "REGEX0093")]
+    [InlineData("(?(?C1)a|b)", "REGEX0093")]
+    [InlineData("(?(VERSION>10)a)", "REGEX0055")]
+    public void AMalformedPcreConditionIsReported(string pattern, string id) => RejectsWith(pattern, Pcre, id);
+
+    [Fact]
+    public void ARelativeSubroutineCallCountsFromWhereItStands()
+    {
+        Assert.Equal("-1", Assert.Single(Accepts("(a)(?-1)", Pcre).GetRoot().DescendantNodes().OfType<RegexRecursionSyntax>()).TargetToken.Text);
+        Accepts("(?+1)(a)", Pcre);
+        RejectsWith("(?-1)(a)", Pcre, "REGEX0030");
+        RejectsWith("(a)(?+1)", Pcre, "REGEX0030");
+        RejectsWith("(a)(?-0)", Pcre, "REGEX0030");
+    }
+
+    [Theory]
+    [InlineData("(*MARK)", "REGEX0090")]
+    [InlineData("(*:)", "REGEX0090")]
+    [InlineData("(*BOGUS)", "REGEX0090")]
+    [InlineData("a(*UTF)", "REGEX0090")]
+    [InlineData("(*MARK:a)(*UTF)", "REGEX0090")]
+    [InlineData("(*FAIL)*", "REGEX0005")]
+    [InlineData("(?C256)", "REGEX0091")]
+    [InlineData("(?Cx)", "REGEX0091")]
+    [InlineData("(?C\"a)", "REGEX0091")]
+    [InlineData("(?C1)*", "REGEX0005")]
+    public void AMalformedVerbOrCalloutIsReported(string pattern, string id) => RejectsWith(pattern, Pcre, id);
+
+    [Theory]
+    [InlineData("(*UTF)(*LIMIT_MATCH=10)a")]
+    [InlineData("(*ACCEPT)+")]
+    [InlineData("(*MARK:a)(*SKIP:a)")]
+    [InlineData("(?C{a})")]
+    [InlineData("(?C\"a\"\"b\")")]
+    public void AWellFormedVerbOrCalloutIsAccepted(string pattern) => Accepts(pattern, Pcre);
+
+    [Theory]
+    [InlineData("(*pla:a)", RegexLookaroundKind.PositiveLookahead)]
+    [InlineData("(*negative_lookahead:a)", RegexLookaroundKind.NegativeLookahead)]
+    [InlineData("(*plb:a)", RegexLookaroundKind.PositiveLookbehind)]
+    [InlineData("(*nlb:a)", RegexLookaroundKind.NegativeLookbehind)]
+    public void AnAlphaAssertionIsALookaround(string pattern, RegexLookaroundKind kind)
+    {
+        var lookaround = Assert.Single(Accepts(pattern, Pcre).GetRoot().DescendantNodes().OfType<RegexLookaroundSyntax>());
+
+        Assert.Equal(kind, lookaround.LookaroundKind);
+    }
+
+    [Theory]
+    [InlineData("(?<=a+)")]
+    [InlineData(@"(?<=\X)")]
+    [InlineData("(?<=(?:a|b{300}))")]
+    [InlineData(@"(?<=(a+)\1)")]
+    [InlineData("(?<=(?1))(a+)")]
+    [InlineData("(*plb:a*)")]
+    public void AnUnboundedLookbehindIsReported(string pattern) => RejectsWith(pattern, Pcre, "REGEX0092");
+
+    [Theory]
+    [InlineData("(?<=a{300})")]
+    [InlineData("(?<=a|bc)")]
+    [InlineData("(?<=a{0,255})")]
+    [InlineData(@"(?<=(a)\1{300})")]
+    [InlineData("(?<=(?=a+))b")]
+    public void ABoundedLookbehindIsAccepted(string pattern) => Accepts(pattern, Pcre);
+
+    [Theory]
+    [InlineData(@"\b*")]
+    [InlineData("^*")]
+    [InlineData(@"a\K+")]
+    [InlineData(@"\Q\E*")]
+    [InlineData("{,2}")]
+    public void PcreCannotRepeatSomethingThatMatchesNothing(string pattern) => RejectsWith(pattern, Pcre, "REGEX0005");
+
+    [Theory]
+    [InlineData("(?^i)")]
+    [InlineData("(?aD)")]
+    [InlineData("(?xx)")]
+    [InlineData("(?r)")]
+    [InlineData("(?-)")]
+    [InlineData(@"\p{ L u }")]
+    [InlineData(@"\p{greek}")]
+    [InlineData(@"\p{sc:Latn}")]
+    [InlineData(@"\p{L&}")]
+    [InlineData(@"\pl")]
+    [InlineData(@"\_")]
+    [InlineData(@"\é")]
+    [InlineData(@"[\8\g\k]")]
+    [InlineData(@"[\Q]\E]")]
+    [InlineData(@"(?<a>x)\k{a}")]
+    [InlineData(@"\8(a)(b)(c)(d)(e)(f)(g)(h)")]
+    [InlineData("(?<\U0001D49C>x)")]
+    public void PcreAcceptsWhatPcre2AcceptsToo(string pattern) => Accepts(pattern, Pcre);
+
+    [Theory]
+    [InlineData("(?u)", "REGEX0010")]
+    [InlineData("(?I)", "REGEX0010")]
+    [InlineData("(?^-i)", "REGEX0010")]
+    [InlineData(@"\p{Letter}", "REGEX0034")]
+    [InlineData(@"\p{gc=L}", "REGEX0034")]
+    [InlineData(@"\pb", "REGEX0034")]
+    [InlineData(@"\u0041", "REGEX0015")]
+    [InlineData(@"\ce", "REGEX0014")]
+    [InlineData(@"\81", "REGEX0030")]
+    [InlineData(@"(?=a\K)", "REGEX0015")]
+    [InlineData(@"[\d-z]", "REGEX0016")]
+    [InlineData("[[:alpha:]-z]", "REGEX0016")]
+    [InlineData("[[:bogus:]]", "REGEX0110")]
+    [InlineData("[[.a.]]", "REGEX0110")]
+    [InlineData("[:alpha:]", "REGEX0110")]
+    [InlineData("a{65536}", "REGEX0008")]
+    [InlineData("(?<a>x)(?<a>y)", "REGEX0035")]
+    public void PcreRejectsWhatPcre2RejectsToo(string pattern, string id)
+    {
+        if (id == "REGEX0014")
+        {
+            pattern = "\\c\u00E9";
+        }
+
+        RejectsWith(pattern, Pcre, id);
+    }
+
+    [Fact]
+    public void APcreBoundMayHaveSpacesAndLeaveOutItsMinimum()
+    {
+        var quantifiers = Accepts("a{ 2 , 3 }b{,4}", Pcre).GetRoot().DescendantNodes().OfType<RegexRangeQuantifierSyntax>().ToArray();
+
+        Assert.Equal((2, (int?)3), (quantifiers[0].MinCount, quantifiers[0].MaxCount));
+        Assert.Equal((0, (int?)4), (quantifiers[1].MinCount, quantifiers[1].MaxCount));
+    }
+
+    [Fact]
+    public void BackslashNFollowedByABoundIsARepeatedShorthand()
+    {
+        var tree = Accepts(@"\N{2,3}[\x{41}]", Pcre);
+
+        Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexQuantifiedSyntax>());
+        Assert.Equal("A", Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexCharacterEscapeSyntax>()).Value);
+    }
+
+    // ---- POSIX, as glibc reads it ----
+
+    [Theory]
+    [InlineData("ere")]
+    [InlineData("bre")]
+    public void ABackslashIsOrdinaryInsideABracketExpression(string dialectName)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+
+        var tree = Accepts(@"[\]]", Options(dialect));
+        var characterClass = Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexCharacterClassSyntax>());
+
+        Assert.Equal(@"[\]", characterClass.ToString());
+        Assert.Equal("]", tree.GetRoot().Alternation.Branches[0].Terms[1].ToString());
+    }
+
+    [Fact]
+    public void AnUnmatchedCloseParenthesisIsACharacterOnlyInAnExtendedExpression()
+    {
+        Accepts("a)", Ere);
+        Accepts(@"a)", Bre);
+        RejectsWith(@"a\)", Bre, "REGEX0001");
+    }
+
+    [Fact]
+    public void OnlyABasicExpressionForbidsStackingStarOrABound()
+    {
+        Accepts("a**", Ere);
+        Accepts("a{2}{3}", Ere);
+        RejectsWith("a**", Bre, "REGEX0006");
+        RejectsWith(@"a\{2\}*", Bre, "REGEX0006");
+        Accepts(@"a*\+", Bre);
+    }
+
+    [Theory]
+    [InlineData("ere", "a{1", "REGEX0111")]
+    [InlineData("ere", "x{}", "REGEX0111")]
+    [InlineData("ere", "{1}", "REGEX0005")]
+    [InlineData("ere", "a{32768}", "REGEX0008")]
+    [InlineData("bre", @"\{1\}", "REGEX0005")]
+    [InlineData("bre", @"^\{1\}", "REGEX0005")]
+    [InlineData("bre", @"a\{1", "REGEX0111")]
+    public void APosixIntervalIsNeverOrdinaryText(string dialectName, string pattern, string id)
+    {
+        Assert.True(RegexDialect.TryParse(dialectName, out var dialect));
+
+        RejectsWith(pattern, Options(dialect), id);
+    }
+
+    [Fact]
+    public void APosixBackreferenceIsOneDigitNamingAGroupAlreadyClosed()
+    {
+        var tree = Accepts(@"(a)\10", Ere);
+        Assert.Equal(1, Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexBackreferenceSyntax>()).Number);
+
+        Accepts("(a)|(b)\\2", Ere);
+        RejectsWith(@"(a\1)", Ere, "REGEX0030");
+        RejectsWith(@"(a)|\1", Ere, "REGEX0030");
+        RejectsWith(@"\1(a)", Ere, "REGEX0030");
+        RejectsWith(@"\(a\)\|\1", Bre, "REGEX0030");
+    }
+
+    [Fact]
+    public void AnExtendedExpressionCannotRepeatAnAssertion()
+    {
+        RejectsWith("^*", Ere, "REGEX0005");
+        RejectsWith(@"\<*", Ere, "REGEX0005");
+
+        // In a basic expression the "*" is the character.
+        var tree = Accepts(@"^*\b*", Bre);
+        Assert.Empty(tree.GetRoot().DescendantNodes().OfType<RegexQuantifiedSyntax>());
+    }
+
+    [Theory]
+    [InlineData(@"\<", RegexAnchorKind.StartOfWord)]
+    [InlineData(@"\>", RegexAnchorKind.EndOfWord)]
+    [InlineData(@"\`", RegexAnchorKind.StartOfInput)]
+    [InlineData(@"\'", RegexAnchorKind.EndOfInput)]
+    public void TheGnuWordAnchorsAreAssertions(string pattern, RegexAnchorKind kind)
+    {
+        Assert.Equal(kind, Assert.Single(Accepts(pattern, Ere).GetRoot().DescendantNodes().OfType<RegexAnchorSyntax>()).AnchorKind);
+    }
+
+    [Theory]
+    [InlineData("[[:bogus:]]", "REGEX0110")]
+    [InlineData("[[.ab.]]", "REGEX0110")]
+    [InlineData("[[:alpha]]", "REGEX0003")]
+    [InlineData("[[:alpha:]-z]", "REGEX0016")]
+    [InlineData("[a-[=z=]]", "REGEX0016")]
+    [InlineData("[z-[.a.]]", "REGEX0009")]
+    [InlineData("[a-z-9]", "REGEX0009")]
+    public void AMalformedBracketExpressionIsReported(string pattern, string id) => RejectsWith(pattern, Ere, id);
+
+    [Theory]
+    [InlineData("[a-[.z.]]")]
+    [InlineData("[[.-.]-z]")]
+    [InlineData("[%--]")]
+    [InlineData("[a-z-]")]
+    [InlineData("[[:alpha:]-]")]
+    public void AWellFormedBracketExpressionIsAccepted(string pattern) => Accepts(pattern, Ere);
 }

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexReviewFeedbackTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexReviewFeedbackTests.cs
@@ -124,7 +124,7 @@ public sealed class RegexReviewFeedbackTests
     [InlineData("javascript", "(?<a-b>x)")]
     [InlineData("javascript", "(?(1)a|b)")]
     [InlineData("javascript", "(?i)a")]
-    [InlineData("javascript", "(?i:a)")]
+    [InlineData("javascript", "(?x:a)")]
     [InlineData("pcre", "(?<a-b>x)")]
     [InlineData("ere", "(?:a)")]
     [InlineData("ere", "(?=a)")]

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexRoundTripFuzzTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexRoundTripFuzzTests.cs
@@ -140,6 +140,53 @@ public sealed class RegexRoundTripFuzzTests
         }
     }
 
+    /// <summary>
+    /// Every dialect and every option that changes the grammar, over text made of the characters each grammar gives a
+    /// meaning to, surrogates and escapes that name surrogates included.
+    /// </summary>
+    [Theory]
+    [InlineData(21)]
+    [InlineData(22)]
+    public void RandomSoup_RoundTripsInEveryDialectAndMode(int seed)
+    {
+        string[] pieces =
+        [
+            "a", "0", "9", "-", "&", "!", "|", "^", "$", ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", ",", ":", "=", "<", ">", "'", "#", " ",
+            "\\", "\\d", "\\p{", "\\q{", "\\u{D83D}", "\\uD83D", "\\uDE00", "\\x{", "\\k<", "\\g{-", "\\Q", "\\E", "\\N{U+", "(?", "(*", "(?(", "(?<",
+            "[:", ":]", "[.", ".]", "&&", "--", "\uD83D", "\uDE00", "\U0001F600", "é",
+        ];
+
+        (RegexDialect Dialect, RegexPatternOptions Options)[] modes =
+        [
+            (RegexDialect.Net, RegexPatternOptions.None),
+            (RegexDialect.Net, RegexPatternOptions.IgnorePatternWhitespace | RegexPatternOptions.EcmaScript),
+            (RegexDialect.JavaScript, RegexPatternOptions.None),
+            (RegexDialect.JavaScript, RegexPatternOptions.Unicode),
+            (RegexDialect.JavaScript, RegexPatternOptions.Unicode | RegexPatternOptions.UnicodeSets),
+            (RegexDialect.PcrePerl, RegexPatternOptions.None),
+            (RegexDialect.PcrePerl, RegexPatternOptions.IgnorePatternWhitespace),
+            (RegexDialect.PosixExtended, RegexPatternOptions.None),
+            (RegexDialect.PosixBasic, RegexPatternOptions.None),
+        ];
+
+        var random = new DeterministicRandom(seed);
+        for (var iteration = 0; iteration < 300; iteration++)
+        {
+            var builder = new StringBuilder();
+            var length = random.Next(16);
+            for (var index = 0; index < length; index++)
+            {
+                builder.Append(pieces[random.Next(pieces.Length)]);
+            }
+
+            var pattern = builder.ToString();
+            foreach (var (dialect, options) in modes)
+            {
+                RegexSyntaxAssert.TextIsFaithful(pattern, new RegexParseOptions(dialect) { PatternOptions = options });
+            }
+        }
+    }
+
     [Fact]
     public void ParseText_NeverThrows()
     {

--- a/tests/Meziantou.Framework.Language.Regex.Tests/RegexSyntaxFactoryTests.cs
+++ b/tests/Meziantou.Framework.Language.Regex.Tests/RegexSyntaxFactoryTests.cs
@@ -105,7 +105,10 @@ public sealed class RegexSyntaxFactoryTests
         foreach (var kind in Enum.GetValues<RegexAnchorKind>())
         {
             var built = SyntaxFactory.Anchor(kind).ToFullString();
-            var tree = RegexSyntaxAssert.TextIsFaithful(built, RegexDialect.PcrePerl);
+
+            // The word anchors are the GNU ones, which only the POSIX dialects have.
+            var dialect = kind is RegexAnchorKind.StartOfWord or RegexAnchorKind.EndOfWord ? RegexDialect.PosixExtended : RegexDialect.PcrePerl;
+            var tree = RegexSyntaxAssert.TextIsFaithful(built, dialect);
 
             var anchor = Assert.Single(tree.GetRoot().DescendantNodes().OfType<RegexAnchorSyntax>());
             Assert.Equal(kind, anchor.AnchorKind);


### PR DESCRIPTION
## Why

`Meziantou.Framework.Language.Regex` claims to parse each dialect the way its engine does, but only the .NET dialect was checked against a real engine. Comparing the other dialects against V8, PCRE2 10.47, and glibc's `regcomp` over ~30K generated and hand-written patterns turned up a large number of disagreements, plus two inputs that made the parser throw (`\u{D83D}` under `u`, and `\q{…\` at the end of a pattern). The .NET dialect had no mismatches.

## What changed

**Shared parser**
- Group numbering is per dialect: JavaScript and PCRE number named groups where they stand (`(a)(?<x>b)(c)` → x is 2), .NET keeps its "names last" rule; PCRE branch reset groups share numbers.
- Character class ranges compare code points, so `[😀-😂]` is a valid range in Unicode mode and in PCRE.
- `UnicodeSets` on its own now implies Unicode mode.

**JavaScript**
- The `v`-flag class set grammar was rewritten: unescaped syntax characters, ranges as `&&`/`--` operands, and strings inside a negated class are reported.
- `\p{…}` names are checked against the spec's tables; properties of strings only under `v`.
- ES2025 `(?ims-ims:…)` modifiers are accepted, and duplicate group names are allowed only in different alternatives.
- Decimal escapes follow the spec (`\1(a)` is a backreference; `(a)\10` is legacy octal without `u`, an error with it).
- Group names are identifiers, `\u` escapes included; `\a`, `\e`, and `\08` are no longer accepted under `u`.

**PCRE**
- Every condition form is read as a reference: `(?(<n>)…)`, `(?(R1)…)`, `(?(R&n)…)`, `(?(DEFINE)…)`, `(?(VERSION>=…)…)`, relative. Previously `(?(<n>)…)` created a capture group.
- Added relative subroutine calls `(?-1)`/`(?+1)`, alpha assertions (`(*plb:…)`), and validation of verbs, start-of-pattern options, and callouts.
- A lookbehind must have a bounded length (≤255 when variable); `\K` is rejected inside lookarounds.
- Option letters `^ r aD J xx` are handled, as are loosely matched `\p{…}` names.
- Bounds may contain spaces and use `{,n}`, and the maximum is 65535.
- `\Q…\E` is handled inside classes, and PCRE's identity-escape rules apply.
- Anchors, callouts, and most verbs are not quantifiable.

**POSIX** (following glibc, including its GNU extensions)
- A backslash is literal inside `[…]`, and an unmatched `)` is literal in ERE.
- Stacked quantifiers are allowed in ERE; in BRE only `\+`/`\?` may stack.
- A `{` always starts an interval, so a malformed one is reported (`RE_DUP_MAX` 32767).
- Backreferences are one digit and must name a group already closed in their branch.
- POSIX class and collating names are validated, and the GNU `\<` `\>` anchors are recognized.

New diagnostic IDs: REGEX0035, REGEX0073–0075, REGEX0090–0093, REGEX0110–0111.

## Tests

- `RegexConformanceTests` replays about 12,000 frozen engine verdicts (validity, group count, and names) from `Corpus/*Conformance.jsonl`, on both target frameworks. Against `main` these records produce 1,130 disagreements. `Corpus/conformance.md` explains how they were generated.
- `RegexOracleAuditTests` gets one targeted test per class of bug, checking tree shape as well as diagnostics.
- `RegexDiagnosticTests` covers spans for the new IDs and error recovery: parsing continues past an error, and each problem is reported once.
- `RegexRoundTripFuzzTests` adds a never-throw/round-trip fuzz over every dialect and mode; it found the second crash.
- Three existing tests asserted behavior the engines contradict and were updated: JS `(?i:a)` is valid, `[\w--a-z]` is invalid under `v`, and anchor kinds were extended.

## For reviewers

- **Public API:** `RegexAnchorKind` gains `StartOfWord` and `EndOfWord`; `ref/` is regenerated.
- **Behavior change:** JS and PCRE `Captures` numbering differs from before.
- **Deliberate divergences:**
  - V8 accepts `(?<a>x)(?:y|(?<a>z))` and clamps `a{99999999999,2147483648}`; the parser follows ECMA-262 instead.
  - PCRE ignores an empty `\Q\E` or a stray `\E` before a quantifier; the parser does not.
  - glibc reads `\,` as a comma inside `{…}`; the parser does not.
