### PR TITLE
Report MFAS0048 when a discarded assertion is followed by ConfigureAwait

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzer.cs
@@ -36,9 +36,9 @@ public sealed class AwaitAssertionAnalyzer : DiagnosticAnalyzer
     private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, AwaitAssertionAnalyzerCommon.Symbols symbols)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-        if (!AwaitAssertionAnalyzerCommon.IsDiscardedTaskAssertion(invocationOperation, assertType, symbols))
+        if (!AwaitAssertionAnalyzerCommon.IsDiscardedTaskAssertion(invocationOperation, assertType, symbols, out var discardedOperation))
             return;
 
-        context.ReportDiagnostic(AwaitAssertionDescriptor, invocationOperation);
+        context.ReportDiagnostic(AwaitAssertionDescriptor, discardedOperation);
     }
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
@@ -26,10 +26,16 @@ internal static class AwaitAssertionAnalyzerCommon
     }
 
     /// <summary>
-    /// Matches an assertion whose returned task is discarded, such as <c>Assert.ThrowsAsync&lt;T&gt;(...);</c>.
+    /// Matches an assertion whose returned task is discarded, such as <c>Assert.ThrowsAsync&lt;T&gt;(...);</c> or
+    /// <c>Assert.ThrowsAsync&lt;T&gt;(...).ConfigureAwait(false);</c>.
     /// </summary>
-    internal static bool IsDiscardedTaskAssertion(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols)
+    /// <param name="discardedOperation">
+    /// The expression whose value is discarded: the assertion itself, or the outermost <c>ConfigureAwait</c> call
+    /// applied to it. Awaiting this expression fixes the issue.
+    /// </param>
+    internal static bool IsDiscardedTaskAssertion(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols, [NotNullWhen(true)] out IOperation? discardedOperation)
     {
+        discardedOperation = null;
         if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
             !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
         {
@@ -42,9 +48,26 @@ internal static class AwaitAssertionAnalyzerCommon
         if (!IsTaskLike(targetMethod.OriginalDefinition.ReturnType, symbols))
             return false;
 
+        // ConfigureAwait only wraps the task in an awaitable, so discarding its result still discards the task
+        IOperation operation = invocationOperation;
+        while (operation.Parent is IInvocationOperation parentInvocation &&
+               parentInvocation.Instance == operation &&
+               IsTaskConfigureAwait(parentInvocation.TargetMethod, symbols))
+        {
+            operation = parentInvocation;
+        }
+
         // Anything else (await, return, assignment, argument) consumes the task
-        return invocationOperation.Parent is IExpressionStatementOperation;
+        if (operation.Parent is not IExpressionStatementOperation)
+            return false;
+
+        discardedOperation = operation;
+        return true;
     }
+
+    private static bool IsTaskConfigureAwait(IMethodSymbol method, Symbols symbols)
+        => method is { IsStatic: false, Name: "ConfigureAwait" } &&
+           IsTaskLike(method.ContainingType, symbols);
 
     private static bool IsTaskLike(ITypeSymbol? type, Symbols symbols)
     {

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
@@ -84,6 +84,84 @@ public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForDiscardedConfigureAwait()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(Func<Task> action)
+                {
+                    {|MFAS0048:Assert.ThrowsAsync<InvalidOperationException>(action).ConfigureAwait(false)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(Func<Task> action)
+                {
+                    await Assert.ThrowsAsync<InvalidOperationException>(action).ConfigureAwait(false);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForDiscardedConfigureAwaitWithOptions()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(IAsyncEnumerable<int> actual)
+                {
+                    {|MFAS0048:Assert.Empty(actual).ConfigureAwait(ConfigureAwaitOptions.None)|};
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(IAsyncEnumerable<int> actual)
+                {
+                    await Assert.Empty(actual).ConfigureAwait(ConfigureAwaitOptions.None);
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForExpressionBodiedMethod()
     {
         var source = """
@@ -279,6 +357,15 @@ public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
                 public static Task Returned(IAsyncEnumerable<int> actual)
                 {
                     return Assert.Empty(actual);
+                }
+
+                public static async Task ConfigureAwaitConsumed(IAsyncEnumerable<int> actual, Func<Task> action)
+                {
+                    await Assert.Empty(actual).ConfigureAwait(false);
+                    await Assert.ThrowsAsync<InvalidOperationException>(action).ConfigureAwait(ConfigureAwaitOptions.None);
+                    _ = Assert.Empty(actual).ConfigureAwait(false);
+                    var awaitable = Assert.Empty(actual).ConfigureAwait(false);
+                    await awaitable;
                 }
 
                 public static void Synchronous(List<int> actual, int value)


### PR DESCRIPTION
## What

MFAS0048 (`AwaitAssertion`) now reports discarded async assertions that are followed by `.ConfigureAwait(...)`:

```csharp
public static void M(Func<Task> action)
{
    Assert.ThrowsAsync<InvalidOperationException>(action).ConfigureAwait(false); // now MFAS0048
}
```

## Why

The analyzer treated every parent other than an expression statement as consuming the task, and a `ConfigureAwait` call is a receiver position. The `ConfiguredTaskAwaitable` was thrown away anyway, so a failing assertion became an unobserved task exception and the test passed. This was a false negative on an error-level rule.

## How

- `AwaitAssertionAnalyzerCommon.IsDiscardedTaskAssertion` steps outward through `ConfigureAwait` calls on `Task`, `Task<T>`, `ValueTask` and `ValueTask<T>` (both the `bool` and `ConfigureAwaitOptions` overloads) before checking for an expression statement.
- The diagnostic now covers the whole discarded expression, not just the assertion. The existing await code fix wraps the diagnostic's expression, so it produces `await Assert.ThrowsAsync<…>(action).ConfigureAwait(false);` without any change. For a plain `Assert.X(...);` the span is unchanged.

## Notes for reviewers

- No assertion in the library returns a `ValueTask`, so that branch shares the `Task` type check but has no dedicated test.

## Tests

- New code fix tests: `ConfigureAwait(false)` in a `void` method (turned into `async Task`), and `ConfigureAwait(ConfigureAwaitOptions.None)` in an async method.
- New negative cases: the `ConfigureAwait` result awaited, discarded with `_ =`, or stored and awaited later.
- `Meziantou.Framework.Assertions.Analyzer.Tests`: 214 passed. A Release + `IsOfficialBuild` build is clean, and `eng/update-all.cs` produced no changes.
