### PR TITLE
Make the JSON parser reject what RFC 8259 forbids and recover from common mistakes

### DIFF
--- a/src/Meziantou.Framework.Language.Json/Internals/JsonDiagnosticDescriptors.cs
+++ b/src/Meziantou.Framework.Language.Json/Internals/JsonDiagnosticDescriptors.cs
@@ -16,11 +16,15 @@ internal static class JsonDiagnosticDescriptors
     public static readonly DiagnosticDescriptor ExpectedCharacter = Error("JSON0006", "Expected a character", "Expected '{0}'.");
     public static readonly DiagnosticDescriptor ExpectedValue = Error("JSON0007", "Expected a value", "Expected a JSON value.");
     public static readonly DiagnosticDescriptor ExpectedPropertyName = Error("JSON0008", "Expected a property name", "Expected a JSON property name.");
+    public static readonly DiagnosticDescriptor UnquotedPropertyName = Error("JSON0008", "Unquoted property name", "JSON property names must be enclosed in double quotes.");
     public static readonly DiagnosticDescriptor ExpectedCommaOrEndOfObject = Error("JSON0009", "Expected a comma or the end of the object", "Expected a comma or the end of the object.");
     public static readonly DiagnosticDescriptor ExpectedCommaOrEndOfArray = Error("JSON0009", "Expected a comma or the end of the array", "Expected a comma or the end of the array.");
     public static readonly DiagnosticDescriptor UnexpectedDataAfterRootValue = Error("JSON0010", "Unexpected data after the root value", "Unexpected data after the root JSON value.");
-    public static readonly DiagnosticDescriptor LineBreakInString = Error("JSON0011", "Line break in a string", "Line breaks are not allowed in JSON strings.");
+    public static readonly DiagnosticDescriptor ControlCharacterInString = Error("JSON0011", "Unescaped control character in a string", "The control character U+{0} must be escaped in a JSON string.");
     public static readonly DiagnosticDescriptor NestingTooDeep = Error("JSON0012", "Nesting too deep", "Objects and arrays cannot nest more than {0} deep.");
+    public static readonly DiagnosticDescriptor InvalidWhitespace = Error("JSON0013", "Invalid whitespace", "The character U+{0} is not whitespace in JSON, which only allows spaces, tabs, and line breaks.");
+    public static readonly DiagnosticDescriptor SingleQuotedString = Error("JSON0014", "Single-quoted string", "JSON strings must be enclosed in double quotes.");
+    public static readonly DiagnosticDescriptor DuplicatePropertyName = new("JSON0015", "Duplicate property name", "The property name '{0}' is already used in this object.", DiagnosticSeverity.Warning);
 
     private static DiagnosticDescriptor Error(string id, string title, string messageFormat) => new(id, title, messageFormat, DiagnosticSeverity.Error);
 }

--- a/src/Meziantou.Framework.Language.Json/Syntax/InternalSyntax/LanguageParser.cs
+++ b/src/Meziantou.Framework.Language.Json/Syntax/InternalSyntax/LanguageParser.cs
@@ -12,6 +12,11 @@ namespace Meziantou.Framework.Language.Json.Syntax.InternalSyntax;
 /// everything up to the first of them, so it always consumes something unless it is already looking at one. Each loop
 /// then excludes exactly the tokens it passes down, which is why none of them can spin.
 /// </para>
+/// <para>
+/// The closers of every enclosing construct are among those tokens, not only the construct's own. That is what lets
+/// <c>{"a": [1, 2}</c> end the array at the brace and report the missing bracket, rather than skip the brace as
+/// garbage and then report the object as unterminated too.
+/// </para>
 /// </remarks>
 internal sealed class LanguageParser
 {
@@ -53,8 +58,7 @@ internal sealed class LanguageParser
         CloseBracket = 8,
 
         Document = EndOfFile,
-        Object = EndOfFile | Comma | CloseBrace,
-        Array = EndOfFile | Comma | CloseBracket,
+        Closers = CloseBrace | CloseBracket,
     }
 
     public JsonDocumentSyntax ParseDocument()
@@ -65,6 +69,14 @@ internal sealed class LanguageParser
 
         while (CurrentKind != SyntaxKind.EndOfFileToken)
         {
+            // Nothing can start with these, so each is reported on its own and parsing picks up after it: a stray
+            // closing brace does not take the rest of the document with it, nor stand in for the root value.
+            if (!CanStartValue(CurrentKind))
+            {
+                values.Add(ParseStrayTokens());
+                continue;
+            }
+
             if (hasRootValue)
             {
                 AddErrorAtCurrentToken(JsonDiagnosticDescriptors.UnexpectedDataAfterRootValue);
@@ -72,6 +84,12 @@ internal sealed class LanguageParser
 
             values.Add(ParseValue(TerminatorState.Document));
             hasRootValue = true;
+        }
+
+        // A document is exactly one value; whitespace and comments alone are not one.
+        if (values.Count == 0)
+        {
+            AddErrorForMissingToken(JsonDiagnosticDescriptors.ExpectedValue);
         }
 
         var node = new JsonDocumentSyntax(SyntaxFactory.List(values.ToArray()), EatToken());
@@ -90,6 +108,16 @@ internal sealed class LanguageParser
         _currentFullStart = _lexer.Position - _current.FullWidth;
 
         return eaten;
+    }
+
+    /// <summary>Gets the kind of the token after the current one, without moving past anything.</summary>
+    private SyntaxKind PeekKind()
+    {
+        var position = _lexer.Position;
+        var next = _lexer.Lex();
+        _lexer.Position = position;
+
+        return (SyntaxKind)next.RawKind;
     }
 
     private GreenToken EatToken(SyntaxKind kind, DiagnosticDescriptor descriptor, params object?[] arguments)
@@ -147,7 +175,7 @@ internal sealed class LanguageParser
         _depth++;
         try
         {
-            return CurrentKind == SyntaxKind.OpenBraceToken ? ParseObject() : ParseArray();
+            return CurrentKind == SyntaxKind.OpenBraceToken ? ParseObject(terminators) : ParseArray(terminators);
         }
         finally
         {
@@ -176,14 +204,33 @@ internal sealed class LanguageParser
         return (JsonSkippedTextSyntax)Finish(node, start, mark);
     }
 
-    private JsonObjectSyntax ParseObject()
+    /// <summary>Parses the tokens at the document level that cannot start a value, reporting each of them.</summary>
+    private JsonSkippedTextSyntax ParseStrayTokens()
+    {
+        var mark = _pending.Count;
+        var start = _currentFullStart;
+        var tokens = new List<GreenNode?>();
+
+        while (CurrentKind != SyntaxKind.EndOfFileToken && !CanStartValue(CurrentKind))
+        {
+            AddErrorAtCurrentToken(JsonDiagnosticDescriptors.UnexpectedToken, _current.Text);
+            tokens.Add(EatToken());
+        }
+
+        var node = new JsonSkippedTextSyntax(SyntaxFactory.ListNode(tokens.ToArray()));
+
+        return (JsonSkippedTextSyntax)Finish(node, start, mark);
+    }
+
+    private JsonObjectSyntax ParseObject(TerminatorState outerTerminators)
     {
         var mark = _pending.Count;
         var start = _currentFullStart;
         var openBrace = EatToken(SyntaxKind.OpenBraceToken, JsonDiagnosticDescriptors.ExpectedCharacter, "{");
         var members = new List<GreenNode?>();
+        var closers = TerminatorState.EndOfFile | TerminatorState.CloseBrace | (outerTerminators & TerminatorState.Closers);
 
-        while (CurrentKind is not SyntaxKind.EndOfFileToken and not SyntaxKind.CloseBraceToken)
+        while (!IsTerminator(CurrentKind, closers))
         {
             if (CurrentKind == SyntaxKind.CommaToken)
             {
@@ -203,8 +250,10 @@ internal sealed class LanguageParser
                 members.Add(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
             }
 
-            members.Add(ParseMember());
+            members.Add(ParseMember(closers | TerminatorState.Comma));
         }
+
+        ReportDuplicateNames(start + openBrace.FullWidth, members);
 
         var closeBrace = EatToken(SyntaxKind.CloseBraceToken, JsonDiagnosticDescriptors.ExpectedCharacter, "}");
         var node = new JsonObjectSyntax(openBrace, SyntaxFactory.ListNode(members.ToArray()), closeBrace);
@@ -212,7 +261,7 @@ internal sealed class LanguageParser
         return (JsonObjectSyntax)Finish(node, start, mark);
     }
 
-    private JsonMemberSyntax ParseMember()
+    private JsonMemberSyntax ParseMember(TerminatorState terminators)
     {
         if (TryReuse(Blender.NodeContext.Member) is JsonMemberSyntax reused)
             return reused;
@@ -225,6 +274,14 @@ internal sealed class LanguageParser
         {
             nameToken = EatToken();
         }
+        else if (CurrentKind is SyntaxKind.BadToken or SyntaxKind.NumberToken or SyntaxKind.TrueKeyword or SyntaxKind.FalseKeyword or SyntaxKind.NullKeyword
+            && PeekKind() == SyntaxKind.ColonToken)
+        {
+            // A bare word before a colon is a name someone forgot to quote. Reading it as the name keeps the member
+            // whole, where skipping it would lose the name, the colon, and the value together.
+            AddErrorAtCurrentToken(JsonDiagnosticDescriptors.UnquotedPropertyName);
+            nameToken = AsStringToken(EatToken());
+        }
         else
         {
             AddErrorForMissingToken(JsonDiagnosticDescriptors.ExpectedPropertyName);
@@ -232,20 +289,21 @@ internal sealed class LanguageParser
         }
 
         var colonToken = EatToken(SyntaxKind.ColonToken, JsonDiagnosticDescriptors.ExpectedCharacter, ":");
-        var value = ParseValue(TerminatorState.Object);
+        var value = ParseValue(terminators);
         var node = new JsonMemberSyntax(nameToken, colonToken, value);
 
         return (JsonMemberSyntax)Finish(node, start, mark);
     }
 
-    private JsonArraySyntax ParseArray()
+    private JsonArraySyntax ParseArray(TerminatorState outerTerminators)
     {
         var mark = _pending.Count;
         var start = _currentFullStart;
         var openBracket = EatToken(SyntaxKind.OpenBracketToken, JsonDiagnosticDescriptors.ExpectedCharacter, "[");
         var elements = new List<GreenNode?>();
+        var closers = TerminatorState.EndOfFile | TerminatorState.CloseBracket | (outerTerminators & TerminatorState.Closers);
 
-        while (CurrentKind is not SyntaxKind.EndOfFileToken and not SyntaxKind.CloseBracketToken)
+        while (!IsTerminator(CurrentKind, closers))
         {
             if (CurrentKind == SyntaxKind.CommaToken)
             {
@@ -265,7 +323,7 @@ internal sealed class LanguageParser
                 elements.Add(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
             }
 
-            elements.Add(ParseValue(TerminatorState.Array));
+            elements.Add(ParseValue(closers | TerminatorState.Comma));
         }
 
         var closeBracket = EatToken(SyntaxKind.CloseBracketToken, JsonDiagnosticDescriptors.ExpectedCharacter, "]");
@@ -292,6 +350,64 @@ internal sealed class LanguageParser
 
         return reused;
     }
+
+    /// <summary>Reports every member whose name an earlier member of the same object already has.</summary>
+    /// <remarks>
+    /// RFC 8259 only says names should be unique, and readers disagree on which of two values they keep, so this is a
+    /// warning rather than an error. The positions are worked out from the widths of the members, which is why a
+    /// member taken from the previous tree is checked like any other.
+    /// </remarks>
+    private void ReportDuplicateNames(int membersStart, List<GreenNode?> members)
+    {
+        var memberCount = (members.Count + 1) / 2;
+        if (memberCount < 2)
+            return;
+
+        // Comparing each name with the ones before it costs nothing for the small objects most documents are made of.
+        HashSet<string>? seen = memberCount > 8 ? new(StringComparer.Ordinal) : null;
+        var position = membersStart;
+        for (var i = 0; i < members.Count; i++)
+        {
+            var item = members[i];
+            if (i % 2 == 0 && GetNameToken(item) is { } nameToken)
+            {
+                var name = nameToken.ValueText;
+                if (seen is null ? IsNameUsedBefore(members, i, name) : !seen.Add(name))
+                {
+                    _pending.Add(new PendingDiagnostic(position + nameToken.GetLeadingTriviaWidth(), nameToken.Text.Length, JsonDiagnosticDescriptors.DuplicatePropertyName, [name]));
+                }
+            }
+
+            position += item?.FullWidth ?? 0;
+        }
+
+        static bool IsNameUsedBefore(List<GreenNode?> members, int index, string name)
+        {
+            for (var i = 0; i < index; i += 2)
+            {
+                if (GetNameToken(members[i]) is { } other && string.Equals(other.ValueText, name, StringComparison.Ordinal))
+                    return true;
+            }
+
+            return false;
+        }
+
+        // A name that is missing, or too broken to have a reliable value, is already reported for that.
+        static GreenToken? GetNameToken(GreenNode? member)
+            => member is JsonMemberSyntax && member.GetSlot(0) is GreenToken { IsMissing: false } token && token.GetDiagnostics().Length == 0 ? token : null;
+    }
+
+    private static GreenToken AsStringToken(GreenToken token)
+    {
+        var converted = SyntaxFactory.TokenWithValue(token.LeadingTrivia, SyntaxKind.StringToken, token.Text, token.Text, token.TrailingTrivia);
+        var diagnostics = token.GetDiagnostics();
+
+        return diagnostics.Length == 0 ? converted : (GreenToken)converted.WithAdditionalDiagnostics(diagnostics);
+    }
+
+    private static bool CanStartValue(SyntaxKind kind)
+        => kind is SyntaxKind.OpenBraceToken or SyntaxKind.OpenBracketToken or SyntaxKind.StringToken or SyntaxKind.NumberToken
+            or SyntaxKind.TrueKeyword or SyntaxKind.FalseKeyword or SyntaxKind.NullKeyword;
 
     private static JsonMemberSyntax MissingMember()
         => new(SyntaxFactory.MissingToken(SyntaxKind.StringToken), SyntaxFactory.MissingToken(SyntaxKind.ColonToken), new JsonSkippedTextSyntax(tokens: null));

--- a/src/Meziantou.Framework.Language.Json/Syntax/InternalSyntax/Lexer.cs
+++ b/src/Meziantou.Framework.Language.Json/Syntax/InternalSyntax/Lexer.cs
@@ -75,12 +75,13 @@ internal sealed class Lexer(SourceText source)
                 return Punctuation(SyntaxKind.ColonToken, out text);
             case ',':
                 return Punctuation(SyntaxKind.CommaToken, out text);
-            case '"':
+            case '"' or '\'':
                 return ScanString(out text, out valueText);
-            case '-' or (>= '0' and <= '9'):
+            case '-' or '+' or (>= '0' and <= '9'):
+            case '.' when IsDigit(LookAhead):
                 return ScanNumber(out text);
             default:
-                while (!IsAtEnd && !IsTokenBoundary(Current))
+                while (!IsAtTokenEnd)
                 {
                     Position++;
                 }
@@ -106,9 +107,16 @@ internal sealed class Lexer(SourceText source)
         return kind;
     }
 
+    /// <summary>Reads a string, which ends at its closing quote or at the end of its line, whichever comes first.</summary>
+    /// <remarks>
+    /// JSON strings cannot contain a line break, so one that reaches the end of its line was never closed. Stopping
+    /// there keeps the lines below out of it: otherwise a single missing quote would turn the rest of the document into
+    /// one string, and every quote after it would open or close the wrong one.
+    /// </remarks>
     private SyntaxKind ScanString(out string text, out string valueText)
     {
         var start = Position;
+        var quote = Current;
         var builder = new StringBuilder();
         Position++;
 
@@ -116,22 +124,25 @@ internal sealed class Lexer(SourceText source)
         while (!IsAtEnd)
         {
             var current = Current;
-            if (current == '"')
+            if (current == quote)
             {
                 Position++;
                 terminated = true;
                 break;
             }
 
+            if (current is '\r' or '\n')
+                break;
+
             if (current == '\\')
             {
-                ScanEscapeSequence(builder, start);
+                ScanEscapeSequence(builder, quote);
                 continue;
             }
 
-            if (current is '\r' or '\n')
+            if (current < ' ')
             {
-                AddDiagnostic(Position, SourceText.GetLineBreakLength(_text, Position), JsonDiagnosticDescriptors.LineBreakInString);
+                AddDiagnostic(Position, 1, JsonDiagnosticDescriptors.ControlCharacterInString, ToCodePoint(current));
             }
 
             builder.Append(current);
@@ -140,7 +151,13 @@ internal sealed class Lexer(SourceText source)
 
         if (!terminated)
         {
-            AddDiagnostic(start, _text.Length - start, JsonDiagnosticDescriptors.UnterminatedString);
+            AddDiagnostic(start, Position - start, JsonDiagnosticDescriptors.UnterminatedString);
+        }
+
+        // Read as a string all the same, so a value written with the wrong quotes is still where it belongs in the tree.
+        if (quote == '\'')
+        {
+            AddDiagnostic(start, Position - start, JsonDiagnosticDescriptors.SingleQuotedString);
         }
 
         text = _text[start..Position];
@@ -149,21 +166,25 @@ internal sealed class Lexer(SourceText source)
         return SyntaxKind.StringToken;
     }
 
-    private void ScanEscapeSequence(StringBuilder builder, int stringStart)
+    private void ScanEscapeSequence(StringBuilder builder, char quote)
     {
         var escapeStart = Position;
         Position++;
-        if (IsAtEnd)
-        {
-            AddDiagnostic(stringStart, _text.Length - stringStart, JsonDiagnosticDescriptors.UnterminatedString);
+
+        // A backslash that ends the text or the line has nothing to escape; the string is reported as unterminated.
+        if (IsAtEnd || Current is '\r' or '\n')
             return;
-        }
 
         switch (Current)
         {
             case '"':
             case '\\':
             case '/':
+                builder.Append(Current);
+                Position++;
+                break;
+            case '\'' when quote == '\'':
+                // The quotes are already reported; escaping the one that delimits the string is what such a string does.
                 builder.Append(Current);
                 Position++;
                 break;
@@ -191,85 +212,68 @@ internal sealed class Lexer(SourceText source)
                 ScanUnicodeEscape(builder, escapeStart);
                 break;
             default:
-                AddDiagnostic(escapeStart, Math.Min(2, _text.Length - escapeStart), JsonDiagnosticDescriptors.InvalidEscapeSequence);
+                AddDiagnostic(escapeStart, 2, JsonDiagnosticDescriptors.InvalidEscapeSequence);
                 builder.Append(Current);
                 Position++;
                 break;
         }
     }
 
+    /// <summary>Reads the four hex digits after <c>\u</c>, stopping at the first character that is not one.</summary>
+    /// <remarks>Stopping there matters: that character may be the closing quote, which must still end the string.</remarks>
     private void ScanUnicodeEscape(StringBuilder builder, int escapeStart)
     {
-        if (Position + 4 >= _text.Length)
-        {
-            AddDiagnostic(escapeStart, _text.Length - escapeStart, JsonDiagnosticDescriptors.InvalidUnicodeEscapeSequence);
-            Position++;
-            return;
-        }
+        Position++;
 
         var value = 0;
-        for (var index = 1; index <= 4; index++)
+        for (var digits = 0; digits < 4; digits++)
         {
-            var digit = GetHexValue(_text[Position + index]);
+            var digit = IsAtEnd ? -1 : GetHexValue(Current);
             if (digit < 0)
             {
-                AddDiagnostic(escapeStart, 6, JsonDiagnosticDescriptors.InvalidUnicodeEscapeSequence);
-                Position++;
+                AddDiagnostic(escapeStart, Position - escapeStart, JsonDiagnosticDescriptors.InvalidUnicodeEscapeSequence);
                 return;
             }
 
             value = (value * 16) + digit;
+            Position++;
         }
 
         builder.Append((char)value);
-        Position += 5;
     }
 
+    /// <summary>Reads a number, and anything glued to it.</summary>
+    /// <remarks>
+    /// Whatever runs on up to the next token boundary is part of the same mistake -- <c>0x1F</c>, <c>1.2.3</c>,
+    /// <c>-Infinity</c>, <c>+1</c> -- so it is kept in the one token and reported once, rather than split into a number
+    /// followed by a stray word that would also be reported as a missing comma.
+    /// </remarks>
     private SyntaxKind ScanNumber(out string text)
     {
         var start = Position;
-        var hasDigits = false;
-        if (Current == '-')
+        var malformed = false;
+        if (Current is '-' or '+')
         {
+            malformed = Current == '+';
             Position++;
         }
 
-        if (Current == '0')
+        var integerStart = Position;
+        SkipDigits();
+        if (Position == integerStart)
         {
-            hasDigits = true;
-            Position++;
-            if (Current is >= '0' and <= '9')
-            {
-                AddDiagnostic(start, Position - start + 1, JsonDiagnosticDescriptors.LeadingZero);
-                while (Current is >= '0' and <= '9')
-                {
-                    Position++;
-                }
-            }
+            malformed = true;
         }
-        else
+        else if (Position - integerStart > 1 && _text[integerStart] == '0')
         {
-            while (Current is >= '0' and <= '9')
-            {
-                hasDigits = true;
-                Position++;
-            }
-        }
-
-        if (!hasDigits)
-        {
-            AddDiagnostic(start, Position - start, JsonDiagnosticDescriptors.InvalidNumber);
+            AddDiagnostic(start, Position - start, JsonDiagnosticDescriptors.LeadingZero);
         }
 
         if (Current == '.')
         {
             Position++;
             var fractionStart = Position;
-            while (Current is >= '0' and <= '9')
-            {
-                Position++;
-            }
-
+            SkipDigits();
             if (Position == fractionStart)
             {
                 AddDiagnostic(fractionStart, 0, JsonDiagnosticDescriptors.ExpectedFractionDigit);
@@ -285,20 +289,39 @@ internal sealed class Lexer(SourceText source)
             }
 
             var exponentStart = Position;
-            while (Current is >= '0' and <= '9')
-            {
-                Position++;
-            }
-
+            SkipDigits();
             if (Position == exponentStart)
             {
                 AddDiagnostic(exponentStart, 0, JsonDiagnosticDescriptors.ExpectedExponentDigit);
             }
         }
 
+        if (!IsAtTokenEnd)
+        {
+            malformed = true;
+            while (!IsAtTokenEnd)
+            {
+                Position++;
+            }
+        }
+
+        if (malformed)
+        {
+            _tokenDiagnostics = null;
+            AddDiagnostic(start, Position - start, JsonDiagnosticDescriptors.InvalidNumber);
+        }
+
         text = _text[start..Position];
 
         return SyntaxKind.NumberToken;
+    }
+
+    private void SkipDigits()
+    {
+        while (IsDigit(Current))
+        {
+            Position++;
+        }
     }
 
     private GreenNode? LexTrivia(bool isTrailing)
@@ -307,14 +330,35 @@ internal sealed class Lexer(SourceText source)
         while (!IsAtEnd)
         {
             var start = Position;
-            if (Current is ' ' or '\t' or '\f' or '\v')
+            if (Current is ' ' or '\t')
             {
-                while (!IsAtEnd && Current is ' ' or '\t' or '\f' or '\v')
+                while (!IsAtEnd && Current is ' ' or '\t')
                 {
                     Position++;
                 }
 
                 Add(ref trivia, SyntaxKind.WhitespaceTrivia, start);
+                continue;
+            }
+
+            // RFC 8259 lets a parser ignore a byte order mark at the start of the text.
+            if (Position == 0 && Current == '\uFEFF')
+            {
+                Position++;
+                Add(ref trivia, SyntaxKind.WhitespaceTrivia, start);
+                continue;
+            }
+
+            // Anything else that looks like whitespace is kept as whitespace, so the tokens around it still read the
+            // way they were meant to, but JSON only has four whitespace characters.
+            if (IsNonJsonWhitespace(Current))
+            {
+                while (!IsAtEnd && IsNonJsonWhitespace(Current))
+                {
+                    Position++;
+                }
+
+                Add(ref trivia, SyntaxKind.WhitespaceTrivia, start, JsonDiagnosticDescriptors.InvalidWhitespace, ToCodePoint(_text[start]));
                 continue;
             }
 
@@ -367,12 +411,12 @@ internal sealed class Lexer(SourceText source)
         return trivia is null ? null : SyntaxFactory.List(trivia.ToArray());
     }
 
-    private void Add(ref List<GreenNode?>? trivia, SyntaxKind kind, int start, DiagnosticDescriptor? descriptor = null)
+    private void Add(ref List<GreenNode?>? trivia, SyntaxKind kind, int start, DiagnosticDescriptor? descriptor = null, params object?[]? arguments)
     {
         GreenNode item = SyntaxFactory.Trivia(kind, _text[start..Position]);
         if (descriptor is not null)
         {
-            item = item.WithAdditionalDiagnostics(new SyntaxDiagnosticInfo(0, Position - start, descriptor));
+            item = item.WithAdditionalDiagnostics(new SyntaxDiagnosticInfo(0, Position - start, descriptor, arguments));
         }
 
         (trivia ??= []).Add(item);
@@ -385,8 +429,20 @@ internal sealed class Lexer(SourceText source)
     private char Current => Position < _text.Length ? _text[Position] : '\0';
     private char LookAhead => Position + 1 < _text.Length ? _text[Position + 1] : '\0';
 
-    private static bool IsTokenBoundary(char value)
-        => value is '\0' or ' ' or '\t' or '\f' or '\v' or '\r' or '\n' or '{' or '}' or '[' or ']' or ':' or ',' or '"';
+    /// <summary>Gets whether the current character cannot continue a number or a bare word.</summary>
+    private bool IsAtTokenEnd => IsAtEnd || Current switch
+    {
+        ' ' or '\t' or '\r' or '\n' or '{' or '}' or '[' or ']' or ':' or ',' or '"' => true,
+        '/' => LookAhead is '/' or '*',
+        var value => IsNonJsonWhitespace(value),
+    };
+
+    private static bool IsDigit(char value) => value is >= '0' and <= '9';
+
+    private static bool IsNonJsonWhitespace(char value)
+        => value is not (' ' or '\t' or '\r' or '\n') && (char.IsWhiteSpace(value) || value == '\uFEFF');
+
+    private static string ToCodePoint(char value) => ((int)value).ToString("X4", CultureInfo.InvariantCulture);
 
     private static int GetHexValue(char value) => value switch
     {

--- a/src/Meziantou.Framework.Language.Json/readme.md
+++ b/src/Meziantou.Framework.Language.Json/readme.md
@@ -166,10 +166,35 @@ foreach (var diagnostic in JsonSyntaxTree.ParseText("{\"a\": }").GetDiagnostics(
 | `JSON0005` | An unexpected token or comma |
 | `JSON0006` | A missing `{`, `}`, `[`, `]`, or `:` |
 | `JSON0007` | A missing value |
-| `JSON0008` | A missing property name |
+| `JSON0008` | A missing or unquoted property name |
 | `JSON0009` | A missing comma |
 | `JSON0010` | Data after the root value |
-| `JSON0011` | A line break inside a string |
+| `JSON0011` | An unescaped control character inside a string |
+| `JSON0012` | Objects and arrays nested more than 256 deep |
+| `JSON0013` | Whitespace JSON does not allow, such as a form feed or a non-breaking space |
+| `JSON0014` | A string in single quotes |
+| `JSON0015` | A property name used twice in one object (a warning) |
+
+Everything is an error except `JSON0015`: RFC 8259 only says names *should* be unique.
+
+### What is accepted
+
+The grammar is [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259), with two extensions that are accepted without a
+diagnostic: `//` and `/* */` comments wherever whitespace may appear, and a trailing comma after the last member or
+element. A byte order mark at the very start of the text is ignored, as the RFC allows. Anything else the RFC does not
+allow is reported, including an empty document, a raw tab inside a string, and `NaN`.
+
+### Recovering from mistakes
+
+The common mistakes are reported once and parsed into the tree they were meant to be, so one error does not bury the
+rest of the document under others:
+
+- A string ends at the end of its line when its closing quote is missing, instead of running on to the next quote.
+- `{name: 1}` and `{'name': 'value'}` produce a member called `name`, with a diagnostic on the quotes.
+- `0x1F`, `1.2.3`, `-Infinity`, and `+1` are each a single malformed number rather than a number and a stray word.
+- A closing brace or bracket ends every construct it closes over: in `{"a": [1, 2}` the array is reported as missing
+  its `]`, and the object still ends at the `}`.
+- A stray `}` after the root value is reported on its own, and the root value is kept.
 
 ## Walking a tree
 

--- a/tests/Meziantou.Framework.Language.Json.Tests/JsonIncrementalParsingTests.cs
+++ b/tests/Meziantou.Framework.Language.Json.Tests/JsonIncrementalParsingTests.cs
@@ -38,6 +38,12 @@ public sealed class JsonIncrementalParsingTests
         "{\"a\": foo}",
         "{} xyz",
         "[1, :, 2]",
+        "{a: 1, 'b': 'c'}",
+        "{\"a\": [1, 2}",
+        "{\"a\":1,\"a\":2}",
+        "[0x1F, -Infinity, \"x\\u12\"]",
+        "{\"a\": \"x\n, \"b\": 2}",
+        "{\"a\":1}}",
     ];
 
     /// <summary>The fragments worth inserting: the ones that change how the text lexes.</summary>
@@ -46,6 +52,7 @@ public sealed class JsonIncrementalParsingTests
         "", " ", "\t", "\n", "\r\n", "\"", "\\", "\\\\", "\\n", "\\u0041",
         "/", "//", "/*", "*/", "{", "}", "[", "]", ",", ":",
         "0", "9", "-", ".", "e", "e+", "+", "true", "fals", "nul", "\"a\"", "\"\"", "x",
+        "'", "\f", "\u00A0", "\uFEFF", "\u0001", "a:", "\"a\":",
     ];
 
     [Theory]

--- a/tests/Meziantou.Framework.Language.Json.Tests/JsonSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Language.Json.Tests/JsonSyntaxTreeTests.cs
@@ -829,6 +829,270 @@ public sealed class JsonSyntaxTreeTests
         Assert.Equal(1, diagnostic.Location.GetLineSpan().Start.Line);
     }
 
+    public static TheoryData<string> ValidJsonSamples => new()
+    {
+        "{}",
+        "[]",
+        "0",
+        "-0",
+        "-0.0e-0",
+        "1E+2",
+        "1e-2",
+        "0e5",
+        "123456789012345678901234567890.123456789e+999",
+        "true",
+        "false",
+        "null",
+        "\"\"",
+        "\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"",
+        "\"\\u0000\\u001f\\uD834\\uDD1E\\uFFFF\"",
+        "\"é中😀\u007F\u0080\u2028\u2029\u00A0\"",
+        " \t\r\n[ 1 , \"a\" ]\r\n ",
+        "{\"\":\"\",\"a\":{\"b\":[[],{}]}}",
+        "\uFEFF{\"a\": 1}",
+        "[true/*comment*/, false//comment\n, null/**/]",
+        "{\"a\"/*c*/:/*c*/1/*c*/}",
+        "[1//comment\n]",
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidJsonSamples))]
+    public void ParseText_ValidJson_ReportsNothing(string text)
+    {
+        var tree = JsonSyntaxTree.ParseText(text);
+
+        Assert.Empty(tree.GetDiagnostics());
+        Assert.Single(tree.GetRoot().Values);
+        Assert.False(tree.GetRoot().ContainsSkippedText);
+        Assert.Equal(text, tree.GetRoot().ToFullString());
+    }
+
+    [Theory]
+    [InlineData("", "JSON0007@0:0")]
+    [InlineData("  ", "JSON0007@2:0")]
+    [InlineData("// only a comment", "JSON0007@17:0")]
+    [InlineData("/* unterminated", "JSON0001@0:15 JSON0007@15:0")]
+    [InlineData("\"a\tb\"", "JSON0011@2:1")]
+    [InlineData("\"a\u0001\u001Fb\"", "JSON0011@2:1 JSON0011@3:1")]
+    [InlineData("\"a\0\"", "JSON0011@2:1")]
+    [InlineData("\"abc\\", "JSON0002@0:5")]
+    [InlineData("\"\\x\"", "JSON0003@1:2")]
+    [InlineData("\"\\u12\"", "JSON0003@1:4")]
+    [InlineData("\"\\u12", "JSON0002@0:5 JSON0003@1:4")]
+    [InlineData("\"\\uZZZZ\"", "JSON0003@1:2")]
+    [InlineData("\"a\\\n", "JSON0002@0:3")]
+    [InlineData("[1\f]", "JSON0013@2:1")]
+    [InlineData("[1\v]", "JSON0013@2:1")]
+    [InlineData("[1,\u00A02]", "JSON0013@3:1")]
+    [InlineData(" \uFEFF1", "JSON0013@1:1")]
+    [InlineData("[+1]", "JSON0004@1:2")]
+    [InlineData("[.5]", "JSON0004@1:2")]
+    [InlineData("[0x1F]", "JSON0004@1:4")]
+    [InlineData("[1.2.3]", "JSON0004@1:5")]
+    [InlineData("[-Infinity]", "JSON0004@1:9")]
+    [InlineData("[01]", "JSON0004@1:2")]
+    [InlineData("[-012]", "JSON0004@1:4")]
+    [InlineData("[1.]", "JSON0004@3:0")]
+    [InlineData("[1e+]", "JSON0004@4:0")]
+    [InlineData("[-]", "JSON0004@1:1")]
+    [InlineData("[NaN]", "JSON0005@1:3")]
+    [InlineData("[True]", "JSON0005@1:4")]
+    [InlineData("{'a': 'b'}", "JSON0014@1:3 JSON0014@6:3")]
+    [InlineData("{a: 1}", "JSON0008@1:1")]
+    [InlineData("{\"a\" 1}", "JSON0006@5:1")]
+    [InlineData("{\"a\": 1}}", "JSON0005@8:1")]
+    [InlineData("{\"a\": 1},", "JSON0005@8:1")]
+    [InlineData("[1]]]", "JSON0005@3:1 JSON0005@4:1")]
+    [InlineData("\"a\" \"b\"", "JSON0010@4:3")]
+    [InlineData("{\"a\": [1, 2}", "JSON0006@11:1")]
+    [InlineData("[{\"a\": 1]", "JSON0006@8:1")]
+    [InlineData("{\"a\": \"x\n, \"b\": 2}", "JSON0002@6:2")]
+    [InlineData("[1 // comment\n 2]", "JSON0009@2:0")]
+    [InlineData("{\"a\": 1, \"a\": 2}", "JSON0015@9:3")]
+    [InlineData("{\"a\": 1, \"\\u0061\": 2}", "JSON0015@9:8")]
+    public void ParseText_InvalidJson_ReportsTheExpectedDiagnostics(string text, string expected)
+    {
+        var tree = ParseWithTimeout(text);
+
+        Assert.Equal(expected, string.Join(' ', tree.GetDiagnostics().Select(diagnostic => $"{diagnostic.Id}@{diagnostic.Location.SourceSpan.Start}:{diagnostic.Location.SourceSpan.Length}")));
+        Assert.Equal(text, tree.GetRoot().ToFullString());
+    }
+
+    [Fact]
+    public void ParseText_DuplicatePropertyName_IsAWarning()
+    {
+        var tree = JsonSyntaxTree.ParseText("""{"a": 1, "b": 2, "a": 3}""");
+
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Equal("The property name 'a' is already used in this object.", diagnostic.Message);
+    }
+
+    [Fact]
+    public void ParseText_UnterminatedString_StopsAtTheEndOfItsLine()
+    {
+        const string Text = "{\n  \"a\": \"unterminated,\n  \"b\": 2\n}";
+
+        var tree = JsonSyntaxTree.ParseText(Text);
+        var obj = Assert.IsType<JsonObjectSyntax>(tree.GetRoot().Value);
+
+        Assert.Equal(["JSON0002", "JSON0009"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        Assert.Equal("unterminated,", Assert.IsType<JsonStringSyntax>(obj.GetMember("a")!.Value).Value);
+        Assert.Equal("2", Assert.IsType<JsonNumberSyntax>(obj.GetMember("b")!.Value).Text);
+        Assert.False(obj.CloseBraceToken.IsMissing);
+    }
+
+    [Fact]
+    public void ParseText_UnquotedPropertyNames_AreReportedAndKeptAsNames()
+    {
+        const string Text = """{ name: "x", age: 3, true: false }""";
+
+        var tree = JsonSyntaxTree.ParseText(Text);
+        var obj = Assert.IsType<JsonObjectSyntax>(tree.GetRoot().Value);
+
+        Assert.Equal(["JSON0008", "JSON0008", "JSON0008"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        Assert.Equal(["name", "age", "true"], obj.Members.Select(member => member.Name));
+        Assert.Equal("x", Assert.IsType<JsonStringSyntax>(obj.GetMember("name")!.Value).Value);
+        Assert.Equal("3", Assert.IsType<JsonNumberSyntax>(obj.GetMember("age")!.Value).Text);
+        Assert.Equal(Text, tree.GetRoot().ToFullString());
+    }
+
+    [Fact]
+    public void ParseText_SingleQuotedStrings_AreReportedAndKeptAsStrings()
+    {
+        const string Text = """{'name': 'it\'s "quoted"'}""";
+
+        var tree = JsonSyntaxTree.ParseText(Text);
+        var member = Assert.Single(Assert.IsType<JsonObjectSyntax>(tree.GetRoot().Value).Members);
+
+        Assert.Equal(["JSON0014", "JSON0014"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        Assert.Equal("name", member.Name);
+        Assert.Equal("it's \"quoted\"", Assert.IsType<JsonStringSyntax>(member.Value).Value);
+    }
+
+    [Fact]
+    public void ParseText_AMissingCloseBracket_LeavesTheEnclosingBraceToTheObject()
+    {
+        const string Text = """{"a": [1, 2}""";
+
+        var tree = JsonSyntaxTree.ParseText(Text);
+        var obj = Assert.IsType<JsonObjectSyntax>(Assert.Single(tree.GetRoot().Values));
+        var array = Assert.IsType<JsonArraySyntax>(obj.GetMember("a")!.Value);
+
+        Assert.False(obj.CloseBraceToken.IsMissing);
+        Assert.True(array.CloseBracketToken.IsMissing);
+        Assert.Equal(2, array.Elements.Count);
+        Assert.False(tree.GetRoot().ContainsSkippedText);
+    }
+
+    [Fact]
+    public void ParseText_AStrayCloserAfterTheRoot_KeepsTheRootAndIsReportedOnce()
+    {
+        var tree = JsonSyntaxTree.ParseText("""{"a": 1}}""");
+
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal("JSON0005", diagnostic.Id);
+        Assert.Equal("1", Assert.IsType<JsonNumberSyntax>(Assert.IsType<JsonObjectSyntax>(tree.GetRoot().Value).GetMember("a")!.Value).Text);
+    }
+
+    [Fact]
+    public void ParseText_TruncatedDocument_ReportsEachMissingPieceOnceAtTheEnd()
+    {
+        const string Text = """{"a": [1, {"b": """;
+
+        var tree = JsonSyntaxTree.ParseText(Text);
+
+        Assert.Equal(["Expected ']'.", "Expected '}'.", "Expected '}'.", "Expected a JSON value."], tree.GetDiagnostics().Select(diagnostic => diagnostic.Message).Order(StringComparer.Ordinal));
+        Assert.All(tree.GetDiagnostics(), diagnostic => Assert.Equal(new TextSpan(Text.Length, 0), diagnostic.Location.SourceSpan));
+    }
+
+    [Fact]
+    public void ParseText_AMissingValueOrColon_DoesNotLoseTheFollowingMembers()
+    {
+        const string Text = """{"a": , "b" 2, "c": 3}""";
+
+        var tree = JsonSyntaxTree.ParseText(Text);
+        var obj = Assert.IsType<JsonObjectSyntax>(tree.GetRoot().Value);
+
+        Assert.Equal(["JSON0007", "JSON0006"], tree.GetDiagnostics().Select(diagnostic => diagnostic.Id));
+        Assert.Equal(["a", "b", "c"], obj.Members.Select(member => member.Name));
+        Assert.Equal("2", Assert.IsType<JsonNumberSyntax>(obj.GetMember("b")!.Value).Text);
+        Assert.Equal("3", Assert.IsType<JsonNumberSyntax>(obj.GetMember("c")!.Value).Text);
+    }
+
+    public static TheoryData<string> DifferentialSeeds => new()
+    {
+        """{"a":[1,-2.5e+3,true,false,null],"b":{"c":"d\n\u0041"}}""",
+        """["x", {"y": [0, 1e5]}, [], "\/"]""",
+        "{\n  // comment\n  \"a\": 1, /* block */\n  \"b\": [1,2,],\n}",
+    };
+
+    /// <summary>
+    /// System.Text.Json, set to accept comments and trailing commas, is a strict implementation of the same grammar, so
+    /// every document it rejects has to produce an error and every document it accepts has to produce none.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DifferentialSeeds))]
+    public void ParseText_ReportsAnErrorExactlyWhenSystemTextJsonRejectsTheText(string seed)
+    {
+        string[] fragments =
+        [
+            "\"", "'", "\\", "/", "*", ",", ":", "{", "}", "[", "]", "0", "-", "+", ".", "e", "x", " ", "\t", "\n", "\r",
+            "\f", "\v", "\u0001", "\u00A0", "\\u", "\\uZ", "//", "/*", "*/", "true", "nul",
+        ];
+
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index <= seed.Length; index++)
+        {
+            candidates.Add(seed[..index]);
+            if (index < seed.Length)
+            {
+                candidates.Add(seed.Remove(index, 1));
+            }
+
+            foreach (var fragment in fragments)
+            {
+                candidates.Add(seed.Insert(index, fragment));
+                if (index < seed.Length)
+                {
+                    candidates.Add(seed.Remove(index, 1).Insert(index, fragment));
+                }
+            }
+        }
+
+        var mismatches = new List<string>();
+        foreach (var candidate in candidates)
+        {
+            var expectedValid = IsAcceptedBySystemTextJson(candidate);
+            var actualValid = !JsonSyntaxTree.ParseText(candidate).GetDiagnostics().Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            if (expectedValid != actualValid)
+            {
+                mismatches.Add($"{(expectedValid ? "valid" : "invalid")}: {System.Text.Json.JsonSerializer.Serialize(candidate)}");
+            }
+        }
+
+        Assert.Empty(mismatches, string.Join('\n', mismatches.Take(30)));
+
+        static bool IsAcceptedBySystemTextJson(string text)
+        {
+            try
+            {
+                using var document = System.Text.Json.JsonDocument.Parse(text, new System.Text.Json.JsonDocumentOptions
+                {
+                    AllowTrailingCommas = true,
+                    CommentHandling = System.Text.Json.JsonCommentHandling.Skip,
+                    MaxDepth = 256,
+                });
+
+                return true;
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return false;
+            }
+        }
+    }
+
     /// <summary>
     /// A member always has a value, so taking it out would leave a member whose own type says the value is there and
     /// whose property returns nothing. The edit is refused instead.


### PR DESCRIPTION
Meziantou.Framework.Language.Json accepted several things RFC 8259 forbids. A few common mistakes also buried the rest of the document under misleading errors. This fixes both. Comments and trailing commas are still accepted, as the readme documents.

## Spec violations

| Input | Before | After |
|---|---|---|
| Empty or comment-only document | no diagnostic | `JSON0007` |
| Raw tab, NUL or other control character inside a string | no diagnostic | `JSON0011` |
| `\f`, `\v`, non-breaking space used as whitespace | accepted, or a confusing "unexpected token" | `JSON0013`, still read as whitespace |
| `true/*c*/`, `null//c` | comment swallowed into a bad token | valid |
| Leading byte order mark | error | ignored (RFC 8259 §8.1) |
| `"\u12"` | diagnostic span ran to the end of the document | spans `\u12` |
| `"abc\` at the end of the text | unterminated string reported twice | reported once |

## Error recovery

- **Unterminated string:** now ends at the end of its line instead of running to the next `"` somewhere below.
- **`{name: 1}` and `{'a': 'b'}`:** one diagnostic each (`JSON0008`, `JSON0014`), and the member keeps its name and value.
- **`0x1F`, `1.2.3`, `-Infinity`, `+1`, `.5`:** one malformed-number diagnostic, not a number plus a stray word plus "missing comma".
- **Mismatched closers:** a closer now ends every construct it closes over. In `{"a": [1, 2}`, only the missing `]` is reported and the object still ends at the `}`.
- **Stray tokens after the root value** (`{"a":1}}`): reported once, and the root value is kept.
- **Duplicate property names:** new `JSON0015` **warning**. RFC 8259 only says names *should* be unique.

## Behavior changes reviewers should weigh

- An empty document now produces an error.
- A duplicate property name now produces a warning, so code that checks `GetDiagnostics().Count == 0` will start rejecting those documents.
- `JSON0011` used to mean "line break in a string". It now means "unescaped control character". A line break ends the string and is reported as unterminated (`JSON0002`).

There are no public API changes.

## Tests

- **Valid inputs:** RFC edge cases must produce no diagnostics.
- **Invalid inputs:** 44 cases, each asserting the exact diagnostic IDs and spans.
- **Recovery:** checks the shape of the recovered tree for each mistake above, plus a truncated document.
- **Differential test against System.Text.Json:** with comments and trailing commas allowed, this parser must report an error exactly when `JsonDocument.Parse` rejects the text. It runs over thousands of single-edit variants of three sample documents.
  - A larger local run of 300,000 random documents (not committed) found only two differences, both where System.Text.Json is stricter. It rejects a comment between a property name and its colon, and it rejects U+2028 inside a `//` comment.
- **Incremental re-parsing:** the existing test that compares a re-parse against a full parse now also covers the new error cases and lexing fragments.

Locally, with warnings as errors: Language.Json.Tests 352/352 (net10.0 + net11.0), Language.Tool.Tests 100/100, DependencyScanning.Tests 236/236. The Release + `IsOfficialBuild` build is clean, and `eng/update-all.cs` produced no changes.

## Not covered

- Unpaired surrogate characters in the raw text are still not reported.
- There is no strict mode that rejects comments and trailing commas. That would need a new parse option.
