### PR TITLE
Make Assert.InRange and Assert.NotInRange treat NaN as never in range

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.InRange.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.InRange.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Assertions;
 
@@ -10,12 +11,40 @@ public partial class Assert
     /// <param name="high">The inclusive upper bound.</param>
     /// <param name="comparer">The comparer used to order values.</param>
     /// <param name="actualExpression">The expression that produced the actual value.</param>
+    /// <remarks>
+    /// When <paramref name="comparer"/> is <see langword="null"/> or <see cref="Comparer{T}.Default"/>, a NaN floating-point value is never in range,
+    /// whether it is the value or one of the bounds. This matches <c>low &lt;= actual &amp;&amp; actual &lt;= high</c>.
+    /// </remarks>
     public static void InRange<T>(T actual, T low, T high, IComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        comparer ??= Comparer<T>.Default;
-        if (comparer.Compare(actual, low) >= 0 && comparer.Compare(actual, high) <= 0)
-            return;
+        if (!IsInRange(actual, low, high, comparer))
+            throw new AssertionException(ErrorFormatter.Format(new InRangeAssertionError<T>(actual, low, high, actualExpression, message)));
+    }
 
-        throw new AssertionException(ErrorFormatter.Format(new InRangeAssertionError<T>(actual, low, high, actualExpression, message)));
+    private static bool IsInRange<T>(T actual, T low, T high, IComparer<T>? comparer)
+    {
+        if (comparer is null || object.ReferenceEquals(comparer, Comparer<T>.Default))
+        {
+            // Comparer<T>.Default orders NaN below every other value and equal to itself, so it would consider NaN in [NaN, x]
+            // and any value in [NaN, x]. Relational operators return false for NaN, so no range can contain it.
+            if (IsNaN(actual) || IsNaN(low) || IsNaN(high))
+                return false;
+
+            comparer = Comparer<T>.Default;
+        }
+
+        return comparer.Compare(actual, low) >= 0 && comparer.Compare(actual, high) <= 0;
+    }
+
+    private static bool IsNaN<T>(T value)
+    {
+        return value switch
+        {
+            double d => double.IsNaN(d),
+            float f => float.IsNaN(f),
+            Half h => Half.IsNaN(h),
+            NFloat n => NFloat.IsNaN(n),
+            _ => false,
+        };
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.NotInRange.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotInRange.cs
@@ -6,10 +6,7 @@ public partial class Assert
 {
     public static void NotInRange<T>(T actual, T low, T high, IComparer<T>? comparer = null, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        comparer ??= Comparer<T>.Default;
-        if (comparer.Compare(actual, low) < 0 || comparer.Compare(actual, high) > 0)
-            return;
-
-        throw new AssertionException(ErrorFormatter.Format(new NegativeRangeAssertionError<T>(nameof(NotInRange), actual, low, high, actualExpression, message)));
+        if (IsInRange(actual, low, high, comparer))
+            throw new AssertionException(ErrorFormatter.Format(new NegativeRangeAssertionError<T>(nameof(NotInRange), actual, low, high, actualExpression, message)));
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertInRangeTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertInRangeTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using AssertionsAssert = Meziantou.Framework.Assertions.Assert;
 
 namespace Meziantou.Framework.Assertions.Tests;
@@ -79,6 +80,73 @@ public sealed class AssertInRangeTests
             Expression: actual
             Not expected: in range [1, 3]
             Actual:       2
+            """);
+    }
+
+    [Theory]
+    [InlineData(double.PositiveInfinity, 0d, double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity, double.NegativeInfinity, 0d)]
+    [InlineData(5d, double.NegativeInfinity, double.PositiveInfinity)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+    public void Infinity_InRange(double actual, double low, double high)
+    {
+        AssertionsAssert.InRange(actual, low, high);
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.NotInRange(actual, low, high));
+    }
+
+    [Theory]
+    [InlineData(double.PositiveInfinity, 0d, 10d)]
+    [InlineData(double.NegativeInfinity, 0d, 10d)]
+    [InlineData(double.NegativeInfinity, 0d, double.PositiveInfinity)]
+    public void Infinity_NotInRange(double actual, double low, double high)
+    {
+        AssertionsAssert.NotInRange(actual, low, high);
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange(actual, low, high));
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0d, 10d)]
+    [InlineData(double.NaN, double.NegativeInfinity, double.PositiveInfinity)]
+    [InlineData(double.NaN, double.NaN, 10d)]
+    [InlineData(double.NaN, 0d, double.NaN)]
+    [InlineData(double.NaN, double.NaN, double.NaN)]
+    [InlineData(5d, double.NaN, 10d)]
+    [InlineData(double.NegativeInfinity, double.NaN, 0d)]
+    [InlineData(5d, 0d, double.NaN)]
+    [InlineData(5d, double.NaN, double.NaN)]
+    public void NaN_NotInRange(double actual, double low, double high)
+    {
+        AssertionsAssert.NotInRange(actual, low, high);
+        AssertionsAssert.NotInRange(actual, low, high, Comparer<double>.Default);
+        AssertionsAssert.NotInRange((float)actual, (float)low, (float)high);
+        AssertionsAssert.NotInRange((Half)actual, (Half)low, (Half)high);
+        AssertionsAssert.NotInRange((NFloat)actual, (NFloat)low, (NFloat)high);
+        AssertionsAssert.NotInRange((double?)actual, low, high);
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange(actual, low, high));
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange(actual, low, high, Comparer<double>.Default));
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange((float)actual, (float)low, (float)high));
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange((Half)actual, (Half)low, (Half)high));
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange((NFloat)actual, (NFloat)low, (NFloat)high));
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.InRange((double?)actual, low, high));
+    }
+
+    [Fact]
+    public void NaN_CustomComparerIsHonored()
+    {
+        AssertionsAssert.InRange(double.NaN, double.NaN, 10d, Comparer<double>.Create((x, y) => x.CompareTo(y)));
+    }
+
+    [Fact]
+    public void NaN_FailureMessage()
+    {
+        var actual = double.NaN;
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.InRange(actual, double.NaN, 10d), """
+            Assert.InRange() assertion failed.
+            Expression: actual
+            Expected: in range [NaN, 10]
+            Actual:   NaN
             """);
     }
 }


### PR DESCRIPTION
`Assert.InRange` and `Assert.NotInRange` ordered values with `Comparer<T>.Default`. For floating-point types that comparer ranks NaN below every value, including -Infinity, and treats NaN as equal to NaN. As a result:

| Case | `InRange` before | `InRange` after |
|---|---|---|
| `NaN in [NaN, 10]` | passed | fails |
| `NaN in [NaN, NaN]` | passed | fails |
| `5 in [NaN, 10]` | passed | fails |
| `-Inf in [NaN, 0]` | passed | fails |

`NotInRange` had the same bugs in reverse.

## Changes
- When the comparer is `null` or `Comparer<T>.Default`, a NaN value or bound means "not in range". This applies to `double`, `float`, `Half` and `NFloat`, including their nullable forms.
- A custom comparer keeps its own ordering.
- `NotInRange` now reuses the same check, so it stays the exact inverse of `InRange`.

## Why these semantics
MFAS0039/MFAS0040 rewrite `Assert.True(low <= x && x <= high)` into `Assert.InRange(x, low, high)`. `<=` returns false whenever NaN is involved, so before this change the rewrite could turn a failing assertion into a passing one. Treating NaN as never in range makes the rewrite give the same result again. Throwing `ArgumentException` on a NaN bound would not.

## Tests
- Infinity as the value and as either bound (it already worked and was untested).
- Nine NaN cases, each checked with `double`, an explicit `Comparer<double>.Default`, `float`, `Half`, `NFloat` and `double?`.
- A custom comparer is still honored.
- The failure message for a NaN range.

Assertions tests pass on net10.0 and net11.0 (900 passed). The Release + `IsOfficialBuild` build succeeds, and `eng/update-all.cs` produced no changes.

## Not covered
Nullable types have a similar gap: `InRange((int?)null, null, 10)` passes, while `null <= x` is false in C#. I left that out of this PR.
