### PR TITLE
Report MFFP0004 for Path.Combine with five or more segments

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
@@ -65,6 +65,43 @@ internal static class FullPathAnalyzerCommon
         }
     }
 
+    /// <summary>
+    /// Returns the values passed to an invocation in source order, expanding the implicit array or collection that the
+    /// compiler creates for the expanded form of a <see langword="params"/> parameter.
+    /// </summary>
+    /// <remarks>
+    /// <c>Path.Combine(a, "b", "c", "d", "e")</c> binds to <c>Path.Combine(params ReadOnlySpan&lt;string&gt;)</c> and has a
+    /// single argument; this method returns its five elements instead.
+    /// </remarks>
+    internal static IEnumerable<IOperation> GetArgumentValues(IInvocationOperation invocationOperation)
+    {
+        foreach (var argument in invocationOperation.Arguments)
+        {
+            switch (argument)
+            {
+                case { ArgumentKind: ArgumentKind.ParamArray, Value: IArrayCreationOperation { Initializer: { } initializer } }:
+                    foreach (var elementValue in initializer.ElementValues)
+                    {
+                        yield return elementValue;
+                    }
+
+                    break;
+
+                case { ArgumentKind: ArgumentKind.ParamCollection, Value: ICollectionExpressionOperation collectionExpressionOperation }:
+                    foreach (var element in collectionExpressionOperation.Elements)
+                    {
+                        yield return element;
+                    }
+
+                    break;
+
+                default:
+                    yield return argument.Value;
+                    break;
+            }
+        }
+    }
+
     private static bool IsFullPathType(ITypeSymbol? typeSymbol, ITypeSymbol? fullPathType)
     {
         return SymbolEqualityComparer.Default.Equals(typeSymbol, fullPathType);

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
@@ -44,9 +44,9 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
         if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))
             return;
 
-        foreach (var argument in invocationOperation.Arguments)
+        foreach (var argumentValue in FullPathAnalyzerCommon.GetArgumentValues(invocationOperation))
         {
-            if (!analyzerContext.IsFullPathType(argument.Value))
+            if (!analyzerContext.IsFullPathType(argumentValue))
                 continue;
 
             context.ReportDiagnostic(Descriptor, invocationOperation, targetMethod.Name);

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
@@ -81,17 +81,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
     {
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is not IInvocationOperation invocationOperation ||
             invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod ||
-            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) ||
-            invocationOperation.Arguments.Length == 0)
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType))
         {
             replacementExpression = null!;
             return false;
         }
 
+        var argumentValues = FullPathAnalyzerCommon.GetArgumentValues(invocationOperation).ToArray();
         var fullPathIndex = -1;
-        for (var i = 0; i < invocationOperation.Arguments.Length; i++)
+        for (var i = 0; i < argumentValues.Length; i++)
         {
-            var argument = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[i].Value, fullPathType);
+            var argument = FullPathAnalyzerCommon.UnwrapToFullPath(argumentValues[i], fullPathType);
             if (SymbolEqualityComparer.Default.Equals(argument.Type, fullPathType))
             {
                 fullPathIndex = i;
@@ -108,14 +108,14 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         // everything before a rooted segment. Dropping them is only safe when evaluating them does nothing.
         for (var i = 0; i < fullPathIndex; i++)
         {
-            if (!IsSideEffectFree(invocationOperation.Arguments[i].Value))
+            if (!IsSideEffectFree(argumentValues[i]))
             {
                 replacementExpression = null!;
                 return false;
             }
         }
 
-        var startOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[fullPathIndex].Value, fullPathType);
+        var startOperation = FullPathAnalyzerCommon.UnwrapToFullPath(argumentValues[fullPathIndex], fullPathType);
         if (startOperation.Syntax is not ExpressionSyntax expression)
         {
             replacementExpression = null!;
@@ -123,9 +123,9 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         }
 
         replacementExpression = expression.WithoutTrivia().Parenthesize();
-        for (var i = fullPathIndex + 1; i < invocationOperation.Arguments.Length; i++)
+        for (var i = fullPathIndex + 1; i < argumentValues.Length; i++)
         {
-            var nextOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[i].Value, fullPathType);
+            var nextOperation = FullPathAnalyzerCommon.UnwrapToFullPath(argumentValues[i], fullPathType);
             if (nextOperation.Syntax is not ExpressionSyntax nextExpression)
             {
                 replacementExpression = null!;

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.Testing;
 using PathCombineWithFullPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.PathCombineWithFullPathAnalyzer;
 using PathCombineWithFullPathCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.PathCombineWithFullPathCodeFixProvider;
 
@@ -79,6 +80,147 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
             """;
 
         await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathCombineWithFullPathFirstAndParamsSegments()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine(fullPath, "value1", "value2", "value3", "value4")|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return fullPath / "value1" / "value2" / "value3" / "value4";
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathCombineWithFullPathInParamsSegments()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine("value1", "value2", "value3", fullPath.Value, "value4")|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return fullPath / "value4";
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathCombineWithFullPathInParamsArray()
+    {
+        // Before .NET 9, Path.Combine has no ReadOnlySpan overload, so five segments bind to 'params string[]'
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine(fullPath, "value1", "value2", "value3", "value4")|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return fullPath / "value1" / "value2" / "value3" / "value4";
+                    }
+                }
+            }
+            """;
+
+        var test = CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource);
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+
+        // The FullPath assembly targets a newer System.Runtime (CS1705), which does not affect overload resolution
+        test.CompilerDiagnostics = CompilerDiagnostics.None;
+        await test.RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathCombineWithStringParamsSegments()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return Path.Combine("value1", "value2", "value3", "value4", "value5");
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PathCombineWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

MFFP0004 (`PathCombineWithFullPathAnalyzer`) never fired for `Path.Combine` calls with five or more segments:

```csharp
string Use(FullPath a) => Path.Combine(a, "b", "c", "d", "e");   // no MFFP0004
string Use(FullPath a) => Path.Combine(a, "b", "c", "d");        // MFFP0004
```

With five or more segments, the call binds to the `params` overload: `params ReadOnlySpan<string>` on .NET 9+, `params string[]` before that. The invocation then has a single argument, created by the compiler, and that argument is never a `FullPath`. The code fix read the arguments the same way and had the same gap.

## Change

- Add `FullPathAnalyzerCommon.GetArgumentValues`. It returns the invocation's values in source order and expands `ArgumentKind.ParamArray` (the initializer of the implicit `IArrayCreationOperation`) and `ArgumentKind.ParamCollection` (the elements of the implicit `ICollectionExpressionOperation`). An array or collection passed explicitly is left as it is.
- Use it in both the analyzer and `PathCombineWithFullPathCodeFixProvider`, so the expanded form is also rewritten to `/` operations. The existing rule still applies: segments before the `FullPath` are dropped only when evaluating them has no side effects.

## Tests

- Five segments with the `FullPath` first, fixed to `fullPath / "value1" / "value2" / "value3" / "value4"`.
- Five segments with `fullPath.Value` in fourth position, fixed to `fullPath / "value4"`.
- Five plain strings, with no diagnostic expected.
- The `params string[]` form, compiled against the .NET 8.0 reference assemblies so that overload is chosen.

## Notes for reviewers

- The .NET 8.0 test sets `CompilerDiagnostics = CompilerDiagnostics.None`. The FullPath test reference is built for .NET 11, which makes that compilation report CS1705. CS1705 is an error and can't be suppressed. It doesn't change which overload is chosen.
- To check that the tests exercise both paths, I disabled each expansion case in turn. Each time, exactly the tests for that form failed.
- All 126 tests in `Meziantou.Framework.FullPath.Analyzer.Tests` pass. The analyzer, code fix and test projects build in Release with `IsOfficialBuild=true` and warnings as errors, with 0 warnings. `eng/update-all.cs` changed no files.
