### PR TITLE
Use the expected set's comparer in ProperSubset/ProperSuperset assertions

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.NotSet.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotSet.cs
@@ -6,10 +6,7 @@ public partial class Assert
 {
     public static void NotProperSubset<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        comparer ??= EqualityComparer<T>.Default;
-        var expectedSet = CreateSet(expected, comparer);
-        var actualSet = CreateSet(actual, comparer);
-        if (!(expectedSet.Count < actualSet.Count && expectedSet.IsSubsetOf(actualSet)))
+        if (!IsProperSubset(expected, expected, actual, comparer))
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new NegativeSetAssertionError(expected, actual, isSuperset: false, actualExpression, expectedExpression, message)));
@@ -22,10 +19,7 @@ public partial class Assert
 
     public static void NotProperSuperset<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        comparer ??= EqualityComparer<T>.Default;
-        var expectedSet = CreateSet(expected, comparer);
-        var actualSet = CreateSet(actual, comparer);
-        if (!(expectedSet.Count > actualSet.Count && expectedSet.IsSupersetOf(actualSet)))
+        if (!IsProperSuperset(expected, expected, actual, comparer))
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new NegativeSetAssertionError(expected, actual, isSuperset: true, actualExpression, expectedExpression, message)));

--- a/src/Meziantou.Framework.Assertions/Assert.Set.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Set.cs
@@ -7,21 +7,20 @@ public partial class Assert
     /// <summary>Asserts that a collection is a proper subset of another collection.</summary>
     /// <param name="expected">The collection expected to be a proper subset of <paramref name="actual"/>.</param>
     /// <param name="actual">The collection expected to contain every unique item in <paramref name="expected"/> and at least one additional unique item.</param>
-    /// <param name="comparer">The comparer used to compare values.</param>
+    /// <param name="comparer">The comparer used to compare values. When <see langword="null"/> and <paramref name="expected"/> is a set, the set compares values itself, like <see cref="ISet{T}.IsProperSubsetOf(IEnumerable{T})"/>; otherwise <see cref="EqualityComparer{T}.Default"/> is used.</param>
     /// <param name="actualExpression">The expression that produced the actual value.</param>
     /// <param name="expectedExpression">The expression that produced the expected value.</param>
     public static void ProperSubset<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        comparer ??= EqualityComparer<T>.Default;
         using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
 
-        var expectedSet = CreateSet(expectedSnapshot, comparer);
-        var actualSet = CreateSet(actualSnapshot, comparer);
-
-        if (expectedSet.Count < actualSet.Count && expectedSet.IsSubsetOf(actualSet))
+        if (IsProperSubset(expected, expectedSnapshot, actualSnapshot, comparer))
             return;
 
+        // A set does not read the snapshots, or may stop reading them early, so they must be completed for the message
+        expectedSnapshot.EnsureComplete();
+        actualSnapshot.EnsureComplete();
         throw new AssertionException(ErrorFormatter.Format(new CollectionSetAssertionError<T>(expectedSnapshot, actualSnapshot, isSuperset: false, actualExpression, expectedExpression, message)));
     }
 
@@ -39,21 +38,20 @@ public partial class Assert
     /// <summary>Asserts that a collection is a proper superset of another collection.</summary>
     /// <param name="expected">The collection expected to be a proper superset of <paramref name="actual"/>.</param>
     /// <param name="actual">The collection expected to be contained in <paramref name="expected"/> with at least one fewer unique item.</param>
-    /// <param name="comparer">The comparer used to compare values.</param>
+    /// <param name="comparer">The comparer used to compare values. When <see langword="null"/> and <paramref name="expected"/> is a set, the set compares values itself, like <see cref="ISet{T}.IsProperSupersetOf(IEnumerable{T})"/>; otherwise <see cref="EqualityComparer{T}.Default"/> is used.</param>
     /// <param name="actualExpression">The expression that produced the actual value.</param>
     /// <param name="expectedExpression">The expression that produced the expected value.</param>
     public static void ProperSuperset<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        comparer ??= EqualityComparer<T>.Default;
         using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
 
-        var expectedSet = CreateSet(expectedSnapshot, comparer);
-        var actualSet = CreateSet(actualSnapshot, comparer);
-
-        if (expectedSet.Count > actualSet.Count && expectedSet.IsSupersetOf(actualSet))
+        if (IsProperSuperset(expected, expectedSnapshot, actualSnapshot, comparer))
             return;
 
+        // A set does not read the snapshots, or may stop reading them early, so they must be completed for the message
+        expectedSnapshot.EnsureComplete();
+        actualSnapshot.EnsureComplete();
         throw new AssertionException(ErrorFormatter.Format(new CollectionSetAssertionError<T>(expectedSnapshot, actualSnapshot, isSuperset: true, actualExpression, expectedExpression, message)));
     }
 
@@ -66,6 +64,30 @@ public partial class Assert
     public static void ProperSuperset(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, System.Collections.IEqualityComparer? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
         ProperSuperset(EnumerateObjects(expected), EnumerateObjects(actual), new ObjectEqualityComparer(comparer), message, actualExpression, expectedExpression);
+    }
+
+    private static bool IsProperSubset<T>(IEnumerable<T> expected, IEnumerable<T> expectedItems, IEnumerable<T> actualItems, IEqualityComparer<T>? comparer)
+    {
+        // A set uses its own comparer, so the assertion agrees with ISet<T>.IsProperSubsetOf
+        if (comparer is null && expected is ISet<T> set)
+            return set.IsProperSubsetOf(actualItems);
+
+        comparer ??= EqualityComparer<T>.Default;
+        var expectedSet = CreateSet(expectedItems, comparer);
+        var actualSet = CreateSet(actualItems, comparer);
+        return expectedSet.Count < actualSet.Count && expectedSet.IsSubsetOf(actualSet);
+    }
+
+    private static bool IsProperSuperset<T>(IEnumerable<T> expected, IEnumerable<T> expectedItems, IEnumerable<T> actualItems, IEqualityComparer<T>? comparer)
+    {
+        // A set uses its own comparer, so the assertion agrees with ISet<T>.IsProperSupersetOf
+        if (comparer is null && expected is ISet<T> set)
+            return set.IsProperSupersetOf(actualItems);
+
+        comparer ??= EqualityComparer<T>.Default;
+        var expectedSet = CreateSet(expectedItems, comparer);
+        var actualSet = CreateSet(actualItems, comparer);
+        return expectedSet.Count > actualSet.Count && expectedSet.IsSupersetOf(actualSet);
     }
 
     private static HashSet<T> CreateSet<T>(IEnumerable<T> items, IEqualityComparer<T> comparer)

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertSetTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertSetTests.cs
@@ -154,4 +154,112 @@ public sealed class AssertSetTests
             Actual:                [1]
             """);
     }
+
+    [Fact]
+    public void ProperSubset_UsesExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+        var actual = new[] { "A", "b" };
+
+        AssertionsAssert.ProperSubset(expected, actual);
+    }
+
+    [Fact]
+    public void ProperSubset_FailsWithExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+        var actual = AssertionTestHelpers.SingleUse("A");
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.ProperSubset(expected, actual), """
+            Assert.ProperSubset() assertion failed.
+            Expected subset expression: expected
+            Actual expression:          actual
+            Expected subset: ["a"]
+            Actual:          ["A"]
+            """);
+    }
+
+    [Fact]
+    public void ProperSubset_ExplicitComparerOverridesExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+        var actual = new[] { "A", "b" };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.ProperSubset(expected, actual, StringComparer.Ordinal), """
+            Assert.ProperSubset() assertion failed.
+            Expected subset expression: expected
+            Actual expression:          actual
+            Expected subset: ["a"]
+            Actual:          ["A", "b"]
+            """);
+    }
+
+    [Fact]
+    public void ProperSubset_IgnoresActualSetComparer()
+    {
+        var expected = new[] { "a" };
+        var actual = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", "b" };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.ProperSubset(expected, actual), """
+            Assert.ProperSubset() assertion failed.
+            Expected subset expression: expected
+            Actual expression:          actual
+            Expected subset: ["a"]
+            Actual:          ["A", "b"]
+            """);
+    }
+
+    [Fact]
+    public void ProperSuperset_UsesExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "b" };
+        var actual = new[] { "A" };
+
+        AssertionsAssert.ProperSuperset(expected, actual);
+    }
+
+    [Fact]
+    public void ProperSuperset_ExplicitComparerOverridesExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "b" };
+        var actual = new[] { "A" };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.ProperSuperset(expected, actual, StringComparer.Ordinal), """
+            Assert.ProperSuperset() assertion failed.
+            Expected superset expression: expected
+            Actual expression:            actual
+            Expected superset: ["a", "b"]
+            Actual:            ["A"]
+            """);
+    }
+
+    [Fact]
+    public void NotProperSubset_UsesExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+        var actual = new[] { "A", "b" };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.NotProperSubset(expected, actual), """
+            Assert.NotProperSubset() assertion failed.
+            Expected subset expression: expected
+            Actual expression:          actual
+            Not expected subset: ["a"]
+            Actual:              ["A", "b"]
+            """);
+    }
+
+    [Fact]
+    public void NotProperSuperset_UsesExpectedSetComparer()
+    {
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "b" };
+        var actual = new[] { "A" };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.NotProperSuperset(expected, actual), """
+            Assert.NotProperSuperset() assertion failed.
+            Expected superset expression: expected
+            Actual expression:            actual
+            Not expected superset: ["a", "b"]
+            Actual:                ["A"]
+            """);
+    }
 }


### PR DESCRIPTION
## Problem

`ISet<T>.IsProperSubsetOf` / `IsProperSupersetOf` compare items with **the set's own comparer**, but `Assert.ProperSubset`, `ProperSuperset`, `NotProperSubset` and `NotProperSuperset` rebuilt both collections with `EqualityComparer<T>.Default` unless a comparer was passed.

The MFAS0041–MFAS0044 code fix rewrites `Assert.True(set.IsProperSubsetOf(other))` into `Assert.ProperSubset(set, other)`, so the fix could change whether a test passes:

```csharp
var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
var other = new[] { "A", "b" };

Assert.True(set.IsProperSubsetOf(other)); // passes
Assert.ProperSubset(set, other);          // failed before this change
```

## Fix

The assertions are fixed rather than the analyzer. When no comparer is passed and `expected` is an `ISet<T>`, they delegate to the set's own `IsProperSubsetOf` / `IsProperSupersetOf`. As a result, the existing code fix is exact for every receiver the analyzer matches (`HashSet<T>`, `SortedSet<T>`, custom sets, `ISet<T>`-typed receivers) without duplicating the receiver expression.

- An explicit `comparer` still wins and keeps the previous behavior.
- Only `expected` is considered; a set passed as `actual` does not provide its comparer.
- The non-generic overloads are unchanged.
- Both snapshots are completed before formatting the failure message: the set does not read the `expected` snapshot and may stop reading `actual` early, which otherwise printed `Expected subset: []`.

## Behavior change

Callers passing a set with a custom comparer as `expected` can see a different result, e.g. `Assert.ProperSubset(new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" }, new[] { "A", "b" })` now passes, and `NotProperSuperset` can go from passing to failing. No caller in this repository is affected.

## Tests

New tests in `AssertSetTests` cover the expected set's comparer for all four assertions, an explicit comparer taking priority, the `actual` set's comparer being ignored, and a single-use `actual` sequence in a failure message. The full `Meziantou.Framework.Assertions.Tests` project passes on net10.0 and net11.0, and the library and test project build with `-c Release /p:IsOfficialBuild=true`.
