### PR TITLE
Report Assert.Same/NotSame when either argument is a value type

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
@@ -135,8 +135,13 @@ internal static class AssertionMethodSelectionAnalyzerCommon
 
         var expectedOperation = expectedArgument.Value.UnwrapImplicitConversions();
         var actualOperation = actualArgument.Value.UnwrapImplicitConversions();
-        if (!AssertionsAnalyzerHelpers.IsValueType(expectedOperation.Type) ||
-            !AssertionsAnalyzerHelpers.IsValueType(actualOperation.Type))
+        // Boxing a value type always allocates a new instance, so the reference comparison can never succeed.
+        // A nullable value type is only excluded when compared to a reference, as both sides can box to null.
+        var isExpectedValueType = AssertionsAnalyzerHelpers.IsValueType(expectedOperation.Type);
+        var isActualValueType = AssertionsAnalyzerHelpers.IsValueType(actualOperation.Type);
+        if (!(isExpectedValueType && isActualValueType) &&
+            !IsNonNullableValueType(expectedOperation.Type) &&
+            !IsNonNullableValueType(actualOperation.Type))
         {
             match = default;
             return false;
@@ -147,6 +152,11 @@ internal static class AssertionMethodSelectionAnalyzerCommon
             actualOperation,
             invocationOperation.TargetMethod.Name == "Same" ? EqualAssertionMethodName : NotEqualAssertionMethodName);
         return true;
+    }
+
+    private static bool IsNonNullableValueType(ITypeSymbol? type)
+    {
+        return type is { IsValueType: true } && type.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
     }
 
     private static bool IsAssertInvocation(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, params string[] methodNames)

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/SameWithValueTypeRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/SameWithValueTypeRuleTests.cs
@@ -72,4 +72,97 @@ public sealed class SameWithValueTypeRuleTests : AssertionsAnalyzerTestBase
 
         await CreateCodeFixTest<SameWithValueTypeAnalyzerType, SameWithValueTypeCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertSameWithValueTypeAndReferenceType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object expected, int actual)
+                {
+                    {|MFAS0010:Assert.Same(expected, actual)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object expected, int actual)
+                {
+                    Assert.Equal(expected, actual);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<SameWithValueTypeAnalyzerType, SameWithValueTypeCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertNotSameWithReferenceTypeAndValueType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int expected, object actual)
+                {
+                    {|MFAS0011:Assert.NotSame(expected, actual)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int expected, object actual)
+                {
+                    Assert.NotEqual(expected, actual);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<SameWithValueTypeAnalyzerType, SameWithValueTypeCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_NoDiagnostic_WhenReferenceIdentityCanSucceed()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M<T>(object obj, string str, int? nullable, T value)
+                {
+                    Assert.Same(obj, str);
+                    Assert.NotSame(obj, str);
+                    Assert.Same(obj, nullable);
+                    Assert.Same(null, nullable);
+                    Assert.NotSame(nullable, obj);
+                    Assert.Same(obj, value);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<SameWithValueTypeAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
## What

MFAS0010 (`Assert.Same`) and MFAS0011 (`Assert.NotSame`) now fire when **either** argument is a non-nullable value type, instead of only when both are.

## Why

`Assert.Same(obj, 42)` boxes `42` into a new object, so the reference comparison can never succeed: `Same` always fails and `NotSame` always passes. The analyzer skipped these mixed calls, so they compiled silently.

## Notes for reviewers

- A nullable value type compared with a reference (e.g. `Assert.Same(null, nullableInt)`) is still allowed, because both sides can box to null and the assertion can pass.
- The existing code fix covers the new cases and rewrites them to `Assert.Equal` / `Assert.NotEqual`.
- Tests added to `SameWithValueTypeRuleTests.cs`: mixed `Same`/`NotSame` with their code fixes, plus the cases that must not be reported (reference/reference, nullable/reference, `null`/nullable, unconstrained generic `T`).
- Every test project that uses `Assert.Same`/`NotSame` still builds with `TreatWarningsAsErrors=true`, so no existing code is affected.