### PR TITLE
Make the MFFP0015 message say whether the comparison is ordinal or culture-sensitive

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/CompareFullPathAsStringAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/CompareFullPathAsStringAnalyzer.cs
@@ -13,7 +13,12 @@ namespace Meziantou.Framework.Analyzers.FullPath;
 /// <para>
 /// <c>fullPath == "value"</c> binds to <c>string.operator ==</c>, because there is no implicit conversion from
 /// <see cref="string"/> to <c>FullPath</c> that would make <c>FullPath.operator ==</c> applicable. The comparison is
-/// therefore ordinal, whereas <c>FullPathComparer.Default</c> is case-insensitive on Windows.
+/// therefore ordinal, whereas <c>FullPathComparer.Default</c> is case-insensitive on Windows. <c>string.Equals</c> is
+/// ordinal as well.
+/// </para>
+/// <para>
+/// <c>string.Compare(string, string)</c> and <c>string.CompareTo(string)</c> use the current culture, so the ordering
+/// of paths depends on the culture of the machine. The message states which kind of comparison is performed.
 /// </para>
 /// <para>
 /// An explicit <see cref="StringComparison"/> is left alone: the developer asked for a string comparison.
@@ -25,10 +30,13 @@ public sealed class CompareFullPathAsStringAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.CompareFullPathAsStringDiagnosticId,
         title: "Compare FullPath values instead of their string representation",
-        messageFormat: "This compares the string representation of a FullPath, which is ordinal, instead of using FullPathComparer",
+        messageFormat: "This compares the string representation of a FullPath, which is {0}, instead of using FullPathComparer",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    private const string OrdinalComparison = "ordinal";
+    private const string CultureSensitiveComparison = "culture-sensitive";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
 
@@ -60,7 +68,7 @@ public sealed class CompareFullPathAsStringAnalyzer : DiagnosticAnalyzer
         if (!analyzerContext.IsFullPathType(binaryOperation.LeftOperand) && !analyzerContext.IsFullPathType(binaryOperation.RightOperand))
             return;
 
-        context.ReportDiagnostic(Descriptor, binaryOperation);
+        context.ReportDiagnostic(Descriptor, binaryOperation, OrdinalComparison);
     }
 
     private static void AnalyzeInvocation(OperationAnalysisContext context, FullPathContext analyzerContext)
@@ -92,7 +100,9 @@ public sealed class CompareFullPathAsStringAnalyzer : DiagnosticAnalyzer
         if (!comparesFullPath)
             return;
 
-        context.ReportDiagnostic(Descriptor, invocationOperation);
+        // string.Equals is ordinal, whereas string.Compare(string, string) and string.CompareTo(string) use the current culture
+        var comparisonKind = targetMethod.Name is "Equals" ? OrdinalComparison : CultureSensitiveComparison;
+        context.ReportDiagnostic(Descriptor, invocationOperation, comparisonKind);
     }
 
     private static bool IsString(IOperation operation)

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/CompareFullPathAsStringRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/CompareFullPathAsStringRuleTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.Testing;
 using CompareFullPathAsStringAnalyzerType = Meziantou.Framework.Analyzers.FullPath.CompareFullPathAsStringAnalyzer;
 
 namespace Meziantou.Framework.Tests;
@@ -50,6 +51,39 @@ public sealed class CompareFullPathAsStringRuleTests : FullPathAnalyzerTestBase
             """;
 
         await CreateAnalyzerTest<CompareFullPathAsStringAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("fullPath == text", "ordinal")]
+    [InlineData("fullPath != text", "ordinal")]
+    [InlineData("string.Equals(fullPath, text)", "ordinal")]
+    [InlineData("fullPath.Value.Equals(text)", "ordinal")]
+    [InlineData("string.Compare(fullPath, text)", "culture-sensitive")]
+    [InlineData("fullPath.Value.CompareTo(text)", "culture-sensitive")]
+    public async Task Analyzer_MessageIndicatesTheKindOfComparison(string expression, string expectedComparisonKind)
+    {
+        var source = $$"""
+            using System;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static object M(FullPath fullPath, string text)
+                    {
+                        return {|#0:{{expression}}|};
+                    }
+                }
+            }
+            """;
+
+        var test = CreateAnalyzerTest<CompareFullPathAsStringAnalyzerType>(source);
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(CompareFullPathAsStringAnalyzerType.Descriptor)
+            .WithLocation(0)
+            .WithMessage($"This compares the string representation of a FullPath, which is {expectedComparisonKind}, instead of using FullPathComparer"));
+
+        await test.RunAsync(XunitCancellationToken);
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

`CompareFullPathAsStringAnalyzer` (MFFP0015) now passes the kind of comparison as a message argument:

> This compares the string representation of a FullPath, which is **{0}**, instead of using FullPathComparer

| Flagged code | `{0}` |
| --- | --- |
| `==`, `!=`, `string.Equals` | `ordinal` |
| `string.Compare(string, string)`, `string.CompareTo(string)` | `culture-sensitive` |

The type's remarks now also explain that `Compare`/`CompareTo` use the current culture.

## Why

The message always said the comparison "is ordinal", but `string.Compare(string, string)` and `string.CompareTo(string)` use the current culture. For those calls, the ordering of paths depends on the machine's culture, which is a bigger risk than the message suggested.

## Notes for reviewers

- The wording for the ordinal cases is unchanged. Only the comparison kind is now a parameter.
- The analyzer only matches `Compare`/`CompareTo` overloads whose arguments are all strings, so no other overload needs its own wording.
- The existing tests use `{|MFFP0015:...|}` markup, which checks where the diagnostic is reported but not its message. The new `Analyzer_MessageIndicatesTheKindOfComparison` theory checks the full message text for six expressions.

## Validation

- All 128 tests in `Meziantou.Framework.FullPath.Analyzer.Tests` pass with `TreatWarningsAsErrors=true`.
- The analyzer project builds in Release with `IsOfficialBuild=true`, with no warnings.
- `dotnet run ./eng/update-all.cs` produced no changes.
