### PR TITLE
Treat ??=, deconstruction, and ref aliases as writes in MFFP0013

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/VariableShouldBeFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/VariableShouldBeFullPathAnalyzer.cs
@@ -60,6 +60,11 @@ public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
                 AnalyzeDeclarator(variableDeclaratorOperation, analyzerContext, candidates);
                 break;
 
+            // 'alias = ref local' lets the alias write to the local
+            case ISimpleAssignmentOperation { IsRef: true } refAssignmentOperation:
+                DisqualifyReferencedLocals(candidates, refAssignmentOperation.Value);
+                break;
+
             case ISimpleAssignmentOperation { Target: ILocalReferenceOperation localReferenceOperation } assignmentOperation:
                 if (candidates.TryGetValue(localReferenceOperation.Local, out var assignedState))
                 {
@@ -72,6 +77,14 @@ public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
             // Any other kind of write means the variable is used as a string
             case ICompoundAssignmentOperation { Target: ILocalReferenceOperation compoundTarget }:
                 Disqualify(candidates, compoundTarget.Local);
+                break;
+
+            case ICoalesceAssignmentOperation { Target: ILocalReferenceOperation coalesceTarget }:
+                Disqualify(candidates, coalesceTarget.Local);
+                break;
+
+            case IDeconstructionAssignmentOperation deconstructionAssignmentOperation:
+                DisqualifyDeconstructionTargets(candidates, deconstructionAssignmentOperation.Target);
                 break;
 
             case IArgumentOperation { Parameter.RefKind: not RefKind.None, Value: ILocalReferenceOperation argumentReference }:
@@ -88,10 +101,19 @@ public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeDeclarator(IVariableDeclaratorOperation operation, FullPathContext analyzerContext, Dictionary<ISymbol, VariableState> candidates)
     {
         var local = operation.Symbol;
-        if (local.Type.SpecialType != SpecialType.System_String)
-            return;
-
+        var initializer = operation.Initializer ?? (operation.Parent as IVariableDeclarationOperation)?.Initializer;
         if (local.IsRef)
+        {
+            // 'ref string alias = ref local' lets the alias write to the local
+            if (initializer is not null)
+            {
+                DisqualifyReferencedLocals(candidates, initializer.Value);
+            }
+
+            return;
+        }
+
+        if (local.Type.SpecialType != SpecialType.System_String)
             return;
 
         // 'var' declarations are left alone: the developer asked for whatever the initializer produces
@@ -99,7 +121,6 @@ public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
             return;
 
         var state = new VariableState { Location = local.GetFirstSourceLocation() };
-        var initializer = operation.Initializer ?? (operation.Parent as IVariableDeclarationOperation)?.Initializer;
         if (initializer is not null)
         {
             state.HasValue = true;
@@ -107,6 +128,44 @@ public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
         }
 
         candidates[local] = state;
+    }
+
+    private static void DisqualifyReferencedLocals(Dictionary<ISymbol, VariableState> candidates, IOperation operation)
+    {
+        switch (operation)
+        {
+            case ILocalReferenceOperation localReferenceOperation:
+                Disqualify(candidates, localReferenceOperation.Local);
+                break;
+
+            // 'ref condition ? ref a : ref b' can alias either branch
+            case IConditionalOperation { IsRef: true } conditionalOperation:
+                DisqualifyReferencedLocals(candidates, conditionalOperation.WhenTrue);
+                if (conditionalOperation.WhenFalse is not null)
+                {
+                    DisqualifyReferencedLocals(candidates, conditionalOperation.WhenFalse);
+                }
+
+                break;
+        }
+    }
+
+    private static void DisqualifyDeconstructionTargets(Dictionary<ISymbol, VariableState> candidates, IOperation target)
+    {
+        switch (target)
+        {
+            case ILocalReferenceOperation localReferenceOperation:
+                Disqualify(candidates, localReferenceOperation.Local);
+                break;
+
+            case ITupleOperation tupleOperation:
+                foreach (var element in tupleOperation.Elements)
+                {
+                    DisqualifyDeconstructionTargets(candidates, element);
+                }
+
+                break;
+        }
     }
 
     private static void Disqualify(Dictionary<ISymbol, VariableState> candidates, ILocalSymbol local)

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/VariableShouldBeFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/VariableShouldBeFullPathRuleTests.cs
@@ -147,6 +147,151 @@ public sealed class VariableShouldBeFullPathRuleTests : FullPathAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsCoalesceAssigned()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath, string other)
+                    {
+                        string path = fullPath;
+                        path ??= other;
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsDeconstructionTarget()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        int count;
+                        (path, count) = ("relative", 1);
+                        return path + count;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsNestedDeconstructionTarget()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        ((var count, path), var flag) = ((1, "relative"), true);
+                        return path + count + flag;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsAliasedByRefLocal()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        ref string alias = ref path;
+                        alias = "relative";
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsAliasedByRefAssignment()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath, bool condition)
+                    {
+                        string path = fullPath;
+                        string other = "";
+                        ref string alias = ref other;
+                        alias = ref condition ? ref other : ref path;
+                        alias = "relative";
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsAliasedByRefReturn()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        Pick(ref path) = "relative";
+                        return path;
+                    }
+
+                    private static ref string Pick(ref string value) => ref value;
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_DoesNotReportDiagnostic_ForStringLocalWithoutValue()
     {
         var source = """


### PR DESCRIPTION
## Problem

`VariableShouldBeFullPathAnalyzer` (MFFP0013) only counted three kinds of write: simple assignments, compound assignments, and `ref`/`out`/`in` arguments. Other writes went unnoticed, so a `string` local could get an arbitrary string and still be reported as "only holds FullPath values":

```csharp
string value = fp;
value ??= other;                  // ICoalesceAssignmentOperation

(value, n) = ("relative", 1);     // IDeconstructionAssignmentOperation

ref string alias = ref value;     // ref local aliasing 'value'
alias = "relative";
```

## Fix

The analyzer now rules out the local when it:
- is the target of `??=`;
- appears in the target tuple of a deconstruction assignment, including nested tuples;
- is taken by reference in a `ref` local initializer or a `ref` assignment (`alias = ref value`), including both branches of a `ref` conditional.

## Notes for reviewers

- **`foreach ((value, _) in pairs)`**, also mentioned in the report, is not valid C#: a `foreach` must declare its loop variables (CS8186). So it needs no handling.
- **`ref` returns** (`Pick(ref value) = "x"`) were already handled, because the `ref` argument rules the local out. I added a regression test for it.

## Tests

- Added 6 tests to `VariableShouldBeFullPathRuleTests`. The 5 new-behavior tests failed before the fix.
- All 128 tests in `Meziantou.Framework.FullPath.Analyzer.Tests` pass with `TreatWarningsAsErrors=true`.
- A full Release rebuild of the analyzer with `IsOfficialBuild=true` is clean.
- `eng/update-all.cs` produced no changes.
