### PR TITLE
Make MFFP0009 recommend FullPath.WithExtension instead of the hidden ChangeExtension

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/PathChangeExtensionWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathChangeExtensionWithFullPathAnalyzer.cs
@@ -11,8 +11,8 @@ public sealed class PathChangeExtensionWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathChangeExtensionWithFullPathDiagnosticId,
-        title: "Use FullPath.ChangeExtension instead of Path.ChangeExtension",
-        messageFormat: "Use FullPath.ChangeExtension instead of calling Path.ChangeExtension",
+        title: "Use FullPath.WithExtension instead of Path.ChangeExtension",
+        messageFormat: "Use FullPath.WithExtension instead of calling Path.ChangeExtension",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true);

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
@@ -46,7 +46,7 @@ public sealed class PathChangeExtensionWithFullPathCodeFixProvider : CodeFixProv
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: "Use FullPath.ChangeExtension",
+                    title: "Use FullPath.WithExtension",
                     createChangedDocument: cancellationToken => ApplyFixAsync(context.Document, expression, pathType, fullPathType, cancellationToken),
                     equivalenceKey: GetType().FullName),
                 diagnostic);
@@ -93,7 +93,7 @@ public sealed class PathChangeExtensionWithFullPathCodeFixProvider : CodeFixProv
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         fullPathExpression.WithoutTrivia().Parenthesize(),
-                        SyntaxFactory.IdentifierName("ChangeExtension")),
+                        SyntaxFactory.IdentifierName("WithExtension")),
                     SyntaxFactory.ArgumentList(
                     [
                         SyntaxFactory.Argument(extensionExpression.WithoutTrivia()),

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -60,7 +60,7 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0006` | FullPath | Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension | Info | ✔️ |
 | `MFFP0007` | FullPath | Use FullPath.Extension instead of Path.GetExtension | Info | ✔️ |
 | `MFFP0008` | FullPath | Use FullPath.Parent instead of Path.GetDirectoryName | Info | ✔️ |
-| `MFFP0009` | FullPath | Use FullPath.ChangeExtension instead of Path.ChangeExtension | Info | ✔️ |
+| `MFFP0009` | FullPath | Use FullPath.WithExtension instead of Path.ChangeExtension | Info | ✔️ |
 | `MFFP0010` | FullPath | Use FullPath.MakePathRelativeTo instead of Path.GetRelativePath | Info | ✔️ |
 | `MFFP0011` | FullPath | Return FullPath instead of string | Info | ✔️ |
 | `MFFP0012` | FullPath | Declare the property as FullPath instead of string | Info | ✔️ |

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathChangeExtensionWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathChangeExtensionWithFullPathRuleTests.cs
@@ -34,7 +34,7 @@ public sealed class PathChangeExtensionWithFullPathRuleTests : FullPathAnalyzerT
                 {
                     public static string M(FullPath fullPath, string extension)
                     {
-                        return fullPath.ChangeExtension(extension);
+                        return fullPath.WithExtension(extension);
                     }
                 }
             }


### PR DESCRIPTION
## What

MFFP0009 (`PathChangeExtensionWithFullPathAnalyzer`) and its code fix now recommend `FullPath.WithExtension` instead of `FullPath.ChangeExtension`:

- The diagnostic title and message say "Use FullPath.WithExtension…".
- The code fix is titled "Use FullPath.WithExtension" and writes `fullPath.WithExtension(extension)`.
- The rule table in the FullPath readme was regenerated by `eng/update-all.cs`.
- The expected output in `PathChangeExtensionWithFullPathRuleTests` is updated.

The diagnostic ID is unchanged.

## Why

`FullPath.ChangeExtension` is kept only for backward compatibility. It is marked `[EditorBrowsable(EditorBrowsableState.Never)]` to push users toward `WithExtension`. The analyzer was suggesting and inserting that hidden member, which works against that goal.

## Notes for reviewers

- No other FullPath code fix writes a hidden member. The only other hidden member is `GetTempFileName`, and no rule suggests it.
- `Meziantou.Framework.FullPath.Analyzer.Tests`: 122 passed, 0 failed, run with `/p:TreatWarningsAsErrors=true`.
