### PR TITLE
Do not validate the public API in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,9 +55,7 @@ jobs:
 
       - run: dotnet restore ${{ steps.package-project.outputs.project }} -p:Configuration=Release /p:IsOfficialBuild=true /bl:restore.binlog
         if: steps.package-project.outputs.has-project == 'true'
-      - run: dotnet build src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj --configuration Release /p:IsOfficialBuild=true /bl:build.publicapi.binlog
-        if: steps.package-project.outputs.has-project == 'true'
-      - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release --no-restore /p:IsOfficialBuild=true /p:PublicApiGeneratorVerifyNoChangeOnBuild=true /bl:build.binlog
+      - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release --no-restore /p:IsOfficialBuild=true /bl:build.binlog
         if: steps.package-project.outputs.has-project == 'true'
 
       - name: Prepare NuGet artifact directory


### PR DESCRIPTION
## Summary

The `create_nuget` job of the publish workflow no longer verifies the public API (`ref/`) when it builds the packages.

## What changed

- Removed `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true` from the package build step.
- Removed the step that built `Meziantou.Framework.PublicApiGenerator.Tool`. It was only needed for that verification: on GitHub Actions, `src/Directory.Build.props` disables both public API generation and verification by default, so the build never runs the tool now.

## Note

This workflow was the only place in CI that verified `ref/`. `ci.yml` still builds the generator tool, but never enables generation or verification, so that step and its comment are stale.

## Validation

- `dotnet run ./eng/update-all.cs` produced no additional changes.
- Workflow-only change; it is exercised by this PR's publish run.
