### PR TITLE
Only report MFFP0002 for FullPath's own division operator

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathDivisionWithFullPathRightAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathDivisionWithFullPathRightAnalyzer.cs
@@ -39,6 +39,10 @@ public sealed class FullPathDivisionWithFullPathRightAnalyzer : DiagnosticAnalyz
         if (binaryOperation.OperatorKind != BinaryOperatorKind.Divide)
             return;
 
+        // Only FullPath.operator / discards its left operand when the right one is rooted
+        if (!analyzerContext.IsFullPathType(binaryOperation.OperatorMethod?.ContainingType))
+            return;
+
         if (!analyzerContext.IsFullPathType(binaryOperation.RightOperand))
             return;
 

--- a/src/Meziantou.Framework.FullPath.CodeFix/FullPathDivisionWithFullPathRightCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/FullPathDivisionWithFullPathRightCodeFixProvider.cs
@@ -76,7 +76,8 @@ public sealed class FullPathDivisionWithFullPathRightCodeFixProvider : CodeFixPr
         out ExpressionSyntax replacementExpression)
     {
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IBinaryOperation binaryOperation &&
-            binaryOperation.OperatorKind == BinaryOperatorKind.Divide)
+            binaryOperation.OperatorKind == BinaryOperatorKind.Divide &&
+            SymbolEqualityComparer.Default.Equals(binaryOperation.OperatorMethod?.ContainingType, fullPathType))
         {
             var rightOperand = FullPathAnalyzerCommon.UnwrapToFullPath(binaryOperation.RightOperand, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(rightOperand.Type, fullPathType) && rightOperand.Syntax is ExpressionSyntax rightExpression)

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FullPathDivisionWithFullPathRightRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FullPathDivisionWithFullPathRightRuleTests.cs
@@ -61,4 +61,30 @@ public sealed class FullPathDivisionWithFullPathRightRuleTests : FullPathAnalyze
 
         await CreateAnalyzerTest<FullPathDivisionWithFullPathRightAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForOtherTypeDivisionOperatorWithFullPathRight()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public readonly struct OtherPath
+                {
+                    public static OtherPath operator /(OtherPath left, string right) => left;
+                }
+
+                public static class TestClass
+                {
+                    public static OtherPath M(OtherPath left, FullPath right)
+                    {
+                        return left / right;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FullPathDivisionWithFullPathRightAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0002 (`FullPathDivisionWithFullPathRightAnalyzer`) only checked that the operation was a division and that the right operand unwraps to a `FullPath`. It never checked which `/` operator was used, so any path-like type with an `operator /(T, string)` was reported:

```csharp
internal readonly struct OtherPath
{
    public static OtherPath operator /(OtherPath a, string b) => a;
}

OtherPath Use(OtherPath other, FullPath fp) => other / fp;   // MFFP0002 was reported
```

That operator may not discard its left side for a rooted segment. Even if it does, the code fix replaced an `OtherPath` expression with a `FullPath`, which either fails to compile or changes overload resolution.

## Changes

- **Analyzer:** returns early unless `binaryOperation.OperatorMethod` is declared on `FullPath`. A built-in numeric division has no operator method, so it is excluded too.
- **Code fix:** checks the operation again before rewriting, so it applies the same condition and can't rewrite a non-`FullPath` division.
- **Test:** a user-defined `OtherPath` with `operator /(OtherPath, string)` is divided by a `FullPath` and must not be reported. This test fails against the previous analyzer.

## Validation

- `Meziantou.Framework.FullPath.Analyzer.Tests`: 123 passed, 0 failed (`/p:TreatWarningsAsErrors=true`).
- `dotnet run ./eng/update-all.cs` changed no files.
